### PR TITLE
ignore gfootball loading error

### DIFF
--- a/kaggle_environments/__init__.py
+++ b/kaggle_environments/__init__.py
@@ -40,4 +40,5 @@ for name in listdir(utils.envs_path):
             "specification": getattr(env, "specification"),
         })
     except Exception as e:
-        print("Loading environment %s failed: %s" % (name, e))
+        if "football" not in name:
+            print("Loading environment %s failed: %s" % (name, e))


### PR DESCRIPTION
Every time a user uses this libarary it prints a misleading loading error that gfootball didn't load. 