### PR TITLE
chore: info lorem text

### DIFF
--- a/kaggle_environments/envs/open_spiel_env/games/chess/visualizer/v2/src/components/BoardControls.tsx
+++ b/kaggle_environments/envs/open_spiel_env/games/chess/visualizer/v2/src/components/BoardControls.tsx
@@ -27,8 +27,8 @@ export default function BoardControls() {
     <div className={styles.boardControls} ref={inertRef}>
       <WithPopover id="info" icon="info" label="Game info">
         <p>
-          Go is an ancient, two-player game in which players try to control more territory on a grid by strategically
-          placing black and white stones. This game follows Tromp-Taylor rules.
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean sed malesuada nulla, ut tempus magna.
+          Suspendisse non consectetur justo, vel fringilla ipsum.
         </p>
       </WithPopover>
       <label className={`grid-pile ${styles.soundToggle}`}>


### PR DESCRIPTION
Removing the Go v2 text in the info panel, putting placeholder lorem ipsum in instead.

<img width="1212" height="907" alt="Screenshot 2026-04-09 at 15 33 29" src="https://github.com/user-attachments/assets/df8d918e-6a84-4aa9-b8f6-224e1280f1b3" />
