### PR TITLE
Nit fix: clean up * import

### DIFF
--- a/kaggle_environments/__init__.py
+++ b/kaggle_environments/__init__.py
@@ -20,7 +20,7 @@ from .core import register
 from .main import http_request
 from . import errors
 
-__version__ = "1.18.0"
+__version__ = "1.19.0"
 
 __all__ = [
     "Agent",


### PR DESCRIPTION
Minor cleanup to eliminate the one instance of `import *` found in the core library. Instances in the older envs are ignored.

Nearly all of the diff (everything beyond the first line) is the result of autoformatting on save.