### PR TITLE
Add missing dependencies for lux and llm envs

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -55,6 +55,8 @@ setup(
         "pettingzoo == 1.24.0",
         "gymnasium == 0.29.0",
         "stable-baselines3 == 2.1.0",
+        "transformers >= 4.33.1",
+        "scipy >= 1.11.2",
     ],
     packages=find_packages(),
     include_package_data=True,


### PR DESCRIPTION
Causing an error on the server:

```
Loading environment lux_ai_s2 failed: No module named 'scipy'
Loading environment llm_20_questions failed: No module named 'transformers'
```