### PR TITLE
build visualizer with replay file

### DIFF
--- a/web/core/src/player/player.ts
+++ b/web/core/src/player/player.ts
@@ -60,7 +60,7 @@ export class ReplayVisualizer<TSteps extends BaseGameStep[] = BaseGameStep[]> {
     }
 
     // 2. (PRIORITY 2) No HMR replay data. Check for VITE_REPLAY_FILE in dev mode.
-    else if (import.meta.env?.DEV) {
+    else if (import.meta.env?.DEV || import.meta.env?.VITE_REPLAY_FILE) {
       const replayFile = import.meta.env.VITE_REPLAY_FILE;
       if (replayFile) {
         fetch(replayFile)


### PR DESCRIPTION
Adds the ability to build stand alone versions of the OpenSpiel visualizers like `go-v2` and `chess-v2`, where we're deploying previews for internal review and to share with the wider Kaggle team.

For these visualizers we're using `.env` to configure whether a local replay file is used during development, and it's path if we are. We've also a script that copies the configured replay file into the `dist` directory after the build is complete so it's available when the app runs.

https://github.com/Kaggle/kaggle-environments/blob/6b047bb2975d13a7cf3c899734f16b417cb47691/kaggle_environments/envs/open_spiel_env/games/go/visualizer/v2/.env.example#L1

https://github.com/Kaggle/kaggle-environments/blob/6b047bb2975d13a7cf3c899734f16b417cb47691/kaggle_environments/envs/open_spiel_env/games/go/visualizer/v2/package.json#L8

So we just need this small change to the logic in `ReplayVisualizer` to use the replay file outside of `dev` mode.

Note: we did have a change a bit like this in `master` previously, but I think it got lost during recent updates to the player and visualizer to bring the transformers into the individual visualizer code folders.