### PR TITLE
chore: remove territory setting

### DIFF
--- a/kaggle_environments/envs/open_spiel_env/games/chess/visualizer/v2/src/components/FeatureToggles.tsx
+++ b/kaggle_environments/envs/open_spiel_env/games/chess/visualizer/v2/src/components/FeatureToggles.tsx
@@ -2,22 +2,11 @@ import usePreferences from '../stores/usePreferences';
 import styles from './FeatureToggles.module.css';
 
 export function FeatureToggles() {
-  const { toggle, showHeroAnimations, showTerritory, showAnnotations, reducedMotion } = usePreferences();
+  const { toggle, showHeroAnimations, showAnnotations, reducedMotion } = usePreferences();
   return (
     <fieldset className={styles.fieldset}>
       <legend className="visually-hidden">Preferences</legend>
       <ul>
-        <li>
-          <label>
-            Live Territory
-            <input
-              type="checkbox"
-              className={styles.switch}
-              checked={showTerritory}
-              onChange={() => toggle('showTerritory')}
-            />
-          </label>
-        </li>
         <li>
           <label>
             Pop Up Animations

--- a/kaggle_environments/envs/open_spiel_env/games/chess/visualizer/v2/src/stores/usePreferences.ts
+++ b/kaggle_environments/envs/open_spiel_env/games/chess/visualizer/v2/src/stores/usePreferences.ts
@@ -2,18 +2,16 @@ import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
 
 interface Preferences {
-  showTerritory: boolean;
   showHeroAnimations: boolean;
   showAnnotations: boolean;
   soundEnabled: boolean;
   reducedMotion: boolean;
-  toggle: (key: 'showTerritory' | 'showHeroAnimations' | 'showAnnotations' | 'soundEnabled' | 'reducedMotion') => void;
+  toggle: (key: 'showHeroAnimations' | 'showAnnotations' | 'soundEnabled' | 'reducedMotion') => void;
 }
 
 const usePreferences = create<Preferences>()(
   persist(
     (set) => ({
-      showTerritory: true,
       showHeroAnimations: true,
       showAnnotations: true,
       soundEnabled: false,
@@ -24,7 +22,6 @@ const usePreferences = create<Preferences>()(
       name: 'go-visualizer-preferences',
       // Explicitly define which keys should persist across sessions.
       partialize: (state) => ({
-        showTerritory: state.showTerritory,
         showHeroAnimations: state.showHeroAnimations,
         showAnnotations: state.showAnnotations,
         reducedMotion: state.reducedMotion,


### PR DESCRIPTION
Remove the unneeded territory option from `FeatureToggles` in the settings panel and `usePreferences`.

<img width="1221" height="845" alt="Screenshot 2026-04-09 at 15 19 29" src="https://github.com/user-attachments/assets/72d98580-e8aa-456d-ba83-b100ed0a6515" />
