### PR TITLE
fix: first step board state

### DIFF
--- a/kaggle_environments/envs/open_spiel_env/games/chess/visualizer/v2/src/components/GameRenderer.tsx
+++ b/kaggle_environments/envs/open_spiel_env/games/chess/visualizer/v2/src/components/GameRenderer.tsx
@@ -10,17 +10,18 @@ export default memo(function GameRenderer(options: GameRendererProps<ChessStep[]
 
   useEffect(() => {
     const step = options.replay.steps.at(options.step);
-    const player = step!.players.find((player: ChessPlayer) => player.isTurn);
+
+    if (!step) return;
 
     const history = options.replay.info!.stateHistory;
-    const fen = history[options.step - 1] ?? undefined;
+    const fen = history.at(Math.max(0, options.step - 1));
     const game = new Chess(fen);
 
+    const player = step.players.find((player: ChessPlayer) => player.isTurn);
     if (player?.actionDisplayText) game.move(player.actionDisplayText);
 
-    step!.players.map((p, i) => {
-      const color = i ? 'b' : 'w';
-      game.setHeader(color, p.name);
+    step.players.map((player, index) => {
+      game.setHeader(index ? 'b' : 'w', player.name);
     });
 
     setState(game, options);

--- a/kaggle_environments/envs/open_spiel_env/games/chess/visualizer/v2/src/utils/getStepRenderTime.ts
+++ b/kaggle_environments/envs/open_spiel_env/games/chess/visualizer/v2/src/utils/getStepRenderTime.ts
@@ -10,9 +10,11 @@ export function getStepRenderTime(step: BaseGameStep, replayMode: ReplayMode, sp
   if (!showHeroAnimations) return time;
 
   const game = useGameStore.getState().game;
-  const move = step?.players.find((p) => p.isTurn)?.actionDisplayText;
-  const previousMove = game.history({ verbose: true }).at(0)?.san;
 
+  // The step time calculation races the game render, so can't rely on game
+  // render to have played the latest move before we work out the hero type
+  const move = step?.players.find((p) => p.isTurn)?.actionDisplayText;
+  const previousMove = game.history({ verbose: true }).at(-1)?.san;
   if (move && move !== previousMove) game.move(move);
 
   if (detectHeroType(game) !== null) return 1000 * 5;


### PR DESCRIPTION
A small fix to the way the initial step board state is set up, making sure to stay in the range of the `history` array in `options`.