### PR TITLE
fix reward in chess.json

### DIFF
--- a/kaggle_environments/envs/chess/chess.json
+++ b/kaggle_environments/envs/chess/chess.json
@@ -21,8 +21,8 @@
       }
     },
     "reward": {
-      "description": "-1 = Lost, 0 = Draw/Ongoing, 1 = Won",
-      "enum": [-1, 0, 1],
+      "description": "0 = Lost/Ongoing, 0.5 = Draw, 1 = Won",
+      "enum": [0, 0.5, 1],
       "default": 0
     },
     "observation": {


### PR DESCRIPTION
Because, at this moment, I can't initialize chess environment with steps if the game's result was a draw.

```python
>>> kaggle_environments.make("chess", steps=game["steps"])

raise InvalidArgument(
kaggle_environments.errors.InvalidArgument: Default state generation failed for #0: 0.5 is not one of [-1, 0, 1]

Failed validating 'enum' in schema['properties']['reward']:
    {'description': '-1 = Lost, 0 = Draw/Ongoing, 1 = Won',
     'type': ['number', 'null'],
     'default': 0,
     'enum': [-1, 0, 1]}

On instance['reward']:
    0.5
```