### PR TITLE
Quality of life improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -132,3 +132,6 @@ dmypy.json
 temp.*
 
 .idea/
+
+# Git merge artifacts
+*.orig

--- a/README.md
+++ b/README.md
@@ -255,7 +255,7 @@ Running above essentially just steps until no agent is still active. To execute 
 ```python
 agent1_action = agent1(env.state[0].observation)
 agent2_action = agent2(env.state[1].observation)
-state = env.step(agent1_action, agent2_action)
+state = env.step([agent1_action, agent2_action])
 ```
 
 ## Playing

--- a/kaggle_environments/agent.py
+++ b/kaggle_environments/agent.py
@@ -17,7 +17,7 @@ import os
 import requests
 import sys
 from io import StringIO
-from time import time
+from time import perf_counter
 from urllib.parse import urlparse
 from .errors import DeadlineExceeded, InvalidArgument
 from .utils import read_file, structify
@@ -107,7 +107,7 @@ class Agent:
 
     def act(self, observation, timeout=10):
         # Start the timer.
-        start = time()
+        start = perf_counter()
 
         if self.agent is None:
             self.agent = build_agent(self.raw, self.environment)
@@ -125,7 +125,7 @@ class Agent:
             action = e
 
         # Timeout reached, throw an error.
-        if time() - start > timeout:
+        if perf_counter() - start > timeout:
             return DeadlineExceeded()
 
         return action

--- a/kaggle_environments/agent.py
+++ b/kaggle_environments/agent.py
@@ -105,10 +105,11 @@ class Agent:
         self.raw = raw
         self.agent = None
 
-    def act(self, observation, timeout=10):
+    def act(self, observation):
         # Start the timer.
         start = perf_counter()
 
+        timeout = self.configuration.actTimeout
         if self.agent is None:
             self.agent = build_agent(self.raw, self.environment)
             # Add in the initialization timeout since this is the first time this agent is called

--- a/kaggle_environments/core.py
+++ b/kaggle_environments/core.py
@@ -544,9 +544,6 @@ class Environment:
             for a in agents
         ]
 
-        # Have the agents had a chance to initialize (first non-empty act).
-        initialized = [False] * len(agents)
-
         def act(none_action=None):
             if len(agents) != len(self.state):
                 raise InvalidArgument(
@@ -559,12 +556,8 @@ class Environment:
                 elif agent is None:
                     actions[i] = none_action
                 else:
-                    timeout = self.configuration.actTimeout
-                    if not initialized[i]:
-                        initialized[i] = True
-                        timeout += self.configuration.agentTimeout
                     state = self.__get_shared_state(i)
-                    actions[i] = agent.act(state["observation"], timeout)
+                    actions[i] = agent.act(state["observation"])
             return actions
 
         return structify({"act": act})

--- a/kaggle_environments/core.py
+++ b/kaggle_environments/core.py
@@ -15,7 +15,7 @@
 import traceback
 import copy
 import json
-from time import time
+from time import perf_counter
 import uuid
 from .agent import Agent
 from .errors import DeadlineExceeded, FailedPrecondition, Internal, InvalidArgument
@@ -198,8 +198,8 @@ class Environment:
                 f"{len(self.state)} agents were expected, but {len(agents)} was given.")
 
         runner = self.__agent_runner(agents)
-        start = time()
-        while not self.done and time() - start < self.configuration.runTimeout:
+        start = perf_counter()
+        while not self.done and perf_counter() - start < self.configuration.runTimeout:
             self.step(runner.act())
         return self.steps
 

--- a/kaggle_environments/envs/halite/halite.py
+++ b/kaggle_environments/envs/halite/halite.py
@@ -15,9 +15,9 @@
 import copy
 import json
 import math
-from os import path
-from random import choice, randint, sample, seed
 import numpy as np
+from os import path
+from random import choice, randint, randrange, sample, seed
 from .helpers import board_agent, Board, ShipAction, ShipyardAction
 from kaggle_environments import utils
 
@@ -87,9 +87,12 @@ def populate_board(state, env):
     uid_counter = 0
 
     # Set seed for random number generators
-    if hasattr(config, "randomSeed"):
-        np.random.seed(config.randomSeed)
-        seed(config.randomSeed)
+    if not hasattr(config, "randomSeed"):
+        max_int_32 = (1 << 31) - 1
+        config.randomSeed = randrange(max_int_32)
+
+    np.random.seed(config.randomSeed)
+    seed(config.randomSeed)
 
     # This is a consistent way to generate unique strings to form ship and shipyard ids
     def create_uid():

--- a/kaggle_environments/envs/halite/helpers.py
+++ b/kaggle_environments/envs/halite/helpers.py
@@ -566,7 +566,7 @@ class Board:
                 raw_action = player_actions.get(ship_id)
                 action = (
                     ShipAction[raw_action]
-                    if raw_action is not None
+                    if raw_action in ShipAction.__members__
                     else None
                 )
                 self._add_ship(Ship(ship_id, ship_position, ship_halite, player_id, self, action))
@@ -576,7 +576,7 @@ class Board:
                 raw_action = player_actions.get(shipyard_id)
                 action = (
                     ShipyardAction[raw_action]
-                    if raw_action is not None
+                    if raw_action in ShipyardAction.__members__
                     else None
                 )
                 self._add_shipyard(Shipyard(shipyard_id, shipyard_position, player_id, self, action))

--- a/kaggle_environments/schemas.json
+++ b/kaggle_environments/schemas.json
@@ -79,6 +79,11 @@
         "type": "number",
         "minimum": 0,
         "default": 1200
+      },
+      "isProduction": {
+        "description": "Whether this episode is running in Kaggle's production evaluation system. Undefined behavior when set to True locally.",
+        "type": "boolean",
+        "default": false
       }
     }
   },


### PR DESCRIPTION
This PR adds a handful of small changes we've had on the backburner for kaggle-environments

* Update docs
* Use perf_counter instead of time for timing (it's more accurate, thanks @pyBlob )
* Export seeds for halite episodes
* Fix a bug that caused an exception in halite when users return an invalid action
* Add --in cmd line parameter for loading episodes from a file
* Add --display cmd line parameter for quickly controlling output format (html vs json vs ipython)
* Remove duplication of initialization timer (it's already handled in the agent class)