### PR TITLE
feat: taken pieces

### DIFF
--- a/kaggle_environments/envs/open_spiel_env/games/chess/visualizer/v2/src/components/GameRenderer.tsx
+++ b/kaggle_environments/envs/open_spiel_env/games/chess/visualizer/v2/src/components/GameRenderer.tsx
@@ -1,7 +1,7 @@
 import { memo, useEffect } from 'react';
 import { Chess } from 'chess.js';
 import { GameRendererProps } from '@kaggle-environments/core';
-import { ChessStep, ChessPlayer } from '../transformers/chessReplayTypes';
+import { ChessStep } from '../transformers/chessReplayTypes';
 import useGameStore from '../stores/useGameStore';
 import Layout from './Layout';
 
@@ -9,20 +9,16 @@ export default memo(function GameRenderer(options: GameRendererProps<ChessStep[]
   const setState = useGameStore((state) => state.setState);
 
   useEffect(() => {
-    const step = options.replay.steps.at(options.step);
+    const game = new Chess();
 
-    if (!step) return;
+    for (const step of options.replay.steps) {
+      if (step.step > options.step) break;
+      const move = step.players.find((p) => p.isTurn)?.actionDisplayText;
+      if (move) game.move(move);
+    }
 
-    const history = options.replay.info!.stateHistory;
-    const fen = history.at(Math.max(0, options.step - 1));
-    const game = new Chess(fen);
-
-    const player = step.players.find((player: ChessPlayer) => player.isTurn);
-    if (player?.actionDisplayText) game.move(player.actionDisplayText);
-
-    step.players.map((player, index) => {
-      game.setHeader(index ? 'b' : 'w', player.name);
-    });
+    game.setHeader('b', options.replay.info?.TeamNames.at(0));
+    game.setHeader('w', options.replay.info?.TeamNames.at(1));
 
     setState(game, options);
   }, [setState, options]);

--- a/kaggle_environments/envs/open_spiel_env/games/chess/visualizer/v2/src/components/PlayerBar.tsx
+++ b/kaggle_environments/envs/open_spiel_env/games/chess/visualizer/v2/src/components/PlayerBar.tsx
@@ -53,11 +53,10 @@ export function PlayerBar({ color }: Props) {
   const name = headers[color];
   const opponent = color === 'w' ? 'b' : 'w';
 
-  const captures = takenPieces(game).filter((p) => p.color === opponent);
+  const captures = takenPieces(game).filter((p) => p.color === color);
 
   // Temporary array of captures, we will do this properly later.
   const temp__captures: PieceName[] = [];
-
   for (const p of captures) {
     if (p.type === 'b') temp__captures.push('bishop');
     if (p.type === 'p') temp__captures.push('pawn');

--- a/kaggle_environments/envs/open_spiel_env/games/chess/visualizer/v2/src/components/PlayerBar.tsx
+++ b/kaggle_environments/envs/open_spiel_env/games/chess/visualizer/v2/src/components/PlayerBar.tsx
@@ -14,6 +14,7 @@ import rookBlackPath from '../assets/images/rook-b-small.webp';
 import rookWhitePath from '../assets/images/rook-w-small.webp';
 import useGameStore from '../stores/useGameStore.ts';
 import { BrandLogo } from './BrandLogo.tsx';
+import { takenPieces } from '../utils/takenPieces.ts';
 import styles from './Playerbar.module.css';
 
 const pieceColorImages = {
@@ -52,29 +53,18 @@ export function PlayerBar({ color }: Props) {
   const name = headers[color];
   const opponent = color === 'w' ? 'b' : 'w';
 
+  const captures = takenPieces(game).filter((p) => p.color === opponent);
+
   // Temporary array of captures, we will do this properly later.
-  const temp__captures: PieceName[] = [
-    'pawn',
-    'knight',
-    'pawn',
-    'queen',
-    'pawn',
-    'pawn',
-    'knight',
-    'pawn',
-    'queen',
-    'pawn',
-    'pawn',
-    'knight',
-    'pawn',
-    'queen',
-    'pawn',
-    'pawn',
-    'knight',
-    'pawn',
-    'queen',
-    'pawn',
-  ];
+  const temp__captures: PieceName[] = [];
+
+  for (const p of captures) {
+    if (p.type === 'b') temp__captures.push('bishop');
+    if (p.type === 'p') temp__captures.push('pawn');
+    if (p.type === 'n') temp__captures.push('knight');
+    if (p.type === 'r') temp__captures.push('rook');
+    if (p.type === 'q') temp__captures.push('queen');
+  }
 
   return (
     <div className={styles.playerBar} data-player={color}>

--- a/kaggle_environments/envs/open_spiel_env/games/chess/visualizer/v2/src/components/VersusBanner.tsx
+++ b/kaggle_environments/envs/open_spiel_env/games/chess/visualizer/v2/src/components/VersusBanner.tsx
@@ -22,7 +22,7 @@ export default function VersusBanner() {
           exit={{ opacity: 0, scale: 0.9, transition: exitTransition }}
         >
           <Ribbon>
-            {blackName ?? 'Black'} vs. {whiteName ?? 'White'}
+            {whiteName ?? 'White'} vs. {blackName ?? 'Black'}
           </Ribbon>
         </motion.div>
       )}

--- a/kaggle_environments/envs/open_spiel_env/games/chess/visualizer/v2/src/transformers/chessTransformer.ts
+++ b/kaggle_environments/envs/open_spiel_env/games/chess/visualizer/v2/src/transformers/chessTransformer.ts
@@ -94,7 +94,7 @@ export const chessTransformer = (environment: any): ChessStep[] => {
     winner: null,
   });
 
-  chessReplay.steps.forEach((step, index) => {
+  for (const step of chessReplay.steps) {
     // Each step contains a tuple of players, one who acted and one who's waiting
     const stepPlayers: ChessPlayer[] = step.map((player, index): ChessPlayer => {
       return {
@@ -112,7 +112,7 @@ export const chessTransformer = (environment: any): ChessStep[] => {
     // Ignore setup steps where no one acted
     if (stepPlayers.findIndex((player) => player.isTurn) !== -1) {
       chessSteps.push({
-        step: index,
+        step: chessSteps.length,
         players: stepPlayers,
         // Both agents have the same observation string for the step, just grab the first one
         fenState: parseFen(step[0].observation.observationString),
@@ -120,7 +120,7 @@ export const chessTransformer = (environment: any): ChessStep[] => {
         winner: '',
       });
     }
-  });
+  }
 
   const lastReplayStep = chessReplay.steps[chessReplay.steps.length - 1];
 

--- a/kaggle_environments/envs/open_spiel_env/games/chess/visualizer/v2/src/utils/getStepLabel.ts
+++ b/kaggle_environments/envs/open_spiel_env/games/chess/visualizer/v2/src/utils/getStepLabel.ts
@@ -9,12 +9,12 @@ export function getStepLabel(step: BaseGameStep) {
     return `Plays ${move}`;
   }
 
-  const whiteName = step.players.at(0)?.name ?? 'White';
-  const blackName = step.players.at(1)?.name ?? 'Black';
+  const blackName = step.players.at(0)?.name ?? 'Black';
+  const whiteName = step.players.at(1)?.name ?? 'White';
 
   // Game Start
   if (step.step === 0) {
-    return `${blackName} vs. ${whiteName}`;
+    return `${whiteName} vs. ${blackName}`;
   }
 
   // Game Over

--- a/kaggle_environments/envs/open_spiel_env/games/chess/visualizer/v2/src/utils/takenPieces.ts
+++ b/kaggle_environments/envs/open_spiel_env/games/chess/visualizer/v2/src/utils/takenPieces.ts
@@ -1,0 +1,15 @@
+import { Chess, Color, PieceSymbol } from 'chess.js';
+
+type TakenPieces = { color: Color; type: PieceSymbol }[];
+
+export function takenPieces(game: Chess): TakenPieces {
+  const takenPieces: TakenPieces = [];
+
+  for (const move of game.history({ verbose: true })) {
+    if (!move.captured) continue;
+    const opponent = move.color === 'b' ? 'w' : 'b';
+    takenPieces.push({ color: opponent, type: move.captured });
+  }
+
+  return takenPieces;
+}

--- a/kaggle_environments/envs/open_spiel_env/games/chess/visualizer/v2/src/utils/takenPieces.ts
+++ b/kaggle_environments/envs/open_spiel_env/games/chess/visualizer/v2/src/utils/takenPieces.ts
@@ -7,8 +7,7 @@ export function takenPieces(game: Chess): TakenPieces {
 
   for (const move of game.history({ verbose: true })) {
     if (!move.captured) continue;
-    const opponent = move.color === 'b' ? 'w' : 'b';
-    takenPieces.push({ color: opponent, type: move.captured });
+    takenPieces.push({ color: move.color, type: move.captured });
   }
 
   return takenPieces;


### PR DESCRIPTION
Adds a `takenPieces` function while goes through the game move history capturing each piece that is taken in order.

Returns an array with the taken pieces of both colors so needs filtering to use in each `PlayerBar`.

<img width="1152" height="861" alt="Screenshot 2026-04-10 at 13 35 36" src="https://github.com/user-attachments/assets/f53e8f26-50c7-47a4-a9a5-a2383da5583d" />

Note it includes a change to how the game state is recreated on each step, this now follows the same pattern as Go v2 where the history is played through to the current step each time in `GameRenderer`.