### PR TITLE
Fix Point comparison to non-subscriptable objects

### DIFF
--- a/kaggle_environments/envs/halite/helpers.py
+++ b/kaggle_environments/envs/halite/helpers.py
@@ -74,7 +74,10 @@ class Point(tuple):
         return self.map2(other, operator.add)
 
     def __eq__(self, other: Union[Tuple[int, int], 'Point']) -> bool:
-        return self[0] == other[0] and self[1] == other[1]
+        try:
+            return self[0] == other[0] and self[1] == other[1]
+        except (TypeError, IndexError):
+            return False
 
     def __floordiv__(self, denominator: int) -> 'Point':
         return self.map(lambda x: x // denominator)


### PR DESCRIPTION
This PR fixes #72. 

As explained in the issue, comparing an instance of `Point` to another object fails when the other object is not subscriptable or is of a length shorter than 2.

I've fixed this by introducing a try/except block taking into account both `TypeError` for non-subscriptable objects and `IndexError` for objects with a length shorter than 2. There's other ways to fix this (eg. by type and length checking), but I feel the current approach is most robust for the context in which this code is used. I expect the comparison mostly to be used against Tuple instances of length two, which is supported by the typehinting already applied to the method, so in most cases the `try` block should be executed and performance should be optimal.