### PR TITLE
Hungry geese scoring updates

### DIFF
--- a/kaggle_environments/__init__.py
+++ b/kaggle_environments/__init__.py
@@ -21,7 +21,7 @@ from .main import http_request
 from . import errors
 from . import utils
 
-__version__ = "1.7.10"
+__version__ = "1.7.11"
 
 __all__ = ["Agent", "environments", "errors", "evaluate", "http_request",
            "make", "register", "utils", "__version__",

--- a/kaggle_environments/envs/hungry_geese/hungry_geese.json
+++ b/kaggle_environments/envs/hungry_geese/hungry_geese.json
@@ -3,7 +3,7 @@
   "title": "Hungry Geese",
   "description": "Similar to the classic snake game with multiple players",
   "version": "1.0.0",
-  "agents": [2, 3, 4, 5, 6, 7, 8],
+  "agents": [1, 2, 3, 4, 5, 6, 7, 8],
   "configuration": {
     "episodeSteps": 200,
     "actTimeout": 1,
@@ -30,10 +30,15 @@
       "type": "integer",
       "default": 2,
       "minimum": 1
+    },
+    "max_length": {
+      "description": "The max length any goose can be. Total reward = (max length + 1) * step + goose length.",
+      "type": "integer",
+      "default": 99
     }
   },
   "reward": {
-    "description": "The number of steps the goose has moved plus its length.",
+    "description": "steps moved * (max goose length + 1) + current goose length.",
     "type": "integer",
     "default": 0,
     "minimum": 0

--- a/kaggle_environments/envs/hungry_geese/hungry_geese.json
+++ b/kaggle_environments/envs/hungry_geese/hungry_geese.json
@@ -32,13 +32,13 @@
       "minimum": 1
     },
     "max_length": {
-      "description": "The max length any goose can be. Total reward = (max length + 1) * step + goose length.",
+      "description": "The max length any goose can be. Total reward = (max length + 1) * steps survived + goose length.",
       "type": "integer",
       "default": 99
     }
   },
   "reward": {
-    "description": "steps moved * (max goose length + 1) + current goose length.",
+    "description": "steps survived * (max goose length + 1) + current goose length.",
     "type": "integer",
     "default": 0,
     "minimum": 0


### PR DESCRIPTION
* Allow a single agent to play HG for training.
* Add configuration.max_length and use it to constrain max goose length and to expand reward space to `reward = (max_length + 1) * current_step + current_length`.
* In episodes with high numbers of min_food or low board size, ensure we don't accidentally try to allocate more food than positions on the board.
* Switch some generators to more efficient / concise set operations.
* Update rewards after goose deletion to prevent a tie on the last step when a goose collides with another goose's body.