### PR TITLE
Reduce max runtime to 5 minutes

### DIFF
--- a/kaggle_environments/envs/chess/chess.json
+++ b/kaggle_environments/envs/chess/chess.json
@@ -7,6 +7,7 @@
     "configuration": {
       "episodeSteps": 1000,
       "actTimeout": 0.1,
+      "runTimeout": 600,
       "agentTimeout": {
         "description": "Obsolete field kept for backwards compatibility, please use observation.remainingOverageTime.",
         "type": "number",

--- a/kaggle_environments/envs/chess/chess.json
+++ b/kaggle_environments/envs/chess/chess.json
@@ -7,7 +7,7 @@
     "configuration": {
       "episodeSteps": 1000,
       "actTimeout": 0.1,
-      "runTimeout": 600,
+      "runTimeout": 300,
       "agentTimeout": {
         "description": "Obsolete field kept for backwards compatibility, please use observation.remainingOverageTime.",
         "type": "number",


### PR DESCRIPTION
With 20s per side and .1/s increment (and max 1000 steps) this is a safer upper bound and will allow the episodes to fail faster for OOM issues.