### PR TITLE
Use colorblind-safe Wong palette and improved fleet chevrons

### DIFF
--- a/kaggle_environments/envs/orbit_wars/orbit_wars.js
+++ b/kaggle_environments/envs/orbit_wars/orbit_wars.js
@@ -72,7 +72,8 @@ async function renderer(context) {
   const current_step = environment.steps[step];
   const obs = current_step[0].observation;
 
-  const colors = ['#FF4444', '#4444FF', '#44FF44', '#FFFF44', '#888888']; // P0, P1, P2, P3, Neutral
+  // Wong palette — colorblind-safe (blue, orange, teal, yellow, neutral grey)
+  const colors = ['#0072B2', '#E69F00', '#009E73', '#F0E442', '#888888'];
 
   // Draw Comet tails (before planets so tails render behind)
   const cometPidSet = new Set(obs.comet_planet_ids || []);
@@ -144,15 +145,34 @@ async function renderer(context) {
       c.save();
       c.translate(x, y);
       c.rotate(angle);
+
+      // Chevron with rounded tip and rounded tail wings
       c.beginPath();
-      // Chevron: tip at front, two wings swept back
-      c.moveTo(sz, 0); // tip
-      c.lineTo(-sz, -sz * 0.7); // top wing
-      c.lineTo(-sz * 0.3, 0); // inner notch
-      c.lineTo(-sz, sz * 0.7); // bottom wing
+      c.moveTo(sz * 0.6, 0);
+      // Rounded nose
+      c.arc(sz * 0.6, 0, sz * 0.4, -Math.PI / 2, Math.PI / 2);
+      // Top wing sweeping back with rounded end
+      c.lineTo(-sz * 0.3, sz * 0.15);
+      c.quadraticCurveTo(-sz * 1.1, sz * 0.5, -sz * 0.7, sz * 0.85);
+      // Inner notch
+      c.lineTo(-sz * 0.2, sz * 0.15);
+      c.lineTo(-sz * 0.2, -sz * 0.15);
+      // Bottom wing with rounded end
+      c.lineTo(-sz * 0.7, -sz * 0.85);
+      c.quadraticCurveTo(-sz * 1.1, -sz * 0.5, -sz * 0.3, -sz * 0.15);
       c.closePath();
       c.fillStyle = color;
       c.fill();
+
+      // Center stripe for readability
+      c.beginPath();
+      c.moveTo(sz * 0.7, 0);
+      c.lineTo(-sz * 0.15, 0);
+      c.strokeStyle = 'rgba(255, 255, 255, 0.5)';
+      c.lineWidth = sz * 0.2;
+      c.lineCap = 'round';
+      c.stroke();
+
       c.restore();
 
       // Draw ship count: north side if fleet is in south half, south side if north

--- a/kaggle_environments/envs/orbit_wars/orbit_wars.js
+++ b/kaggle_environments/envs/orbit_wars/orbit_wars.js
@@ -146,32 +146,40 @@ async function renderer(context) {
       c.translate(x, y);
       c.rotate(angle);
 
-      // Chevron with rounded tip and rounded tail wings
+      // Standard chevron shape for all players
       c.beginPath();
-      c.moveTo(sz * 0.6, 0);
-      // Rounded nose
-      c.arc(sz * 0.6, 0, sz * 0.4, -Math.PI / 2, Math.PI / 2);
-      // Top wing sweeping back with rounded end
-      c.lineTo(-sz * 0.3, sz * 0.15);
-      c.quadraticCurveTo(-sz * 1.1, sz * 0.5, -sz * 0.7, sz * 0.85);
-      // Inner notch
-      c.lineTo(-sz * 0.2, sz * 0.15);
-      c.lineTo(-sz * 0.2, -sz * 0.15);
-      // Bottom wing with rounded end
-      c.lineTo(-sz * 0.7, -sz * 0.85);
-      c.quadraticCurveTo(-sz * 1.1, -sz * 0.5, -sz * 0.3, -sz * 0.15);
+      c.moveTo(sz, 0); // tip
+      c.lineTo(-sz, -sz * 0.7); // top wing
+      c.lineTo(-sz * 0.3, 0); // inner notch
+      c.lineTo(-sz, sz * 0.7); // bottom wing
       c.closePath();
       c.fillStyle = color;
       c.fill();
 
-      // Center stripe for readability
-      c.beginPath();
-      c.moveTo(sz * 0.7, 0);
-      c.lineTo(-sz * 0.15, 0);
-      c.strokeStyle = 'rgba(255, 255, 255, 0.5)';
-      c.lineWidth = sz * 0.2;
+      // Per-player marking lines for colorblind accessibility
+      // P0: none, P1: 1 center line, P2: 2 lines (tip-to-wings), P3: 3 lines
+      c.strokeStyle = 'rgba(255, 255, 255, 0.55)';
+      c.lineWidth = sz * 0.15;
       c.lineCap = 'round';
-      c.stroke();
+      if (owner === 1 || owner === 3) {
+        // Center line (tip to notch)
+        c.beginPath();
+        c.moveTo(sz * 0.8, 0);
+        c.lineTo(-sz * 0.2, 0);
+        c.stroke();
+      }
+      if (owner === 2 || owner === 3) {
+        // Top line (tip toward top wing)
+        c.beginPath();
+        c.moveTo(sz * 0.6, -sz * 0.15);
+        c.lineTo(-sz * 0.7, -sz * 0.5);
+        c.stroke();
+        // Bottom line (tip toward bottom wing)
+        c.beginPath();
+        c.moveTo(sz * 0.6, sz * 0.15);
+        c.lineTo(-sz * 0.7, sz * 0.5);
+        c.stroke();
+      }
 
       c.restore();
 

--- a/kaggle_environments/envs/orbit_wars/visualizer/default/src/renderer.ts
+++ b/kaggle_environments/envs/orbit_wars/visualizer/default/src/renderer.ts
@@ -6,8 +6,8 @@ const BOARD_SIZE = 100;
 const CENTER = 50;
 const SUN_RADIUS = 10;
 
-// Player colors (bright for dark background)
-const PLAYER_COLORS = ['#FF4444', '#4a9eff', '#44FF44', '#FFFF44'];
+// Wong palette — colorblind-safe (blue, orange, teal, yellow)
+const PLAYER_COLORS = ['#0072B2', '#E69F00', '#009E73', '#F0E442'];
 const NEUTRAL_COLOR = '#666666';
 
 // Text size presets: [planetFont, deltaFont, fleetFont, stepFont]
@@ -333,11 +333,17 @@ export function renderer(options: RendererOptions) {
     c.save();
     c.translate(fx, fy);
     c.rotate(fleet.angle);
+
+    // Chevron with rounded tip and rounded tail wings
     c.beginPath();
-    c.moveTo(sz, 0);
-    c.lineTo(-sz, -sz * 0.6);
-    c.lineTo(-sz * 0.3, 0);
-    c.lineTo(-sz, sz * 0.6);
+    c.moveTo(sz * 0.6, 0);
+    c.arc(sz * 0.6, 0, sz * 0.4, -Math.PI / 2, Math.PI / 2);
+    c.lineTo(-sz * 0.3, sz * 0.15);
+    c.quadraticCurveTo(-sz * 1.1, sz * 0.5, -sz * 0.7, sz * 0.85);
+    c.lineTo(-sz * 0.2, sz * 0.15);
+    c.lineTo(-sz * 0.2, -sz * 0.15);
+    c.lineTo(-sz * 0.7, -sz * 0.85);
+    c.quadraticCurveTo(-sz * 1.1, -sz * 0.5, -sz * 0.3, -sz * 0.15);
     c.closePath();
     c.fillStyle = color;
     c.globalAlpha = 0.85;
@@ -346,6 +352,16 @@ export function renderer(options: RendererOptions) {
     c.strokeStyle = '#222';
     c.lineWidth = 0.5;
     c.stroke();
+
+    // Center stripe
+    c.beginPath();
+    c.moveTo(sz * 0.7, 0);
+    c.lineTo(-sz * 0.15, 0);
+    c.strokeStyle = 'rgba(255, 255, 255, 0.5)';
+    c.lineWidth = sz * 0.2;
+    c.lineCap = 'round';
+    c.stroke();
+
     c.restore();
   }
 
@@ -374,7 +390,7 @@ export function renderer(options: RendererOptions) {
         if (delta !== 0) {
           const deltaText = delta > 0 ? `+${delta}` : `${delta}`;
           c.font = `bold ${deltaFontSize}px Inter, sans-serif`;
-          c.fillStyle = delta > 0 ? '#44FF44' : '#FF4444';
+          c.fillStyle = delta > 0 ? '#009E73' : '#D55E00';
           c.fillText(deltaText, px, py - planet.radius * scale - deltaFontSize);
         }
       }

--- a/kaggle_environments/envs/orbit_wars/visualizer/default/src/renderer.ts
+++ b/kaggle_environments/envs/orbit_wars/visualizer/default/src/renderer.ts
@@ -334,16 +334,12 @@ export function renderer(options: RendererOptions) {
     c.translate(fx, fy);
     c.rotate(fleet.angle);
 
-    // Chevron with rounded tip and rounded tail wings
+    // Standard chevron shape for all players
     c.beginPath();
-    c.moveTo(sz * 0.6, 0);
-    c.arc(sz * 0.6, 0, sz * 0.4, -Math.PI / 2, Math.PI / 2);
-    c.lineTo(-sz * 0.3, sz * 0.15);
-    c.quadraticCurveTo(-sz * 1.1, sz * 0.5, -sz * 0.7, sz * 0.85);
-    c.lineTo(-sz * 0.2, sz * 0.15);
-    c.lineTo(-sz * 0.2, -sz * 0.15);
-    c.lineTo(-sz * 0.7, -sz * 0.85);
-    c.quadraticCurveTo(-sz * 1.1, -sz * 0.5, -sz * 0.3, -sz * 0.15);
+    c.moveTo(sz, 0);
+    c.lineTo(-sz, -sz * 0.6);
+    c.lineTo(-sz * 0.3, 0);
+    c.lineTo(-sz, sz * 0.6);
     c.closePath();
     c.fillStyle = color;
     c.globalAlpha = 0.85;
@@ -353,14 +349,27 @@ export function renderer(options: RendererOptions) {
     c.lineWidth = 0.5;
     c.stroke();
 
-    // Center stripe
-    c.beginPath();
-    c.moveTo(sz * 0.7, 0);
-    c.lineTo(-sz * 0.15, 0);
-    c.strokeStyle = 'rgba(255, 255, 255, 0.5)';
-    c.lineWidth = sz * 0.2;
+    // Per-player marking lines for colorblind accessibility
+    // P0: none, P1: 1 center line, P2: 2 lines (tip-to-wings), P3: 3 lines
+    c.strokeStyle = 'rgba(255, 255, 255, 0.55)';
+    c.lineWidth = sz * 0.15;
     c.lineCap = 'round';
-    c.stroke();
+    if (fleet.owner === 1 || fleet.owner === 3) {
+      c.beginPath();
+      c.moveTo(sz * 0.8, 0);
+      c.lineTo(-sz * 0.2, 0);
+      c.stroke();
+    }
+    if (fleet.owner === 2 || fleet.owner === 3) {
+      c.beginPath();
+      c.moveTo(sz * 0.6, -sz * 0.15);
+      c.lineTo(-sz * 0.7, -sz * 0.45);
+      c.stroke();
+      c.beginPath();
+      c.moveTo(sz * 0.6, sz * 0.15);
+      c.lineTo(-sz * 0.7, sz * 0.45);
+      c.stroke();
+    }
 
     c.restore();
   }


### PR DESCRIPTION
Switch player colors from red/green/blue/yellow to the Wong palette (blue/orange/teal/yellow) to avoid red-green confusion. Update fleet with patterns to help make them visually distinct