### PR TITLE
Make sure the answerer agents get they keyword and category

### DIFF
--- a/kaggle_environments/envs/llm_20_questions/llm_20_questions.py
+++ b/kaggle_environments/envs/llm_20_questions/llm_20_questions.py
@@ -87,6 +87,8 @@ def answerer_agent(obs):
 agents = {GUESSER: guesser_agent, ANSWERER: answerer_agent}
 
 def guesser_action(active, inactive, step):
+    inactive.observation.keyword = keyword
+    inactive.observation.category = category
     guessed = False
     if not active.action:
         active.status = ERROR


### PR DESCRIPTION
On round 1 they keyword isn't given to the answerer agent before it's their turn to answer. See https://www.kaggle.com/competitions/llm-20-questions/discussion/506456

https://b.corp.google.com/issues/342612136