### PR TITLE
Add kaggle-environments docker image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,16 @@
+FROM gcr.io/kaggle-images/python
+
+WORKDIR /usr/src/app/kaggle_environments
+
+# gfootball dependencies
+RUN apt-get update
+RUN apt-get --assume-yes install libsdl2-gfx-dev libsdl2-ttf-dev libboost-all-dev libsdl2-image-dev
+RUN pip install gfootball
+
+ADD ./kaggle_environments ./kaggle_environments
+ADD ./setup.py ./setup.py
+ADD ./README.md ./README.md
+ADD ./MANIFEST.in ./MANIFEST.in
+RUN pip install .
+
+CMD kaggle-environments

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,12 @@
+# kaggle-environments Docker Image
+This image encapsulates the kaggle-environments library, its dependencies, and agent execution environment.
+This image is hosted at gcr.io/kaggle-images/python-simulations
+
+## Usage
+`./build.sh` will build the image including any local changes to kaggle_environments.
+`./run.sh` will pass any arguments to the kaggle-environments command line tool running in docker.
+Note that this also binds port 8080 to run `kaggle-environments http-server` commands.
+    `./run.sh list`
+    `./run.sh run --environment connectx --agent random random`
+    `./run.sh http-server`
+`./test.sh` will run the unit test suite in docker with pytest.

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,12 +1,11 @@
-# kaggle-environments Docker Image
-This image encapsulates the kaggle-environments library, its dependencies, and agent execution environment.
-This image is hosted at gcr.io/kaggle-images/python-simulations
+# Docker Image
+This image encapsulates the kaggle-environments library, its dependencies, and agent execution environment.  
+This image is hosted at `gcr.io/kaggle-images/python-simulations`
 
 ## Usage
-`./build.sh` will build the image including any local changes to kaggle_environments.
-`./run.sh` will pass any arguments to the kaggle-environments command line tool running in docker.
-Note that this also binds port 8080 to run `kaggle-environments http-server` commands.
-    `./run.sh list`
-    `./run.sh run --environment connectx --agent random random`
-    `./run.sh http-server`
-`./test.sh` will run the unit test suite in docker with pytest.
+* `./build.sh` will build the image including any local changes to kaggle_environments.  
+* `./run.sh` will pass any arguments to the kaggle-environments command line tool running in docker. Note that this also binds port 8080 to run `kaggle-environments http-server` commands.  
+    * `./run.sh list`  
+    * `./run.sh run --environment connectx --agent random random`  
+    * `./run.sh http-server`  
+* `./test.sh` will run the unit test suite in docker with pytest.

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -1,0 +1,6 @@
+# Just build the orchestrator container
+path=$(dirname $0)
+# cd to the parent directory to include kaggle_environments folder in Docker build context
+cd $path/..
+docker build -f ./docker/Dockerfile -t python-simulations .
+cd -

--- a/docker/cloudbuild.yaml
+++ b/docker/cloudbuild.yaml
@@ -1,0 +1,6 @@
+steps:
+- id: 'build-image'
+  name: gcr.io/cloud-builders/docker
+  args: ['build', '-f', './docker/Dockerfile', '-t', 'python-simulations', '.']
+images: ['gcr.io/kaggle-images/python-simulations']
+timeout: 24h

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -1,0 +1,2 @@
+# Start the orchestrator container in Docker
+docker run -it --rm -p 127.0.0.1:8080:8080/tcp --name python-simulations python-simulations

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -1,2 +1,2 @@
 # Start the orchestrator container in Docker
-docker run -it --rm -p 127.0.0.1:8080:8080/tcp --name python-simulations python-simulations
+docker run -it --entrypoint kaggle-environments --rm -p 127.0.0.1:8080:8080/tcp --name python-simulations python-simulations "$@"

--- a/docker/test.sh
+++ b/docker/test.sh
@@ -1,0 +1,3 @@
+# Start the orchestrator container in Docker
+# The double slash in the test directory is to force it to translate to a Linux path rather than a Windows path
+docker run -it --entrypoint pytest --rm -p 127.0.0.1:8080:8080/tcp --name python-simulations python-simulations '//usr/src/app/kaggle_environments'

--- a/docker/test.sh
+++ b/docker/test.sh
@@ -1,3 +1,3 @@
 # Start the orchestrator container in Docker
 # The double slash in the test directory is to force it to translate to a Linux path rather than a Windows path
-docker run -it --entrypoint pytest --rm -p 127.0.0.1:8080:8080/tcp --name python-simulations python-simulations '//usr/src/app/kaggle_environments'
+docker run -it --entrypoint pytest --rm --name python-simulations python-simulations '//usr/src/app/kaggle_environments'


### PR DESCRIPTION
This PR migrates the agent image to the kaggle-environments repo. Making this image publicly available will improve competitors' ability to reproduce our production environment locally. I also added some scripts to make using the image a little easier.