### PR TITLE
Parallel Agent Refinement

### DIFF
--- a/kaggle_environments/agent.py
+++ b/kaggle_environments/agent.py
@@ -96,7 +96,7 @@ def build_agent(raw, builtin_agents, environment_name):
 
     # Not a string, static action.
     if not isinstance(raw, str):
-        return lambda: raw, True
+        return lambda: raw, False
 
     # A URL and will be initialized on the calling server.
     if is_url(raw):
@@ -137,10 +137,18 @@ class Agent:
             timeout += self.configuration.agentTimeout
             self.is_initialized = True
 
+        args = [
+            structify(observation),
+            structify(self.configuration)
+        ]
+
+        if hasattr(self.agent, "__code__"):
+            args = args[:self.agent.__code__.co_argcount]
+
         # Start the timer.
         start = perf_counter()
         try:
-            action = self.agent(structify(observation), structify(self.configuration))
+            action = self.agent(*args)
         except Exception as e:
             action = e
 

--- a/kaggle_environments/core.py
+++ b/kaggle_environments/core.py
@@ -157,7 +157,6 @@ class Environment:
         Returns:
             list of dict: The agents states after the step.
         """
-
         if self.done:
             raise FailedPrecondition("Environment done, reset required.")
         if not actions or len(actions) != len(self.state):
@@ -572,12 +571,12 @@ class Environment:
                 for i, agent in enumerate(agents)
             ]
 
-            if all(agent.is_parallelizable for agent in agents):
+            if all((agent is None or agent.is_parallelizable) for agent in agents):
                 if self.pool is None:
                     self.pool = Pool(processes=len(agents))
                 return self.pool.map(act_agent, act_args)
 
-            return map(act_agent, act_args)
+            return list(map(act_agent, act_args))
 
         return structify({"act": act})
 

--- a/kaggle_environments/envs/halite/helpers.py
+++ b/kaggle_environments/envs/halite/helpers.py
@@ -14,8 +14,10 @@
 
 from copy import deepcopy
 from enum import Enum, auto
+from functools import wraps
 from typing import *
 import operator
+import sys
 
 
 # region Helper Classes and Methods
@@ -840,8 +842,12 @@ def board_agent(agent: Callable[[Board], None]):
     def my_agent(board: Board) -> None:
         ...
     """
+    @wraps(agent)
     def agent_wrapper(obs, config) -> Dict[str, str]:
         board = Board(obs, config)
         agent(board)
         return board.current_player.next_actions
+
+    if agent.__module__ is not None and agent.__module__ in sys.modules:
+        setattr(sys.modules[agent.__module__], agent.__name__, agent_wrapper)
     return agent_wrapper

--- a/kaggle_environments/main.py
+++ b/kaggle_environments/main.py
@@ -111,9 +111,7 @@ def action_act(args):
         return {"error": "One agent must be provided."}
     raw = args.agents[0]
 
-    # Pass empty steps in here because we just need the configuration from the environment
-    env = make(args.environment, args.configuration, [], args.debug)
-    config = env.configuration
+    env = make(args.environment, args.configuration, [args.state], args.debug)
 
     if cached_agent is None or cached_agent.raw != raw:
         cached_agent = Agent(raw, env)

--- a/kaggle_environments/main.py
+++ b/kaggle_environments/main.py
@@ -116,7 +116,7 @@ def action_act(args):
     config = env.configuration
 
     if cached_agent is None or cached_agent.raw != raw:
-        cached_agent = Agent(raw, config, env)
+        cached_agent = Agent(raw, env)
     observation = utils.get(args.state, dict, {}, ["observation"])
     action = cached_agent.act(observation)
     if isinstance(action, errors.DeadlineExceeded):


### PR DESCRIPTION
This fixes several corner cases across kaggle-env features.

* Move URL agent to picklable class
* Reintroduce arg trimming for agents that don't accept all params
* Pass state to env during act calls to prevent reinitialization of env