### PR TITLE
feat(kore): implement basic ts interpreter for Kore 2022

### DIFF
--- a/kaggle_environments/envs/kore_fleets/starter_bots/ts/README.md
+++ b/kaggle_environments/envs/kore_fleets/starter_bots/ts/README.md
@@ -31,6 +31,6 @@
 
 A basic TS interpreter has been created in `interpreter.ts`. You can use or modify this file to train machine learning models in JS/TS.
 
-Currently it supports 4 agents and customizable number of episodes. After each episode, you can access the complete history of the game, including the observation (state), action and reward for each turn.
+Currently it supports 2 agents and customizable number of episodes. After each episode, you can access the complete history of the game. For each turn, you can access the full observation (state) as a Board object, actions performed and the reward obtained after performing the action.
 
 Sample command to run the interpreter can be found in npm scripts as `npm run interpreter`.

--- a/kaggle_environments/envs/kore_fleets/starter_bots/ts/README.md
+++ b/kaggle_environments/envs/kore_fleets/starter_bots/ts/README.md
@@ -26,3 +26,11 @@
 ## Running tests
 
 1. `npm test`
+
+## Interpreter and training
+
+A basic TS interpreter has been created in `interpreter.ts`. You can use or modify this file to train machine learning models in JS/TS.
+
+Currently it supports 4 agents and customizable number of episodes. After each episode, you can access the complete history of the game, including the observation (state), action and reward for each turn.
+
+Sample command to run the interpreter can be found in npm scripts as `npm run interpreter`.

--- a/kaggle_environments/envs/kore_fleets/starter_bots/ts/interpreter.ts
+++ b/kaggle_environments/envs/kore_fleets/starter_bots/ts/interpreter.ts
@@ -1,7 +1,10 @@
 const { spawn } = require('child_process');
 const fs = require('fs');
 
-const example = 'node --require ts-node/register interpreter.ts 2 ./main.py simple simple attacker out.log replay.json';
+const example = 'node --require ts-node/register interpreter.ts 2 ./main.py simple simple attacker [out.log] [replay.json]';
+
+const DEFAULT_LOG_FILE_NAME = 'out.log';
+const DEFAULT_RESULT_FILE_NAME = 'replay.json';
 
 const MAX_CONCURRENT = 5;
 
@@ -10,7 +13,7 @@ const MAIN_AGENT_INDEX = 0;
 const myArgs = process.argv.slice(2);
 
 // TODO: better handling of arguments, named args.
-if (myArgs.length !== 7) {
+if (myArgs.length < 5) {
   console.log('Please follow the format in the example below:');
   console.log(example);
   process.exit(1);
@@ -31,19 +34,9 @@ if (agentNames.length !== 4) {
   process.exit(1);
 }
 
-const userLogfilename = myArgs[5];
-if (!userLogfilename) {
-  console.log('Please provide a filename for the log. Example:');
-  console.log(example);
-  process.exit(1);
-}
+const userLogfilename = myArgs[5] || DEFAULT_LOG_FILE_NAME;
 
-const userResultfilename = myArgs[6];
-if (!userResultfilename) {
-  console.log('Please provide a filename for the result. Example:');
-  console.log(example);
-  process.exit(1);
-}
+const userResultfilename = myArgs[6] || DEFAULT_RESULT_FILE_NAME;
 
 console.log(`Running ${episodes} episodes with agents: ${agentNames.join(' ')}`);
 

--- a/kaggle_environments/envs/kore_fleets/starter_bots/ts/interpreter.ts
+++ b/kaggle_environments/envs/kore_fleets/starter_bots/ts/interpreter.ts
@@ -1,0 +1,179 @@
+const { spawn } = require('child_process');
+const fs = require('fs');
+const resolve = require('path').resolve;
+
+const example = 'node --require ts-node/register interpreter.ts 2 ./main.py simple simple attacker out.log replay.json';
+
+const MAX_CONCURRENT = 5;
+
+// agent under test
+const MAIN_AGENT_INDEX = 0;
+const myArgs = process.argv.slice(2);
+
+// TODO: better handling of arguments, named args.
+if (myArgs.length !== 7) {
+  console.log('Please follow the format in the example below:');
+  console.log(example);
+  process.exit(1);
+}
+
+const episodes = parseInt(myArgs[0], 10);
+if (!episodes) {
+  console.log('Please provide number of episodes to run. Example:');
+  console.log(example);
+  process.exit(1);
+}
+
+const agentNames = myArgs.slice(1, 5);
+// TODO: support other number of agents
+if (agentNames.length !== 4) {
+  console.log('Please provide exactly 4 agents. Example:');
+  console.log(example);
+  process.exit(1);
+}
+
+const userLogfilename = myArgs[5];
+if (!userLogfilename) {
+  console.log('Please provide a filename for the log. Example:');
+  console.log(example);
+  process.exit(1);
+}
+
+const userResultfilename = myArgs[6];
+if (!userResultfilename) {
+  console.log('Please provide a filename for the result. Example:');
+  console.log(example);
+  process.exit(1);
+}
+
+console.log(`Running ${episodes} episodes with agents: ${agentNames.join(' ')}`);
+
+runAgent(episodes, agentNames, () => {
+  // post processing
+  console.log('done');
+});
+
+async function runAgent(iterations: number, agents: string[], callback: Function = () => {}) {
+  let running = 0;
+  let completed = 0;
+  const results = new Array(iterations);
+
+  const agent = agents[MAIN_AGENT_INDEX];
+  const cleanAgentName = agent.replace(/\.py$/g, '').replace(/\W/g, '');
+
+  for (let index = 0; index < iterations; index++) {
+    const resultFilename = `${userResultfilename}_${index}`;
+    const logFilename = `${userLogfilename}_${index}`;
+    const pyArguments = [
+      'run',
+      // TODO: support evaluate mode
+      // 'evaluate',
+      // '--episodes',
+      // '1',
+      '--environment',
+      'kore_fleets',
+      '--agents',
+      ...agents,
+      '--log',
+      logFilename,
+      '--out',
+      resultFilename,
+    ];
+
+    while (running >= MAX_CONCURRENT) {
+      await sleep(1000);
+    }
+
+    const kaggle = spawn('kaggle-environments', pyArguments, { cwd: __dirname });
+    running++;
+
+    kaggle.stdout.on('data', (data) => {
+      console.log(`stdout: ${data}`);
+    });
+
+    kaggle.stderr.on('data', (data) => {
+      console.error(`stderr: ${data}`);
+    });
+
+    kaggle.on('close', (code) => {
+      completed++;
+      console.log(`${completed}/${iterations}`);
+      running--;
+      const result = processResult(resultFilename);
+      // ensure consistent result order
+      results[index] = result;
+      if (completed === iterations) {
+        compileRunResults(cleanAgentName, results);
+        callback();
+      }
+    });
+  }
+}
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function compileRunResults(agent: string, results: any[]) {
+  try {
+    let games = 0;
+    let wins = 0;
+    let seconds = 0;
+    for (let i = 0; i < results.length; i++) {
+      games++;
+      const steps = results[i].steps;
+      const lastStep = steps[steps.length - 1];
+      if (lastStep.length !== 4) {
+        throw new Error(`${agent} ${i} has invalid result`);
+      }
+      const rewards = lastStep.map((r) => r.reward);
+      console.log(`game ${pad(i)} rewards: ${rewards.map((r) => r.toFixed(0)).join(', ')}`);
+      const [p0, p1, p2, p3] = rewards;
+      if (p0 > p1 && p0 > p2 && p0 > p3) {
+        wins++;
+      } else if ((p0 > p1 && p0 > p2) || (p0 > p1 && p0 > p3) || (p0 > p2 && p0 > p3)) {
+        seconds++;
+      }
+    }
+    console.log(`agent ${agent} wins: ${pad(wins)}/${pad(games)}, top-twos: ${pad(wins + seconds)}/${pad(games)}`);
+  } catch (e) {
+    console.error(e);
+  }
+}
+
+// will be used in the future for evaluate mode
+function compileEvaluateResults(agent: string, results: number[][]) {
+  try {
+    let games = 0;
+    let wins = 0;
+    let seconds = 0;
+    for (let i = 0; i < results.length; i++) {
+      games++;
+      const [p0, p1, p2, p3] = results[i];
+      if (p0 > p1 && p0 > p2 && p0 > p3) {
+        wins++;
+      } else if ((p0 > p1 && p0 > p2) || (p0 > p1 && p0 > p3) || (p0 > p2 && p0 > p3)) {
+        seconds++;
+      }
+    }
+    console.log(`${agent} win: ${pad(wins)}/${pad(games)} top two: ${pad(wins + seconds)}/${pad(games)}`);
+  } catch (e) {
+    console.error(e);
+  }
+}
+
+function processResult(filename: string) {
+  try {
+    const results = JSON.parse(fs.readFileSync(filename, 'utf8'));
+    return results;
+  } catch (e) {
+    console.error(e);
+  }
+}
+
+function pad(number) {
+  if (number < 10) {
+    return '0' + number;
+  }
+  return number;
+}

--- a/kaggle_environments/envs/kore_fleets/starter_bots/ts/interpreter.ts
+++ b/kaggle_environments/envs/kore_fleets/starter_bots/ts/interpreter.ts
@@ -1,6 +1,5 @@
 const { spawn } = require('child_process');
 const fs = require('fs');
-const resolve = require('path').resolve;
 
 const example = 'node --require ts-node/register interpreter.ts 2 ./main.py simple simple attacker out.log replay.json';
 

--- a/kaggle_environments/envs/kore_fleets/starter_bots/ts/package.json
+++ b/kaggle_environments/envs/kore_fleets/starter_bots/ts/package.json
@@ -11,6 +11,7 @@
     "test": "mocha --require ts-node/register test/**/*.ts",
     "compile": "tsc",
     "package": "tsc && tar -czvf submission.tar.gz main.py dist/*",
+    "interpreter": "node --require ts-node/register interpreter.ts 2 ./main.py simple simple attacker out.log replay.json",
     "watch4": "kaggle-environments run --environment kore_fleets --agents ./main.py ./main.py ./main.py ./main.py --log out.log --render '{\"mode\": \"html\"}' --out replay.html && google-chrome replay.html",
     "watch2": "kaggle-environments run --environment kore_fleets --agents ./main.py ./main.py --log out.log --render '{\"mode\": \"html\"}' --out replay.html && google-chrome replay.html",
     "watch1": "kaggle-environments run --environment kore_fleets --agents ./main.py --log out.log --render '{\"mode\": \"html\"}' --out replay.html && google-chrome replay.html",

--- a/kaggle_environments/envs/kore_fleets/starter_bots/ts/package.json
+++ b/kaggle_environments/envs/kore_fleets/starter_bots/ts/package.json
@@ -11,7 +11,7 @@
     "test": "mocha --require ts-node/register test/**/*.ts",
     "compile": "tsc",
     "package": "tsc && tar -czvf submission.tar.gz main.py dist/*",
-    "interpreter": "node --require ts-node/register interpreter.ts 2 ./main.py simple simple attacker",
+    "interpreter": "node --require ts-node/register interpreter.ts 2 ./main.py simple",
     "watch4": "kaggle-environments run --environment kore_fleets --agents ./main.py ./main.py ./main.py ./main.py --log out.log --render '{\"mode\": \"html\"}' --out replay.html && google-chrome replay.html",
     "watch2": "kaggle-environments run --environment kore_fleets --agents ./main.py ./main.py --log out.log --render '{\"mode\": \"html\"}' --out replay.html && google-chrome replay.html",
     "watch1": "kaggle-environments run --environment kore_fleets --agents ./main.py --log out.log --render '{\"mode\": \"html\"}' --out replay.html && google-chrome replay.html",

--- a/kaggle_environments/envs/kore_fleets/starter_bots/ts/package.json
+++ b/kaggle_environments/envs/kore_fleets/starter_bots/ts/package.json
@@ -11,7 +11,7 @@
     "test": "mocha --require ts-node/register test/**/*.ts",
     "compile": "tsc",
     "package": "tsc && tar -czvf submission.tar.gz main.py dist/*",
-    "interpreter": "node --require ts-node/register interpreter.ts 2 ./main.py simple simple attacker out.log replay.json",
+    "interpreter": "node --require ts-node/register interpreter.ts 2 ./main.py simple simple attacker",
     "watch4": "kaggle-environments run --environment kore_fleets --agents ./main.py ./main.py ./main.py ./main.py --log out.log --render '{\"mode\": \"html\"}' --out replay.html && google-chrome replay.html",
     "watch2": "kaggle-environments run --environment kore_fleets --agents ./main.py ./main.py --log out.log --render '{\"mode\": \"html\"}' --out replay.html && google-chrome replay.html",
     "watch1": "kaggle-environments run --environment kore_fleets --agents ./main.py --log out.log --render '{\"mode\": \"html\"}' --out replay.html && google-chrome replay.html",


### PR DESCRIPTION
This is a very basic interpreter for Kore 2022 in TypeScript, leveraging on the existing `kaggle-environments` cli.

I supposed this is not very useful as a standalone cli, but it can be a good starting point / reference to writing training code.

Current features:
- `run` mode (for basic training)
- support exactly 2 agents
- ability to specify number of episodes
- built-in concurrency (default 5)
- friendly statistics at end of the run
- access to `Board` object after each turn

Features not implemented yet:
- support for other number of agents
- `evaluate` mode
- `step` mode (for better training controls)
- proper cli args handling (might need to introduce 3rd party libraries)

Sample output:
```
$ npm run interpreter

> interpreter
> node --require ts-node/register interpreter.ts 2 ./main.py simple

Running 2 episodes with agents: ./main.py simple
1/2
[epi 1][step 000] current player kore:500 action 0: undefined reward: 500 status: ACTIVE
[epi 1][step 100] current player kore:34 action 0: SPAWN_1 reward: 34 status: ACTIVE
[epi 1][step 200] current player kore:125 action 0: LAUNCH_2_W reward: 126 status: ACTIVE
[epi 1][step 300] current player kore:253 action 0: undefined reward: 254 status: ACTIVE
[epi 1][step 317] current player kore:253 action 0: undefined reward: -84 status: DONE
2/2
[epi 0][step 000] current player kore:500 action 0: undefined reward: 500 status: ACTIVE
[epi 0][step 100] current player kore:55 action 0: SPAWN_1 reward: 55 status: ACTIVE
[epi 0][step 200] current player kore:236 action 0: LAUNCH_2_W reward: 236 status: ACTIVE
[epi 0][step 300] current player kore:617 action 0: SPAWN_1 reward: 617 status: ACTIVE
[epi 0][step 347] current player kore:369 action 0: SPAWN_2 reward: -54 status: DONE
game 00 rewards: -54, 37409
game 01 rewards: -84, 6743
agent main wins: 00/02
done

```

@bovard let me know what you think. I am happy to continue working on it if there are further changes needed.