### PR TITLE
UTF-8 Encoding for opening scripts

### DIFF
--- a/kaggle_environments/envs/chess/chess.py
+++ b/kaggle_environments/envs/chess/chess.py
@@ -249,5 +249,5 @@ with open(jsonpath) as f:
 
 def html_renderer():
     jspath = path.abspath(path.join(path.dirname(__file__), "chess.js"))
-    with open(jspath) as g:
+    with open(jspath, encoding="utf-8") as g:
         return g.read()

--- a/kaggle_environments/envs/connectx/connectx.py
+++ b/kaggle_environments/envs/connectx/connectx.py
@@ -208,5 +208,5 @@ with open(jsonpath) as f:
 
 def html_renderer():
     jspath = path.abspath(path.join(dirpath, "connectx.js"))
-    with open(jspath) as f:
+    with open(jspath, encoding="utf-8") as f:
         return f.read()

--- a/kaggle_environments/envs/halite/halite.py
+++ b/kaggle_environments/envs/halite/halite.py
@@ -259,5 +259,5 @@ with open(json_path) as json_file:
 
 def html_renderer():
     js_path = path.abspath(path.join(dir_path, "halite.js"))
-    with open(js_path) as js_file:
+    with open(js_path, encoding="utf-8") as js_file:
         return js_file.read()

--- a/kaggle_environments/envs/hungry_geese/hungry_geese.py
+++ b/kaggle_environments/envs/hungry_geese/hungry_geese.py
@@ -326,5 +326,5 @@ with open(jsonpath) as f:
 
 def html_renderer():
     jspath = path.abspath(path.join(dirpath, "hungry_geese.js"))
-    with open(jspath) as f:
+    with open(jspath, encoding="utf-8") as f:
         return f.read()

--- a/kaggle_environments/envs/kore_fleets/kore_fleets.py
+++ b/kaggle_environments/envs/kore_fleets/kore_fleets.py
@@ -507,5 +507,5 @@ with open(json_path) as json_file:
 
 def html_renderer():
     js_path = path.abspath(path.join(dir_path, "kore_fleets.js"))
-    with open(js_path) as js_file:
+    with open(js_path, encoding="utf-8") as js_file:
         return js_file.read()

--- a/kaggle_environments/envs/llm_20_questions/llm_20_questions.py
+++ b/kaggle_environments/envs/llm_20_questions/llm_20_questions.py
@@ -293,7 +293,7 @@ with open(jsonpath) as f:
 
 def html_renderer():
     jspath = path.abspath(path.join(path.dirname(__file__), "llm_20_questions.js"))
-    with open(jspath) as f:
+    with open(jspath, encoding="utf-8") as f:
         return f.read()
 
 

--- a/kaggle_environments/envs/tictactoe/tictactoe.py
+++ b/kaggle_environments/envs/tictactoe/tictactoe.py
@@ -122,5 +122,5 @@ with open(jsonpath) as f:
 
 def html_renderer():
     jspath = path.abspath(path.join(path.dirname(__file__), "tictactoe.js"))
-    with open(jspath) as f:
+    with open(jspath, encoding="utf-8") as f:
         return f.read()


### PR DESCRIPTION
I encontered the error while trying to html_render one of the environments on this repository after a gameplay, and I encountered this error

```python
UnicodeDecodeError                        Traceback (most recent call last)
Cell In[27], [line 1](vscode-notebook-cell:?execution_count=27&line=1)
----> [1](vscode-notebook-cell:?execution_count=27&line=1) env.render(mode="ipython", width=700, height=700)

File c:\Users\user\AppData\Local\Programs\Python\Python311\Lib\site-packages\kaggle_environments\core.py:336, in Environment.render(self, **kwargs)
    [325](file:///C:/Users/user/AppData/Local/Programs/Python/Python311/Lib/site-packages/kaggle_environments/core.py:325) window_kaggle = {
    [326](file:///C:/Users/user/AppData/Local/Programs/Python/Python311/Lib/site-packages/kaggle_environments/core.py:326)     "debug": get(kwargs, bool, self.debug, path=["debug"]),
    [327](file:///C:/Users/user/AppData/Local/Programs/Python/Python311/Lib/site-packages/kaggle_environments/core.py:327)     "playing": is_playing,
   (...)
    [332](file:///C:/Users/user/AppData/Local/Programs/Python/Python311/Lib/site-packages/kaggle_environments/core.py:332)     **kwargs,
    [333](file:///C:/Users/user/AppData/Local/Programs/Python/Python311/Lib/site-packages/kaggle_environments/core.py:333) }
    [334](file:///C:/Users/user/AppData/Local/Programs/Python/Python311/Lib/site-packages/kaggle_environments/core.py:334) args = [self]
    [335](file:///C:/Users/user/AppData/Local/Programs/Python/Python311/Lib/site-packages/kaggle_environments/core.py:335) player_html = get_player(window_kaggle,
--> [336](file:///C:/Users/user/AppData/Local/Programs/Python/Python311/Lib/site-packages/kaggle_environments/core.py:336)                          self.html_renderer(*args[:self.html_renderer.__code__.co_argcount]))
    [337](file:///C:/Users/user/AppData/Local/Programs/Python/Python311/Lib/site-packages/kaggle_environments/core.py:337) if mode == "html":
    [338](file:///C:/Users/user/AppData/Local/Programs/Python/Python311/Lib/site-packages/kaggle_environments/core.py:338)     return player_html

File c:\Users\user\AppData\Local\Programs\Python\Python311\Lib\site-packages\kaggle_environments\envs\chess\chess.py:253, in html_renderer()
    [251](file:///C:/Users/user/AppData/Local/Programs/Python/Python311/Lib/site-packages/kaggle_environments/envs/chess/chess.py:251) jspath = path.abspath(path.join(path.dirname(__file__), "chess.js"))
    [252](file:///C:/Users/user/AppData/Local/Programs/Python/Python311/Lib/site-packages/kaggle_environments/envs/chess/chess.py:252) with open(jspath) as g:
--> [253](file:///C:/Users/user/AppData/Local/Programs/Python/Python311/Lib/site-packages/kaggle_environments/envs/chess/chess.py:253)     return g.read()

File c:\Users\user\AppData\Local\Programs\Python\Python311\Lib\encodings\cp1252.py:23, in IncrementalDecoder.decode(self, input, final)
     [22](file:///C:/Users/user/AppData/Local/Programs/Python/Python311/Lib/encodings/cp1252.py:22) def decode(self, input, final=False):
---> [23](file:///C:/Users/user/AppData/Local/Programs/Python/Python311/Lib/encodings/cp1252.py:23)     return codecs.charmap_decode(input,self.errors,decoding_table)[0]

UnicodeDecodeError: 'charmap' codec can't decode byte 0x9d in position 30474: character maps to <undefined>
```

The fix to this is to explicitly specify the encoding format to 'utf-8' when  loading the .js scripts to handle HTML rendering. So I made this PR to fix it.