### PR TITLE
Fix renderer context logic for player.html

### DIFF
--- a/kaggle_environments/static/player.html
+++ b/kaggle_environments/static/player.html
@@ -570,10 +570,13 @@
                         steps: event.data.environment?.steps ?? [],
                       },
                     };
-                    window.kaggle = nextContext;
-                    if (!window.kaggle.renderer) {
-                      window.kaggle.renderer = window.renderer;
+                    if (
+                      !nextContext.renderer ||
+                      typeof nextContext.renderer !== "function"
+                    ) {
+                      nextContext.renderer = contextRef.current.renderer;
                     }
+                    window.kaggle = nextContext;
                     updateContext(nextContext);
                   }
                   if (event.data.setSteps) {
@@ -584,10 +587,14 @@
                         steps: event.data.setSteps,
                       },
                     };
-                    window.kaggle = nextContext;
-                    if (!window.kaggle.renderer) {
-                      window.kaggle.renderer = window.renderer;
+                    if (
+                      !nextContext.renderer ||
+                      typeof nextContext.renderer !== "function"
+                    ) {
+                      nextContext.renderer = contextRef.current.renderer;
                     }
+
+                    window.kaggle = nextContext;
                     updateContext(nextContext);
                   }
 


### PR DESCRIPTION
OK this ~should fix it for realz :famous-last-words: 

The `(!window.kaggle.renderer) { window.kaggle.renderer = window.renderer; }` is faulty as usually window.renderer isn't defined, so we were overriding the renderer getting passed to the context with an undefined value. I verified this works by editing the iframe currently on admin with this change and it seemed happy. 