### PR TITLE
Added error if run-timeout is exceeded

### DIFF
--- a/kaggle_environments/core.py
+++ b/kaggle_environments/core.py
@@ -266,6 +266,10 @@ class Environment:
         while not self.done and perf_counter() - start < self.configuration.runTimeout:
             actions, logs = runner.act()
             self.step(actions, logs)
+        if !self.done and perf_counter() - start >= self.configuration.runTimeout:
+            raise DeadlineExceeded(
+                f"runtime of {perf_counter() - start} exceeded the runTimeout of {self.configuration.runTimeout}")
+
         return self.steps
 
     def reset(self, num_agents=None):


### PR DESCRIPTION
If the game isn't complete and we hit the specified runTimeout, throw an error.