### PR TITLE
train agents fix

### DIFF
--- a/kaggle_environments/core.py
+++ b/kaggle_environments/core.py
@@ -302,7 +302,7 @@ class Environment:
 
         def advance():
             while not self.done and self.state[position].status == "INACTIVE":
-                self.step(self.__get_actions(agents=self.agents))
+                self.step(self.__get_actions(agents=agents))
 
         def reset():
             self.reset(len(agents))


### PR DESCRIPTION
Testing put the starter pack for the recent connectX Kaggle competition, I noticed that the train function always seemed to run the negamax agent, regardless of which agent was chosen.
Looking at the code, it seems that advance function always passed `self.agents` rather than `agents`. This pull request should hopefully fix this, (assuming that it is a bug).
I've done a quick test and was able to adjust whether the agent was random or negamax.