### PR TITLE
feat(kore): miner starter bot in TS

### DIFF
--- a/kaggle_environments/envs/kore_fleets/starter_bots/ts/MinerBot.ts
+++ b/kaggle_environments/envs/kore_fleets/starter_bots/ts/MinerBot.ts
@@ -1,0 +1,61 @@
+import {Board} from "./kore/Board";
+import { Direction } from "./kore/Direction";
+import { ShipyardAction } from "./kore/ShipyardAction";
+import { KoreIO } from "./kore/KoreIO";
+
+const io = new KoreIO();
+// agent.run takes care of running your code per tick
+io.run((board: Board): Board => {
+    const me = board.currentPlayer;
+    const spawnCost = board.configuration.spawnCost;
+    const convertCost = board.configuration.convertCost;
+    let remainingKore = me.kore;
+
+    // the following code is mostly auto-generated using GitHub co-pilot
+    // using miner Python code and instruction "convert python into javascript" as comment prompts
+    for (let shipyard of me.shipyards) {
+        if(remainingKore > 1000 && shipyard.maxSpawn > 5) {
+            if(shipyard.shipCount >= convertCost + 10) {
+                const gap1 = getRandomInt(3, 9);
+                const gap2 = getRandomInt(3, 9);
+                const startDir = Math.floor(Math.random() * 4);
+                let flightPlan = Direction.listDirections()[startDir].toChar() + gap1;
+                const nextDir = (startDir + 1) % 4;
+                flightPlan += Direction.listDirections()[nextDir].toChar() + gap2;
+                const nextDir2 = (nextDir + 1) % 4;
+                flightPlan += Direction.listDirections()[nextDir2].toChar();
+                shipyard.setNextAction(ShipyardAction.launchFleetWithFlightPlan(Math.min(convertCost + 10, Math.floor(shipyard.shipCount / 2)), flightPlan));
+            } else if(remainingKore >= spawnCost) {
+                remainingKore -= spawnCost;
+                shipyard.setNextAction(ShipyardAction.spawnShips(Math.min(shipyard.maxSpawn, Math.floor(remainingKore / spawnCost))));
+            }
+        } else if(shipyard.shipCount >= 21) {
+            const gap1 = getRandomInt(3, 9);
+            const gap2 = getRandomInt(3, 9);
+            const startDir = Math.floor(Math.random() * 4);
+            let flightPlan = Direction.listDirections()[startDir].toChar() + gap1;
+            const nextDir = (startDir + 1) % 4;
+            flightPlan += Direction.listDirections()[nextDir].toChar() + gap2;
+            const nextDir2 = (nextDir + 1) % 4;
+            flightPlan += Direction.listDirections()[nextDir2].toChar() + gap1;
+            const nextDir3 = (nextDir2 + 1) % 4;
+            flightPlan += Direction.listDirections()[nextDir3].toChar();
+            shipyard.setNextAction(ShipyardAction.launchFleetWithFlightPlan(21, flightPlan));
+        } else if(remainingKore > board.configuration.spawnCost * shipyard.maxSpawn) {
+            remainingKore -= board.configuration.spawnCost;
+            if(remainingKore >= spawnCost) {
+                shipyard.setNextAction(ShipyardAction.spawnShips(Math.min(shipyard.maxSpawn, Math.floor(remainingKore / spawnCost))));
+            }
+        } else if(shipyard.shipCount >= 2) {
+            const dirStr = Direction.randomDirection().toChar();
+            shipyard.setNextAction(ShipyardAction.launchFleetWithFlightPlan(2, dirStr));
+        }
+    }
+
+    // nextActions will be pulled off of your shipyards
+    return board;
+});
+
+function getRandomInt(min, max) {
+    return Math.floor(Math.random() * (max - min + 1)) + min;
+}

--- a/kaggle_environments/envs/kore_fleets/starter_bots/ts/README.md
+++ b/kaggle_environments/envs/kore_fleets/starter_bots/ts/README.md
@@ -34,3 +34,12 @@ A basic TS interpreter has been created in `interpreter.ts`. You can use or modi
 Currently it supports 2 agents and customizable number of episodes. After each episode, you can access the complete history of the game. For each turn, you can access the full observation (state) as a Board object, actions performed and the reward obtained after performing the action.
 
 Sample command to run the interpreter can be found in npm scripts as `npm run interpreter`.
+
+## Miner bot
+
+A sample miner bot `MinerBot.ts` is provided, with Python entrypoint as `miner.py`. It has the same logic as the Python `miner` bot in `kore_fleets.py`.
+
+To run it aginst Python miner bot with TS interpreter for 20 episodes:
+
+1. `npm run compile`
+2. `node --require ts-node/register interpreter.ts 20 ./miner.py miner`

--- a/kaggle_environments/envs/kore_fleets/starter_bots/ts/kore/Direction.ts
+++ b/kaggle_environments/envs/kore_fleets/starter_bots/ts/kore/Direction.ts
@@ -153,6 +153,10 @@ export class Direction extends Point {
         throw new Error("invalid direction");
     }
 
+    public static randomDirection(): Direction {
+        return Direction.fromIndex(Math.floor(Math.random() * 4));
+    }
+
     public static listDirections(): Direction[] {
         return [
             Direction.NORTH,

--- a/kaggle_environments/envs/kore_fleets/starter_bots/ts/miner.py
+++ b/kaggle_environments/envs/kore_fleets/starter_bots/ts/miner.py
@@ -1,0 +1,66 @@
+from subprocess import Popen, PIPE
+from threading  import Thread
+from queue import Queue, Empty
+
+import atexit
+import os
+import sys
+agent_processes = [None, None, None, None]
+t = None
+q = None
+def cleanup_process():
+    global agent_processes
+    for proc in agent_processes:
+        if proc is not None:
+            proc.kill()
+def enqueue_output(out, queue):
+    for line in iter(out.readline, b''):
+        queue.put(line)
+    out.close()
+
+def agent(observation, configuration):
+    global agent_processes, t, q
+
+    agent_process = agent_processes[observation.player]
+    ### Do not edit ###
+    if agent_process is None:
+        if "__raw_path__" in configuration:
+            cwd = os.path.dirname(configuration["__raw_path__"])
+        else:
+            cwd = os.path.dirname(__file__)
+        agent_process = Popen(["node", "dist/MinerBot.js"], stdin=PIPE, stdout=PIPE, stderr=PIPE, cwd=cwd)
+        agent_processes[observation.player] = agent_process
+        atexit.register(cleanup_process)
+
+        # following 4 lines from https://stackoverflow.com/questions/375427/a-non-blocking-read-on-a-subprocess-pipe-in-python
+        q = Queue()
+        t = Thread(target=enqueue_output, args=(agent_process.stderr, q))
+        t.daemon = True # thread dies with the program
+        t.start()
+    
+    # print observations to agent
+    import json
+    agent_process.stdin.write((json.dumps(observation) + "\n").encode())
+    agent_process.stdin.write((json.dumps(configuration) + "\n").encode())
+    agent_process.stdin.flush()
+
+    # wait for data written to stdout
+    agent1res = (agent_process.stdout.readline()).decode()
+
+    while True:
+        try:  line = q.get_nowait()
+        except Empty:
+            # no standard error received, break
+            break
+        else:
+            # standard error output received, print it out
+            print(line.decode(), file=sys.stderr, end='')
+
+    agent1res = agent1res.strip()
+    outputs = agent1res.split(",")
+    actions = {}
+    for cmd in outputs:
+        if cmd != "":
+            shipyard_id, action_str = cmd.split(":")
+            actions[shipyard_id] = action_str
+    return actions


### PR DESCRIPTION
@bovard as we have discussed before, ultimately I want to implement a full-fledged TS interpreter that allows step-by-step execution of the game (`step` interpreter) to allow for more advanced training using `tf.js`. This is the first step towards that.

By implementing a miner bot in TS, I can using it for training a new model in the new `step` interpreter (to be developed), and compare the performance against the model trained using the old `run` interpreter and `miner` bot in Python.

This is an attempt to mimic the python miner bot into TS by leveraging capabilities of GitHub co-pilot.

The result is promising, with about 50/50 win rate against the python miner bot:

```
$ node --require ts-node/register interpreter.ts 20 ./miner.py miner
Running 20 episodes with agents: ./miner.py miner
game 00 rewards: -50, 4975
game 01 rewards: -122, 17
game 02 rewards: 5218, 3196
game 03 rewards: 3315, 38
game 04 rewards: 16, 17459
game 05 rewards: 2241, -92
game 06 rewards: 1633, -86
game 07 rewards: 15, 2409
game 08 rewards: 917, -22
game 09 rewards: 15, 2583
game 10 rewards: 187, 87
game 11 rewards: 1022, 249
game 12 rewards: 67, -57
game 13 rewards: -108, 3460
game 14 rewards: -94, 7807
game 15 rewards: 2898, 3
game 16 rewards: -19, 9734
game 17 rewards: -45, 8578
game 18 rewards: 3859, -15
game 19 rewards: 3953, 1235
agent miner wins: 11/20
```