### PR TITLE
[RPS] Add step to player 2 observation dictionary

### DIFF
--- a/kaggle_environments/envs/rps/rps.py
+++ b/kaggle_environments/envs/rps/rps.py
@@ -14,6 +14,7 @@ def interpreter(state, env):
 
     step = len(env.steps)
     player1.observation.step = step
+    player2.observation.step = step
 
     def is_valid_action(player, sign_count):
         return (


### PR DESCRIPTION
As you can see, the `step` parameter in the dictionary is not present for player 2. 

**Code to reproduce the issue**
```
from kaggle_environments import make

ENV_NAME = "rps"

env = make(ENV_NAME)

env.reset()

print(env.step([2,2]))
```

**Output**
```
[{'action': 2, 'reward': 0, 'info': {}, 'observation': {'step': 1, 'lastOpponentAction': 2}, 'status': 'ACTIVE'},
 {'action': 2, 'reward': 0, 'info': {}, 'observation': {'lastOpponentAction': 2}, 'status': 'ACTIVE'}]
```

This fixes the update of the parameter step, but there is still a small problem: in the very first state (when `state=0`) player 2 does not have the state field defined. Where is this declared? I cannot find it.
