### PR TITLE
Add uv

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # [<img src="https://kaggle.com/static/images/site-logo.png" height="50" style="margin-bottom:-15px" />](https://kaggle.com) Environments
 
 ```bash
-pip install kaggle-environments
+uv pip install kaggle-environments
 ```
 
 # TLDR;

--- a/docker/cpu.Dockerfile
+++ b/docker/cpu.Dockerfile
@@ -31,8 +31,8 @@ ADD ./MANIFEST.in ./MANIFEST.in
 ADD ./kaggle_environments ./kaggle_environments
 
 
-# install kaggle-environments
-RUN pip install Flask bitsandbytes accelerate vec-noise jax gymnax==0.0.8 litellm && pip install . && pytest
+# install kaggle-environments. vec-noise cannot be installed with uv's more stringent checks.
+RUN pip install vec-noise && uv pip install Flask bitsandbytes accelerate jax gymnax==0.0.8 litellm && uv pip install . && pytest
 
 # SET UP KAGGLE-ENVIRONMENTS CHESS
 # minimal package to reduce memory footprint
@@ -51,6 +51,6 @@ RUN sed -i 's/kaggle_environments/kaggle_environments_chess/g' ./setup.py
 RUN sed -i 's/kaggle_environments/kaggle_environments_chess/g' ./MANIFEST.in
 
 # install kaggle-environments-chess
-RUN pip install . && pytest
+RUN uv pip install . && pytest
 
 CMD kaggle-environments

--- a/docker/gpu.Dockerfile
+++ b/docker/gpu.Dockerfile
@@ -29,6 +29,7 @@ ADD ./setup.py ./setup.py
 ADD ./README.md ./README.md
 ADD ./MANIFEST.in ./MANIFEST.in
 ADD ./kaggle_environments ./kaggle_environments
-RUN pip install Flask bitsandbytes accelerate vec-noise jax gymnax==0.0.8 && pip install . && pytest
+# vec-noise cannot be installed with uv's more stringent checks.
+RUN pip install vec-noise && uv pip install Flask bitsandbytes accelerate jax gymnax==0.0.8 && uv pip install . && pytest
 
 CMD kaggle-environments

--- a/kaggle_environments/envs/football/football.ipynb
+++ b/kaggle_environments/envs/football/football.ipynb
@@ -21,7 +21,7 @@
       },
       "source": [
         "## Installing kaggle-environments.\n",
-        "!pip install kaggle-environments\n",
+        "!uv pip install kaggle-environments\n",
         "\n",
         "# 4. Import register to define the environment and make to create it.\n",
         "from kaggle_environments import make, register"

--- a/kaggle_environments/envs/kore_fleets/kore_fleets.ipynb
+++ b/kaggle_environments/envs/kore_fleets/kore_fleets.ipynb
@@ -15,7 +15,7 @@
    },
    "outputs": [],
    "source": [
-    "!pip install ../../.."
+    "!uv pip install ../../.."
    ]
   },
   {


### PR DESCRIPTION
- Add support for [uv](https://docs.astral.sh/uv/), a substantially faster replacement for pip that now comes preinstalled with Kaggle's docker-python image. 
- It's somewhat more strict than pip so the `vec-noise` install and `open_spiel.Dockerfile` aren't covered.