### PR TITLE
Enforce match timeouts when calling agents

### DIFF
--- a/kaggle_environments/agent.py
+++ b/kaggle_environments/agent.py
@@ -20,6 +20,7 @@ import sys
 import traceback
 from contextlib import redirect_stderr, redirect_stdout
 from io import StringIO
+from requests.exceptions import Timeout
 from time import perf_counter
 from urllib.parse import urlparse
 from .errors import DeadlineExceeded, InvalidArgument
@@ -78,16 +79,25 @@ class UrlAgent:
                 "observation": observation,
             },
         }
-        response = requests.post(url=self.raw, data=json.dumps(data))
-        response_json = response.json()
-        action = response_json["action"]
-        if action == "DeadlineExceeded":
-            action = DeadlineExceeded()
-        elif isinstance(action, str) and action.startswith("BaseException::"):
-            # Deserialize the exception message
-            parts = action.split("::", 1)
-            action = BaseException(parts[1])
-        return action
+        try:
+            timeout = float(observation.remainingOverageTime) + float(configuration.actTimeout) + 10
+            response = requests.post(url=self.raw, data=json.dumps(data), timeout=timeout)
+            response.raise_for_status()
+            response_json = response.json()
+            action = response_json["action"]
+            if action == "DeadlineExceeded":
+                action = DeadlineExceeded()
+            elif isinstance(action, str) and action.startswith("BaseException::"):
+                # Deserialize the exception message
+                parts = action.split("::", 1)
+                action = BaseException(parts[1])
+            return action
+        except Timeout:
+            print(f"Request timed out after {self.timeout} seconds")
+            return DeadlineExceeded()
+        except requests.exceptions.RequestException as e:
+            print(f"Request error: {e}")
+            return None
 
 
 def build_agent(raw, builtin_agents, environment_name):

--- a/kaggle_environments/agent.py
+++ b/kaggle_environments/agent.py
@@ -79,8 +79,8 @@ class UrlAgent:
                 "observation": observation,
             },
         }
+        timeout = float(observation.remainingOverageTime) + float(configuration.actTimeout) + 10
         try:
-            timeout = float(observation.remainingOverageTime) + float(configuration.actTimeout) + 10
             response = requests.post(url=self.raw, data=json.dumps(data), timeout=timeout)
             response.raise_for_status()
             response_json = response.json()
@@ -93,7 +93,7 @@ class UrlAgent:
                 action = BaseException(parts[1])
             return action
         except Timeout:
-            print(f"Request timed out after {self.timeout} seconds")
+            print(f"Request timed out after {timeout} seconds")
             return DeadlineExceeded()
         except requests.exceptions.RequestException as e:
             print(f"Request error: {e}")


### PR DESCRIPTION
Before we would wait forever for a agent to return, THEN check and enforce the timeouts. If the agent died we would hang forever waiting for it.

Verified that this works locally:

```
[{"action": "", "info": {}, "observation": {"board": "rnbqkbnr/pppppppp/8/8/7P/8/PPPPPPP1/RNBQKBNR b KQkq h3 0 1", "mark": "white", "opponentRemainingOverageTime": 10, "remainingOverageTime": 10, "step": 2}, "reward": 0, "status": "DONE"}, {"action": null, "info": {}, "observation": {"board": "rnbqkbnr/pppppppp/8/8/7P/8/PPPPPPP1/RNBQKBNR b KQkq h3 0 1", "mark": "black", "opponentRemainingOverageTime": 10, "remainingOverageTime": -10.048537999999997}, "reward": null, "status": "TIMEOUT"}]
```

remainingOverageTime is -10 seconds and status is `TIMEOUT` which is what should be expected