### PR TITLE
feat: game over

### DIFF
--- a/kaggle_environments/envs/open_spiel_env/games/chess/visualizer/v2/src/components/GameOver.module.css
+++ b/kaggle_environments/envs/open_spiel_env/games/chess/visualizer/v2/src/components/GameOver.module.css
@@ -1,0 +1,154 @@
+.modal {
+  --font-size: 1.25rem;
+  --border-size: 2px;
+  --cell-padding: 0.75rem 1.5rem;
+  --reveal-delay: 1s;
+  position: fixed;
+  top: var(--area-top);
+  left: var(--area-left);
+  width: var(--area-width);
+  height: var(--area-height);
+  margin: 0;
+  border: none;
+  max-width: none;
+  max-height: none;
+  padding: 1rem;
+  display: grid;
+  place-content: safe center;
+  overflow: auto;
+  text-align: center;
+  gap: 1.5rem;
+  background-image: url("./images/paper.webp");
+  background-size: cover;
+  background-position: center;
+  color: #050001;
+  font-size: var(--font-size);
+  z-index: 20;
+}
+
+.heading {
+  font: inherit;
+  margin: 0;
+}
+
+.meta {
+  text-align: center;
+  line-height: 1.6;
+}
+
+.table {
+  border-collapse: separate;
+  border-spacing: 0;
+  text-align: center;
+  min-width: 32rem;
+}
+
+.table th,
+.table td {
+  padding: var(--cell-padding);
+  background: url("./images/squiggle-solid.png") repeat-x bottom / 5rem
+    var(--border-size);
+}
+
+.table :where(td, th):not(:last-of-type) {
+  background:
+    url("./images/squiggle-solid.png") repeat-x bottom / 5rem var(--border-size),
+    url("./images/squiggle-v.png") repeat-y right / var(--border-size) 5rem;
+}
+
+.table thead th {
+  font-weight: 400;
+  background:
+    url("./images/squiggle-solid.png") repeat-x top / 5rem var(--border-size),
+    url("./images/squiggle-solid.png") repeat-x bottom / 5rem var(--border-size);
+}
+
+.table thead th:not(:last-of-type) {
+  background:
+    url("./images/squiggle-solid.png") repeat-x top / 5rem var(--border-size),
+    url("./images/squiggle-solid.png") repeat-x bottom / 5rem var(--border-size),
+    url("./images/squiggle-v.png") repeat-y right / var(--border-size) 5rem;
+}
+
+.table tbody td:not(:first-child) {
+  font-family: "Mynerve", cursive;
+  font-size: 1.25em;
+  color: #444343;
+}
+
+.labelCell {
+  text-align: left;
+}
+
+/* Animate-in. */
+
+.modal {
+  transition:
+    opacity 300ms,
+    transform 500ms;
+  transition-delay: var(--reveal-delay);
+
+  @starting-style {
+    opacity: 0;
+    transform: scale(0.98);
+  }
+}
+
+:where(.meta, .table, .ribbon, .rulesNote) {
+  transition:
+    opacity 400ms,
+    transform 500ms;
+  transition-delay: calc(var(--reveal-delay) + 100ms);
+
+  @starting-style {
+    opacity: 0;
+    transform: translateY(0.5rem);
+  }
+}
+
+.meta {
+  transition-delay: calc(var(--reveal-delay) + 400ms);
+}
+
+.table {
+  transition-delay: calc(var(--reveal-delay) + 900ms);
+}
+
+.rulesNote {
+  transition-delay: calc(var(--reveal-delay) + 1100ms);
+}
+
+.rulesNote a {
+  color: inherit;
+  font-weight: 400;
+  text-decoration: underline;
+
+  &:where(:hover, :focus-visible) {
+    opacity: 0.8;
+  }
+}
+
+@container (max-width: 800px) {
+  .modal {
+    --font-size: 13px;
+    --border-size: 1px;
+    --cell-padding: 0.4rem 0.5rem;
+    gap: 1rem;
+    line-height: 1.4;
+  }
+
+  :global(.ribbon) {
+    --ribbon-font-size: 0.875rem;
+  }
+}
+
+@container (max-width: 680px) {
+  .modal {
+    --font-size: 11px;
+  }
+
+  .table {
+    min-width: unset;
+    width: 100%;
+  }
+}

--- a/kaggle_environments/envs/open_spiel_env/games/chess/visualizer/v2/src/components/GameOver.tsx
+++ b/kaggle_environments/envs/open_spiel_env/games/chess/visualizer/v2/src/components/GameOver.tsx
@@ -1,0 +1,135 @@
+import { useEffect, useRef } from 'react';
+import { Ribbon } from './Ribbon';
+import useGameStore from '../stores/useGameStore';
+import styles from './GameOver.module.css';
+
+function formatDuration(totalSeconds: number): string {
+  const h = Math.floor(totalSeconds / 3600);
+  const m = Math.floor((totalSeconds % 3600) / 60);
+  const s = Math.floor(totalSeconds % 60);
+  return [h, m, s].map((n) => String(n).padStart(2, '0')).join(':');
+}
+
+function avg(nums: number[]): number {
+  if (nums.length === 0) return 0;
+  return nums.reduce((a, b) => a + b, 0) / nums.length;
+}
+
+interface StatRow {
+  label: string;
+  black: string | number;
+  white: string | number;
+}
+
+export default function GameOver() {
+  const dialogRef = useRef<HTMLDialogElement>(null);
+  const game = useGameStore((state) => state.game);
+  const options = useGameStore((state) => state.options);
+
+  useEffect(() => {
+    const dialog = dialogRef.current;
+    if (dialog && !dialog.open) {
+      dialog.show();
+      dialog.focus();
+    }
+  }, []);
+
+  const step = options.replay.steps.at(options.step);
+  // TODO(pim-at-stink): https://github.com/Stinkstudios/kaggle-ai-visualiser/issues/15
+  if (!step) return null;
+  if (!step.winner) return null;
+
+  const winnerColor = game.turn() === 'b' ? 'black' : 'white';
+  const blackName = game.getHeaders()['b'] ?? 'Black';
+  const whiteName = game.getHeaders()['w'] ?? 'White';
+  const winnerName = winnerColor === 'black' ? blackName : whiteName;
+
+  const board = game.board().flat();
+  const captures = {
+    black: 16 - board.filter((s) => s?.color === 'w').length,
+    white: 16 - board.filter((s) => s?.color === 'b').length,
+  };
+
+  const tokens = { black: 0, white: 0 };
+  const durations: { black: number[]; white: number[] } = { black: [], white: [] };
+
+  for (const replayStep of options.replay.steps) {
+    const player = replayStep.players.find((player) => player.generateReturns);
+    if (!player?.generateReturns) continue;
+
+    for (const json of player.generateReturns) {
+      const ret = JSON.parse(json);
+      const modelName: string = ret.model ?? ret.request_for_logging?.model ?? '';
+      const promptTokens: number = ret.prompt_tokens ?? 0;
+      let generationTokens: number = ret.generation_tokens ?? 0;
+      const reasoningTokens: number = ret.reasoning_tokens ?? 0;
+      let totalTokens: number = ret.total_tokens ?? 0;
+
+      if (modelName.includes('grok') || modelName.includes('gemini')) {
+        generationTokens = totalTokens - promptTokens;
+      }
+      if (totalTokens === 0) {
+        totalTokens = promptTokens + generationTokens + reasoningTokens;
+      }
+
+      const color = player.id ? 'white' : 'black';
+      tokens[color] += totalTokens;
+      durations[color].push(ret.duration_success_only_secs ?? 0);
+    }
+  }
+
+  const totalMoves = game.moveNumber() * 2;
+  const allDurations = [...durations.black, ...durations.white];
+  const gameDuration = allDurations.reduce((a, b) => a + b, 0);
+
+  const rows: StatRow[] = [
+    {
+      label: 'Pieces Captured',
+      black: captures.white.toLocaleString(),
+      white: captures.black.toLocaleString(),
+    },
+    {
+      label: 'Tokens Used',
+      black: tokens.white.toLocaleString(),
+      white: tokens.black.toLocaleString(),
+    },
+    {
+      label: 'Average Time per Move',
+      black: `${Math.round(avg(durations.white))}s`,
+      white: `${Math.round(avg(durations.black))}s`,
+    },
+  ];
+
+  return (
+    <dialog ref={dialogRef} className={styles.modal} aria-label="Game over" tabIndex={-1}>
+      <div className="ribbon">
+        <Ribbon>
+          <h2 className={styles.heading}>Winner is {winnerName}!</h2>
+        </Ribbon>
+      </div>
+      <div className={styles.meta}>
+        Game Duration: {formatDuration(gameDuration)}
+        <br />
+        Total Moves: {totalMoves}
+      </div>
+      <table className={styles.table}>
+        <thead>
+          <tr>
+            <th />
+            <th>{blackName}</th>
+            <th>{whiteName}</th>
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map((row) => (
+            <tr key={row.label}>
+              <td>{row.label}</td>
+              <td>{row.black}</td>
+              <td>{row.white}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </dialog>
+  );
+}

--- a/kaggle_environments/envs/open_spiel_env/games/chess/visualizer/v2/src/components/HeroAnimation.tsx
+++ b/kaggle_environments/envs/open_spiel_env/games/chess/visualizer/v2/src/components/HeroAnimation.tsx
@@ -15,6 +15,7 @@ interface Hero {
 
 export default function HeroAnimation() {
   const game = useGameStore((state) => state.game);
+  const options = useGameStore((state) => state.options);
   const showHeroAnimations = usePreferences((state) => state.showHeroAnimations);
   const prevStepRef = useRef<number | null>(null);
   const [hero, setHero] = useState<Hero | null>(null);
@@ -55,7 +56,7 @@ export default function HeroAnimation() {
     };
   }, [game, showHeroAnimations]);
 
-  const isVisible = !!hero;
+  const isVisible = !!hero && !options.replay.steps.at(options.step)?.winner;
 
   return (
     <AnimatePresence>

--- a/kaggle_environments/envs/open_spiel_env/games/chess/visualizer/v2/src/components/Layout.tsx
+++ b/kaggle_environments/envs/open_spiel_env/games/chess/visualizer/v2/src/components/Layout.tsx
@@ -4,6 +4,7 @@ import BoardControls from './BoardControls';
 import GameBoard from './GameBoard';
 import Annotation from './Annotation';
 import VersusBanner from './VersusBanner';
+import GameOver from './GameOver';
 import HeroAnimation from './HeroAnimation';
 import useBoardRect from '../hooks/useBoardRect';
 import styles from './Layout.module.css';
@@ -20,6 +21,7 @@ export default memo(function Layout() {
         <Annotation />
       </div>
       <VersusBanner />
+      <GameOver />
       <HeroAnimation />
     </main>
   );

--- a/kaggle_environments/envs/open_spiel_env/games/chess/visualizer/v2/src/stores/useGameStore.ts
+++ b/kaggle_environments/envs/open_spiel_env/games/chess/visualizer/v2/src/stores/useGameStore.ts
@@ -5,13 +5,13 @@ import { ChessStep } from '../transformers/chessReplayTypes';
 
 interface GameStore {
   game: Chess;
-  options: GameRendererProps<ChessStep[]> | null;
+  options: GameRendererProps<ChessStep[]>;
   setState: (chess: Chess, options: GameRendererProps<ChessStep[]>) => void;
 }
 
 const useGameStore = create<GameStore>((set) => ({
   game: new Chess(),
-  options: null,
+  options: { replay: { name: '', version: '', steps: [], configuration: {} }, step: 0, agents: [] },
   setState: (game: Chess, options: GameRendererProps<ChessStep[]>) => set({ game, options }),
 }));
 

--- a/kaggle_environments/envs/open_spiel_env/games/chess/visualizer/v2/src/transformers/chessReplayTypes.ts
+++ b/kaggle_environments/envs/open_spiel_env/games/chess/visualizer/v2/src/transformers/chessReplayTypes.ts
@@ -61,7 +61,7 @@ export interface ChessReplay {
  * Only used internally as part of the type for replay data,
  * do not use elsewhere.
  */
-interface ChessReplayStep {
+export interface ChessReplayStep {
   action?: {
     actionString?: string;
     generate_returns?: string[];

--- a/kaggle_environments/envs/open_spiel_env/games/chess/visualizer/v2/src/transformers/chessTransformer.ts
+++ b/kaggle_environments/envs/open_spiel_env/games/chess/visualizer/v2/src/transformers/chessTransformer.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { ChessReplay, ChessPlayer, ChessStep, FenState } from './chessReplayTypes';
+import { ChessReplay, ChessPlayer, ChessStep, FenState, ChessReplayStep } from './chessReplayTypes';
 
 function parseFen(fen?: string): FenState {
   if (!fen || typeof fen !== 'string') {
@@ -63,20 +63,10 @@ export function getChessStepDescription(step: ChessStep) {
   return step.players.find((player) => player.isTurn)?.thoughts ?? '';
 }
 
-export function deriveWinnerFromRewards(players: ChessPlayer[]) {
-  if (players.length < 2) return '';
-
-  const player0Reward = players[0].reward;
-  const player1Reward = players[1].reward;
-
-  if (player0Reward === player1Reward) {
-    return 'Draw';
-  }
-
-  const winnerPlayerIndex = player0Reward === 1 ? 0 : 1;
-  const color = winnerPlayerIndex === 0 ? 'Black' : 'White';
-
-  return `🎉 ${color} (${players[winnerPlayerIndex].name}) Wins!`;
+function deriveWinner(step: ChessReplayStep[]): string | null {
+  if (step[0].observation.isTerminal === false) return null;
+  if (step[0].reward === step[1].reward) return null;
+  return step[0].reward === 1 ? 'white' : 'black';
 }
 
 export const chessTransformer = (environment: any): ChessStep[] => {
@@ -132,27 +122,14 @@ export const chessTransformer = (environment: any): ChessStep[] => {
     }
   });
 
-  const lastStep = chessSteps[chessSteps.length - 1];
-  const winDescription = deriveWinnerFromRewards(lastStep.players);
+  const lastReplayStep = chessReplay.steps[chessReplay.steps.length - 1];
 
-  // Artificially insert a step at the end to emphasize the win state
   chessSteps.push({
-    players: [
-      {
-        id: -1,
-        name: 'System',
-        thumbnail: '',
-        isTurn: false,
-        actionDisplayText: '',
-        thoughts: '',
-        reward: 0,
-        generateReturns: null,
-      },
-    ],
+    players: extraStepPlayers,
     isTerminal: true,
-    fenState: lastStep.fenState,
-    step: lastStep.step + 1,
-    winner: winDescription,
+    fenState: chessSteps[chessSteps.length - 1].fenState,
+    step: chessSteps.length,
+    winner: deriveWinner(lastReplayStep),
   });
 
   return chessSteps;

--- a/kaggle_environments/envs/open_spiel_env/games/chess/visualizer/v2/src/utils/getStepLabel.ts
+++ b/kaggle_environments/envs/open_spiel_env/games/chess/visualizer/v2/src/utils/getStepLabel.ts
@@ -9,9 +9,18 @@ export function getStepLabel(step: BaseGameStep) {
     return `Plays ${move}`;
   }
 
+  const whiteName = step.players.at(0)?.name ?? 'White';
+  const blackName = step.players.at(1)?.name ?? 'Black';
+
+  // Game Start
+  if (step.step === 0) {
+    return `${blackName} vs. ${whiteName}`;
+  }
+
+  // Game Over
   const winner = (step as ChessStep).winner;
   if (winner) {
-    return winner;
+    return `${winner === 'black' ? blackName : whiteName} wins`;
   }
 
   return '';


### PR DESCRIPTION
Adds the `GameOver` component, also adapts `chessTransformer` and  `getStepLabel` to align them with how things work in the Go v2 visualizer.

<img width="1247" height="911" alt="Screenshot 2026-04-09 at 13 30 58" src="https://github.com/user-attachments/assets/1d572138-4f1c-4a38-8611-26220dc36a0f" />

Note: The number calculations are not fully implemented just yet, they are not accounting for promotions and there are probably other ways they're not fully correct, but they are enough to work on implementing design and animation.
