### PR TITLE
Bugfix helpers.py "to_index" "from_index"

### DIFF
--- a/kaggle_environments/envs/halite/helpers.py
+++ b/kaggle_environments/envs/halite/helpers.py
@@ -40,7 +40,7 @@ class Point(tuple):
         Converts a 2d position in the form (x, y) to an index in the observation.halite list.
         See index_to_position for the inverse.
         """
-        return (size - self.y - 1) * size + self.x
+        return self.y * size + self.x
 
     @staticmethod
     def from_index(index: int, size: int) -> 'Point':
@@ -49,7 +49,7 @@ class Point(tuple):
         See position_to_index for the inverse.
         """
         y, x = divmod(index, size)
-        return Point(x, (size - y - 1))
+        return Point(x, y)
 
     def __abs__(self) -> 'Point':
         return self.map(operator.abs)


### PR DESCRIPTION
issue #51 
Hi,
in halite-rules (https://www.kaggle.com/c/halite/overview/halite-rules) it says:
In the game code positions are given as serialized list where each cell is an integer calculated by the formula:
[position = row * 21 + column]

The function "to_index" do:
return (size - self.y - 1) * size + self.x

Correct would be:
return self.y * size + self.x

Same for function "from_index":
y, x = divmod(index, size)
return Point(x, (size - y - 1))

Correct would be:
y, x = divmod(index, size)
return Point(x, y)