### PR TITLE
Drop library requiring GPU from cpu only install

### DIFF
--- a/docker/cpu.Dockerfile
+++ b/docker/cpu.Dockerfile
@@ -32,7 +32,7 @@ ADD ./kaggle_environments ./kaggle_environments
 
 
 # install kaggle-environments. vec-noise cannot be installed with uv's more stringent checks.
-RUN pip install vec-noise && uv pip install Flask bitsandbytes accelerate jax gymnax==0.0.8 litellm && uv pip install . && pytest
+RUN pip install vec-noise && uv pip install Flask accelerate jax gymnax==0.0.8 litellm && uv pip install . && pytest
 
 # SET UP KAGGLE-ENVIRONMENTS CHESS
 # minimal package to reduce memory footprint


### PR DESCRIPTION
The `bitsandbytes` library has experimental support for CPUs but it's primary role is to support GPUs. Adding it to the CPU dockerfile is causing Nvidia cuDNN to get installed in the CPU image, which is a substantial chunk of the build time and cannot ever actually be used. It appears to have been ported over [from the GPU dockerfile](https://github.com/Kaggle/kaggle-environments/commit/3788f3557faf5a0a6419178c19eb3624bacc5386) some time ago.