### PR TITLE
Halite helpers

### DIFF
--- a/kaggle_environments/agent.py
+++ b/kaggle_environments/agent.py
@@ -102,8 +102,7 @@ def runner(raw, message, environment, debug=False):
         run_agent(agent, message)
 
 
-class Agent():
-
+class Agent:
     def __init__(self, raw, configuration, environment, id=None, debug=False):
         self.id = id or str(uuid.uuid1())
         self.configuration = configuration

--- a/kaggle_environments/core.py
+++ b/kaggle_environments/core.py
@@ -251,7 +251,6 @@ class Environment:
             out = self.renderer(*args[:self.renderer.__code__.co_argcount])
             if mode == "ansi":
                 return out
-            print(out)
         elif mode == "html" or mode == "ipython":
             window_kaggle = {
                 "debug": get(kwargs, bool, self.debug, path=["debug"]),

--- a/kaggle_environments/core.py
+++ b/kaggle_environments/core.py
@@ -192,7 +192,7 @@ class Environment:
         Returns:
             list of list of dict: The agent states of all steps executed.
         """
-        if self.state == None or len(self.steps) == 1 or self.done:
+        if self.state is None or len(self.steps) == 1 or self.done:
             self.reset(len(agents))
         if len(self.state) != len(agents):
             raise InvalidArgument(
@@ -548,8 +548,12 @@ class Environment:
                 agents[i] = self.agents[agent]
 
         # Generate the agents.
-        agents = [Agent(a, self.configuration, self.name, debug=self.debug) if a !=
-                  None else None for a in agents]
+        agents = [
+            Agent(a, self.configuration, self.name, debug=self.debug)
+            if a is not None
+            else None
+            for a in agents
+        ]
 
         # Have the agents had a chance to initialize (first non-empty act).
         initialized = [False] * len(agents)

--- a/kaggle_environments/envs/halite/halite.json
+++ b/kaggle_environments/envs/halite/halite.json
@@ -6,11 +6,6 @@
   "agents": [1, 2, 4],
   "configuration": {
     "episodeSteps": 400,
-    "halite": {
-      "description": "Deprecated, please use startingHalite instead.",
-      "type": "integer",
-      "default": 24000
-    },
     "startingHalite": {
       "description": "The starting amount of halite available on the board.",
       "type": "integer",

--- a/kaggle_environments/envs/halite/halite.py
+++ b/kaggle_environments/envs/halite/halite.py
@@ -46,7 +46,7 @@ def random_agent(obs, config):
     shipyards = me.shipyards
     for shipyard in shipyards:
         shipyard.pending_spawn = choice([True, False])
-    return board.current_player.agent_actions
+    return board.current_player.pending_actions
 
 
 agents = {"random": random_agent}

--- a/kaggle_environments/envs/halite/halite.py
+++ b/kaggle_environments/envs/halite/halite.py
@@ -18,6 +18,7 @@ import math
 from os import path
 from random import choice, randint, shuffle
 import numpy as np
+from .helpers import Board, Observation, ShipAction
 
 
 def get_col_row(size, pos):
@@ -36,129 +37,105 @@ def get_to_pos(size, pos, direction):
         return pos - 1 if col > 0 else (row + 1) * size - 1
 
 
-class Board:
-    def __init__(self, obs, config):
-        self.action = {}
-        self.obs = obs
-        self.config = config
-        size = config.size
-        
-        self.shipyards = [-1] * size ** 2
-        self.shipyards_by_uid = {}
-        self.ships = [None] * size ** 2
-        self.ships_by_uid = {}
-        self.possible_ships = [{} for _ in range(size ** 2)]
-
-        for index, player in enumerate(obs.players):
-            _, shipyards, ships = player
-            for uid, pos in shipyards.items():
-                self.shipyards[pos] = index
-                self.shipyards_by_uid[uid] = {"player_index": index, "uid": uid, "pos": pos}
-            for uid, ship in ships.items():
-                pos, ship_halite = ship
-                details = {"halite": ship_halite, "player_index": index, "uid": uid, "pos": pos}
-                self.ships[pos] = details
-                self.ships_by_uid[uid] = details
-                for direction in ["NORTH", "EAST", "SOUTH", "WEST"]:
-                    self.possible_ships[get_to_pos(size, pos, direction)][uid] = details
-    
-    def move(self, ship_uid, direction):
-        self.action[ship_uid] = direction
-        # Update the board.
-        self.__remove_possibles(ship_uid)
-        ship = self.ships_by_uid[ship_uid]
-        pos = ship["pos"]
-        to_pos = get_to_pos(self.config.size, pos, direction)
-        ship["pos"] = to_pos
-        self.ships[pos] = None
-        self.ships[to_pos] = ship
-    
-    def convert(self, ship_uid):
-        self.action[ship_uid] = "CONVERT"
-        # Update the board.
-        self.__remove_possibles(ship_uid)
-        pos = self.ships_by_uid[ship_uid]["pos"]
-        self.shipyards[pos] = self.obs.player
-        self.ships[pos] = None
-        del self.ships_by_uid[ship_uid]
-    
-    def spawn(self, shipyard_uid):
-        self.action[shipyard_uid] = "SPAWN"
-        # Update the board.
-        temp_uid = f"Spawn_Ship_{shipyard_uid}"
-        pos = self.shipyards_by_uid[shipyard_uid]["pos"]
-        details = {"halite": 0, "player_index": self.obs.player, "uid": temp_uid, "pos": pos}
-        self.ships[pos] = details
-        self.ships_by_uid[temp_uid] = details
-    
-    def __remove_possibles(self, ship_uid):
-        pos = self.ships_by_uid[ship_uid]["pos"]
-        for d in ["NORTH", "EAST", "SOUTH", "WEST"]:
-            to_pos = get_to_pos(self.config.size, pos, d)
-            del self.possible_ships[to_pos][ship_uid]
-
-
 def random_agent(obs, config):
-    size = config.size
-    halite = obs.halite
-    board = Board(obs, config)
-    player_halite, shipyards, ships = obs.players[obs.player]  
-
-    # Move, Convert, or have ships collect halite.
-    ships_items = list(ships.items())
-    # shuffle so ship1 doesn't always have first moving dibs.
-    shuffle(ships_items)
-    for uid, ship in ships_items:
-        pos, ship_halite = ship
-        # Collect Halite (50% probability when cell halite > ship_halite).
-        if board.shipyards[pos] == -1 and halite[pos] > ship_halite and randint(0,1) == 1:
-            continue
-        # Convert to Shipyard (50% probability when no shipyards, 5% otherwise).
-        if board.shipyards[pos] == -1 and player_halite >= config.convertCost and randint(0, 20 if len(shipyards) else 1) == 1:
-            player_halite -= config.convertCost
-            board.convert(uid)
-            continue
-        # Move Ship (random between all available directions).
-        move_choices = [None]
-        for direction in ["NORTH", "EAST", "SOUTH", "WEST"]:
-            to_pos = get_to_pos(size, pos, direction)
-            # Enemy shipyard present.
-            if board.shipyards[to_pos] != obs.player and board.shipyards[to_pos] != -1:
-                continue
-            # Larger ship most likely staying in place.
-            if board.ships[to_pos] is not None and board.ships[to_pos]["halite"] >= ship_halite:
-                continue
-            # Weigh the direction based on number of possible larger ships that could be present.
-            weight = 6
-            if board.ships[to_pos] is not None and board.ships[to_pos]["player_index"] == obs.player:
-                weight -= 1
-            for s in board.possible_ships[to_pos].values():
-                if s["halite"] > ship_halite:
-                    weight -= 1
-            move_choices += [direction] * weight
-        move = choice(move_choices)
-        if move is not None:
-            board.move(uid, move)
-            
-    # Spawn ships (30% probability when possible, or 100% if no ships).
-    for uid, pos in shipyards.items():
-        if board.ships[pos] is None and player_halite >= config.spawnCost and (randint(0, 2) == 2 or len(ships_items) == 0):
-            player_halite -= config.spawnCost
-            board.spawn(uid)
-
-    return board.action
+    board = Board(obs, config, {})
+    me = board.current_player
+    ships = me.ships
+    for ship in ships:
+        ship.pending_action = choice([ship_action for ship_action in ShipAction])
+    shipyards = me.shipyards
+    for shipyard in shipyards:
+        shipyard.pending_spawn = choice([True, False])
+    return board.current_player.agent_actions
 
 
 agents = {"random": random_agent}
 
 
-def interpreter(state, env):
+def populate_board(state, env, create_uid):
     obs = state[0].observation
     config = env.configuration
     size = env.configuration.size
 
-    # Update step index.
-    obs.step = len(env.steps)
+    # Set step for initialization to 0.
+    obs.step = 0
+    # Distribute Halite evenly into quartiles.
+    half = math.ceil(size / 2)
+    grid = [[0] * half for _ in range(half)]
+
+    # Randomly place a few halite "seeds".
+    for i in range(half):
+        # random distribution across entire quartile
+        grid[randint(0, half - 1)][randint(0, half - 1)] = i ** 2
+
+        # as well as a particular distribution weighted toward the center of the map
+        grid[randint(half // 2, half - 1)][randint(half // 2, half - 1)] = i ** 2
+
+    # Spread the seeds radially.
+    radius_grid = copy.deepcopy(grid)
+    for r in range(half):
+        for c in range(half):
+            value = grid[r][c]
+            if value == 0:
+                continue
+
+            # keep initial seed values, but constrain radius of clusters
+            radius = min(round((value / half) ** 0.5), 1)
+            for r2 in range(r - radius + 1, r + radius):
+                for c2 in range(c - radius + 1, c + radius):
+                    if 0 <= r2 < half and 0 <= c2 < half:
+                        distance = (abs(r2 - r) ** 2 + abs(c2 - c) ** 2) ** 0.5
+                        radius_grid[r2][c2] += int(value / max(1, distance) ** distance)
+
+    # add some random sprouts of halite
+    radius_grid = np.asarray(radius_grid)
+    add_grid = np.random.gumbel(0, 300.0, size=(half, half)).astype(int)
+    sparse_radius_grid = np.random.binomial(1, 0.5, size=(half, half))
+    add_grid = np.clip(add_grid, 0, a_max=None) * sparse_radius_grid
+    radius_grid += add_grid
+
+    # add another set of random locations to the center corner
+    corner_grid = np.random.gumbel(0, 500.0, size=(half // 4, half // 4)).astype(int)
+    corner_grid = np.clip(corner_grid, 0, a_max=None)
+    radius_grid[half - (half // 4):, half - (half // 4):] += corner_grid
+
+    # Normalize the available halite against the defined configuration starting halite.
+    total = sum([sum(row) for row in radius_grid])
+    obs.halite = [0] * (size ** 2)
+    for r, row in enumerate(radius_grid):
+        for c, val in enumerate(row):
+            val = int(val * config.startingHalite / total / 4)
+            obs.halite[size * r + c] = val
+            obs.halite[size * r + (size - c - 1)] = val
+            obs.halite[size * (size - 1) - (size * r) + c] = val
+            obs.halite[size * (size - 1) - (size * r) + (size - c - 1)] = val
+
+    # Distribute the starting ships evenly.
+    num_agents = len(state)
+    starting_positions = [0] * num_agents
+    if num_agents == 1:
+        starting_positions[0] = size * (size // 2) + size // 2
+    elif num_agents == 2:
+        starting_positions[0] = size * (size // 2) + size // 4
+        starting_positions[1] = size * (size // 2) + math.ceil(3 * size / 4) - 1
+    elif num_agents == 4:
+        starting_positions[0] = size * (size // 4) + size // 4
+        starting_positions[1] = size * (size // 4) + 3 * size // 4
+        starting_positions[2] = size * (3 * size // 4) + size // 4
+        starting_positions[3] = size * (3 * size // 4) + 3 * size // 4
+
+    # Initialize the players.
+    obs.players = []
+    for i in range(num_agents):
+        ships = {create_uid(): [starting_positions[i], 0]}
+        obs.players.append([state[0].reward, {}, ships])
+
+    return state
+
+
+def interpreter(state, env):
+    obs = state[0].observation
+    config = env.configuration
 
     # UID generator.
     uid_counter = 0
@@ -170,151 +147,12 @@ def interpreter(state, env):
 
     # Initialize the board (place cell halite and starting ships).
     if env.done:
-        # Set step for initialization to 0.
-        obs.step = 0
-        # Distribute Halite evenly into quartiles.
-        half = math.ceil(size / 2)
-        grid = [[0] * half for _ in range(half)]
+        return populate_board(state, env, create_uid)
 
-        # Randomly place a few halite "seeds".
-        for i in range(half):
-            # random distribution across entire quartile
-            grid[randint(0, half-1)][randint(0, half-1)] = i ** 2
-
-            # as well as a particular distribution weighted toward the center of the map
-            grid[randint(half//2, half-1)][randint(half//2, half-1)] = i ** 2
-
-        # Spread the seeds radially.
-        radius_grid = copy.deepcopy(grid)
-        for r in range(half):
-            for c in range(half):
-                value = grid[r][c]
-                if value == 0:
-                    continue
-
-                # keep initial seed values, but constrain radius of clusters
-                radius = min(round((value / half) ** 0.5), 1)
-                for r2 in range(r-radius+1, r+radius):
-                    for c2 in range(c-radius+1, c+radius):
-                        if 0 <= r2 < half and 0 <= c2 < half:
-                            distance = (abs(r2-r) ** 2 + abs(c2-c) ** 2) ** 0.5
-                            radius_grid[r2][c2] += int(value / max(1, distance) ** distance)
-
-        # add some random sprouts of halite
-        radius_grid = np.asarray(radius_grid)
-        add_grid = np.random.gumbel(0, 300.0, size=(half, half)).astype(int)
-        sparse_radius_grid = np.random.binomial(1, 0.5, size=(half, half))
-        add_grid = np.clip(add_grid, 0, a_max=None) * sparse_radius_grid
-        radius_grid += add_grid
-
-        # add another set of random locations to the center corner
-        corner_grid = np.random.gumbel(0, 500.0, size=(half//4, half//4)).astype(int)
-        corner_grid = np.clip(corner_grid, 0, a_max=None)
-        radius_grid[half - (half//4):, half - (half//4):] += corner_grid
-
-        # Normalize the available halite against the defined configuration starting halite.
-        total = sum([sum(row) for row in radius_grid])
-        obs.halite = [0] * (size ** 2)
-        for r, row in enumerate(radius_grid):
-            for c, val in enumerate(row):
-                val = int(val * config.startingHalite / total / 4)
-                obs.halite[size * r + c] = val
-                obs.halite[size * r + (size - c - 1)] = val
-                obs.halite[size * (size - 1) - (size * r) + c] = val
-                obs.halite[size * (size - 1) - (size * r) + (size - c - 1)] = val
-
-        # Distribute the starting ships evenly.
-        num_agents = len(state)
-        starting_positions = [0] * num_agents
-        if num_agents == 1:
-            starting_positions[0] = size * (size // 2) + size // 2
-        elif num_agents == 2:
-            starting_positions[0] = size * (size // 2) + size // 4
-            starting_positions[1] = size * (size // 2) + math.ceil(3 * size / 4) - 1
-        elif num_agents == 4:
-            starting_positions[0] = size * (size // 4) + size // 4
-            starting_positions[1] = size * (size // 4) + 3 * size // 4
-            starting_positions[2] = size * (3 * size // 4) + size // 4
-            starting_positions[3] = size * (3 * size // 4) + 3 * size // 4
-
-        # Initialize the players.
-        obs.players = []
-        for i in range(num_agents):
-            ships = {create_uid(): [starting_positions[i], 0]}
-            obs.players.append([state[0].reward, {}, ships])
-
-        return state
-
-    # Apply actions to create an updated observation.
     for index, agent in enumerate(state):
-        player_halite, shipyards, ships = obs.players[index]
-        if agent.action is None:
-            continue
-        for uid, action in agent.action.items():
-            # Shipyard action (spawn ship):
-            if action == "SPAWN":
-                if uid in shipyards and player_halite >= config.spawnCost:
-                    ships[create_uid()] = [shipyards[uid], 0]
-                    player_halite -= int(config.spawnCost)
-                continue
-            # Ship Actions. Ship must be present.
-            elif uid not in ships:
-                continue
-            ship_pos, ship_halite = ships[uid]
-
-            # Create a Shipyard.
-            if action == "CONVERT":
-                if player_halite >= config.convertCost - ship_halite and ship_pos not in shipyards.values():
-                    # Must have enough halite and must not be in a shipyard spot to convert
-                    shipyards[create_uid()] = ship_pos
-                    player_halite += int(ship_halite - config.convertCost)
-                    obs.halite[ship_pos] = 0
-                    del ships[uid]
-                continue
-
-            # Move Ship Actions.
-            to_pos = get_to_pos(size, ship_pos, action)
-            ships[uid] = [to_pos, int(ship_halite * (1 - config.moveCost))]
-
-        # Update the player.
-        obs.players[index] = [player_halite, shipyards, ships]
-
-    # Detect collisions
-    # 1. Ships into Foreign Shipyards.
-    # 2. Ships into Ships.
-    board = [[-1, {}, -1] for _ in range(size ** 2)]
-    for index, agent in enumerate(state):
-        if agent.status != "ACTIVE":
-            continue
-        _, shipyards, ships = obs.players[index]
-        for uid, shipyard_pos in shipyards.items():
-            board[shipyard_pos][0] = index
-            board[shipyard_pos][2] = uid
-        for uid, ship in ships.items():
-            board[ship[0]][1][uid] = index
-    for pos, cell in enumerate(board):
-        shipyard, ships, shipyard_uid = cell
-        # Detect Ship Collisions
-        if len(ships) > 1:
-            smallest_ships = [[i, uid, obs.players[i][2][uid][1]] for uid, i in ships.items()]
-            smallest_ships.sort(key=lambda s: s[2])
-            for i, l_ship in enumerate(smallest_ships):
-                player_index, uid, ship_halite = l_ship
-                # Remove collided ships.
-                if i > 0 or ship_halite == smallest_ships[i+1][2]:
-                    del ships[uid]
-                    del obs.players[player_index][2][uid]
-                # Reduce halite available with remaining ship.
-                else:
-                    obs.players[player_index][2][uid][1] += smallest_ships[i+1][2]
-        # Detect Shipyard Collisions.
-        if shipyard > -1:
-            enemy_occupied = any(x != shipyard for x in ships.values())
-            if enemy_occupied:
-                del obs.players[shipyard][1][shipyard_uid]
-                for uid, index in list(ships.items()):
-                    del ships[uid]
-                    del obs.players[index][2][uid]
+        board = Board(obs, config, agent.action)
+        board = board.simulate_actions()
+        state[0].observation = obs = Observation(board.raw())
 
     # Remove players with invalid status or insufficient potential.
     for index, agent in enumerate(state):
@@ -324,30 +162,6 @@ def interpreter(state, env):
             agent.status = "DONE"
         if agent.status != "ACTIVE":
             obs.players[index] = [0, {}, {}]
-
-    # Collect and Regenerate Halite.
-    asset_positions = []
-    for index, agent in enumerate(state):
-        player_halite, shipyards, ships = obs.players[index]
-        shipyard_positions = shipyards.values()
-        asset_positions.extend(shipyard_positions)
-        for uid, ship in ships.items():
-            ship_pos, ship_halite = ship
-            asset_positions.append(ship_pos)
-            # Collect halite from ships into shipyards.
-            if ship_pos in shipyard_positions:
-                obs.players[index][0] += ship_halite
-                ship[1] = 0
-            # Collect halite from cells into ships, ensure ship didn't move this turn.
-            elif obs.halite[ship_pos] * config.collectRate >= 1 and uid not in agent.action:
-                # Ship halite is int based, so drop off that bit of fractional halite
-                collect_halite = math.floor(obs.halite[ship_pos] * config.collectRate)
-                obs.halite[ship_pos] -= collect_halite
-                ship[1] += collect_halite
-    for pos, halite in enumerate(obs.halite):
-        if pos in asset_positions:
-            continue
-        obs.halite[pos] = min(config.maxCellHalite, halite * (1 + config.regenRate))
 
     # Check if done (< 2 players and num_agents > 1)
     if len(state) > 1 and sum(1 for agent in state if agent.status == "ACTIVE") < 2:

--- a/kaggle_environments/envs/halite/halite.py
+++ b/kaggle_environments/envs/halite/halite.py
@@ -48,7 +48,7 @@ class Board:
         self.ships = [None] * size ** 2
         self.ships_by_uid = {}
         self.possible_ships = [{} for _ in range(size ** 2)]
-        
+
         for index, player in enumerate(obs.players):
             _, shipyards, ships = player
             for uid, pos in shipyards.items():

--- a/kaggle_environments/envs/halite/halite.py
+++ b/kaggle_environments/envs/halite/halite.py
@@ -46,12 +46,13 @@ def random_agent(board):
     for ship in ships:
         # None represents the chance to do nothing
         actions = [ship_action for ship_action in ShipAction]
-        ship.next_action = choices(actions + [None], [1] * len(actions) + [3])
+        ship.next_action = choices(actions + [None], [1] * len(actions) + [3], k=1)[0]
     shipyards = me.shipyards
     shipyards = sample(shipyards, len(shipyards))
     for shipyard in shipyards:
         # 20% chance to spawn
-        shipyard.next_action = choices([ShipyardAction.SPAWN, None], [1, 4])
+        if board.next().current_player.halite > board.configuration.spawn_cost:
+            shipyard.next_action = choices([ShipyardAction.SPAWN, None], [1, 4], k=1)[0]
 
 
 agents = {"random": random_agent}

--- a/kaggle_environments/envs/halite/halite.py
+++ b/kaggle_environments/envs/halite/halite.py
@@ -16,9 +16,9 @@ import copy
 import json
 import math
 from os import path
-from random import choice, randint, shuffle
+from random import choice, randint
 import numpy as np
-from .helpers import Board, Observation, ShipAction
+from .helpers import board_agent, Board, ShipAction, ShipyardAction
 from kaggle_environments import utils
 
 
@@ -38,16 +38,17 @@ def get_to_pos(size, pos, direction):
         return pos - 1 if col > 0 else (row + 1) * size - 1
 
 
-def random_agent(obs, config):
-    board = Board(obs, config, {})
+@board_agent
+def random_agent(board):
     me = board.current_player
     ships = me.ships
     for ship in ships:
-        ship.next_action = choice([ship_action for ship_action in ShipAction])
+        # None represents the chance to do nothing
+        ship.next_action = choice([ship_action for ship_action in ShipAction] + [None])
     shipyards = me.shipyards
     for shipyard in shipyards:
-        shipyard.pending_spawn = choice([True, False])
-    return board.current_player.next_actions
+        # 20% chance to spawn
+        shipyard.next_action = choice([ShipyardAction.SPAWN, None, None, None, None])
 
 
 agents = {"random": random_agent}

--- a/kaggle_environments/envs/halite/halite.py
+++ b/kaggle_environments/envs/halite/halite.py
@@ -16,7 +16,7 @@ import copy
 import json
 import math
 from os import path
-from random import choices, randint, sample
+from random import choice, randint, sample
 import numpy as np
 from .helpers import board_agent, Board, ShipAction, ShipyardAction
 from kaggle_environments import utils
@@ -41,18 +41,40 @@ def get_to_pos(size, pos, direction):
 @board_agent
 def random_agent(board):
     me = board.current_player
+    remaining_halite = me.halite
     ships = me.ships
+    # randomize ship order
     ships = sample(ships, len(ships))
     for ship in ships:
+        if ship.cell.halite > ship.halite and randint(0, 1) == 0:
+            # 50% chance to mine
+            continue
+        if ship.cell.shipyard is None and remaining_halite > board.configuration.convert_cost:
+            # 5% chance to convert at any time
+            if randint(0, 19) == 0:
+                remaining_halite -= board.configuration.convert_cost
+                ship.next_action = ShipAction.CONVERT
+                continue
+            # 50% chance to convert if there are no shipyards
+            if randint(0, 1) == 0 and len(me.shipyards) == 0:
+                remaining_halite -= board.configuration.convert_cost
+                ship.next_action = ShipAction.CONVERT
+                continue
         # None represents the chance to do nothing
-        actions = [ship_action for ship_action in ShipAction]
-        ship.next_action = choices(actions + [None], [1] * len(actions) + [3], k=1)[0]
+        ship.next_action = choice(ShipAction.moves())
     shipyards = me.shipyards
+    # randomize shipyard order
     shipyards = sample(shipyards, len(shipyards))
+    ship_count = len(board.next().current_player.ships)
     for shipyard in shipyards:
-        # 20% chance to spawn
-        if board.next().current_player.halite > board.configuration.spawn_cost:
-            shipyard.next_action = choices([ShipyardAction.SPAWN, None], [1, 4], k=1)[0]
+        # If there are no ships, always spawn if possible
+        if ship_count == 0 and remaining_halite > board.configuration.spawn_cost:
+            remaining_halite -= board.configuration.spawn_cost
+            shipyard.next_action = ShipyardAction.SPAWN
+        # 20% chance to spawn if no ships
+        elif randint(0, 4) == 0 and remaining_halite > board.configuration.spawn_cost:
+            remaining_halite -= board.configuration.spawn_cost
+            shipyard.next_action = ShipyardAction.SPAWN
 
 
 agents = {"random": random_agent}

--- a/kaggle_environments/envs/halite/halite.py
+++ b/kaggle_environments/envs/halite/halite.py
@@ -161,6 +161,7 @@ def interpreter(state, env):
         if agent.status == "ACTIVE" and len(ships) == 0 and (len(shipyards) == 0 or player_halite < config.spawnCost):
             # Agent can no longer gather any halite
             agent.status = "DONE"
+            agent.reward = board.step - board.configuration.episode_steps - 1
         if agent.status != "ACTIVE" and agent.status != "DONE":
             obs.players[index] = [0, {}, {}]
 
@@ -172,9 +173,9 @@ def interpreter(state, env):
 
     # Update Rewards.
     for index, agent in enumerate(state):
-        if agent.status == "ACTIVE" or agent.status == "DONE":
+        if agent.status == "ACTIVE":
             agent.reward = obs.players[index][0]
-        else:
+        elif agent.status != "DONE":
             agent.reward = 0
 
     return state

--- a/kaggle_environments/envs/halite/halite.py
+++ b/kaggle_environments/envs/halite/halite.py
@@ -150,7 +150,6 @@ def interpreter(state, env):
     if env.done:
         return populate_board(state, env)
 
-    obs.step = len(env.steps)
     actions = [agent.action for agent in state]
     board = Board(obs, config, actions)
     board = board.next()

--- a/kaggle_environments/envs/halite/halite.py
+++ b/kaggle_environments/envs/halite/halite.py
@@ -16,7 +16,7 @@ import copy
 import json
 import math
 from os import path
-from random import choice, randint
+from random import choices, randint, sample
 import numpy as np
 from .helpers import board_agent, Board, ShipAction, ShipyardAction
 from kaggle_environments import utils
@@ -42,13 +42,16 @@ def get_to_pos(size, pos, direction):
 def random_agent(board):
     me = board.current_player
     ships = me.ships
+    ships = sample(ships, len(ships))
     for ship in ships:
         # None represents the chance to do nothing
-        ship.next_action = choice([ship_action for ship_action in ShipAction] + [None])
+        actions = [ship_action for ship_action in ShipAction]
+        ship.next_action = choices(actions + [None], [1] * len(actions) + [3])
     shipyards = me.shipyards
+    shipyards = sample(shipyards, len(shipyards))
     for shipyard in shipyards:
         # 20% chance to spawn
-        shipyard.next_action = choice([ShipyardAction.SPAWN, None, None, None, None])
+        shipyard.next_action = choices([ShipyardAction.SPAWN, None], [1, 4])
 
 
 agents = {"random": random_agent}

--- a/kaggle_environments/envs/halite/helpers.py
+++ b/kaggle_environments/envs/halite/helpers.py
@@ -702,13 +702,6 @@ class Board:
 
             player._halite += leftover_convert_halite
 
-        # Deposit halite from ships into shipyards
-        for shipyard in list(board.shipyards.values()):
-            ship = shipyard.cell.ship
-            if ship is not None and ship.player_id == shipyard.player_id:
-                shipyard.player._halite += ship.halite
-                ship._halite = 0
-
         def resolve_collision(ships: List[Ship]) -> Tuple[Optional[Ship], List[Ship]]:
             """
             Accepts the list of ships at a particular position (must not be empty).
@@ -741,13 +734,17 @@ class Board:
         # Check for ship to shipyard collisions
         for shipyard in list(board.shipyards.values()):
             ship = shipyard.cell.ship
-            if ship is None:
-                # No collision
-                continue
-            elif ship.player_id != shipyard.player_id:
+            if ship is not None and ship.player_id != shipyard.player_id:
                 # Ship to shipyard collision
                 board._delete_shipyard(shipyard)
                 board._delete_ship(ship)
+
+        # Deposit halite from ships into shipyards
+        for shipyard in list(board.shipyards.values()):
+            ship = shipyard.cell.ship
+            if ship is not None and ship.player_id == shipyard.player_id:
+                shipyard.player._halite += ship.halite
+                ship._halite = 0
 
         # Collect halite from cells into ships
         for ship in board.ships.values():

--- a/kaggle_environments/envs/halite/helpers.py
+++ b/kaggle_environments/envs/halite/helpers.py
@@ -214,6 +214,15 @@ class ShipAction(Enum):
     def __str__(self) -> str:
         return self.name
 
+    @staticmethod
+    def moves() -> List['ShipAction']:
+        return [
+            ShipAction.NORTH,
+            ShipAction.EAST,
+            ShipAction.SOUTH,
+            ShipAction.WEST,
+        ]
+
 
 class ShipyardAction(Enum):
     SPAWN = auto()

--- a/kaggle_environments/envs/halite/helpers.py
+++ b/kaggle_environments/envs/halite/helpers.py
@@ -702,6 +702,13 @@ class Board:
 
             player._halite += leftover_convert_halite
 
+        # Deposit halite from ships into shipyards
+        for shipyard in list(board.shipyards.values()):
+            ship = shipyard.cell.ship
+            if ship is not None and ship.player_id == shipyard.player_id:
+                shipyard.player._halite += ship.halite
+                ship._halite = 0
+
         def resolve_collision(ships: List[Ship]) -> Tuple[Optional[Ship], List[Ship]]:
             """
             Accepts the list of ships at a particular position (must not be empty).
@@ -737,11 +744,7 @@ class Board:
             if ship is None:
                 # No collision
                 continue
-            elif ship.player_id == shipyard.player_id:
-                # Ship depositing halite
-                shipyard.player._halite += ship.halite
-                ship._halite = 0
-            else:
+            elif ship.player_id != shipyard.player_id:
                 # Ship to shipyard collision
                 board._delete_shipyard(shipyard)
                 board._delete_ship(ship)
@@ -756,8 +759,9 @@ class Board:
 
         # Regenerate halite in cells
         for cell in board.cells.values():
-            next_halite = round(cell.halite * (1 + configuration.regen_rate), 3)
-            cell._halite = min(next_halite, configuration.max_cell_halite)
+            if cell.ship_id is None:
+                next_halite = round(cell.halite * (1 + configuration.regen_rate), 3)
+                cell._halite = min(next_halite, configuration.max_cell_halite)
 
         board._step += 1
 

--- a/kaggle_environments/envs/halite/helpers.py
+++ b/kaggle_environments/envs/halite/helpers.py
@@ -35,70 +35,69 @@ class Observation(Object):
         return self["step"]
 
 
-# TODO: Convert this to a typed object
 class Configuration(Object):
     @property
-    def episode_steps(self):
+    def episode_steps(self) -> int:
         """Total number of steps/turns in the run."""
         return self["episodeSteps"]
 
     @property
-    def agent_exec(self):
+    def agent_exec(self) -> str:
         """How the agent is executed alongside the running envionment ('LOCAL' or separate 'PROCESS')."""
         return self["agentExec"]
 
     @property
-    def agent_timeout(self):
+    def agent_timeout(self) -> float:
         """Maximum runtime (seconds) to initialize an agent."""
         return self["agentTimeout"]
 
     @property
-    def act_timeout(self):
+    def act_timeout(self) -> float:
         """Maximum runtime (seconds) to obtain an action from an agent."""
         return self["actTimeout"]
 
     @property
-    def run_timeout(self):
+    def run_timeout(self) -> float:
         """Maximum runtime (seconds) of an episode (not necessarily DONE)."""
         return self["runTimeout"]
 
     @property
-    def halite(self):
+    def halite(self) -> int:
         """The starting amount of halite available on the board."""
         return self["halite"]
 
     @property
-    def size(self):
+    def size(self) -> int:
         """The number of cells vertically and horizontally on the board."""
         return self["size"]
 
     @property
-    def spawn_cost(self):
+    def spawn_cost(self) -> int:
         """The amount of halite to spawn a new ship."""
         return self["spawnCost"]
 
     @property
-    def convert_cost(self):
+    def convert_cost(self) -> int:
         """The amount of halite to convert a ship into a shipyard."""
         return self["convertCost"]
 
     @property
-    def move_cost(self):
+    def move_cost(self) -> float:
         """The percent deducted from ship's current halite per move."""
         return self["moveCost"]
 
     @property
-    def collect_rate(self):
+    def collect_rate(self) -> float:
         """The rate of halite collected by a ship from a cell by not moving."""
         return self["collectRate"]
 
     @property
-    def regen_rate(self):
+    def regen_rate(self) -> float:
         """The rate halite regenerates on the board."""
         return self["regenRate"]
 
     @property
-    def max_cell_halite(self):
+    def max_cell_halite(self) -> int:
         """The maximum halite that can be in any cell."""
         return self["maxCellHalite"]
 
@@ -113,11 +112,8 @@ class Point:
         self.x = x
         self.y = y
 
-    def map(self, f: Callable[[int], int]) -> 'Point':
-        return Point(f(self.x), f(self.y))
-
     def __abs__(self) -> 'Point':
-        return self.map(abs)
+        return Point(abs(self.x), abs(self.y))
 
     def __add__(self, other: 'Point') -> 'Point':
         return Point(self.x + other.x, self.y + other.y)
@@ -134,62 +130,244 @@ class Point:
     def __str__(self) -> str:
         return Template('($x, $y)').substitute(x=self.x, y=self.y)
 
+    def __mul__(self, other) -> 'Point':
+        return Point(self.x * other, self.y * other)
+
+
+class Direction:
+    NORTH = Point(0, 1)
+    SOUTH = Point(0, -1)
+    EAST = Point(1, 0)
+    WEST = Point(-1, 0)
+    ZERO = Point(0, 0)
+    ONE = Point(1, 1)
+
 
 class Cell:
     def __init__(self, position: Point, halite: float, ship_id: Optional[ShipId], shipyard_id: Optional[ShipyardId], board: 'Board') -> None:
-        self.position = position
-        self.halite = halite
-        self.ship_id = ship_id
-        self.shipyard_id = shipyard_id
-        self.board = board
+        self._position = position
+        self._halite = halite
+        self._ship_id = ship_id
+        self._shipyard_id = shipyard_id
+        self._board = board
+
+    @property
+    def position(self) -> Point:
+        return self._position
+
+    @property
+    def halite(self) -> float:
+        return self._halite
+
+    @property
+    def ship_id(self) -> Optional[ShipId]:
+        return self._ship_id
+
+    @property
+    def shipyard_id(self) -> Optional[ShipyardId]:
+        return self._shipyard_id
+
+    @property
+    def ship(self) -> Optional['Ship']:
+        return (
+            self._board.ships.get(self.ship_id)
+            if self.ship_id is not None
+            else None
+        )
+
+    @property
+    def shipyard(self) -> Optional['Shipyard']:
+        return (
+            self._board.shipyards.get(self.shipyard_id)
+            if self.shipyard_id is not None
+            else None
+        )
+
+    def neighbor(self, direction: Point) -> 'Cell':
+        return self._board.cells[self.position + direction]
+
+    @property
+    def north(self) -> 'Cell':
+        return self.neighbor(Point.NORTH)
+
+    @property
+    def south(self) -> 'Cell':
+        return self.neighbor(Point.SOUTH)
+
+    @property
+    def east(self) -> 'Cell':
+        return self.neighbor(Point.EAST)
+
+    @property
+    def west(self) -> 'Cell':
+        return self.neighbor(Point.WEST)
 
 
 class Ship:
     def __init__(self, ship_id: ShipId, position: Point, halite: int, player_id: PlayerId, board: 'Board') -> None:
-        self.ship_id = ship_id
-        self.position = position
-        self.halite = halite
-        self.player_id = player_id
-        self.board = board
+        self._ship_id = ship_id
+        self._position = position
+        self._halite = halite
+        self._player_id = player_id
+        self._board = board
+
+    @property
+    def ship_id(self) -> ShipId:
+        return self._ship_id
+
+    @property
+    def position(self) -> Point:
+        return self._position
+
+    @property
+    def halite(self) -> int:
+        return self._halite
+
+    @property
+    def player_id(self) -> PlayerId:
+        return self._player_id
+
+    @property
+    def cell(self) -> Cell:
+        return self._board.cells[self.position]
+
+    @property
+    def player(self) -> 'Player':
+        return self._board.players[self.player_id]
 
 
 class Shipyard:
     def __init__(self, shipyard_id: ShipyardId, position: Point, player_id: PlayerId, board: 'Board') -> None:
-        self.shipyard_id = shipyard_id
-        self.position = position
-        self.player_id = player_id
-        self.board = board
+        self._shipyard_id = shipyard_id
+        self._position = position
+        self._player_id = player_id
+        self._board = board
+
+    @property
+    def shipyard_id(self) -> ShipyardId:
+        return self._shipyard_id
+
+    @property
+    def position(self) -> Point:
+        return self._position
+
+    @property
+    def player_id(self) -> PlayerId:
+        return self._player_id
+
+    @property
+    def cell(self) -> Cell:
+        return self._board.cells[self.position]
+
+    @property
+    def player(self) -> 'Player':
+        return self._board.players[self.player_id]
 
 
 class Player:
     def __init__(self, player_id: PlayerId, halite: int, shipyard_ids: Set[ShipyardId], ship_ids: Set[ShipId], board: 'Board') -> None:
-        self.player_id = player_id
-        self.halite = halite
-        self.shipyard_ids = shipyard_ids
-        self.ship_ids = ship_ids
-        self.board = board
+        self._player_id = player_id
+        self._halite = halite
+        self._shipyard_ids = shipyard_ids
+        self._ship_ids = ship_ids
+        self._board = board
+
+    @property
+    def player_id(self) -> PlayerId:
+        return self._player_id
+
+    @property
+    def halite(self) -> int:
+        return self._halite
+
+    @property
+    def shipyard_ids(self) -> Set[ShipyardId]:
+        return self._shipyard_ids
+
+    @property
+    def ship_ids(self) -> Set[ShipId]:
+        return self._ship_ids
+
+    @property
+    def shipyards(self) -> Set[Shipyard]:
+        return set([self._board.shipyards[shipyard_id] for shipyard_id in self.shipyard_ids])
+
+    @property
+    def ships(self) -> Set[Ship]:
+        return set([self._board.ships[ship_id] for ship_id in self.ship_ids])
 
 
 class Board:
     def __init__(self, observation: Observation, configuration: Configuration) -> None:
-        size = configuration.size
-        self.players: Dict[PlayerId, Player] = {}
-        self.ships: Dict[ShipId, Ship] = {}
-        self.shipyards: Dict[ShipyardId, Shipyard] = {}
-        self.cells: Dict[Point, Cell] = {}
-        for (player_id, player) in observation.players.items():
-            # We know the length of player is always 3 based on the schema -- this is a tuple in json
-            [player_halite, shipyards, ships] = player
-            self.players[player_id] = Player(player_id, player_halite, shipyards.keys(), ships.keys(), self)
+        self._configuration = configuration
+        self._players: Dict[PlayerId, Player] = {}
+        self._ships: Dict[ShipId, Ship] = {}
+        self._shipyards: Dict[ShipyardId, Shipyard] = {}
+        self._cells: Dict[Point, Cell] = {}
+        # We know the length of player is always 3 based on the schema -- this is a tuple in json
+        for (player_id, [player_halite, shipyards, ships]) in enumerate(observation.players):
+            self._players[player_id] = Player(player_id, player_halite, shipyards.keys(), ships.keys(), self)
             for (ship_id, [ship_position, ship_halite]) in ships.items():
-                self.ships[ship_id] = Ship(ship_id, ship_position, ship_halite, player_id, self)
+                self._ships[ship_id] = Ship(ship_id, ship_position, ship_halite, player_id, self)
             for (shipyard_id, shipyard_position) in shipyards.items():
-                self.shipyards[shipyard_id] = Shipyard(shipyard_id, shipyard_position, player_id, self)
-        ships_by_position = {ship.position: ship.ship_id for ship in self.ships}
-        shipyards_by_position = {shipyard.position: shipyard.shipyard_id for shipyard in self.shipyards}
+                self._shipyards[shipyard_id] = Shipyard(shipyard_id, shipyard_position, player_id, self)
+        ships_by_position = {ship.position: ship.ship_id for ship in self.ships.values()}
+        shipyards_by_position = {shipyard.position: shipyard.shipyard_id for shipyard in self.shipyards.values()}
+        size = self._configuration.size
         for x in range(size):
             for y in range(size):
                 position = Point(x, y)
                 index = size * x + y
                 halite = observation.halite[index]
-                self.cells[position] = Cell(position, halite, ships_by_position.get(position), shipyards_by_position.get(position), self)
+                self._cells[position] = Cell(position, halite, ships_by_position.get(position), shipyards_by_position.get(position), self)
+
+    @property
+    def configuration(self):
+        return self._configuration
+
+    @property
+    def players(self):
+        return self._players
+
+    @property
+    def ships(self):
+        return self._ships
+
+    @property
+    def shipyards(self):
+        return self._shipyards
+
+    @property
+    def cells(self):
+        return self._cells
+
+    def __str__(self):
+        size = self.configuration.size
+        result = ''
+        for x in range(size):
+            for y in range(size):
+                position = Point(x, y)
+                cell = self.cells[position]
+                result += '.'
+            result += '\n'
+        return result
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/kaggle_environments/envs/halite/helpers.py
+++ b/kaggle_environments/envs/halite/helpers.py
@@ -1,0 +1,195 @@
+from typing import *
+from string import Template
+
+
+# See https://github.com/Kaggle/kaggle-environments/blob/master/kaggle_environments/envs/halite/halite.json for schema
+
+
+class Object:
+    def __init__(self, data: Dict[str, any]):
+        self._data = data
+
+    def __getitem__(self, item):
+        return self._data[item]
+
+
+class Observation(Object):
+    @property
+    def halite(self) -> List[int]:
+        """Serialized list of available halite per cell on the board."""
+        return self["halite"]
+
+    @property
+    def players(self) -> List[List[int]]:
+        """List of players and their assets."""
+        return self["players"]
+
+    @property
+    def player(self) -> int:
+        """The current agent's player index."""
+        return self["player"]
+
+    @property
+    def step(self) -> int:
+        """The current step index within the episode."""
+        return self["step"]
+
+
+# TODO: Convert this to a typed object
+class Configuration(Object):
+    @property
+    def episode_steps(self):
+        """Total number of steps/turns in the run."""
+        return self["episodeSteps"]
+
+    @property
+    def agent_exec(self):
+        """How the agent is executed alongside the running envionment ('LOCAL' or separate 'PROCESS')."""
+        return self["agentExec"]
+
+    @property
+    def agent_timeout(self):
+        """Maximum runtime (seconds) to initialize an agent."""
+        return self["agentTimeout"]
+
+    @property
+    def act_timeout(self):
+        """Maximum runtime (seconds) to obtain an action from an agent."""
+        return self["actTimeout"]
+
+    @property
+    def run_timeout(self):
+        """Maximum runtime (seconds) of an episode (not necessarily DONE)."""
+        return self["runTimeout"]
+
+    @property
+    def halite(self):
+        """The starting amount of halite available on the board."""
+        return self["halite"]
+
+    @property
+    def size(self):
+        """The number of cells vertically and horizontally on the board."""
+        return self["size"]
+
+    @property
+    def spawn_cost(self):
+        """The amount of halite to spawn a new ship."""
+        return self["spawnCost"]
+
+    @property
+    def convert_cost(self):
+        """The amount of halite to convert a ship into a shipyard."""
+        return self["convertCost"]
+
+    @property
+    def move_cost(self):
+        """The percent deducted from ship's current halite per move."""
+        return self["moveCost"]
+
+    @property
+    def collect_rate(self):
+        """The rate of halite collected by a ship from a cell by not moving."""
+        return self["collectRate"]
+
+    @property
+    def regen_rate(self):
+        """The rate halite regenerates on the board."""
+        return self["regenRate"]
+
+    @property
+    def max_cell_halite(self):
+        """The maximum halite that can be in any cell."""
+        return self["maxCellHalite"]
+
+
+ShipId = NewType('ShipId', str)
+ShipyardId = NewType('ShipyardId', str)
+PlayerId = NewType('PlayerId', int)
+
+
+class Point:
+    def __init__(self, x: int, y: int) -> None:
+        self.x = x
+        self.y = y
+
+    def map(self, f: Callable[[int], int]) -> 'Point':
+        return Point(f(self.x), f(self.y))
+
+    def __abs__(self) -> 'Point':
+        return self.map(abs)
+
+    def __add__(self, other: 'Point') -> 'Point':
+        return Point(self.x + other.x, self.y + other.y)
+
+    def __eq__(self, other: 'Point') -> bool:
+        return self.x == other.x and self.y == other.y
+
+    def __hash__(self) -> int:
+        return hash((self.x, self.y))
+
+    def __neg__(self) -> 'Point':
+        return Point(-self.x, -self.y)
+
+    def __str__(self) -> str:
+        return Template('($x, $y)').substitute(x=self.x, y=self.y)
+
+
+class Cell:
+    def __init__(self, position: Point, halite: float, ship_id: Optional[ShipId], shipyard_id: Optional[ShipyardId], board: 'Board') -> None:
+        self.position = position
+        self.halite = halite
+        self.ship_id = ship_id
+        self.shipyard_id = shipyard_id
+        self.board = board
+
+
+class Ship:
+    def __init__(self, ship_id: ShipId, position: Point, halite: int, player_id: PlayerId, board: 'Board') -> None:
+        self.ship_id = ship_id
+        self.position = position
+        self.halite = halite
+        self.player_id = player_id
+        self.board = board
+
+
+class Shipyard:
+    def __init__(self, shipyard_id: ShipyardId, position: Point, player_id: PlayerId, board: 'Board') -> None:
+        self.shipyard_id = shipyard_id
+        self.position = position
+        self.player_id = player_id
+        self.board = board
+
+
+class Player:
+    def __init__(self, player_id: PlayerId, halite: int, shipyard_ids: Set[ShipyardId], ship_ids: Set[ShipId], board: 'Board') -> None:
+        self.player_id = player_id
+        self.halite = halite
+        self.shipyard_ids = shipyard_ids
+        self.ship_ids = ship_ids
+        self.board = board
+
+
+class Board:
+    def __init__(self, observation: Observation, configuration: Configuration) -> None:
+        size = configuration.size
+        self.players: Dict[PlayerId, Player] = {}
+        self.ships: Dict[ShipId, Ship] = {}
+        self.shipyards: Dict[ShipyardId, Shipyard] = {}
+        self.cells: Dict[Point, Cell] = {}
+        for (player_id, player) in observation.players.items():
+            # We know the length of player is always 3 based on the schema -- this is a tuple in json
+            [player_halite, shipyards, ships] = player
+            self.players[player_id] = Player(player_id, player_halite, shipyards.keys(), ships.keys(), self)
+            for (ship_id, [ship_position, ship_halite]) in ships.items():
+                self.ships[ship_id] = Ship(ship_id, ship_position, ship_halite, player_id, self)
+            for (shipyard_id, shipyard_position) in shipyards.items():
+                self.shipyards[shipyard_id] = Shipyard(shipyard_id, shipyard_position, player_id, self)
+        ships_by_position = {ship.position: ship.ship_id for ship in self.ships}
+        shipyards_by_position = {shipyard.position: shipyard.shipyard_id for shipyard in self.shipyards}
+        for x in range(size):
+            for y in range(size):
+                position = Point(x, y)
+                index = size * x + y
+                halite = observation.halite[index]
+                self.cells[position] = Cell(position, halite, ships_by_position.get(position), shipyards_by_position.get(position), self)

--- a/kaggle_environments/envs/halite/helpers.py
+++ b/kaggle_environments/envs/halite/helpers.py
@@ -336,7 +336,7 @@ class Ship:
         self._next_action = value
 
     @property
-    def observation(self) -> List[int]:
+    def _observation(self) -> List[int]:
         """Converts a ship back to the normalized observation subset that constructed it."""
         return [position_to_index(self.position, self._board.configuration.size), self.halite]
 
@@ -381,7 +381,7 @@ class Shipyard:
         self._next_action = value
 
     @property
-    def observation(self) -> int:
+    def _observation(self) -> int:
         """Converts a shipyard back to the normalized observation subset that constructed it."""
         return position_to_index(self.position, self._board.configuration.size)
 
@@ -447,10 +447,10 @@ class Player:
         return {**ship_actions, **shipyard_actions}
 
     @property
-    def observation(self):
+    def _observation(self):
         """Converts a player back to the normalized observation subset that constructed it."""
-        shipyards = {shipyard.id: shipyard.observation for shipyard in self.shipyards}
-        ships = {ship.id: ship.observation for ship in self.ships}
+        shipyards = {shipyard.id: shipyard._observation for shipyard in self.shipyards}
+        ships = {ship.id: ship._observation for ship in self.ships}
         return [self.halite, shipyards, ships]
 # endregion
 
@@ -573,7 +573,7 @@ class Board:
         """Converts a Board back to the normalized observation that constructed it."""
         size = self.configuration.size
         halite = [self[index_to_position(index, size)].halite for index in range(size * size)]
-        players = [player.observation for player in self.players.values()]
+        players = [player._observation for player in self.players.values()]
 
         return {
             "halite": halite,
@@ -652,7 +652,7 @@ class Board:
         Returns a new board with the current board's next actions applied.
         The current board is unmodified.
         This can form a halite interpreter, e.g.
-            next_observation = Board(current_observation, configuration, actions).next.observation
+            next_observation = Board(current_observation, configuration, actions).next().observation
         """
         # Create a copy of the board to modify so we don't affect the current board
         board = deepcopy(self)

--- a/kaggle_environments/envs/halite/helpers.py
+++ b/kaggle_environments/envs/halite/helpers.py
@@ -695,6 +695,7 @@ class Board:
                     # If the action is not None and is not CONVERT it must be NORTH, SOUTH, EAST, or WEST
                     ship.cell._ship_id = None
                     ship._position = wrap_point(translate_point(ship.position, ship.next_action.to_point()), configuration.size)
+                    ship._halite *= (1 - board.configuration.move_cost)
                     # We don't set the new cell's ship_id here as it would be overwritten by another ship in the case of collision.
                     # Later we'll iterate through all ships and re-set the cell._ship_id as appropriate.
                 # Clear the ship's action so it doesn't repeat the same action automatically

--- a/kaggle_environments/envs/halite/test_halite.py
+++ b/kaggle_environments/envs/halite/test_halite.py
@@ -1,6 +1,6 @@
 from kaggle_environments import make
 from .halite import random_agent
-from .helpers import Board
+from .helpers import *
 
 
 def test_halite_no_repeated_steps():
@@ -40,7 +40,11 @@ def test_halite_helpers():
 
     def helper_agent(obs, config):
         board = Board(obs, config)
-        return random_agent(obs, config)
+        for ship in board.current_player.ships:
+            ship.try_set_pending_action(ShipAction.NORTH)
+        for shipyard in board.current_player.shipyards:
+            shipyard.try_set_pending_spawn(True)
+        return board.pending_actions
 
     env.run([helper_agent, helper_agent])
     json = env.toJSON()

--- a/kaggle_environments/envs/halite/test_halite.py
+++ b/kaggle_environments/envs/halite/test_halite.py
@@ -38,16 +38,108 @@ def test_halite_exception_action_has_error_status():
 def test_halite_helpers():
     env = make("halite", debug=True, configuration={"size": 3})
 
-    def helper_agent(obs, config):
-        board = Board(obs, config)
+    @board_agent
+    def helper_agent(board):
         for ship in board.current_player.ships:
             ship.next_action = ShipAction.NORTH
         for shipyard in board.current_player.shipyards:
             shipyard.next_action = ShipyardAction.SPAWN
-        return board.current_player.next_actions
 
     env.run([helper_agent, helper_agent])
 
     json = env.toJSON()
     assert json["name"] == "halite"
     assert json["statuses"] == ["DONE", "DONE"]
+
+
+def create_board(size=3, starting_halite=0, agent_count=2):
+    env = make("halite", configuration={"size": size, "startingHalite": starting_halite})
+    return Board(env.reset(agent_count)[0].observation, env.configuration)
+
+
+def test_move_moves_ship():
+    size = 3
+    board = create_board(size, agent_count=1)
+    for ship in board.current_player.ships:
+        ship.next_action = ShipAction.SOUTH
+    next_board = board.next()
+    for ship in board.ships.values():
+        next_position = wrap_point(translate_point(ship.position, ShipAction.SOUTH.to_point()), size)
+        next_ship = next_board.ships[ship.id]
+        assert next_ship.position == next_position
+
+
+def move_toward(ship, target: Point):
+    (x1, y1) = ship.position
+    (x2, y2) = target
+    if x2 > x1:
+        return ShipAction.EAST
+    elif x2 < x1:
+        return ShipAction.WEST
+    elif y2 > y1:
+        return ShipAction.NORTH
+    elif y2 < y1:
+        return ShipAction.SOUTH
+
+
+def test_equal_ship_collision_destroys_both_ships():
+    size = 3
+    board = create_board(size, agent_count=2)
+    for ship in board.ships.values():
+        ship.next_action = move_toward(ship, (1, 1))
+    next_board = board.next()
+    assert len(next_board.ships) == 0
+
+
+def test_unequal_ship_collision_destroys_weaker_ship():
+    board = create_board(agent_count=2)
+    for opponent in board.opponents:
+        for ship in opponent.ships:
+            # Make the opponents' ships have more halite so they'll be destroyed
+            ship._halite = 1000
+    for ship in board.ships.values():
+        ship.next_action = move_toward(ship, (1, 1))
+    next_board = board.next()
+    assert len(next_board.current_player.ships) == 1
+    assert len(next_board.ships) == 1
+
+
+def first(iterable):
+    return next(iter(iterable))
+
+
+def test_ship_shipyard_collision_destroys_both():
+    board = create_board(agent_count=2)
+    player_ship = first(board.current_player.ships)
+    opponent_ship = first(first(board.opponents).ships)
+    opponent_ship.next_action = ShipAction.CONVERT
+    board = board.next()
+    assert len(board.ships) == 1
+    assert len(board.shipyards) == 1
+    while player_ship.id in board.ships:
+        board.ships[player_ship.id].next_action = move_toward(player_ship, opponent_ship.position)
+        board = board.next()
+    assert len(board.ships) == 0
+    assert len(board.shipyards) == 0
+
+
+def test_cells_regen_halite():
+    board = create_board(starting_halite=1000, agent_count=1)
+    cell = first(board.cells.values())
+    next_board = board.next()
+    next_cell = next_board[cell.position]
+    expected_regen = round(cell.halite * board.configuration.regen_rate, 3)
+    assert next_cell.halite - cell.halite == expected_regen
+
+
+def test_no_move_on_halite_gathers_halite():
+    board = create_board(starting_halite=1000, agent_count=1)
+    ship = first(board.ships.values())
+    expected_delta = int(ship.cell.halite * board.configuration.collect_rate)
+    next_board = board.next()
+    next_ship = next_board.ships[ship.id]
+    ship_delta = next_ship.halite - ship.halite
+    cell_delta = round(ship.cell.halite - next_ship.cell.halite, 3)
+    cell_regen = round((ship.cell.halite - expected_delta) * board.configuration.regen_rate, 3)
+    assert ship_delta == expected_delta
+    assert cell_delta + cell_regen == expected_delta

--- a/kaggle_environments/envs/halite/test_halite.py
+++ b/kaggle_environments/envs/halite/test_halite.py
@@ -40,6 +40,7 @@ def test_halite_helpers():
 
     def helper_agent(obs, config):
         board = Board(obs, config)
+        assert board.to_observation()._data == obs
         for ship in board.current_player.ships:
             ship.try_set_pending_action(ShipAction.NORTH)
         for shipyard in board.current_player.shipyards:
@@ -47,6 +48,7 @@ def test_halite_helpers():
         return board.pending_actions
 
     env.run([helper_agent, helper_agent])
+
     json = env.toJSON()
     assert json["name"] == "halite"
     assert json["statuses"] == ["DONE", "DONE"]

--- a/kaggle_environments/envs/halite/test_halite.py
+++ b/kaggle_environments/envs/halite/test_halite.py
@@ -36,18 +36,18 @@ def test_halite_exception_action_has_error_status():
 
 
 def test_halite_helpers():
-    env = make("halite", debug=True)
+    env = make("halite", debug=True, configuration={"size": 3})
 
     def helper_agent(obs, config):
-        board = Board(obs, config)
-        assert board.to_observation()._data == obs
+        board = Board(obs, config, {})
         for ship in board.current_player.ships:
-            ship.try_set_pending_action(ShipAction.NORTH)
+            ship.pending_action = ShipAction.NORTH
         for shipyard in board.current_player.shipyards:
-            shipyard.try_set_pending_spawn(True)
-        return board.pending_actions
+            shipyard.pending_spawn = True
+        print(board)
+        return board.current_player.agent_actions
 
-    env.run([helper_agent, helper_agent])
+    env.run([helper_agent, random_agent])
 
     json = env.toJSON()
     assert json["name"] == "halite"

--- a/kaggle_environments/envs/halite/test_halite.py
+++ b/kaggle_environments/envs/halite/test_halite.py
@@ -1,5 +1,6 @@
 from kaggle_environments import make
 from .halite import random_agent
+from .helpers import Board
 
 
 def test_halite_no_repeated_steps():
@@ -25,9 +26,24 @@ def test_halite_completes():
 
 def test_halite_exception_action_has_error_status():
     env = make("halite", debug=True)
+
     def error_agent(obs, config):
         raise Exception("An exception occurred!")
     env.run([error_agent, random_agent])
     json = env.toJSON()
     assert json["name"] == "halite"
     assert json["statuses"] == ["ERROR", "DONE"]
+
+
+def test_halite_helpers():
+    env = make("halite")
+
+    def helper_agent(obs, config):
+        print("YAH")
+        board = Board(obs, config)
+        print(board)
+        return random_agent(obs, config)
+    env.run([helper_agent, None])
+    json = env.toJSON()
+    assert json["name"] == "halite"
+    assert json["statuses"] == ["DONE", "DONE"]

--- a/kaggle_environments/envs/halite/test_halite.py
+++ b/kaggle_environments/envs/halite/test_halite.py
@@ -44,8 +44,7 @@ def test_halite_helpers():
             ship.pending_action = ShipAction.NORTH
         for shipyard in board.current_player.shipyards:
             shipyard.pending_spawn = True
-        print(board)
-        return board.current_player.agent_actions
+        return board.current_player.pending_actions
 
     env.run([helper_agent, random_agent])
 

--- a/kaggle_environments/envs/halite/test_halite.py
+++ b/kaggle_environments/envs/halite/test_halite.py
@@ -40,9 +40,9 @@ def test_halite_helpers():
 
     def helper_agent(obs, config):
         board = Board(obs, config)
-        print(board)
         return random_agent(obs, config)
-    env.run([helper_agent, None])
+
+    env.run([helper_agent, helper_agent])
     json = env.toJSON()
     assert json["name"] == "halite"
     assert json["statuses"] == ["DONE", "DONE"]

--- a/kaggle_environments/envs/halite/test_halite.py
+++ b/kaggle_environments/envs/halite/test_halite.py
@@ -11,13 +11,13 @@ def test_halite_no_repeated_steps():
         actual_steps.append(obs.step)
         return {}
 
-    env = make("halite", configuration={"episodeSteps": step_count})
+    env = make("halite", configuration={"episodeSteps": step_count}, debug=True)
     env.run({step_appender_agent})
     assert actual_steps == list(range(step_count - 1))
 
 
 def test_halite_completes():
-    env = make("halite")
+    env = make("halite", debug=True)
     env.run([random_agent, random_agent])
     json = env.toJSON()
     assert json["name"] == "halite"
@@ -36,10 +36,9 @@ def test_halite_exception_action_has_error_status():
 
 
 def test_halite_helpers():
-    env = make("halite")
+    env = make("halite", debug=True)
 
     def helper_agent(obs, config):
-        print("YAH")
         board = Board(obs, config)
         print(board)
         return random_agent(obs, config)

--- a/kaggle_environments/envs/halite/test_halite.py
+++ b/kaggle_environments/envs/halite/test_halite.py
@@ -129,7 +129,8 @@ def test_cells_regen_halite():
     next_board = board.next()
     next_cell = next_board[cell.position]
     expected_regen = round(cell.halite * board.configuration.regen_rate, 3)
-    assert next_cell.halite - cell.halite == expected_regen
+    # We compare to a floating point value here to handle float rounding errors
+    assert next_cell.halite - cell.halite - expected_regen < .000001
 
 
 def test_no_move_on_halite_gathers_halite():

--- a/kaggle_environments/envs/halite/test_halite.py
+++ b/kaggle_environments/envs/halite/test_halite.py
@@ -12,7 +12,7 @@ def test_halite_no_repeated_steps():
         return {}
 
     env = make("halite", configuration={"episodeSteps": step_count}, debug=True)
-    env.run({step_appender_agent})
+    env.run([step_appender_agent])
     assert actual_steps == list(range(step_count - 1))
 
 
@@ -39,14 +39,14 @@ def test_halite_helpers():
     env = make("halite", debug=True, configuration={"size": 3})
 
     def helper_agent(obs, config):
-        board = Board(obs, config, {})
+        board = Board(obs, config)
         for ship in board.current_player.ships:
-            ship.pending_action = ShipAction.NORTH
+            ship.next_action = ShipAction.NORTH
         for shipyard in board.current_player.shipyards:
-            shipyard.pending_spawn = True
-        return board.current_player.pending_actions
+            shipyard.next_action = ShipyardAction.SPAWN
+        return board.current_player.next_actions
 
-    env.run([helper_agent, random_agent])
+    env.run([helper_agent, helper_agent])
 
     json = env.toJSON()
     assert json["name"] == "halite"

--- a/kaggle_environments/main.py
+++ b/kaggle_environments/main.py
@@ -63,6 +63,9 @@ parser.add_argument(
 parser.add_argument(
     "--host", type=str, help="http-server Host (default=127.0.0.1)."
 )
+parser.add_argument(
+    "--out", type=str, help="Output file to write the results of the episode."
+)
 
 
 def render(args, env):
@@ -73,8 +76,12 @@ def render(args, env):
         args.render["mode"] = "html"
     else:
         args.render["mode"] = "json"
-    return env.render(**args.render)
-
+    result = env.render(**args.render)
+    if args.out is not None:
+        with open(args.out, mode="w") as out_file:
+            out_file.write(str(result))
+        return 0
+    return result
 
 def action_list(args):
     return json.dumps([*environments])
@@ -156,7 +163,8 @@ def parse_args(args):
             "render": utils.get(args, dict, {"mode": "json"}, ["render"]),
             "debug": utils.get(args, bool, False, ["debug"]),
             "host": utils.get(args, str, "127.0.0.1", ["host"]),
-            "port": utils.get(args, int, 8000, ["port"])
+            "port": utils.get(args, int, 8000, ["port"]),
+            "out": utils.get(args, str, None, ["out"]),
         }
     )
 
@@ -250,7 +258,7 @@ def main():
     args = parser.parse_args()
     if args.action == "http-server":
         action_http(args)
-    print(action_handler(parse_args(vars(args))))
+    return action_handler(parse_args(vars(args)))
 
 
 if __name__ == "__main__":

--- a/kaggle_environments/utils.py
+++ b/kaggle_environments/utils.py
@@ -115,13 +115,13 @@ def get_exec(raw, fallback=None):
         exec(code_object, env)
         sys.stdout = orig_out
         output = buffer.getvalue()
-        if not output.isspace():
+        if output:
             print(output)
         return env
     except Exception as e:
         sys.stdout = orig_out
         output = buffer.getvalue()
-        if not output.isspace():
+        if output:
             print(output)
         if fallback is not None:
             return fallback


### PR DESCRIPTION
REVIEWERS' NOTE: This PR is kind of a monster, apologies in advance. I've annotated each file with some commentary about what's worth reading and what's worth skipping, large parts of the PR are boring refactors on which I welcome comments but are not likely the best use of your time.

Feel free to skip any parts you don't feel are relevant to your interests. We are on a relatively tight timeline to get this out before Halite so if there are any larger pieces of feedback I'll likely save those for a future iteration. If you don't have time to read through this, then no worries and feel free to disregard the PR.

This PR provides wrapper classes for the halite environment and state as well as a convenient hook for the interpreter. This also reimplements the bulk of the original halite interpreter in the new board class, straightens out some logic inconsistencies in corner cases of the old implementation, and hopefully makes it a bit easier to parse what's happening in the code.

I tested the interpreter reimplementation by writing unit tests and by running actual episodes using the agents submitted to the shared repo. I can't validate that behavior is exactly the same but I can at least confirm that everyone's agents played complete and reasonably strategic-looking games that seemed similar or identical to the current implementation.