### PR TITLE
feat(chess): initialise pixi + respond to game changes

### DIFF
--- a/kaggle_environments/envs/open_spiel_env/games/chess/visualizer/v2/src/components/GameBoard.module.css
+++ b/kaggle_environments/envs/open_spiel_env/games/chess/visualizer/v2/src/components/GameBoard.module.css
@@ -1,0 +1,9 @@
+.board {
+  padding: 0.5rem;
+}
+
+.board canvas {
+  width: 100%;
+  height: 100%;
+  display: block;
+}

--- a/kaggle_environments/envs/open_spiel_env/games/chess/visualizer/v2/src/components/GameBoard.tsx
+++ b/kaggle_environments/envs/open_spiel_env/games/chess/visualizer/v2/src/components/GameBoard.tsx
@@ -1,62 +1,47 @@
-import { Chessboard } from 'react-chessboard';
-import bishopBlackPath from '../assets/images/bishop-b-small.webp';
-import bishopWhitePath from '../assets/images/bishop-w-small.webp';
-import kingBlackPath from '../assets/images/king-b-small.webp';
-import kingWhitePath from '../assets/images/king-w-small.webp';
-import knightBlackPath from '../assets/images/knight-b-small.webp';
-import knightWhitePath from '../assets/images/knight-w-small.webp';
-import pawnBlackPath from '../assets/images/pawn-b-small.webp';
-import pawnWhitePath from '../assets/images/pawn-w-small.webp';
-import queenBlackPath from '../assets/images/queen-b-small.webp';
-import queenWhitePath from '../assets/images/queen-w-small.webp';
-import rookBlackPath from '../assets/images/rook-b-small.webp';
-import rookWhitePath from '../assets/images/rook-w-small.webp';
+import { memo, useEffect, useRef } from 'react';
+import { createGame, type Game } from '../graphics/game';
 import useGameStore from '../stores/useGameStore';
+import styles from './GameBoard.module.css';
 
-export default function GameBoard() {
-  const game = useGameStore((state) => state.game);
-  const position = game.fen();
+export default memo(function GameBoard() {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const gameRef = useRef<Game | null>(null);
+  const chess = useGameStore((state) => state.game);
 
-  const style = { width: '100%', height: '100%' };
-  const pieces = {
-    wP: () => <img src={pawnWhitePath} style={style} />,
-    wK: () => <img src={kingWhitePath} style={style} />,
-    wQ: () => <img src={queenWhitePath} style={style} />,
-    wR: () => <img src={rookWhitePath} style={style} />,
-    wB: () => <img src={bishopWhitePath} style={style} />,
-    wN: () => <img src={knightWhitePath} style={style} />,
-    bP: () => <img src={pawnBlackPath} style={style} />,
-    bK: () => <img src={kingBlackPath} style={style} />,
-    bQ: () => <img src={queenBlackPath} style={style} />,
-    bR: () => <img src={rookBlackPath} style={style} />,
-    bB: () => <img src={bishopBlackPath} style={style} />,
-    bN: () => <img src={knightBlackPath} style={style} />,
-  };
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
 
-  const lightSquareStyle = {
-    // backgroundImage: 'url(./react-chessboard/wBg.png)',
-    backgroundPosition: 'center',
-    backgroundSize: 'cover',
-    backgroundRepeat: 'no-repeat',
-    backgroundColor: 'transparent',
-  };
+    let cancelled = false;
 
-  const darkSquareStyle = {
-    backgroundImage: 'url(./react-chessboard/bBg.png)',
-    backgroundPosition: 'center',
-    backgroundSize: 'cover',
-    backgroundRepeat: 'no-repeat',
-    backgroundColor: 'transparent',
-  };
+    // Defer init so StrictMode cleanup can cancel before we touch WebGL.
+    // Without this, two app.init() calls race on the same canvas and the context is corrupted.
+    const frameId = requestAnimationFrame(() => {
+      createGame(canvas).then((game) => {
+        if (cancelled) {
+          game.destroy();
+          return;
+        }
+        gameRef.current = game;
+        game.update(useGameStore.getState().game);
+      });
+    });
+
+    return () => {
+      cancelled = true;
+      cancelAnimationFrame(frameId);
+      gameRef.current?.destroy();
+      gameRef.current = null;
+    };
+  }, []);
+
+  useEffect(() => {
+    gameRef.current?.update(chess);
+  }, [chess]);
 
   return (
-    <div id="board" style={{ padding: '0.5em' }}>
-      <Chessboard
-        position={position}
-        customDarkSquareStyle={darkSquareStyle}
-        customLightSquareStyle={lightSquareStyle}
-        customPieces={pieces}
-      />
+    <div id="board" className={styles.board}>
+      <canvas ref={canvasRef} width={1024} height={1024} />
     </div>
   );
-}
+});

--- a/kaggle_environments/envs/open_spiel_env/games/chess/visualizer/v2/src/components/Layout.tsx
+++ b/kaggle_environments/envs/open_spiel_env/games/chess/visualizer/v2/src/components/Layout.tsx
@@ -8,7 +8,7 @@ import GameOver from './GameOver';
 import HeroAnimation from './HeroAnimation';
 import useBoardRect from '../hooks/useBoardRect';
 import styles from './Layout.module.css';
-import { PlayerBar } from './PlayerBar.tsx';
+import PlayerBar from './PlayerBar.tsx';
 
 export default memo(function Layout() {
   useBoardRect();

--- a/kaggle_environments/envs/open_spiel_env/games/chess/visualizer/v2/src/components/PlayerBar.tsx
+++ b/kaggle_environments/envs/open_spiel_env/games/chess/visualizer/v2/src/components/PlayerBar.tsx
@@ -46,7 +46,7 @@ interface Props {
   color: 'b' | 'w';
 }
 
-export function PlayerBar({ color }: Props) {
+export default function PlayerBar({ color }: Props) {
   const game = useGameStore((state) => state.game);
   const headers = game.getHeaders();
   const name = headers[color];

--- a/kaggle_environments/envs/open_spiel_env/games/chess/visualizer/v2/src/graphics/board/index.ts
+++ b/kaggle_environments/envs/open_spiel_env/games/chess/visualizer/v2/src/graphics/board/index.ts
@@ -1,0 +1,23 @@
+import { Graphics } from 'pixi.js';
+import { BOARD_SIZE } from '../constants';
+
+const LIGHT_SQUARE_COLOR = 0xffffff;
+const DARK_SQUARE_COLOR = 0x000000;
+
+// TODO(pim-at-stink): Use textures for the board.
+export function drawBoard(squareSize: number): Graphics {
+  const g = new Graphics();
+
+  for (let row = 0; row < BOARD_SIZE; row++) {
+    for (let col = 0; col < BOARD_SIZE; col++) {
+      const isLight = (row + col) % 2 === 0;
+      g.rect(col * squareSize, row * squareSize, squareSize, squareSize).fill(
+        isLight ? LIGHT_SQUARE_COLOR : DARK_SQUARE_COLOR
+      );
+    }
+  }
+
+  g.alpha = 0.6;
+
+  return g;
+}

--- a/kaggle_environments/envs/open_spiel_env/games/chess/visualizer/v2/src/graphics/constants.ts
+++ b/kaggle_environments/envs/open_spiel_env/games/chess/visualizer/v2/src/graphics/constants.ts
@@ -1,0 +1,17 @@
+export const BOARD_SIZE = 8;
+export const CHAR_CODE_A = 97; // 'a'.charCodeAt(0)
+
+export const LAYERS = ['background', 'pieces'] as const;
+export type Layer = (typeof LAYERS)[number];
+
+export type PieceType = 'p' | 'n' | 'b' | 'r' | 'q' | 'k';
+export type PieceColor = 'w' | 'b';
+
+export const PIECE_NAMES: Record<PieceType, string> = {
+  p: 'pawn',
+  n: 'knight',
+  b: 'bishop',
+  r: 'rook',
+  q: 'queen',
+  k: 'king',
+};

--- a/kaggle_environments/envs/open_spiel_env/games/chess/visualizer/v2/src/graphics/coordinates.ts
+++ b/kaggle_environments/envs/open_spiel_env/games/chess/visualizer/v2/src/graphics/coordinates.ts
@@ -1,0 +1,16 @@
+import { BOARD_SIZE, CHAR_CODE_A } from './constants';
+
+export type Orientation = 'white' | 'black';
+
+export function squareToPixel(square: string, squareSize: number, orientation: Orientation): { x: number; y: number } {
+  const file = square.charCodeAt(0) - CHAR_CODE_A;
+  const rank = Number(square[1]) - 1;
+
+  const col = orientation === 'white' ? file : BOARD_SIZE - 1 - file;
+  const row = orientation === 'white' ? BOARD_SIZE - 1 - rank : rank;
+
+  return {
+    x: col * squareSize + squareSize / 2,
+    y: row * squareSize + squareSize / 2,
+  };
+}

--- a/kaggle_environments/envs/open_spiel_env/games/chess/visualizer/v2/src/graphics/engine.ts
+++ b/kaggle_environments/envs/open_spiel_env/games/chess/visualizer/v2/src/graphics/engine.ts
@@ -1,0 +1,36 @@
+import { Application, Container, type Texture } from 'pixi.js';
+import { BOARD_SIZE, LAYERS, type Layer } from './constants';
+
+export function engine() {
+  const app = new Application();
+
+  const resources = {
+    background: new Container(),
+    pieces: new Container(),
+  } satisfies Record<Layer, Container>;
+
+  for (const layer of LAYERS) app.stage.addChild(resources[layer]);
+
+  return {
+    app,
+    resources,
+    textures: {} as Record<string, Texture>,
+    squareSize: 0,
+  };
+}
+
+export async function initialiseEngine(engine: Engine, canvas: HTMLCanvasElement) {
+  await engine.app.init({
+    canvas,
+    width: canvas.width,
+    height: canvas.height,
+    antialias: false,
+    backgroundAlpha: 0,
+    resolution: 1,
+    autoDensity: false,
+  });
+
+  engine.squareSize = engine.app.renderer.width / BOARD_SIZE;
+}
+
+export type Engine = ReturnType<typeof engine>;

--- a/kaggle_environments/envs/open_spiel_env/games/chess/visualizer/v2/src/graphics/game.ts
+++ b/kaggle_environments/envs/open_spiel_env/games/chess/visualizer/v2/src/graphics/game.ts
@@ -1,0 +1,30 @@
+import type { Chess } from 'chess.js';
+import { drawBoard } from './board';
+import { engine, initialiseEngine } from './engine';
+import { loadPieceTextures, syncPieces } from './pieces';
+
+export interface Game {
+  update: (chess: Chess) => void;
+  destroy: () => void;
+}
+
+export async function createGame(canvas: HTMLCanvasElement): Promise<Game> {
+  const eng = engine();
+  await initialiseEngine(eng, canvas);
+
+  eng.textures = await loadPieceTextures();
+
+  // Draw board.
+  const board = drawBoard(eng.squareSize);
+  board.cacheAsTexture(true);
+  eng.resources.background.addChild(board);
+
+  return {
+    update(chess: Chess) {
+      syncPieces(eng, chess);
+    },
+    destroy() {
+      eng.app.destroy({ removeView: true }, { children: true });
+    },
+  };
+}

--- a/kaggle_environments/envs/open_spiel_env/games/chess/visualizer/v2/src/graphics/pieces/index.ts
+++ b/kaggle_environments/envs/open_spiel_env/games/chess/visualizer/v2/src/graphics/pieces/index.ts
@@ -38,6 +38,8 @@ export async function loadPieceTextures(): Promise<Record<string, Texture>> {
   return Object.fromEntries(loaded);
 }
 
+// TODO(pim-at-stink): Note - We may need to make these sprites persist
+//  throughout the game.
 export function syncPieces(engine: Engine, chess: Chess) {
   const { squareSize, textures, resources } = engine;
 

--- a/kaggle_environments/envs/open_spiel_env/games/chess/visualizer/v2/src/graphics/pieces/index.ts
+++ b/kaggle_environments/envs/open_spiel_env/games/chess/visualizer/v2/src/graphics/pieces/index.ts
@@ -1,0 +1,64 @@
+import { Assets, Sprite, type Texture } from 'pixi.js';
+import { Chess } from 'chess.js';
+import type { Engine } from '../engine';
+import { squareToPixel } from '../coordinates';
+import type { PieceColor, PieceType } from '../constants';
+
+import bishopBlackPath from '../../assets/images/bishop-b-small.webp';
+import bishopWhitePath from '../../assets/images/bishop-w-small.webp';
+import kingBlackPath from '../../assets/images/king-b-small.webp';
+import kingWhitePath from '../../assets/images/king-w-small.webp';
+import knightBlackPath from '../../assets/images/knight-b-small.webp';
+import knightWhitePath from '../../assets/images/knight-w-small.webp';
+import pawnBlackPath from '../../assets/images/pawn-b-small.webp';
+import pawnWhitePath from '../../assets/images/pawn-w-small.webp';
+import queenBlackPath from '../../assets/images/queen-b-small.webp';
+import queenWhitePath from '../../assets/images/queen-w-small.webp';
+import rookBlackPath from '../../assets/images/rook-b-small.webp';
+import rookWhitePath from '../../assets/images/rook-w-small.webp';
+
+const PIECE_PATHS: Record<`${PieceColor}${PieceType}`, string> = {
+  wp: pawnWhitePath,
+  wn: knightWhitePath,
+  wb: bishopWhitePath,
+  wr: rookWhitePath,
+  wq: queenWhitePath,
+  wk: kingWhitePath,
+  bp: pawnBlackPath,
+  bn: knightBlackPath,
+  bb: bishopBlackPath,
+  br: rookBlackPath,
+  bq: queenBlackPath,
+  bk: kingBlackPath,
+};
+
+export async function loadPieceTextures(): Promise<Record<string, Texture>> {
+  const entries = Object.entries(PIECE_PATHS);
+  const loaded = await Promise.all(entries.map(async ([key, path]) => [key, await Assets.load(path)] as const));
+  return Object.fromEntries(loaded);
+}
+
+export function syncPieces(engine: Engine, chess: Chess) {
+  const { squareSize, textures, resources } = engine;
+
+  resources.pieces.removeChildren();
+
+  const board = chess.board();
+
+  for (const row of board) {
+    for (const cell of row) {
+      if (!cell) continue;
+
+      const texture = textures[`${cell.color}${cell.type}`];
+      if (!texture) continue;
+
+      const sprite = new Sprite({ texture, anchor: 0.5 });
+      sprite.scale.set(squareSize / texture.width);
+
+      const { x, y } = squareToPixel(cell.square, squareSize, 'white');
+      sprite.position.set(x, y);
+
+      resources.pieces.addChild(sprite);
+    }
+  }
+}


### PR DESCRIPTION
- Initialise PIXI (including a workaround for StrictMode)
- Draw a simple board (and cache it as a texture so it only draws/renders once)
- Feed game state into Pixi to sync pieces.