### PR TITLE
Restore run timeout

### DIFF
--- a/kaggle_environments/envs/lux_ai_2022/lux_ai_2022.json
+++ b/kaggle_environments/envs/lux_ai_2022/lux_ai_2022.json
@@ -22,6 +22,7 @@
       "type": "integer"
     },
     "actTimeout": 3,
+    "runTimeout": 9600,
     "env_cfg": {
       "type": "object"
     }


### PR DESCRIPTION
Setting `runTimeout` to be the same as halite.