### PR TITLE
Cache environments by serialized config id rather than unserialized env id

### DIFF
--- a/kaggle_environments/envs/football/football.json
+++ b/kaggle_environments/envs/football/football.json
@@ -8,6 +8,11 @@
           "type": "string",
           "default": "11_vs_11_competition"
       },
+      "id": {
+          "description": "Id of this environment run, a random uuid.",
+          "type": "string",
+          "default": null
+      },
       "team_1": {
           "description": "Number of players from the first team that agent controls.",
           "type": "integer",

--- a/kaggle_environments/envs/football/football.py
+++ b/kaggle_environments/envs/football/football.py
@@ -2,29 +2,31 @@ import importlib
 import json
 from os import path
 import numpy as np
+import uuid
+
 
 def renderer(state, env):
-  return "inline rendering not supported."
+    return "inline rendering not supported."
 
 
 def run_right_agent(obs):
-  # keep running right.
-  return [5] * obs.controlled_players
+    # keep running right.
+    return [5] * obs.controlled_players
 
 
 def run_left_agent(obs):
-  # keep running left.
-  return [1] * obs.controlled_players
+    # keep running left.
+    return [1] * obs.controlled_players
 
 
 def do_nothing_agent(obs):
-  # do nothing.
-  return [0] * obs.controlled_players
+    # do nothing.
+    return [0] * obs.controlled_players
 
 
 def builtin_ai_agent(obs):
-  # execute builtin AI behavior.
-  return [19] * obs.controlled_players
+    # execute builtin AI behavior.
+    return [19] * obs.controlled_players
 
 
 agents = {
@@ -36,56 +38,56 @@ agents = {
 
 
 def parse_single_player(obs_raw_entry):
-  # Remove pixel information.
-  if "frame" in obs_raw_entry:
-    del obs_raw_entry["frame"]
-  for k,v in obs_raw_entry.items():
-    if type(v) == np.ndarray:
-      obs_raw_entry[k] = v.tolist()
-  return obs_raw_entry
+    # Remove pixel information.
+    if "frame" in obs_raw_entry:
+        del obs_raw_entry["frame"]
+    for k, v in obs_raw_entry.items():
+        if type(v) == np.ndarray:
+            obs_raw_entry[k] = v.tolist()
+    return obs_raw_entry
 
 
 def update_observations_and_rewards(configuration, state, obs, rew=None):
-  """Updates agent-visible observations given 'raw' observations from environment.
-  
-  Observations in 'obs' are coming directly from the environment and are in 'raw' format.
-  """
-  state[0].observation.controlled_players = configuration.team_1
-  state[1].observation.controlled_players = configuration.team_2
+    """Updates agent-visible observations given 'raw' observations from environment.
 
-  assert len(obs) == configuration.team_1 + configuration.team_2
-  if rew is not None:
-    if type(rew) == np.float32:
-      rew = [rew]
-    assert len(rew) == configuration.team_1 + configuration.team_2
-    if configuration.team_1 > 0:
-      state[0].reward = float(rew[0])
-    else:
-      state[0].reward = float(-rew[0])
-    state[1].reward = -state[1].reward
+    Observations in 'obs' are coming directly from the environment and are in 'raw' format.
+    """
+    state[0].observation.controlled_players = configuration.team_1
+    state[1].observation.controlled_players = configuration.team_2
 
-  state[0].observation.players_raw = [
-      parse_single_player(obs[x]) for x in range(configuration.team_1)
-  ]
-  state[1].observation.players_raw = [
-      parse_single_player(obs[x + configuration.team_1])
-      for x in range(configuration.team_2)
-  ]
+    assert len(obs) == configuration.team_1 + configuration.team_2
+    if rew is not None:
+        if type(rew) == np.float32:
+            rew = [rew]
+        assert len(rew) == configuration.team_1 + configuration.team_2
+        if configuration.team_1 > 0:
+            state[0].reward = float(rew[0])
+        else:
+            state[0].reward = float(-rew[0])
+        state[1].reward = -state[1].reward
+
+    state[0].observation.players_raw = [
+        parse_single_player(obs[x]) for x in range(configuration.team_1)
+    ]
+    state[1].observation.players_raw = [
+        parse_single_player(obs[x + configuration.team_1])
+        for x in range(configuration.team_2)
+    ]
 
 
 def update_state_on_invalid_action(bad_agent, good_agent, message):
-  bad_agent.status = "INVALID"
-  bad_agent.reward = -100
-  bad_agent.info.debug_info = message
+    bad_agent.status = "INVALID"
+    bad_agent.reward = -100
+    bad_agent.info.debug_info = message
 
-  good_agent.status = "DONE"
-  good_agent.reward = 100
-  good_agent.info.debug_info = "Opponent made invalid move. You win."
+    good_agent.status = "DONE"
+    good_agent.reward = 100
+    good_agent.info.debug_info = "Opponent made invalid move. You win."
 
 
 def football_env():
-  # Use lazy-import to avoid this heavy dependency unless it is really needed.
-  return importlib.import_module("gfootball.env")
+    # Use lazy-import to avoid this heavy dependency unless it is really needed.
+    return importlib.import_module("gfootball.env")
 
 
 # Global dictionary with active environments.
@@ -93,125 +95,128 @@ m_envs = {}
 
 
 def cleanup(env):
-  global m_envs
-  del m_envs[env.id]
+    global m_envs
+    del m_envs[env.configuration.id]
 
 
 def cleanup_all():
-  global m_envs
-  del m_envs
+    global m_envs
+    del m_envs
 
 
 def interpreter(state, env):
-  global m_envs
-  if (env.id not in m_envs) or env.done:
-    if env.id not in m_envs:
-      print("Staring a new environment %s: with scenario: %s" %
-            (env.id, env.configuration.scenario_name))
+    global m_envs
+    if "id" not in env.configuration or env.configuration.id is None:
+        env.configuration.id = str(uuid.uuid4())
 
-      other_config_options = {}
-      if env.configuration.running_in_notebook:
-        # Use webp to encode videos (so that you can see them in the browser).
-        other_config_options["video_format"] = "webm"
-        assert not env.configuration.render, "Render is not supported inside notebook environment."
+    if (env.configuration.id not in m_envs) or env.done:
+        if env.configuration.id not in m_envs:
+            print("Starting a new environment %s: with scenario: %s" %
+                  (env.configuration.id, env.configuration.scenario_name))
 
-      env.football_video_path = None
-      m_envs[env.id] = football_env().create_environment(
-          env_name=env.configuration.scenario_name,
-          stacked=False,
-          # We use 'raw' representation to transfer data between server and agents.
-          representation='raw',
-          logdir=path.join(env.configuration.logdir, env.id),
-          write_goal_dumps=False,
-          write_full_episode_dumps=env.configuration.save_video,
-          write_video=env.configuration.save_video,
-          render=env.configuration.render,
-          number_of_left_players_agent_controls=env.configuration.team_1,
-          number_of_right_players_agent_controls=env.configuration.team_2,
-          other_config_options=other_config_options)
-    else:
-      print("Resetting environment %s: with scenario: %s" %
-            (env.id, env.configuration.scenario_name))
-    obs = m_envs[env.id].reset()
+            other_config_options = {}
+            if env.configuration.running_in_notebook:
+                # Use webp to encode videos (so that you can see them in the browser).
+                other_config_options["video_format"] = "webm"
+                assert not env.configuration.render, "Render is not supported inside notebook environment."
+
+            env.football_video_path = None
+            m_envs[env.configuration.id] = football_env().create_environment(
+                env_name=env.configuration.scenario_name,
+                stacked=False,
+                # We use 'raw' representation to transfer data between server and agents.
+                representation='raw',
+                logdir=path.join(env.configuration.logdir, env.configuration.id),
+                write_goal_dumps=False,
+                write_full_episode_dumps=env.configuration.save_video,
+                write_video=env.configuration.save_video,
+                render=env.configuration.render,
+                number_of_left_players_agent_controls=env.configuration.team_1,
+                number_of_right_players_agent_controls=env.configuration.team_2,
+                other_config_options=other_config_options)
+        else:
+            print("Resetting environment %s: with scenario: %s" %
+                  (env.configuration.id, env.configuration.scenario_name))
+        obs = m_envs[env.configuration.id].reset()
+        update_observations_and_rewards(configuration=env.configuration,
+                                        state=state,
+                                        obs=obs)
+
+    if env.done:
+        return state
+
+    # Check if both players responded.
+    for agent in range(2):
+        # TODO: it seems that ACTIVE/INACTIVE/DONE are not present in 'status_codes.json'
+        # not sure what are the correct values here.
+        if (state[agent].status != "OK" and state[agent].status != "ACTIVE"):
+            # something went wrong.
+            print("AGENT %d returned invalid state: %s" %
+                  (agent, state[agent].status))
+            return state
+
+    # verify actions.
+    controlled_players = env.configuration.team_1
+
+    if len(state[0].action) != env.configuration.team_1:
+        # Player 1 sent wrong data.
+        update_state_on_invalid_action(
+            state[0], state[1], "Invalid number of actions provided: Expected %d, got %d." %
+                                (env.configuration.team_1, len(state[0].action)))
+        return state
+    actions_to_env = state[0].action
+
+    if len(state[1].action) != env.configuration.team_2:
+        # Player 2 sent wrong data.
+        update_state_on_invalid_action(
+            state[1], state[0], "Invalid number of actions provided: Expected %d, got %d." %
+                                (env.configuration.team_2, len(state[1].action)))
+        return state
+
+    if env.configuration.team_2:
+        actions_to_env = actions_to_env + state[1].action
+
+    obs, rew, done, info = m_envs[env.configuration.id].step(actions_to_env)
+
+    if "dumps" in info:
+        print("Episode finished - received video link.")
+        for entry in info["dumps"]:
+            if entry['name'] == 'episode_done':
+                env.football_video_path = entry['video']
+
     update_observations_and_rewards(configuration=env.configuration,
                                     state=state,
-                                    obs=obs)
+                                    obs=obs,
+                                    rew=rew)
 
-  if env.done:
+    ## TODO: pass other information from 'info' to the state/agent.
+    if done:
+        for agent in range(2):
+            state[agent].status = "INACTIVE"
+
     return state
-
-  # Check if both players responded.
-  for agent in range(2):
-    # TODO: it seems that ACTIVE/INACTIVE/DONE are not present in 'status_codes.json'
-    # not sure what are the correct values here.
-    if (state[agent].status != "OK" and state[agent].status != "ACTIVE"):
-      # something went wrong.
-      print("AGENT %d returned invalid state: %s" %
-            (agent, state[agent].status))
-      return state
-
-  # verify actions.
-  controlled_players = env.configuration.team_1
-
-  if len(state[0].action) != env.configuration.team_1:
-    # Player 1 sent wrong data.
-    update_state_on_invalid_action(
-        state[0], state[1], "Invalid number of actions provided: Expected %d, got %d." %
-        (env.configuration.team_1, len(state[0].action)))
-    return state
-  actions_to_env = state[0].action
-
-  if len(state[1].action) != env.configuration.team_2:
-    # Player 2 sent wrong data.
-    update_state_on_invalid_action(
-        state[1], state[0], "Invalid number of actions provided: Expected %d, got %d." %
-        (env.configuration.team_2, len(state[1].action)))
-    return state
-
-  if env.configuration.team_2:
-    actions_to_env = actions_to_env + state[1].action
-
-  obs, rew, done, info = m_envs[env.id].step(actions_to_env)
-
-  if "dumps" in info:
-    print("Episode finished - received video link.")
-    for entry in info["dumps"]:
-      if entry['name'] == 'episode_done':
-        env.football_video_path = entry['video']
-
-  update_observations_and_rewards(configuration=env.configuration,
-                                  state=state,
-                                  obs=obs,
-                                  rew=rew)
-
-  ## TODO: pass other information from 'info' to the state/agent.
-  if done:
-    for agent in range(2):
-      state[agent].status = "INACTIVE"
-
-  return state
 
 
 dirpath = path.dirname(__file__)
 jsonpath = path.abspath(path.join(dirpath, "football.json"))
 with open(jsonpath) as f:
-  specification = json.load(f)
+    specification = json.load(f)
 
 
 def html_renderer(env):
-  if not env.football_video_path:
-    raise Exception(
-        "No video found. Did episode finish successfully? Was environment created with save_video enabled?"
-    )
+    if not env.football_video_path:
+        raise Exception(
+            "No video found. Did episode finish successfully? Was environment created with save_video enabled?"
+        )
 
-  from IPython.display import display, HTML
-  from base64 import b64encode
+    from IPython.display import display, HTML
+    from base64 import b64encode
 
-  video = open(env.football_video_path, 'rb').read()
-  data_url = "data:video/webm;base64," + b64encode(video).decode()
+    video = open(env.football_video_path, 'rb').read()
+    data_url = "data:video/webm;base64," + b64encode(video).decode()
 
-  display(
-      HTML("""
+    display(
+        HTML("""
 <video width=800 controls>
   <source src="%s" type="video/webm">
 </video>


### PR DESCRIPTION
@qstanczyk Looks like I can't assign this to you directly as a reviewer, but please take a read through and LMK your thoughts. The OOM issues we see in production are caused by the environment getting reinitialized on every agent call. This happens because the env.id parameter is not serialized when the orchestrator invokes an agent and instead env.id is always randomly assigned when the env is initialized. Instead we'll add a config parameter to football that does the same thing but is serialized correctly.