### PR TITLE
Fix local dev x staging Kaggle breakages due to duplicate listeners

### DIFF
--- a/web/core/src/components/EpisodePlayer.tsx
+++ b/web/core/src/components/EpisodePlayer.tsx
@@ -244,16 +244,16 @@ export function EpisodePlayer<TSteps extends BaseGameStep[] = BaseGameStep[]>({
   });
 
   useEffect(() => {
-    if (parentData.replay) {
+    if (parentData.replay && !skipTransform) {
       setReplay(parentData.replay as ReplayData<TSteps>);
     }
-  }, [parentData.replay]);
+  }, [parentData.replay, skipTransform]);
 
   useEffect(() => {
-    if (parentData.agents) {
+    if (parentData.agents && !skipTransform) {
       setCurrentAgents(parentData.agents);
     }
-  }, [parentData.agents]);
+  }, [parentData.agents, skipTransform]);
 
   // Calculate interesting events for the slider
   const interestingEvents = useMemo<InterestingEvent[]>(() => {


### PR DESCRIPTION
Two independent listeners inside the iframe both process a message from the parent: ReplayVisualizer (transforms the raw data through the game-specific transformer) and usePlayerController (stores the raw, untransformed data). The raw data from the second listener overwrites the transformed data in EpisodePlayer's state, so when the renderer for a game tried to access `step.players`, it crashed. Narrowing the conditions under which we set the replay and players helps for now.

There's a better longer term fix here where usePlayerController no longer does data handling and instead focuses just on playback controls, thus giving us a single point where we listen to the message instead of two, but for now I need to get unblocked on fixing other issues for Stink. 