### PR TITLE
Fix 3-fold draws

### DIFF
--- a/kaggle_environments/envs/chess/chess.py
+++ b/kaggle_environments/envs/chess/chess.py
@@ -204,8 +204,9 @@ def interpreter(state, env):
         inactive.status = DONE
         return state
     fen = game.get_fen()
-    board_str = fen.split(" ", maxsplit=1)[0]
-    seen_positions[board_str] += 1
+    # board, player turn, en passant, and castling status form board status for 3-fold draws
+    board_position = ' '.join(fen.split()[:-2]) 
+    seen_positions[board_position] += 1
 
     # Update the board in the observation
     state[0].observation.board = fen

--- a/kaggle_environments/envs/chess/chess.py
+++ b/kaggle_environments/envs/chess/chess.py
@@ -166,6 +166,7 @@ def square_str_to_int(square_str):
 
 seen_positions = defaultdict(int)
 
+
 def interpreter(state, env):
     global seen_positions
     if env.done:
@@ -204,8 +205,9 @@ def interpreter(state, env):
         inactive.status = DONE
         return state
     fen = game.get_fen()
-    # board, player turn, en passant, and castling status form board status for 3-fold draws
-    board_position = ' '.join(fen.split()[:-2]) 
+    # board, player turn, en passant, and castling status form board status
+    # for 3-fold draws
+    board_position = ' '.join(fen.split()[:4])
     seen_positions[board_position] += 1
 
     # Update the board in the observation
@@ -220,11 +222,11 @@ def interpreter(state, env):
         fen.split(" ")[4])  # fen keeps track of this
     # Check for game end conditions
     if pawn_or_capture_move_count == 100 or is_insufficient_material(
-            game.board) or seen_positions[board_str] >= 3 or game.status == Game.STALEMATE:
+            game.board) or seen_positions[board_position] >= 3 or game.status == Game.STALEMATE:
         active.reward += .5
         inactive.reward += .5
         active.status = DONE
-        inactive.status = DONE 
+        inactive.status = DONE
     elif game.status == Game.CHECKMATE:
         active.reward += 1
         active.status = DONE


### PR DESCRIPTION
As pointed out in https://www.kaggle.com/competitions/fide-google-efficiency-chess-ai-challenge/discussion/548615 the 3-fold draw calculations should include player turn, castling rights and en passant status.

In the FEN these are the first 4 parts.
```
"rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1"
```