### PR TITLE
Add imageConfig to agent observation.

### DIFF
--- a/kaggle_environments/__init__.py
+++ b/kaggle_environments/__init__.py
@@ -16,7 +16,7 @@ from importlib import import_module
 from os import listdir
 from .agent import Agent
 from .api import get_episode_replay, list_episodes, list_episodes_for_team, list_episodes_for_submission
-from .core import register
+from .core import make, register
 from .main import http_request
 from . import errors
 

--- a/kaggle_environments/envs/open_spiel/open_spiel.py
+++ b/kaggle_environments/envs/open_spiel/open_spiel.py
@@ -354,6 +354,8 @@ def interpreter(
             "isTerminal": os_state.is_terminal(),
             "serializedGameAndState": pyspiel.serialize_game_and_state(os_game, os_state),
         }
+        if "imageConfig" in env.configuration:
+          obs_update_dict["imageConfig"] = env.configuration["imageConfig"]
 
         # Apply updates
         for k, v in obs_update_dict.items():

--- a/kaggle_environments/envs/open_spiel/test_open_spiel.py
+++ b/kaggle_environments/envs/open_spiel/test_open_spiel.py
@@ -184,6 +184,7 @@ class OpenSpielEnvTest(absltest.TestCase):
         self.assertTrue("imageConfig" in env.configuration)
         self.assertEqual(env.configuration["imageConfig"]["color"], "blue")
         self.assertEqual(env.configuration["imageConfig"]["pieceSet"], "cardinal")
+        self.assertTrue("imageConfig" in env.state[0]["observation"])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Missing `make` import introduced in https://github.com/Kaggle/kaggle-environments/commit/e0cc2a69c69662f23d08cd96e5651da90093b091.