### PR TITLE
Fix null coalescing

### DIFF
--- a/kaggle_environments/envs/open_spiel/games/chess/chess.js
+++ b/kaggle_environments/envs/open_spiel/games/chess/chess.js
@@ -295,8 +295,8 @@ function renderer(options) {
         const isMobile = window.innerWidth < 768;
 
         // Calculate and apply board size
-        const containerWidth = currentBoardContainer.clientWidth ?? width;
-        const containerHeight = currentBoardContainer.clientHeight ?? height;
+        const containerWidth = currentBoardContainer?.clientWidth ?? width;
+        const containerHeight = currentBoardContainer?.clientHeight ?? height;
         const smallestContainerEdge = Math.min(containerWidth, containerHeight);
         const newSquareSize = Math.floor(smallestContainerEdge / displayCols);
 


### PR DESCRIPTION
The iframe was crashing with this error message:
```
"TypeError: Cannot read properties of null (reading 'clientHeight')\n at renderFrame (https://www.kaggleusercontent.com/runEpisode?environment=open_spiel_chess&action=load&render{}={%22mode%22:%22html%22,%22loading%22:true}:779:39)\n at https://www.kaggleusercontent.com/runEpisode?environment=open_spiel_chess&action=load&render{}={%22mode%22:%22html%22,%22loading%22:true}:793:48"
```
Pretty sure this should fix it/'I'm trying to exactly replicate our setup locally and it seems to work, but the replication isn't quite exact. Happy to GVC quick so I can own deploying/reverting this if needed as I'm sure you have better things to do with your time 