### PR TITLE
[hungry_geese] Bugfix in  GreedyAgent

### DIFF
--- a/kaggle_environments/envs/hungry_geese/hungry_geese.py
+++ b/kaggle_environments/envs/hungry_geese/hungry_geese.py
@@ -135,7 +135,7 @@ class GreedyAgent:
             opponent_head_adjacent
             for opponent in opponents
             for opponent_head in [opponent[0]]
-            for opponent_head_adjacent in adjacent_positions(opponent_head, rows, columns)
+            for opponent_head_adjacent in adjacent_positions(opponent_head, columns, rows)
         }
         # Don't move into any bodies
         bodies = {position for goose in geese for position in goose}


### PR DESCRIPTION
Hi!
There is a small typo in the detection of cells adjacent to the heads of other geese: `adjacent_positions` take `columns, rows` as parameters and they were given the other way around.