### PR TITLE
Mirror gym to gymnasium migration in requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 Flask
-gym
+gymnasium
 ipython
 jsonschema
 numpy


### PR DESCRIPTION
Setup.py [has already migrated](https://github.com/Kaggle/kaggle-environments/blob/master/setup.py#L67) to `gymnasium`, but requirements.txt is still using the deprecated`gym` library. This leads to irrelevant migration alerts if using a development environment based on requirements.txt.