### PR TITLE
Modified turn code to make sure on error condition reward is distributed equally

### DIFF
--- a/kaggle_environments/envs/llm_20_questions/llm_20_questions.json
+++ b/kaggle_environments/envs/llm_20_questions/llm_20_questions.json
@@ -6,7 +6,7 @@
     "agents": [4],
     "configuration": {
       "episodeSteps": 61,
-      "actTimeout": 1,
+      "actTimeout": 60,
       "runTimeout": 9600,
       "agentTimeout": {
         "description": "Obsolete field kept for backwards compatibility, please use observation.remainingOverageTime.",
@@ -58,7 +58,7 @@
         "shared": "false",
         "default": ""
       },
-      "remainingOverageTime": 3
+      "remainingOverageTime": 300
     },
     "action": {
       "description": "LLM agent response.",

--- a/kaggle_environments/envs/llm_20_questions/llm_20_questions.json
+++ b/kaggle_environments/envs/llm_20_questions/llm_20_questions.json
@@ -6,7 +6,7 @@
     "agents": [4],
     "configuration": {
       "episodeSteps": 61,
-      "actTimeout": 60,
+      "actTimeout": 1,
       "runTimeout": 9600,
       "agentTimeout": {
         "description": "Obsolete field kept for backwards compatibility, please use observation.remainingOverageTime.",
@@ -58,7 +58,7 @@
         "shared": "false",
         "default": ""
       },
-      "remainingOverageTime": 300
+      "remainingOverageTime": 3
     },
     "action": {
       "description": "LLM agent response.",

--- a/kaggle_environments/envs/llm_20_questions/test_llm_20_questions.py
+++ b/kaggle_environments/envs/llm_20_questions/test_llm_20_questions.py
@@ -9,9 +9,45 @@ def custom_questioner(obs):
 def custom_answerer():
     return "no"
 
-def test_lux_completes():
+def bad_answerer():
+    return "maybe?"
+
+def error_agent():
+    raise ValueError
+
+def test_llm_20_q_completes():
     env = make("llm_20_questions", debug=True)
     env.run([custom_questioner, custom_answerer, custom_questioner, custom_answerer])
     json = env.toJSON()
     assert json["name"] == "llm_20_questions"
     assert json["statuses"] == ["DONE", "DONE", "DONE", "DONE"]
+
+def test_llm_20_q_errors_on_bad_answer():
+    env = make("llm_20_questions", debug=True)
+    env.run([custom_questioner, custom_answerer, custom_questioner, bad_answerer])
+    json = env.toJSON()
+    assert json["name"] == "llm_20_questions"
+    assert json["rewards"] == [1, 1, 1, None]
+    assert json["statuses"] == ["DONE", "DONE", "DONE", "ERROR"]
+    print(len(json["steps"]))
+    assert len(json["steps"]) == 3
+
+def test_llm_20_q_errors_on_error_answer():
+    env = make("llm_20_questions", debug=True)
+    env.run([custom_questioner, custom_answerer, custom_questioner, error_agent])
+    json = env.toJSON()
+    assert json["name"] == "llm_20_questions"
+    assert json["rewards"] == [1, 1, 1, None]
+    assert json["statuses"] == ["DONE", "DONE", "DONE", "ERROR"]
+    print(len(json["steps"]))
+    assert len(json["steps"]) == 3
+
+def test_llm_20_q_errors_on_error_question():
+    env = make("llm_20_questions", debug=True)
+    env.run([custom_questioner, custom_answerer, error_agent, custom_answerer])
+    json = env.toJSON()
+    assert json["name"] == "llm_20_questions"
+    assert json["rewards"] == [1, 1, None, 1]
+    assert json["statuses"] == ["DONE", "DONE", "ERROR", "DONE"]
+    print(len(json["steps"]))
+    assert len(json["steps"]) == 2


### PR DESCRIPTION
When an agent times out or has a bad response, make sure that agent loses and all others have the same reward.

https://b.corp.google.com/issues/343793215