### PR TITLE
Fix the team names and winner string in Chess visualizer

### DIFF
--- a/kaggle_environments/envs/open_spiel/games/chess/chess.js
+++ b/kaggle_environments/envs/open_spiel/games/chess/chess.js
@@ -174,7 +174,7 @@ function renderer(options) {
             return 'draw';
         }
         
-        const winnerPlayerIndex = player0Reward === 1.0 ? 0 : 1;
+        const winnerPlayerIndex = player0Reward === 1 ? 0 : 1;
         const color = winnerPlayerIndex === 0 ? 'Black' : 'White';
         
         if (teamNames) {


### PR DESCRIPTION
Previous visualizer string just said "Game ended." because it wasn't reading the correct data from the replay.