### PR TITLE
Add ruff toml without running the formatter

### DIFF
--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,24 @@
+target-version = "py311"
+line-length = 120
+indent-width = 4
+
+[format]
+quote-style = "double"
+indent-style = "space"
+
+[lint.pydocstyle]
+convention = "google"
+
+[lint]
+ignore = [
+    # zip() without strict=True is fine for this codebase's Python version.
+    "B905",
+    # The following docstring rules are disabled to avoid overwhelming errors
+    # on the existing codebase. It's recommended to enable them gradually.
+    "D100", # Missing docstring in public module
+    "D101", # Missing docstring in public class
+    "D102", # Missing docstring in public method
+    "D103", # Missing docstring in public function
+    "D104", # Missing docstring in public package
+    "D107", # Missing docstring in __init__
+]


### PR DESCRIPTION
- Add a config file to support the [ruff linter & formatter](https://docs.astral.sh/ruff/), which are now installed as part of the base docker-python image.
- I set the line length to 120 just to match a relatively common standard for projects that go above 80. We could also set this to 160 to skip most of the length changes.
- Does not include any changes that result from running the formatter in order to avoid merge conflicts with other PRs.