### PR TITLE
Process converts after collisions

### DIFF
--- a/kaggle_environments/envs/halite/halite.py
+++ b/kaggle_environments/envs/halite/halite.py
@@ -261,7 +261,6 @@ def interpreter(state, env):
 
             # Check for invalid converts.  Process good converts later.
             if action == "CONVERT":
-                ship_pos, ship_halite = ships[uid]
                 if ship_pos in shipyards.values():
                     agent.status = "Shipyard already present. Cannot convert ship."
                 continue


### PR DESCRIPTION
Updated to reflect new commits.

Does the following in order:
- process ship movements (processing movements before collisions is required)
- calculates ship-shipyard and ship-ship collisions
- process spawns and converts 
  - ignores any converts issued to ships lost in ship-ship collisions
  - ignores any spawns issued to shipyard lost in collisions
  - does not spawn new ship if shipyard is already occupied (does not do normal collision calc)

FYI: As far as I could tell version 0.3.1 never destroyed shipyards.