### PR TITLE
Invoke agents in parallel when all agents are picklable

### DIFF
--- a/kaggle_environments/agent.py
+++ b/kaggle_environments/agent.py
@@ -57,7 +57,7 @@ def get_last_callable(raw, fallback=None):
 
 def build_agent(raw, builtin_agents, environment_name):
     """
-    Returns the agent and whether the agent is picklable.
+    Returns the agent and whether the agent is parallelizable.
     """
     if raw in builtin_agents:
         return builtin_agents[raw], False
@@ -118,7 +118,7 @@ class Agent:
         self.configuration = environment.configuration
         self.environment_name = environment.name
         self.raw = raw
-        self.agent, self.is_picklable = build_agent(self.raw, self.builtin_agents, self.environment_name)
+        self.agent, self.is_parallelizable = build_agent(self.raw, self.builtin_agents, self.environment_name)
         self.is_initialized = False
 
     def act(self, observation):

--- a/kaggle_environments/agent.py
+++ b/kaggle_environments/agent.py
@@ -121,10 +121,8 @@ class Agent:
         self.agent, self.is_picklable = build_agent(self.raw, self.builtin_agents, self.environment_name)
         self.is_initialized = False
 
-    def act(self, observation, timeout=10):
-        # Start the timer.
-        start = perf_counter()
-
+    def act(self, observation):
+        timeout = self.configuration.actTimeout
         if not self.is_initialized:
             # Add in the initialization timeout since this is the first time this agent is called
             timeout += self.configuration.agentTimeout
@@ -135,6 +133,8 @@ class Agent:
            structify(self.configuration)
         ][:self.agent.__code__.co_argcount]
 
+        # Start the timer.
+        start = perf_counter()
         try:
             action = self.agent(*args)
         except Exception as e:

--- a/kaggle_environments/core.py
+++ b/kaggle_environments/core.py
@@ -572,7 +572,7 @@ class Environment:
                 for i, agent in enumerate(agents)
             ]
 
-            if all(agent.is_picklable for agent in agents):
+            if all(agent.is_parallelizable for agent in agents):
                 if self.pool is None:
                     self.pool = Pool(processes=len(agents))
                 return self.pool.map(act_agent, act_args)

--- a/kaggle_environments/core.py
+++ b/kaggle_environments/core.py
@@ -86,16 +86,13 @@ def make(environment, configuration={}, steps=[], debug=False):
 
 
 def act_agent(args):
-    agent, state, is_initialized, configuration, none_action = args
+    agent, state, configuration, none_action = args
     if state["status"] != "ACTIVE":
         return None
     elif agent is None:
         return none_action
     else:
-        timeout = configuration.actTimeout
-        if not is_initialized:
-            timeout += configuration.agentTimeout
-        return agent.act(state["observation"], timeout)
+        return agent.act(state["observation"])
 
 
 class Environment:
@@ -569,7 +566,6 @@ class Environment:
                 (
                     agent,
                     self.__get_shared_state(i),
-                    len(self.steps) == 1,
                     self.configuration,
                     none_action,
                 )

--- a/kaggle_environments/core.py
+++ b/kaggle_environments/core.py
@@ -15,8 +15,9 @@
 import traceback
 import copy
 import json
-from time import perf_counter
 import uuid
+from multiprocessing import Pool
+from time import perf_counter
 from .agent import Agent
 from .errors import DeadlineExceeded, FailedPrecondition, Internal, InvalidArgument
 from .utils import get, has, get_player, process_schema, schemas, structify
@@ -84,6 +85,19 @@ def make(environment, configuration={}, steps=[], debug=False):
     raise InvalidArgument("Unknown Environment Specification")
 
 
+def act_agent(args):
+    agent, state, is_initialized, configuration, none_action = args
+    if state["status"] != "ACTIVE":
+        return None
+    elif agent is None:
+        return none_action
+    else:
+        timeout = configuration.actTimeout
+        if not is_initialized:
+            timeout += configuration.agentTimeout
+        return agent.act(state["observation"], timeout)
+
+
 class Environment:
     def __init__(
         self,
@@ -133,6 +147,8 @@ class Environment:
         else:
             self.__set_state(steps[-1])
             self.steps = steps[0:-1] + self.steps
+
+        self.pool = None
 
     def step(self, actions):
         """
@@ -538,34 +554,34 @@ class Environment:
     def __agent_runner(self, agents):
         # Generate the agents.
         agents = [
-            Agent(a, self.configuration, self)
-            if a is not None
+            Agent(agent, self)
+            if agent is not None
             else None
-            for a in agents
+            for agent in agents
         ]
-
-        # Have the agents had a chance to initialize (first non-empty act).
-        initialized = [False] * len(agents)
 
         def act(none_action=None):
             if len(agents) != len(self.state):
                 raise InvalidArgument(
                     "Number of agents must match the state length")
 
-            actions = [0] * len(agents)
-            for i, agent in enumerate(agents):
-                if self.state[i]["status"] != "ACTIVE":
-                    actions[i] = None
-                elif agent is None:
-                    actions[i] = none_action
-                else:
-                    timeout = self.configuration.actTimeout
-                    if not initialized[i]:
-                        initialized[i] = True
-                        timeout += self.configuration.agentTimeout
-                    state = self.__get_shared_state(i)
-                    actions[i] = agent.act(state["observation"], timeout)
-            return actions
+            act_args = [
+                (
+                    agent,
+                    self.__get_shared_state(i),
+                    len(self.steps) == 1,
+                    self.configuration,
+                    none_action,
+                )
+                for i, agent in enumerate(agents)
+            ]
+
+            if all(agent.is_picklable for agent in agents):
+                if self.pool is None:
+                    self.pool = Pool(processes=len(agents))
+                return self.pool.map(act_agent, act_args)
+
+            return map(act_agent, act_args)
 
         return structify({"act": act})
 

--- a/kaggle_environments/main.py
+++ b/kaggle_environments/main.py
@@ -117,7 +117,7 @@ def action_act(args):
     timeout = config.actTimeout
 
     if cached_agent is None or cached_agent.raw != raw:
-        cached_agent = Agent(raw, config, env)
+        cached_agent = Agent(raw, env)
         timeout = config.agentTimeout
     observation = utils.get(args.state, dict, {}, ["observation"])
     action = cached_agent.act(observation, timeout)


### PR DESCRIPTION
Currently simulation agents are invoked round-robin. When all agents can be both pickled (which is a requirement of multiprocessing) and invoked with trivial local overhead (to prevent resource contention), they will all be invoked in parallel. This is useful in production because each agent runs with dedicated resources and the agent protocol is picklable which allows agents to be invoked in parallel in production causing a significant episode speed up.