### PR TITLE
Use single-file JS renderer for orbit_wars in ipython mode

### DIFF
--- a/kaggle_environments/core.py
+++ b/kaggle_environments/core.py
@@ -368,7 +368,7 @@ class Environment:
                 "logs": self.logs,
                 **kwargs,
             }
-            args = [self]
+            args = [self, mode]
             player_html = get_player(
                 window_kaggle, self.html_renderer(*args[: self.html_renderer.__code__.co_argcount])
             )

--- a/kaggle_environments/envs/orbit_wars/orbit_wars.py
+++ b/kaggle_environments/envs/orbit_wars/orbit_wars.py
@@ -736,11 +736,19 @@ with open(json_path) as json_file:
     specification = json.load(json_file)
 
 
-def html_renderer():
+def html_renderer(env, mode):
+    # In ipython/notebook mode, use the lightweight single-file JS renderer
+    if mode == "ipython":
+        js_path = path.abspath(path.join(dir_path, "orbit_wars.js"))
+        if path.exists(js_path):
+            with open(js_path, encoding="utf-8") as js_file:
+                return js_file.read()
+    # Default: use the full Vite-built visualizer
     jspath = path.join(dir_path, "visualizer", "default", "dist", "index.html")
     if path.exists(jspath):
         with open(jspath, encoding="utf-8") as f:
             return f.read()
+    # Fallback to single-file JS renderer
     js_path = path.abspath(path.join(dir_path, "orbit_wars.js"))
     if path.exists(js_path):
         with open(js_path, encoding="utf-8") as js_file:


### PR DESCRIPTION
Pass render mode to html_renderer (backwards compatible via co_argcount) so orbit_wars can return orbit_wars.js for notebooks and the Vite visualizer for html mode.