### PR TITLE
Fix env.render(mode="human")

### DIFF
--- a/kaggle_environments/core.py
+++ b/kaggle_environments/core.py
@@ -280,6 +280,7 @@ class Environment:
             out = self.renderer(*args[:self.renderer.__code__.co_argcount])
             if mode == "ansi":
                 return out
+            print(out)
         elif mode == "html" or mode == "ipython":
             window_kaggle = {
                 "debug": get(kwargs, bool, self.debug, path=["debug"]),


### PR DESCRIPTION
**Problem description**: 
`env.render()` or `env.render(mode="human")`, wasnt't working anymore [after this change](https://github.com/Kaggle/kaggle-environments/commit/06bd76f0024f2f9e6ad170356d36c0e034c3fbf4#diff-ac990a77ca06fb03bd66a777f7729f6db1e5e4dfef68fbd7a3f8f60caf032e98L254) in #43 

This change was IMO an error and should be reverted, this is the purpose of this commit.
Should resolve #92