### PR TITLE
Use Inter font for game-over result text to match team names

### DIFF
--- a/kaggle_environments/envs/orbit_wars/visualizer/default/src/style.css
+++ b/kaggle_environments/envs/orbit_wars/visualizer/default/src/style.css
@@ -184,7 +184,8 @@ html, body, #app {
 }
 
 .game-over-modal .result-text {
-  font-family: 'Mynerve', cursive;
+  font-family: 'Inter', sans-serif;
+  font-weight: 700;
   font-size: 1.1rem;
   color: #8ac4ff;
 }


### PR DESCRIPTION
Replace Mynerve cursive with Inter bold in the orbit_wars game-over dialog so the result text matches the header player name styling.