### PR TITLE
feat(go): use `howler` to handle audio

### DIFF
--- a/kaggle_environments/envs/open_spiel_env/games/go/visualizer/v2/package.json
+++ b/kaggle_environments/envs/open_spiel_env/games/go/visualizer/v2/package.json
@@ -17,6 +17,7 @@
     "monkey": "node ./scripts/monkey.js"
   },
   "devDependencies": {
+    "@types/howler": "^2.2.12",
     "@types/react": "^18.2.0",
     "@types/react-dom": "^18.2.0",
     "@vitejs/plugin-react": "^5.1.2",
@@ -29,6 +30,7 @@
     "@kaggle-environments/core": "workspace:*",
     "@rive-app/react-webgl2": "^4.27.0",
     "gsap": "^3.14.2",
+    "howler": "^2.2.4",
     "motion": "^12.38.0",
     "pixi.js": "^8.16.0",
     "react": "^18.2.0",

--- a/kaggle_environments/envs/open_spiel_env/games/go/visualizer/v2/src/components/SoundEffects.tsx
+++ b/kaggle_environments/envs/open_spiel_env/games/go/visualizer/v2/src/components/SoundEffects.tsx
@@ -1,58 +1,12 @@
 import { useEffect, useRef } from 'react';
-import placeSoundUrl from '../assets/audio/go-stone-placing.mp3';
-import captureSoundUrl from '../assets/audio/go-stone-removal.mp3';
+import { Howl } from 'howler';
 import useGameStore from '../stores/useGameStore';
 import usePreferences from '../stores/usePreferences';
+import placeSoundUrl from '../assets/audio/go-stone-placing.mp3';
+import captureSoundUrl from '../assets/audio/go-stone-removal.mp3';
 
-// Web Audio API - shared across component mounts
-let audioCtx: AudioContext | null = null;
-let placeBuffer: AudioBuffer | null = null;
-let captureBuffer: AudioBuffer | null = null;
-let buffersLoading = false;
-
-function getAudioContext(): AudioContext {
-  if (!audioCtx) {
-    audioCtx = new AudioContext({ latencyHint: 'interactive' });
-  }
-  return audioCtx;
-}
-
-/** Replace the current AudioContext with a fresh one and re-decode buffers. */
-function resetAudioContext() {
-  audioCtx?.close().catch(() => {});
-  audioCtx = null;
-  placeBuffer = null;
-  captureBuffer = null;
-  buffersLoading = false;
-}
-
-async function loadBuffers() {
-  if (buffersLoading || (placeBuffer && captureBuffer)) return;
-  buffersLoading = true;
-  try {
-    const ctx = getAudioContext();
-    const [placeData, captureData] = await Promise.all([
-      fetch(placeSoundUrl).then((r) => r.arrayBuffer()),
-      fetch(captureSoundUrl).then((r) => r.arrayBuffer()),
-    ]);
-    [placeBuffer, captureBuffer] = await Promise.all([
-      ctx.decodeAudioData(placeData),
-      ctx.decodeAudioData(captureData),
-    ]);
-  } catch {
-    buffersLoading = false;
-  }
-}
-
-function playBuffer(buffer: AudioBuffer) {
-  const ctx = getAudioContext();
-  const source = ctx.createBufferSource();
-  const gain = ctx.createGain();
-  gain.gain.value = 0.5;
-  source.buffer = buffer;
-  source.connect(gain).connect(ctx.destination);
-  source.start();
-}
+const placeSound = new Howl({ src: [placeSoundUrl], volume: 0.5 });
+const captureSound = new Howl({ src: [captureSoundUrl], volume: 0.5 });
 
 const THROTTLE_MS = 150;
 
@@ -62,43 +16,12 @@ export default function SoundEffects() {
   const prevRef = useRef({ move: 0, captures: 0 });
   const lastPlayedRef = useRef(0);
 
-  // Some operating systems will kill existing AudioContext instances
-  // unprompted, e.g. on iOS when the browser is backgrounded.
-  useEffect(() => {
-    function unlockAudio() {
-      let ctx = getAudioContext();
-      if (ctx.state === 'running') {
-        loadBuffers();
-        return;
-      }
-
-      // If the context is not running, attempt to re-create the context.
-      // This has to happen synchronously for iOS to see it as a
-      // user-interaction.
-      resetAudioContext();
-      ctx = getAudioContext();
-      ctx.resume().catch(() => {});
-      loadBuffers();
-    }
-
-    document.addEventListener('click', unlockAudio);
-    document.addEventListener('touchstart', unlockAudio);
-    document.addEventListener('keydown', unlockAudio);
-
-    if (getAudioContext().state === 'running') loadBuffers();
-
-    return () => {
-      document.removeEventListener('click', unlockAudio);
-      document.removeEventListener('touchstart', unlockAudio);
-      document.removeEventListener('keydown', unlockAudio);
-    };
-  }, []);
-
   useEffect(() => {
     const state = game.currentState();
     const move = state.moveNumber;
-    const captures = state.blackStonesCaptured + state.whiteStonesCaptured;
+    const captures = (state.blackStonesCaptured || 0) + (state.whiteStonesCaptured || 0);
     const prev = prevRef.current;
+
     const placed = move > prev.move && state.playedPoint;
     const captured = captures > prev.captures;
 
@@ -111,8 +34,8 @@ export default function SoundEffects() {
     if (now - lastPlayedRef.current < THROTTLE_MS) return;
     lastPlayedRef.current = now;
 
-    if (placed && placeBuffer) playBuffer(placeBuffer);
-    if (captured && captureBuffer) playBuffer(captureBuffer);
+    if (placed) placeSound.play();
+    if (captured) captureSound.play();
   }, [game, soundEnabled]);
 
   return null;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -394,6 +394,9 @@ importers:
       gsap:
         specifier: ^3.14.2
         version: 3.14.2
+      howler:
+        specifier: ^2.2.4
+        version: 2.2.4
       motion:
         specifier: ^12.38.0
         version: 12.38.0(@emotion/is-prop-valid@1.4.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -413,6 +416,9 @@ importers:
         specifier: ^5.0.10
         version: 5.0.12(@types/react@18.3.28)(react@18.3.1)
     devDependencies:
+      '@types/howler':
+        specifier: ^2.2.12
+        version: 2.2.12
       '@types/react':
         specifier: ^18.2.0
         version: 18.3.28
@@ -1395,6 +1401,9 @@ packages:
   '@types/hast@3.0.4':
     resolution: {integrity: sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==}
 
+  '@types/howler@2.2.12':
+    resolution: {integrity: sha512-hy769UICzOSdK0Kn1FBk4gN+lswcj1EKRkmiDtMkUGvFfYJzgaDXmVXkSShS2m89ERAatGIPnTUlp2HhfkVo5g==}
+
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
 
@@ -2372,6 +2381,9 @@ packages:
 
   hookified@1.15.1:
     resolution: {integrity: sha512-MvG/clsADq1GPM2KGo2nyfaWVyn9naPiXrqIe4jYjXNZQt238kWyOGrsyc/DmRAQ+Re6yeo6yX/yoNCG5KAEVg==}
+
+  howler@2.2.4:
+    resolution: {integrity: sha512-iARIBPgcQrwtEr+tALF+rapJ8qSc+Set2GJQl7xT1MQzWaVkFebdJhR3alVlSiUf5U7nAANKuj3aWpwerocD5w==}
 
   html-encoding-sniffer@6.0.0:
     resolution: {integrity: sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==}
@@ -4615,6 +4627,8 @@ snapshots:
     dependencies:
       '@types/unist': 3.0.3
 
+  '@types/howler@2.2.12': {}
+
   '@types/json-schema@7.0.15': {}
 
   '@types/mdast@4.0.4':
@@ -5819,6 +5833,8 @@ snapshots:
       react-is: 16.13.1
 
   hookified@1.15.1: {}
+
+  howler@2.2.4: {}
 
   html-encoding-sniffer@6.0.0:
     dependencies:


### PR DESCRIPTION
The WebAudio API has had compatibility issues and quirks for almost a decade, and for Go we have resolved these by adding less-than-ideal complexity to cover some of these quirks.

However, for future games I'd love to introduce a reputable, battle-tested library like `Howler`, as it is entirely possible audio on future games will be more complex. Introducing Howler will also reduce the time to implement audio, and "risk" in general. _and_ It also has an added bonus that AI agents will be able to use a consistent API, preventing the need to re-invent the wheel every time.

What do you think?

- https://howlerjs.com/
- https://github.com/goldfire/howler.js/blob/master/LICENSE.md
