### PR TITLE
Set size from height and width.

### DIFF
--- a/kaggle_environments/envs/open_spiel/games/chess/chess.js
+++ b/kaggle_environments/envs/open_spiel/games/chess/chess.js
@@ -1,5 +1,5 @@
 function renderer(options) {
-    const { environment, step, parent } = options;
+    const { environment, step, parent, width = 400, height = 400 } = options;
 
     // Chess-specific constants
     const DEFAULT_NUM_ROWS = 8;
@@ -90,7 +90,7 @@ function renderer(options) {
         }
         parentElementToClear.appendChild(currentRendererContainer);
 
-        const smallestParentEdge = Math.min(currentRendererContainer.offsetWidth, currentRendererContainer.offsetHeight);
+        const smallestParentEdge = Math.min(width, height);
         squareSize = Math.floor(smallestParentEdge / DEFAULT_NUM_COLS);
         currentBoardElement = document.createElement('div');
         Object.assign(currentBoardElement.style, {


### PR DESCRIPTION
This matches how size is set for [ConnectX](https://github.com/Kaggle/kaggle-environments/blob/master/kaggle_environments/envs/connectx/connectx.js#L20), which is passed (I believe?) from [player.html](https://github.com/Kaggle/kaggle-environments/blob/master/kaggle_environments/static/player.html#L148).

I've been having trouble testing the change, though, because it looks like the code that runs the UI is in kaggleazure, and apparently I need to be part of mdb/kaggle-eng-team to set up my development environment to run the site.

Note: ConnectX works on different sizes (including mobile), but it doesn't resize if they change the window size.  I'd try to fix that problem, too, but again, without being able to test it, I feel really unconfident throwing things at the wall.