### PR TITLE
feat: versus banner

### DIFF
--- a/kaggle_environments/envs/open_spiel_env/games/chess/visualizer/v2/src/components/GameRenderer.tsx
+++ b/kaggle_environments/envs/open_spiel_env/games/chess/visualizer/v2/src/components/GameRenderer.tsx
@@ -12,20 +12,18 @@ export default memo(function GameRenderer(options: GameRendererProps<ChessStep[]
     const step = options.replay.steps.at(options.step);
     const player = step!.players.find((player: ChessPlayer) => player.isTurn);
 
-    if (player) {
-      const history = options.replay.info!.stateHistory;
-      const fen = history.at(options.step);
-      const game = new Chess(fen);
-      const move = game.move(player.actionDisplayText!);
+    const history = options.replay.info!.stateHistory;
+    const fen = history[options.step - 1] ?? undefined;
+    const game = new Chess(fen);
 
-      step!.players.map((p) => {
-        const opposite = { w: 'b', b: 'w' };
-        const color = p.isTurn ? move.color : opposite[move.color];
-        game.setHeader(color, p.name);
-      });
+    if (player?.actionDisplayText) game.move(player.actionDisplayText);
 
-      setState(game, options);
-    }
+    step!.players.map((p, i) => {
+      const color = i ? 'b' : 'w';
+      game.setHeader(color, p.name);
+    });
+
+    setState(game, options);
   }, [setState, options]);
 
   return <Layout />;

--- a/kaggle_environments/envs/open_spiel_env/games/chess/visualizer/v2/src/components/Layout.tsx
+++ b/kaggle_environments/envs/open_spiel_env/games/chess/visualizer/v2/src/components/Layout.tsx
@@ -3,6 +3,7 @@ import HiddenHeader from './HiddenHeader';
 import BoardControls from './BoardControls';
 import GameBoard from './GameBoard';
 import Annotation from './Annotation';
+import VersusBanner from './VersusBanner';
 import HeroAnimation from './HeroAnimation';
 import useBoardRect from '../hooks/useBoardRect';
 import styles from './Layout.module.css';
@@ -18,6 +19,7 @@ export default memo(function Layout() {
         <GameBoard />
         <Annotation />
       </div>
+      <VersusBanner />
       <HeroAnimation />
     </main>
   );

--- a/kaggle_environments/envs/open_spiel_env/games/chess/visualizer/v2/src/components/Ribbon.module.css
+++ b/kaggle_environments/envs/open_spiel_env/games/chess/visualizer/v2/src/components/Ribbon.module.css
@@ -1,0 +1,45 @@
+.ribbon {
+  --shadow-size: 0.3125rem;
+  --shadow-color: rgb(0 0 0 / 35%);
+  font-size: var(--ribbon-font-size, 1.5rem);
+  position: relative;
+  width: fit-content;
+  height: 100%;
+  margin-inline: auto;
+  text-align: center;
+  line-height: 1.4;
+  filter: drop-shadow(
+    calc(var(--shadow-size) * -1) var(--shadow-size) var(--shadow-color)
+  );
+  /* Fixes Safari filters. */
+  transform: translateZ(0);
+
+  & svg {
+    position: absolute;
+    top: 10%;
+    width: auto;
+    height: 80%;
+    display: block;
+    stroke-width: 2px;
+  }
+
+  /* Left flag. */
+  & svg:nth-child(1) {
+    left: 0;
+    transform: translateX(-90%);
+  }
+
+  /* Right flag. */
+  & svg:nth-child(2) {
+    right: 0;
+    transform: translateX(90%) scale(-1);
+  }
+}
+
+.text {
+  padding: var(--ribbon-padding-block, 1em) var(--ribbon-padding-inline, 1.5em);
+  position: relative;
+  background: white;
+  border: 0.125rem solid black;
+  border-radius: 0.25rem;
+}

--- a/kaggle_environments/envs/open_spiel_env/games/chess/visualizer/v2/src/components/Ribbon.tsx
+++ b/kaggle_environments/envs/open_spiel_env/games/chess/visualizer/v2/src/components/Ribbon.tsx
@@ -1,0 +1,30 @@
+import { ReactNode } from 'react';
+import styles from './Ribbon.module.css';
+
+interface Props {
+  children: ReactNode;
+}
+
+export function FlagEnd() {
+  return (
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 55 116" width="55" height="114">
+      <path
+        fill="#fff"
+        stroke="currentColor"
+        strokeWidth="2"
+        vectorEffect="non-scaling-stroke"
+        d="M52 113H3q-2-1-2-3l28-51v-4L1 4q0-2 2-3h49l2 2v108z"
+      />
+    </svg>
+  );
+}
+
+export function Ribbon({ children }: Props) {
+  return (
+    <div className={`grid-pile ${styles.ribbon}`}>
+      <FlagEnd />
+      <FlagEnd />
+      <div className={styles.text}>{children}</div>
+    </div>
+  );
+}

--- a/kaggle_environments/envs/open_spiel_env/games/chess/visualizer/v2/src/components/VersusBanner.module.css
+++ b/kaggle_environments/envs/open_spiel_env/games/chess/visualizer/v2/src/components/VersusBanner.module.css
@@ -1,0 +1,25 @@
+.versusBanner {
+  position: fixed;
+  top: calc(var(--board-top) + var(--board-height) / 2);
+  left: var(--board-left);
+  width: var(--board-width);
+
+  /* <Ribbon> element. */
+  & > * {
+    --ribbon-font-size: 1rem;
+    --ribbon-padding-inline: 2em;
+    --ribbon-padding-block: 1.25em;
+  }
+
+  & span {
+    white-space: nowrap;
+  }
+}
+
+@container (max-width: 680px) {
+  .versusBanner > * {
+    --ribbon-font-size: 0.75rem;
+    --ribbon-padding-inline: 1.5em;
+    --ribbon-padding-block: 0.8125em;
+  }
+}

--- a/kaggle_environments/envs/open_spiel_env/games/chess/visualizer/v2/src/components/VersusBanner.tsx
+++ b/kaggle_environments/envs/open_spiel_env/games/chess/visualizer/v2/src/components/VersusBanner.tsx
@@ -1,0 +1,31 @@
+import { AnimatePresence, motion } from 'motion/react';
+import { Ribbon } from './Ribbon';
+import useGameStore from '../stores/useGameStore';
+import { useTransition } from '../hooks/useReducedMotion';
+import styles from './VersusBanner.module.css';
+
+export default function VersusBanner() {
+  const game = useGameStore((state) => state.game);
+  const enterTransition = useTransition({ duration: 1.3, ease: [0.22, 1.15, 0.36, 1] });
+  const exitTransition = useTransition({ duration: 0.3 });
+  const whiteName = game.getHeaders()['w'];
+  const blackName = game.getHeaders()['b'];
+
+  return (
+    <AnimatePresence>
+      {game.moveNumber() === 1 && game.turn() === 'b' && (
+        <motion.div
+          className={styles.versusBanner}
+          aria-hidden="true"
+          initial={{ y: '-100vh', rotate: 12, opacity: 1 }}
+          animate={{ y: '-50%', rotate: 0, opacity: 1, transition: enterTransition }}
+          exit={{ opacity: 0, scale: 0.9, transition: exitTransition }}
+        >
+          <Ribbon>
+            {blackName ?? 'Black'} vs. {whiteName ?? 'White'}
+          </Ribbon>
+        </motion.div>
+      )}
+    </AnimatePresence>
+  );
+}

--- a/kaggle_environments/envs/open_spiel_env/games/chess/visualizer/v2/src/components/VersusBanner.tsx
+++ b/kaggle_environments/envs/open_spiel_env/games/chess/visualizer/v2/src/components/VersusBanner.tsx
@@ -13,7 +13,7 @@ export default function VersusBanner() {
 
   return (
     <AnimatePresence>
-      {game.moveNumber() === 1 && game.turn() === 'b' && (
+      {game.moveNumber() === 1 && game.turn() === 'w' && (
         <motion.div
           className={styles.versusBanner}
           aria-hidden="true"

--- a/kaggle_environments/envs/open_spiel_env/games/chess/visualizer/v2/src/transformers/chessTransformer.ts
+++ b/kaggle_environments/envs/open_spiel_env/games/chess/visualizer/v2/src/transformers/chessTransformer.ts
@@ -81,16 +81,35 @@ export function deriveWinnerFromRewards(players: ChessPlayer[]) {
 
 export const chessTransformer = (environment: any): ChessStep[] => {
   const chessReplay = environment as ChessReplay;
-  const agents = environment.info.TeamNames;
-
   const chessSteps: ChessStep[] = [];
+
+  const extraStepPlayers = [0, 1].map(
+    (index): ChessPlayer => ({
+      id: index,
+      name: environment.info.TeamNames[index],
+      thumbnail: '',
+      isTurn: false,
+      actionDisplayText: '',
+      thoughts: '',
+      reward: null,
+      generateReturns: null,
+    })
+  );
+
+  chessSteps.push({
+    step: chessSteps.length,
+    players: extraStepPlayers,
+    fenState: parseFen(''),
+    isTerminal: false,
+    winner: null,
+  });
 
   chessReplay.steps.forEach((step, index) => {
     // Each step contains a tuple of players, one who acted and one who's waiting
     const stepPlayers: ChessPlayer[] = step.map((player, index): ChessPlayer => {
       return {
         id: index,
-        name: agents[index],
+        name: environment.info.TeamNames[index],
         thumbnail: '',
         isTurn: player.action?.submission !== -1,
         actionDisplayText: player.action?.actionString ?? '',


### PR DESCRIPTION
Adding the `VersusBanner` component, including inserting the extra step at the very beginning of the replay steps.

<img width="1069" height="871" alt="Screenshot 2026-04-09 at 12 11 20" src="https://github.com/user-attachments/assets/0c105791-b5e7-42c2-8591-a93013f1ae71" />
