### PR TITLE
Fix pgn to not include game result

### DIFF
--- a/kaggle_environments/envs/chess/chess.js
+++ b/kaggle_environments/envs/chess/chess.js
@@ -64,8 +64,6 @@ async function renderer(context) {
         agent1,
         "Black",
         agent2,
-        "Result",
-        result.join("-")
       );
 
       const openingIdx = OPENINGS.indexOf(board);
@@ -89,7 +87,13 @@ async function renderer(context) {
         }
       }
 
-      const pgn = game.pgn();
+      let pgn = game.pgn();
+
+      // for some reason the pgn doesn't calculate the result correctly
+      // until we can fix this bug, remove it.
+      if (pgn.contains(" 0-0")) {
+        pgn = pgn.split(" 0-0")[0]
+      }
 
       downloadButton = document.createElement("button");
       downloadButton.id = "copy-pgn";

--- a/kaggle_environments/envs/chess/chess.js
+++ b/kaggle_environments/envs/chess/chess.js
@@ -92,7 +92,7 @@ async function renderer(context) {
       // for some reason the pgn doesn't calculate the result correctly
       // until we can fix this bug, remove it.
       // b/383366972
-      if (pgn.contains(" 0-0")) {
+      if (pgn.indexOf(" 0-0") !== -1) {
         pgn = pgn.split(" 0-0")[0]
       }
 

--- a/kaggle_environments/envs/chess/chess.js
+++ b/kaggle_environments/envs/chess/chess.js
@@ -91,6 +91,7 @@ async function renderer(context) {
 
       // for some reason the pgn doesn't calculate the result correctly
       // until we can fix this bug, remove it.
+      // b/383366972
       if (pgn.contains(" 0-0")) {
         pgn = pgn.split(" 0-0")[0]
       }


### PR DESCRIPTION
For example this game that ended in checkmate:
```
[Event "FIDE & Google Efficient Chess AI Challenge (https://www.kaggle.com/competitions/fide-google-efficiency-chess-ai-challenge)"]
[White "SSE"]
[Black "Ethereal"]
[Result "0-0"]

1. e4 c5 2. Nf3 d6 3. d4 cxd4 4. Nxd4 a6 5. c4 g6 6. Nc3 Bg7 7. Be2 Nf6 8. O-O O-O 9. Be3 Nbd7 10. Qc2 Re8 11. Rad1 b6 12. Qd2 Bb7 13. f3 Rc8 14. Nc2 Ne5 15. b3 Ned7 16. Rc1 Nh5 17. Bd4 Bxd4+ 18. Nxd4 e6 19. Rfd1 Qh4 20. Nc2 Nf4 21. Bf1 Ne5 22. Kh1 Nh5 23. Qxd6 Nc6 24. Qd2 Ng3+ 25. Kg1 Nxf1 26. Rxf1 Qe7 27. Qe3 Qc7 28. h3 Ne5 29. Nd4 Nd7 30. Rfd1 Red8 31. Rd2 Ne5 32. f4 Nd7 33. Rcd1 Nf8 34. Na4 Rd6 35. Rd3 Rdd8 36. Nc3 Qc5 37. Na4 Qc7 38. b4 a5 39. b5 Rb8 40. Rc1 e5 41. fxe5 Qxe5 42. Nc3 Re8 43. Nf3 Qe7 44. Re1 Rbc8 45. Qxb6 Rxc4 46. Nd5 Bxd5 47. exd5 Re4 48. Rdd1 Qd7 49. Rxe4 Rxe4 50. d6 Rb4 51. Ne5 Qxb5 52. Qxb5 Rxb5 53. d7 Nxd7 54. Nxd7 Rb2 55. a4 Rb4 56. Nc5 Rc4 57. Rd5 Kg7 58. Kf2 h5 59. Ke3 h4 60. Kd2 Rb4 61. Kc3 Rf4 62. Rd4 Rf2 63. Rd2 Rf4 64. Ra2 g5 65. Nb7 Rf5 66. Kc4 Re5 67. Nd6 f6 68. Kd4 Kh7 69. Nc4 Rf5 70. Ne3 Rf4+ 71. Kc5 Kg6 72. Nc4 Kf7 73. Nxa5 g4 74. hxg4 Rxg4 75. Nc6 Rg3 76. a5 Rb3 77. a6 h3 78. gxh3 Rc3+ 79. Kb6 Re3 80. a7 Re8 81. Nb8 Re6+ 82. Kc5 f5 83. a8=Q Kg7 84. Nc6 Rh6 85. Nd4 Kh7 86. Qb7+ Kg6 87. Rg2+ Kh5 88. Qf3+ Kh4 89. Nxf5# 0-0
```
Can't be copy/pasted as is. The 0-0 at the end is incorrect. (as is the Result "0-0"). Remove these for now so we have a valid pgn