### PR TITLE
Fix word association history

### DIFF
--- a/kaggle_environments/envs/word_association/harness/main.py
+++ b/kaggle_environments/envs/word_association/harness/main.py
@@ -133,12 +133,12 @@ class LLMWordAssociationAgent:
         prompt += f"The clue from your Spymaster is: '{clue}' for {clue_number} words. (You have {remaining} guesses remaining this turn.)\n\n"
         
         if clue_number > 0:
+            prompt += f"If you correctly guess {clue_number} words based on this clue, you may make a bonus guess based on all information you've received so far.\n\n"
+            
             correct_guesses = (clue_number + 1) - remaining
             words_remaining = remaining - 1
             
-            if correct_guesses == 0:
-                prompt += f"If you correctly guess {clue_number} words based on this clue, you may make a bonus guess based on all information you've received so far.\n\n"
-            else:
+            if correct_guesses > 0:
                 current_guesses = []
                 if hasattr(obs, "current_game_turns") and obs.current_game_turns:
                     current_guesses = obs.current_game_turns[-1]["guesses"]

--- a/kaggle_environments/envs/word_association/harness/main.py
+++ b/kaggle_environments/envs/word_association/harness/main.py
@@ -154,7 +154,7 @@ class LLMWordAssociationAgent:
         elif clue_number == -1:
             prompt += "A clue number of -1 means 'Infinity'. You get unlimited guesses based on this clue and previous clues. You must make at least one guess.\n\n"
             
-        # Fix 1: Show full board with revealed status and roles
+        # Show full board with revealed status and roles
         prompt += "Here is the board state:\n"
         roles = obs.roles # This is already masked by the environment for guessers!
         for i in range(25):

--- a/kaggle_environments/envs/word_association/harness/main.py
+++ b/kaggle_environments/envs/word_association/harness/main.py
@@ -131,18 +131,36 @@ class LLMWordAssociationAgent:
             prompt += "Note: The last entry in the 'Clues and guesses in this game so far' list above represents your current turn, showing the guesses you have already made for the current clue.\n\n"
         
         prompt += f"The clue from your Spymaster is: '{clue}' for {clue_number} words. (You have {remaining} guesses remaining this turn.)\n\n"
-        prompt += f"If you correctly guess {clue_number} words based on this clue, you may make a bonus guess based on all information you've received so far.\n\n"
+        
+        if clue_number > 0:
+            correct_guesses = (clue_number + 1) - remaining
+            words_remaining = remaining - 1
+            
+            if correct_guesses == 0:
+                prompt += f"If you correctly guess {clue_number} words based on this clue, you may make a bonus guess based on all information you've received so far.\n\n"
+            else:
+                current_guesses = []
+                if hasattr(obs, "current_game_turns") and obs.current_game_turns:
+                    current_guesses = obs.current_game_turns[-1]["guesses"]
+                guesses_str = ", ".join(current_guesses)
+                
+                if words_remaining == 0:
+                    prompt += f"You have correctly guessed all {clue_number} words for this clue (Guessed: {guesses_str}). You are now on your bonus guess!\n\n"
+                else:
+                    prompt += f"You have correctly guessed {correct_guesses} times for this clue already (Guessed: {guesses_str}), meaning there are {words_remaining} words related to the clue remaining.\n\n"
         
         if clue_number == 0:
             prompt += "A clue number of 0 means NONE of your remaining words relate to this clue (often used to point out the assassin). You get unlimited guesses, but you MUST still make at least one guess.\n\n"
         elif clue_number == -1:
             prompt += "A clue number of -1 means 'Infinity'. You get unlimited guesses based on this clue and previous clues. You must make at least one guess.\n\n"
             
-        prompt += "Here are the unrevealed words on the board you can choose from:\n"
-        
+        # Fix 1: Show full board with revealed status and roles
+        prompt += "Here is the board state:\n"
+        roles = obs.roles # This is already masked by the environment for guessers!
         for i in range(25):
-            if not revealed[i]:
-                prompt += f"{i}: {words[i]}\n"
+            status = "Revealed" if revealed[i] else "Hidden"
+            # roles[i] will be "Unknown" for hidden cards and the actual role for revealed cards
+            prompt += f"- {i}: {words[i]} ({roles[i].upper()}, {status})\n"
                 
         prompt += "\nThink step-by-step about which unrevealed word matches the clue best. Provide your reasoning in a 'thinking' key.\n"
         prompt += "Then provide the integer index of the ONE word you want to guess right now in a 'guess' key.\n"

--- a/kaggle_environments/envs/word_association/word_association.py
+++ b/kaggle_environments/envs/word_association/word_association.py
@@ -248,8 +248,9 @@ def interpreter(state, env):
     obs = state[0].observation
     games_per_episode = env.configuration.get("games_per_episode", 1)
     
-    # Always track turns within the current game
-    track_turn(obs, state)
+    # Always track turns within the current game for all agents
+    for s in state:
+        track_turn(s.observation, state)
     
     if games_per_episode > 1:
         is_done = all(s.status in ["DONE", "INVALID"] for s in state)


### PR DESCRIPTION
Now, the Guesser can see 

- Session History: A list of completed past games (if playing a multi-game episode).
- Match History: The turn-by-turn log of clues and guesses for the current game.
- Current Status: The active clue, guesses remaining, and a dynamic summary of what was just guessed for this specific clue.
- The Board: All 25 words with their indices, hidden/revealed status, and team roles (masked for guessers).
- Output Instructions: Strict JSON formatting rules with fields for reasoning and action.

--------------------------
Showing the dynamic current turn prompt given to guesser.
Case 1: Before making any guesses (4 guesses allowed)

`The clue from your Spymaster is: 'PIXEL' for 3 words. (You have 4 guesses remaining this turn.)
If you correctly guess 3 words based on this clue, you may make a bonus guess based on all information you've received so far.`

Case 2: After 1 correct guess (3 guesses remaining)

`The clue from your Spymaster is: 'PIXEL' for 3 words. (You have 3 guesses remaining this turn.)
You have correctly guessed 1 times for this clue already (Guessed: CAMERA), meaning there are 2 words related to the clue remaining.`

Case 3: On the bonus guess (all 3 words found, 1 guess remaining)

`The clue from your Spymaster is: 'PIXEL' for 3 words. (You have 1 guesses remaining this turn.)
You have correctly guessed all 3 words for this clue (Guessed: CAMERA, SCREEN, PHOTO). You are now on your bonus guess!`