### PR TITLE
Feat/codenames prompt refactor

### DIFF
--- a/kaggle_environments/envs/codenames/codenames.py
+++ b/kaggle_environments/envs/codenames/codenames.py
@@ -228,8 +228,9 @@ def interpreter(state, env):
     # Initialization
     if len(state[0].observation.get("words", [])) == 0:
          initialize_game(state, env.configuration)
+         active_player = state[0].observation.current_turn
          for i in range(4):
-             state[i].status = "ACTIVE" if i == 0 else "INACTIVE"
+             state[i].status = "ACTIVE" if i == active_player else "INACTIVE"
          update_visibility(state)
          return state
              
@@ -243,9 +244,10 @@ def interpreter(state, env):
     obs = state[0].observation
     games_per_episode = env.configuration.get("games_per_episode", 1)
     
+    # Always track turns within the current game
+    track_turn(obs, state)
+    
     if games_per_episode > 1:
-        track_turn(obs, state)
-        
         is_done = all(s.status in ["DONE", "INVALID"] for s in state)
         if is_done:
             winner = None

--- a/kaggle_environments/envs/codenames/harness/main.py
+++ b/kaggle_environments/envs/codenames/harness/main.py
@@ -38,6 +38,15 @@ class LLMCodenamesAgent:
             prompt += json.dumps(obs.history[-window_size:], indent=2)
             prompt += "\n\n"
             
+        # Inject full turn log for the current game.
+        # This allows the Spymaster to:
+        # 1. See what clues have already been used.
+        # 2. See what the guesser missed to plan follow-up clues.
+        if hasattr(obs, "current_game_turns") and obs.current_game_turns:
+            prompt += "Clues and guesses in this game so far:\n"
+            prompt += json.dumps(obs.current_game_turns, indent=2)
+            prompt += "\n\n"
+            
         prompt += "Here is the board state:\n"
         
         for i in range(25):
@@ -106,19 +115,31 @@ class LLMCodenamesAgent:
         team = "red" if turn == 1 else "blue"
         
         clue_number = obs.clue_number
-        prompt = f"You are the {team.upper()} Guesser in Codenames.\n"
+        prompt = f"You are the {team.upper()} Guesser in Codenames.\n\n"
+        prompt += f"Your goal is to correctly guess your team's words based on the Spymaster's clues while avoiding the opposite team's words and the assassin.\n"
+        
+        # Inject history if present
+        if hasattr(obs, "history") and obs.history:
+            prompt += "\nHere is the history of past games in this session:\n"
+            window_size = config.get("memory_window_size", 0)
+            prompt += json.dumps(obs.history[-window_size:], indent=2)
+            prompt += "\n\n"
+            
         prompt += f"The clue from your Spymaster is: '{clue}' for {clue_number} words. (You have {remaining} guesses remaining this turn.)\n\n"
+        prompt += f"If you correctly guess {clue_number} words based on this clue, you may make a bonus guess based on all information you've received so far.\n\n"
         
         if clue_number == 0:
             prompt += "A clue number of 0 means NONE of your remaining words relate to this clue (often used to point out the assassin). You get unlimited guesses, but you MUST still make at least one guess.\n\n"
         elif clue_number == -1:
             prompt += "A clue number of -1 means 'Infinity'. You get unlimited guesses based on this clue and previous clues. You must make at least one guess.\n\n"
             
-        # Inject history if present
-        if hasattr(obs, "history") and obs.history:
-            prompt += "Here is the history of past games in this session:\n"
-            window_size = config.get("memory_window_size", 0)
-            prompt += json.dumps(obs.history[-window_size:], indent=2)
+        # Inject full turn log for the current game.
+        # This allows the LLM to:
+        # 1. See guesses made in the current turn (to detect bonus guess state).
+        # 2. See previous clues to help make decisions on bonus guesses.
+        if hasattr(obs, "current_game_turns") and obs.current_game_turns:
+            prompt += "Clues and guesses in this game so far:\n"
+            prompt += json.dumps(obs.current_game_turns, indent=2)
             prompt += "\n\n"
             
         prompt += "Here are the unrevealed words on the board you can choose from:\n"

--- a/kaggle_environments/envs/codenames/harness/main.py
+++ b/kaggle_environments/envs/codenames/harness/main.py
@@ -126,6 +126,10 @@ class LLMCodenamesAgent:
         # Inject memory context (past games and current turns)
         prompt = self._inject_memory_context(prompt, obs, config)
         
+        # Add note to clarify the last entry in current_game_turns
+        if hasattr(obs, "current_game_turns") and obs.current_game_turns:
+            prompt += "Note: The last entry in the 'Clues and guesses in this game so far' list above represents your current turn, showing the guesses you have already made for the current clue.\n\n"
+        
         prompt += f"The clue from your Spymaster is: '{clue}' for {clue_number} words. (You have {remaining} guesses remaining this turn.)\n\n"
         prompt += f"If you correctly guess {clue_number} words based on this clue, you may make a bonus guess based on all information you've received so far.\n\n"
         

--- a/kaggle_environments/envs/codenames/harness/main.py
+++ b/kaggle_environments/envs/codenames/harness/main.py
@@ -21,6 +21,24 @@ class LLMCodenamesAgent:
         else:
             return self.guesser_turn(obs, config)
 
+    def _inject_memory_context(self, prompt, obs, config):
+        # Inject history if present
+        if hasattr(obs, "history") and obs.history:
+            prompt += "\nHere is the history of past games in this session:\n"
+            window_size = config.get("memory_window_size", 0)
+            prompt += json.dumps(obs.history[-window_size:], indent=2)
+            prompt += "\n\n"
+            
+        # Inject the running log of turns for the current game.
+        # This provides the LLM with context on previous clues given, guesses made,
+        # and their results, allowing it to see the progression of the match.
+        if hasattr(obs, "current_game_turns") and obs.current_game_turns:
+            prompt += "Clues and guesses in this game so far:\n"
+            prompt += json.dumps(obs.current_game_turns, indent=2)
+            prompt += "\n\n"
+            
+        return prompt
+
     def spymaster_turn(self, obs, config):
         roles = obs.roles
         words = obs.words
@@ -31,21 +49,8 @@ class LLMCodenamesAgent:
         prompt = f"You are the {team.upper()} Spymaster in Codenames.\n\n"
         prompt += f"Your goal is to get your team to guess all your {team.upper()} words while avoiding the opposite team's words and the assassin.\n"
         
-        # Inject history if present
-        if hasattr(obs, "history") and obs.history:
-            prompt += "\nHere is the history of past games in this session:\n"
-            window_size = config.get("memory_window_size", 0)
-            prompt += json.dumps(obs.history[-window_size:], indent=2)
-            prompt += "\n\n"
-            
-        # Inject full turn log for the current game.
-        # This allows the Spymaster to:
-        # 1. See what clues have already been used.
-        # 2. See what the guesser missed to plan follow-up clues.
-        if hasattr(obs, "current_game_turns") and obs.current_game_turns:
-            prompt += "Clues and guesses in this game so far:\n"
-            prompt += json.dumps(obs.current_game_turns, indent=2)
-            prompt += "\n\n"
+        # Inject memory context (past games and current turns)
+        prompt = self._inject_memory_context(prompt, obs, config)
             
         prompt += "Here is the board state:\n"
         
@@ -118,13 +123,9 @@ class LLMCodenamesAgent:
         prompt = f"You are the {team.upper()} Guesser in Codenames.\n\n"
         prompt += f"Your goal is to correctly guess your team's words based on the Spymaster's clues while avoiding the opposite team's words and the assassin.\n"
         
-        # Inject history if present
-        if hasattr(obs, "history") and obs.history:
-            prompt += "\nHere is the history of past games in this session:\n"
-            window_size = config.get("memory_window_size", 0)
-            prompt += json.dumps(obs.history[-window_size:], indent=2)
-            prompt += "\n\n"
-            
+        # Inject memory context (past games and current turns)
+        prompt = self._inject_memory_context(prompt, obs, config)
+        
         prompt += f"The clue from your Spymaster is: '{clue}' for {clue_number} words. (You have {remaining} guesses remaining this turn.)\n\n"
         prompt += f"If you correctly guess {clue_number} words based on this clue, you may make a bonus guess based on all information you've received so far.\n\n"
         
@@ -132,15 +133,6 @@ class LLMCodenamesAgent:
             prompt += "A clue number of 0 means NONE of your remaining words relate to this clue (often used to point out the assassin). You get unlimited guesses, but you MUST still make at least one guess.\n\n"
         elif clue_number == -1:
             prompt += "A clue number of -1 means 'Infinity'. You get unlimited guesses based on this clue and previous clues. You must make at least one guess.\n\n"
-            
-        # Inject full turn log for the current game.
-        # This allows the LLM to:
-        # 1. See guesses made in the current turn (to detect bonus guess state).
-        # 2. See previous clues to help make decisions on bonus guesses.
-        if hasattr(obs, "current_game_turns") and obs.current_game_turns:
-            prompt += "Clues and guesses in this game so far:\n"
-            prompt += json.dumps(obs.current_game_turns, indent=2)
-            prompt += "\n\n"
             
         prompt += "Here are the unrevealed words on the board you can choose from:\n"
         

--- a/kaggle_environments/envs/codenames/test_llm_game.py
+++ b/kaggle_environments/envs/codenames/test_llm_game.py
@@ -10,7 +10,7 @@ def run_llm_game():
         
     # Inject dummy environment variables so local testing evaluates correctly against the required runner
     if "MODEL_NAME" not in os.environ:
-        os.environ["MODEL_NAME"] = "gemini-2.5-flash"
+        os.environ["MODEL_NAME"] = "gemini-3.1-flash-lite-preview"
     if "MODEL_PROXY_KEY" not in os.environ:
         # Pass the local api key in so that litellm can use it when it drops the dummy proxy url
         os.environ["MODEL_PROXY_KEY"] = os.environ.get("GEMINI_API_KEY", os.environ.get("OPENAI_API_KEY", "dummy"))


### PR DESCRIPTION
This makes agents "turn-aware" by injecting the current game's clue and guess history into their prompts. This allows agents to recognize their progress within a turn and make more informed decisions during bonus guesses.