### PR TITLE
Fix simultaneous shipyard collisions

### DIFF
--- a/kaggle_environments/envs/halite/halite.py
+++ b/kaggle_environments/envs/halite/halite.py
@@ -303,12 +303,13 @@ def interpreter(state, env):
         shipyard, ships, shipyard_uid = cell
         # Detect Shipyard Collisions.
         if shipyard > -1:
-            for uid, index in list(ships.items()):
-                if shipyard != index:
+            occupiers = [x for x in ships.values()]
+            enemy_occupied = any(x != shipyard for x in occupiers)
+            if enemy_occupied:
+                del obs.players[shipyard][1][shipyard_uid]
+                for uid, index in list(ships.items()):
                     del ships[uid]
                     del obs.players[index][2][uid]
-                    if uid != shipyard_uid:
-                        del obs.players[shipyard][1][shipyard_uid]
         # Detect Ship Collisions
         if len(ships) > 1:
             smallest_ships = [[i, uid, obs.players[i][2][uid][1]]

--- a/kaggle_environments/envs/halite/halite.py
+++ b/kaggle_environments/envs/halite/halite.py
@@ -303,8 +303,7 @@ def interpreter(state, env):
         shipyard, ships, shipyard_uid = cell
         # Detect Shipyard Collisions.
         if shipyard > -1:
-            occupiers = [x for x in ships.values()]
-            enemy_occupied = any(x != shipyard for x in occupiers)
+            enemy_occupied = any(x != shipyard for x in ships.values())
             if enemy_occupied:
                 del obs.players[shipyard][1][shipyard_uid]
                 for uid, index in list(ships.items()):


### PR DESCRIPTION
Issue #33 

If a shipyard is occupied by an enemy ship then the shipyard and all occupying ships (enemy and friendly) are destroyed.