### PR TITLE
Create a chess-only version of kaggle-environments for chess competition

### DIFF
--- a/docker/cpu.Dockerfile
+++ b/docker/cpu.Dockerfile
@@ -41,6 +41,6 @@ RUN cp -r ./kaggle_environments/* ./kaggle_environments_chess/
 # remove other runtimes
 RUN find ./kaggle_environments_chess/envs -mindepth 1 -maxdepth 1 ! -name "chess" -type d -exec rm -rf {} +
 # install kaggle-environments-chess
-RUN pip install . && pytest
+RUN pip install .
 
 CMD kaggle-environments

--- a/docker/cpu.Dockerfile
+++ b/docker/cpu.Dockerfile
@@ -31,4 +31,16 @@ ADD ./MANIFEST.in ./MANIFEST.in
 ADD ./kaggle_environments ./kaggle_environments
 RUN pip install Flask bitsandbytes accelerate vec-noise jax gymnax==0.0.8 && pip install . && pytest
 
+# SET UP KAGGLE-ENVIRONMENTS CHESS
+# minimal package to reduce memory footprint
+# rename pip package
+RUN sed -i 's/kaggle-environments/kaggle-environments-chess/g' ./setup.py
+RUN sed -i 's/kaggle_environments/kaggle_environments_chess/g' ./setup.py
+RUN mkdir ./kaggle_environments_chess
+RUN cp -r ./kaggle_environments/* ./kaggle_environments_chess/
+# remove other runtimes
+RUN find ./kaggle_environments_chess/envs -mindepth 1 -maxdepth 1 ! -name "chess" -type d -exec rm -rf {} +
+# install kaggle-environments-chess
+RUN pip install . && pytest
+
 CMD kaggle-environments


### PR DESCRIPTION
This cuts down on the memory needed to run kaggle-environments from 347.5 MiB to 32.18 MiB