### PR TITLE
Enforce min setuptools version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,38 +14,48 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # coding=utf-8
-from setuptools import setup, find_packages
+
 import codecs
 import os.path
+import setuptools
+from packaging.version import Version
+
+
+if Version(setuptools.__version__) < Version("60"):
+    raise AssertionError(
+        f"Your setuptools version {setuptools.__version__} is below the minimum of v60 required by PEP 625 & enforced by PyPy."
+    )
+
 
 def read(rel_path):
     here = os.path.abspath(os.path.dirname(__file__))
-    with codecs.open(os.path.join(here, rel_path), 'r') as fp:
+    with codecs.open(os.path.join(here, rel_path), "r") as fp:
         return fp.read()
+
 
 def get_version(rel_path):
     for line in read(rel_path).splitlines():
-        if line.startswith('__version__'):
+        if line.startswith("__version__"):
             delim = '"' if '"' in line else "'"
             return line.split(delim)[1]
     else:
         raise RuntimeError("Unable to find version string.")
 
+
 with open("README.md", "r") as f:
     long_description = f.read()
 
-setup(
-    name='kaggle-environments',
+setuptools.setup(
+    name="kaggle-environments",
     version=get_version("kaggle_environments/__init__.py"),
-    description='Kaggle Environments',
+    description="Kaggle Environments",
     long_description=long_description,
-    long_description_content_type='text/markdown',
-    author='Kaggle',
-    author_email='support@kaggle.com',
-    url='https://github.com/Kaggle/kaggle-environments',
-    keywords=['Kaggle'],
-    entry_points={'console_scripts': [
-        'kaggle-environments = kaggle_environments.main:main']},
+    long_description_content_type="text/markdown",
+    author="Kaggle",
+    author_email="support@kaggle.com",
+    url="https://github.com/Kaggle/kaggle-environments",
+    keywords=["Kaggle"],
+    entry_points={"console_scripts": ["kaggle-environments = kaggle_environments.main:main"]},
     install_requires=[
         "jsonschema >= 3.0.1",
         "Flask >= 1.1.2",
@@ -60,7 +70,8 @@ setup(
         "Chessnut >= 0.4.1",
         "open_spiel >= 1.6.0",
     ],
-    packages=find_packages(),
+    packages=setuptools.find_packages(),
     include_package_data=True,
-    python_requires='>=3.8',
-    license='Apache 2.0')
+    python_requires=">=3.8",
+    license="Apache 2.0",
+)


### PR DESCRIPTION
This is sufficient for PEP 625 compliance for manual releases, but not for automated deployment.