### PR TITLE
Reapply chess visualizer fixes

### DIFF
--- a/kaggle_environments/envs/open_spiel/games/chess/chess.js
+++ b/kaggle_environments/envs/open_spiel/games/chess/chess.js
@@ -158,6 +158,33 @@ function renderer(options) {
         return true;
     }
 
+    // White is in position 1, Black is in position 0
+    function _getTeamNameForColor(color, teamNames) {
+        if (!teamNames || teamNames.length < 2) return null;
+        return color.toLowerCase() === 'white' ? teamNames[1] : teamNames[0];
+    }
+
+    function _deriveWinnerFromRewards(currentStepAgents, teamNames) {
+        if (!currentStepAgents || currentStepAgents.length < 2) return null;
+        
+        const player0Reward = currentStepAgents[0].reward;
+        const player1Reward = currentStepAgents[1].reward;
+        
+        if (player0Reward === player1Reward) {
+            return 'draw';
+        }
+        
+        const winnerPlayerIndex = player0Reward === 1 ? 0 : 1;
+        const color = winnerPlayerIndex === 0 ? 'Black' : 'White';
+        
+        if (teamNames) {
+            const teamName = _getTeamNameForColor(color, teamNames);
+            return `${color} (${teamName})`;
+        }
+        
+        return color.toLowerCase();
+    }
+
     function _parseFen(fen) {
         if (!fen || typeof fen !== 'string') return null;
 
@@ -235,15 +262,17 @@ function renderer(options) {
                  if (String(winner).toLowerCase() === 'draw') {
                     currentWinnerTextElement.textContent = "It's a Draw!";
                  } else {
-                    const winnerColor = String(winner).toLowerCase() === 'white' ? 'White' : 'Black';
-                    currentWinnerTextElement.innerHTML = `Winner: <span style="font-weight: bold;">${winnerColor}</span>`;
+                    currentWinnerTextElement.innerHTML = `Winner: <span style="font-weight: bold;">${winner}</span>`;
                  }
             } else {
                  currentWinnerTextElement.textContent = "Game ended.";
             }
         } else {
           const playerColor = String(activeColor).toLowerCase() === 'w' ? 'White' : 'Black';
-          currentStatusTextElement.innerHTML = `Current Player: <span style="font-weight: bold;">${playerColor}</span>`;
+          const teamName = _getTeamNameForColor(playerColor, environment.info?.TeamNames);
+          const currentPlayerText = teamName ? `${playerColor} (${teamName})` : playerColor;
+          
+          currentStatusTextElement.innerHTML = `Current Player: <span style="font-weight: bold;">${currentPlayerText}</span>`;
         }
     }
 
@@ -285,11 +314,12 @@ function renderer(options) {
             const fen = observationForRenderer.observationString;
             const parsedFen = _parseFen(fen);
             if (parsedFen) {
-                // Assuming `isTerminal` and `winner` are provided in the top-level observation
+                const winner = observationForRenderer.isTerminal ? 
+                    _deriveWinnerFromRewards(currentStepAgents, environment.info?.TeamNames) : null;
                 gameSpecificState = { 
                     ...parsedFen,
                     isTerminal: observationForRenderer.isTerminal,
-                    winner: observationForRenderer.winner
+                    winner: winner
                 };
             }
         } catch (e) {

--- a/kaggle_environments/envs/open_spiel/games/chess/chess.js
+++ b/kaggle_environments/envs/open_spiel/games/chess/chess.js
@@ -1,5 +1,5 @@
 function renderer(options) {
-    const { environment, step, parent } = options;
+    const { environment, step, parent, width = 400, height = 400 } = options;
 
     // Chess-specific constants
     const DEFAULT_NUM_ROWS = 8;
@@ -90,7 +90,7 @@ function renderer(options) {
         }
         parentElementToClear.appendChild(currentRendererContainer);
 
-        const smallestParentEdge = Math.min(currentRendererContainer.offsetWidth, currentRendererContainer.offsetHeight);
+        const smallestParentEdge = Math.min(width, height);
         squareSize = Math.floor(smallestParentEdge / DEFAULT_NUM_COLS);
         currentBoardElement = document.createElement('div');
         Object.assign(currentBoardElement.style, {


### PR DESCRIPTION
Originally reverted to determine what was breaking the visualizer.  We don't believe it was these changes, so we're re-applying them.

The first fixes the height and width calculations to ensure the board is properly sized on mobile and larger desktops.  The second updates the strings at the bottom of the visualizer to be clearer.