### PR TITLE
Remove vec noise as a direct dependency

### DIFF
--- a/docker/cpu.Dockerfile
+++ b/docker/cpu.Dockerfile
@@ -29,6 +29,6 @@ ADD ./setup.py ./setup.py
 ADD ./README.md ./README.md
 ADD ./MANIFEST.in ./MANIFEST.in
 ADD ./kaggle_environments ./kaggle_environments
-RUN pip install Flask bitsandbytes accelerate && pip install . && pytest
+RUN pip install Flask bitsandbytes accelerate vec-noise && pip install . && pytest
 
 CMD kaggle-environments

--- a/docker/gpu.Dockerfile
+++ b/docker/gpu.Dockerfile
@@ -29,6 +29,6 @@ ADD ./setup.py ./setup.py
 ADD ./README.md ./README.md
 ADD ./MANIFEST.in ./MANIFEST.in
 ADD ./kaggle_environments ./kaggle_environments
-RUN pip install Flask bitsandbytes accelerate && pip install . && pytest
+RUN pip install Flask bitsandbytes accelerate vec-noise && pip install . && pytest
 
 CMD kaggle-environments

--- a/kaggle_environments/envs/lux_ai_s2/lux_ai_s2.py
+++ b/kaggle_environments/envs/lux_ai_s2/lux_ai_s2.py
@@ -14,8 +14,6 @@ __dir__ = osp.dirname(__file__)
 syspath.append(__dir__)
 
 
-import vec_noise
-
 from luxai_s2.env import LuxAI_S2
 import numpy as np
 

--- a/kaggle_environments/envs/lux_ai_s2/luxai_s2/map_generator/symnoise.py
+++ b/kaggle_environments/envs/lux_ai_s2/luxai_s2/map_generator/symnoise.py
@@ -1,7 +1,6 @@
 from collections.abc import Iterable
 
 import numpy as np
-from vec_noise import snoise2
 
 
 def symmetrize(x, symmetry="vertical"):
@@ -91,6 +90,8 @@ class SymmetricNoise(object):
         x = x + self.noise_shift
 
         x, y = np.meshgrid(x, y)
+        # importing here because vec_noise causes import issues in cloud functions
+        from vec_noise import snoise2
         total = snoise2(x, y, octaves=self.octaves)
         symmetrize(total, self.symmetry)
         # Normalize between [0, 1]

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,6 @@ setup(
         "Flask >= 1.1.2",
         "numpy >= 1.19.5",
         "requests >= 2.25.1",
-        "vec-noise >= 1.1.4",
         "pettingzoo == 1.24.0",
         "gymnasium == 0.29.0",
         "stable-baselines3 == 2.1.0",


### PR DESCRIPTION
vec noise install is failing in cloud functions and is not required to run in that context.