### PR TITLE
Instead of initialization timer, provide agents with overage timer in observation that can be used on any step

### DIFF
--- a/kaggle_environments/agent.py
+++ b/kaggle_environments/agent.py
@@ -125,7 +125,6 @@ def build_agent(raw, builtin_agents, environment_name):
 
     return callable_agent, False
 
-
 class Agent:
     def __init__(self, raw, environment):
         self.builtin_agents = environment.agents
@@ -134,15 +133,8 @@ class Agent:
         self.environment_name = environment.name
         self.raw = raw
         self.agent, self.is_parallelizable = build_agent(self.raw, self.builtin_agents, self.environment_name)
-        self.is_initialized = False
 
     def act(self, observation):
-        timeout = self.configuration.actTimeout
-        if not self.is_initialized:
-            # Add in the initialization timeout since this is the first time this agent is called
-            timeout += self.configuration.agentTimeout
-            self.is_initialized = True
-
         args = [
             structify(observation),
             structify(self.configuration)
@@ -178,8 +170,8 @@ class Agent:
             if not log["stderr"].isspace():
                 print(log["stderr"], end="")
 
-        # Timeout reached, throw an error.
-        if perf_counter() - start > timeout:
+        if duration - self.configuration.actTimeout > observation.remainingOverageTime:
+            # No overage time left, timeout agent
             action = DeadlineExceeded()
 
         return action, log

--- a/kaggle_environments/core.py
+++ b/kaggle_environments/core.py
@@ -601,10 +601,7 @@ class Environment:
             spec[field_name] = field
 
         extend_specification(schemas, "configuration")
-        try:
-            extend_specification(schemas["state"]["properties"], "observation")
-        except Exception as e:
-            print(e)
+        extend_specification(schemas["state"]["properties"], "observation")
 
         return process_schema(schemas.specification, spec)
 

--- a/kaggle_environments/envs/connectx/connectx.json
+++ b/kaggle_environments/envs/connectx/connectx.json
@@ -23,12 +23,12 @@
       "default": 4,
       "minimum": 1
     },
-    "agentTimeout": 16,
-    "actTimeout": 8,
+    "agentTimeout": 60,
+    "actTimeout": 2,
     "timeout": {
       "description": "Obsolete copy of actTimeout maintained for backwards compatibility. May be removed in the future.",
       "type": "integer",
-      "default": 8,
+      "default": 2,
       "minimum": 0
     }
   },
@@ -51,7 +51,8 @@
       "defaults": [1, 2],
       "description": "Which checkers are the agents.",
       "enum": [1, 2]
-    }
+    },
+    "remainingOverageTime": 60
   },
   "action": {
     "description": "Column to drop a checker onto the board.",

--- a/kaggle_environments/envs/football/football.json
+++ b/kaggle_environments/envs/football/football.json
@@ -1,87 +1,86 @@
 {
-    "name": "football",
-    "agents": [2],
-    "configuration": {
-      "episodeSteps": 3002,
-      "agentTimeout": 60,
-      "actTimeout": 0.5,
-      "runTimeout": 1600,
-      "scenario_name": {
-          "description": "Name of the scenario: for example 11_vs_11_kaggle. Look inside https://github.com/google-research/football/tree/master/gfootball/scenarios.",
-          "type": "string",
-          "default": "11_vs_11_kaggle"
-      },
-      "id": {
-          "description": "Id of this environment run, a random uuid.",
-          "type": "string",
-          "default": null
-      },
-      "team_1": {
-          "description": "Number of players from the first team that agent controls.",
-          "type": "integer",
-          "minimum": 0,
-          "maximum": 11,
-          "default": 1
-      },
-      "team_2": {
-          "description": "Number of players that other agent controls. If set to 0 - the second agent will always have to return 0 as action.",
-          "type": "integer",
-          "minimum": 0,
-          "maximum": 11,
-          "default": 1
-      },
-      "render": {
-          "description": "If true - renders the game on the screen. This option will work on your local computer, but is not supported in colabs/notebooks.",
-          "type": "boolean",
-          "default": false
-      },
-      "save_video": {
-          "description": "If true, will record the video of the playthrough.",
-          "type": "boolean",
-          "default": false 
-      },
-      "logdir": {
-          "description": "Directory to write the state dump and video information.",
-          "type": "string",
-          "default": "/tmp/football"
-      },
-      "running_in_notebook": {
-          "description": "Set to true, if you're creating this environment inside Kaggle/Colab notebook.",
-          "type": "boolean",
-          "default": false
-      }
+  "name": "football",
+  "agents": [2],
+  "configuration": {
+    "episodeSteps": 3002,
+    "agentTimeout": 60,
+    "actTimeout": 0.5,
+    "runTimeout": 12000,
+    "scenario_name": {
+      "description": "Name of the scenario: for example 11_vs_11_kaggle. Look inside https://github.com/google-research/football/tree/master/gfootball/scenarios.",
+      "type": "string",
+      "default": "11_vs_11_kaggle"
     },
-    "reward": {
-      "description": "1.0 for scored goal, -1.0 for lost goal (it is given only when the goal is scored, and changes back to 0 afterwards)",
-      "type": "number"
+    "id": {
+      "description": "Id of this environment run, a random uuid.",
+      "type": "string",
+      "default": null
     },
-
-    "info": {
-      "debug_info": {
-          "description": "Human readable information passed from the system.",
-          "type": "string"
-      }
+    "team_1": {
+      "description": "Number of players from the first team that agent controls.",
+      "type": "integer",
+      "minimum": 0,
+      "maximum": 11,
+      "default": 1
     },
-
-    "observation": {
-        "players_raw": {
-          "description": "Array of raw observations, one entry per each player that your agent controls. See https://github.com/google-research/football/blob/master/gfootball/doc/observation.md for detailed description. WARNING: your players will always look like they are 'playing from left to right' (to make training easier).",
-          "type": "array"
-        },
-        "controlled_players": {
-            "description": "number of players that agent controls",
-            "type": "number",
-            "minimum": 0,
-            "maximum": 11
-        }
+    "team_2": {
+      "description": "Number of players that other agent controls. If set to 0 - the second agent will always have to return 0 as action.",
+      "type": "integer",
+      "minimum": 0,
+      "maximum": 11,
+      "default": 1
     },
-    "action": {
-      "description": "An action to execute for each player that agent controls: 0-idle, 1-left, 2-top_left, etc. See https://github.com/google-research/football/blob/master/gfootball/doc/observation.md",
-      "type": "array",
-      "items": {
-        "type": "number",
-        "minimum": 0,
-        "maximum": 19
-      }
+    "render": {
+      "description": "If true - renders the game on the screen. This option will work on your local computer, but is not supported in colabs/notebooks.",
+      "type": "boolean",
+      "default": false
+    },
+    "save_video": {
+      "description": "If true, will record the video of the playthrough.",
+      "type": "boolean",
+      "default": false
+    },
+    "logdir": {
+      "description": "Directory to write the state dump and video information.",
+      "type": "string",
+      "default": "/tmp/football"
+    },
+    "running_in_notebook": {
+      "description": "Set to true, if you're creating this environment inside Kaggle/Colab notebook.",
+      "type": "boolean",
+      "default": false
     }
+  },
+  "reward": {
+    "description": "1.0 for scored goal, -1.0 for lost goal (it is given only when the goal is scored, and changes back to 0 afterwards)",
+    "type": "number"
+  },
+  "info": {
+    "debug_info": {
+      "description": "Human readable information passed from the system.",
+      "type": "string"
+    }
+  },
+  "observation": {
+    "players_raw": {
+      "description": "Array of raw observations, one entry per each player that your agent controls. See https://github.com/google-research/football/blob/master/gfootball/doc/observation.md for detailed description. WARNING: your players will always look like they are 'playing from left to right' (to make training easier).",
+      "type": "array"
+    },
+    "controlled_players": {
+      "description": "number of players that agent controls",
+      "type": "number",
+      "minimum": 0,
+      "maximum": 11
+    },
+    "remainingOverageTime": 60
+  },
+  "action": {
+    "description": "An action to execute for each player that agent controls: 0-idle, 1-left, 2-top_left, etc. See https://github.com/google-research/football/blob/master/gfootball/doc/observation.md",
+    "type": "array",
+    "items": {
+      "type": "number",
+      "minimum": 0,
+      "maximum": 19
+    }
+  }
 }

--- a/kaggle_environments/envs/halite/halite.json
+++ b/kaggle_environments/envs/halite/halite.json
@@ -58,8 +58,8 @@
       "type": "integer",
       "default": null
     },
-    "agentTimeout": 30,
-    "actTimeout": 6,
+    "agentTimeout": 60,
+    "actTimeout": 3,
     "runTimeout": 9600
   },
   "reward": {
@@ -132,7 +132,8 @@
       "type": "integer",
       "shared": true,
       "minimum": 0
-    }
+    },
+    "remainingOverageTime": 60
   },
   "action": {
     "description": "Actions taken per asset (ship or shipyard).",

--- a/kaggle_environments/envs/halite/helpers.py
+++ b/kaggle_environments/envs/halite/helpers.py
@@ -172,6 +172,11 @@ class Observation(ReadOnlyDict[str, any]):
         """The current step index within the episode."""
         return self["step"]
 
+    @property
+    def remaining_overage_time(self) -> int:
+        """The current step index within the episode."""
+        return self["remainingOverageTime"]
+
 
 class Configuration(ReadOnlyDict[str, any]):
     """
@@ -542,6 +547,7 @@ class Board:
         next_actions = next_actions or ([{}] * len(observation.players))
 
         self._step = observation.step
+        self._remaining_overage_time = observation.remaining_overage_time
         self._configuration = Configuration(raw_configuration)
         self._current_player_id = observation.player
         self._players: Dict[PlayerId, Player] = {}
@@ -642,7 +648,8 @@ class Board:
             "halite": halite,
             "players": players,
             "player": self.current_player_id,
-            "step": self.step
+            "step": self.step,
+            "remainingOverageTime": self._remaining_overage_time,
         }
 
     def __deepcopy__(self, _) -> 'Board':

--- a/kaggle_environments/envs/identity/identity.json
+++ b/kaggle_environments/envs/identity/identity.json
@@ -21,13 +21,17 @@
       "description": "Noise added to the reward.",
       "type": "number",
       "default": 0
-    }
+    },
+    "actTimeout": 1,
+    "episodeSteps": 25
   },
   "reward": {
     "description": "The value of the agent action is set as: action + gauss * noise.",
     "type": "integer"
   },
-  "observation": {},
+  "observation": {
+    "remainingOverageTime": 12
+  },
   "action": {
     "description": "Reward = action if number, otherwise 0.",
     "type": ["number", "string", "null"]

--- a/kaggle_environments/envs/rps/rps.json
+++ b/kaggle_environments/envs/rps/rps.json
@@ -39,7 +39,8 @@
       "shared": true,
       "minimum": 0,
       "default": 0
-    }
+    },
+    "remainingOverageTime": 60
   },
   "action": {
     "description": "Choice of sign for the step (Rock = 0, Paper = 1, Scissors = 2, etc)",

--- a/kaggle_environments/main.py
+++ b/kaggle_environments/main.py
@@ -164,7 +164,7 @@ def action_step(args):
 
 def action_run(args):
     # Create a fake env so we can make the real env in our try body
-    env = {"logs": args.logs}
+    env = utils.structify({"logs": args.logs})
     try:
         env = make(args.environment, args.configuration, args.info, args.steps, args.logs, args.debug)
         env.run(args.agents)

--- a/kaggle_environments/schemas.json
+++ b/kaggle_environments/schemas.json
@@ -112,11 +112,11 @@
         "additionalProperties": true,
         "properties": {
           "remainingOverageTime": {
-            "description": "Remaining per-step timeout overage -- agent is disqualified by TIMEOUT when this drops below 0.",
+            "description": "Total remaining banked time (seconds) that can be used in excess of per-step actTimeouts -- agent is disqualified with TIMEOUT status when this drops below 0.",
             "shared": false,
             "type": "number",
             "minimum": 0,
-            "default": 1
+            "default": 12
           }
         },
         "default": {}

--- a/kaggle_environments/schemas.json
+++ b/kaggle_environments/schemas.json
@@ -112,7 +112,7 @@
         "additionalProperties": true,
         "properties": {
           "remainingOverageTime": {
-            "description": "Remaining per-step timeout overage -- agent is disqualified when this reaches 0.",
+            "description": "Remaining per-step timeout overage -- agent is disqualified by TIMEOUT when this reaches 0.",
             "shared": false,
             "type": "number",
             "minimum": 0,

--- a/kaggle_environments/schemas.json
+++ b/kaggle_environments/schemas.json
@@ -63,7 +63,7 @@
         "default": 1000
       },
       "agentTimeout": {
-        "description": "Maximum runtime (seconds) to initialize an agent.",
+        "description": "Obsolete field kept for backwards compatibility, please use observation.remainingOverageTime.",
         "type": "number",
         "minimum": 0,
         "default": 12
@@ -109,6 +109,16 @@
       "observation": {
         "description": "Observation to create an action based upon.",
         "type": "object",
+        "additionalProperties": true,
+        "properties": {
+          "remainingOverageTime": {
+            "description": "Remaining per-step timeout overage -- agent is disqualified when this reaches 0.",
+            "shared": false,
+            "type": "number",
+            "minimum": 0,
+            "default": 1
+          }
+        },
         "default": {}
       },
       "status": {

--- a/kaggle_environments/schemas.json
+++ b/kaggle_environments/schemas.json
@@ -112,7 +112,7 @@
         "additionalProperties": true,
         "properties": {
           "remainingOverageTime": {
-            "description": "Remaining per-step timeout overage -- agent is disqualified by TIMEOUT when this reaches 0.",
+            "description": "Remaining per-step timeout overage -- agent is disqualified by TIMEOUT when this drops below 0.",
             "shared": false,
             "type": "number",
             "minimum": 0,


### PR DESCRIPTION
cc @qstanczyk 

Now in each observation for every environment you'll receive a top level field named `remainingOverageTime` that replaces the previous `configuration.agentTimeout` initialization timer property. The only difference is that the new field can be used on any step, and will decrease on each new observation as the banked time is consumed. Agents will only be timed out when they have less than 0 remaining overage time.

The old field will still be available, and agents that spend all of their time on their first step will continue to work as normal.