### PR TITLE
Fix orbit_wars initial_planets sync after comet updates

### DIFF
--- a/kaggle_environments/envs/orbit_wars/orbit_wars.py
+++ b/kaggle_environments/envs/orbit_wars/orbit_wars.py
@@ -670,6 +670,7 @@ def interpreter(state, env):
 
     for i in range(1, num_agents):
         state[i].observation.planets = obs0.planets
+        state[i].observation.initial_planets = obs0.initial_planets
         state[i].observation.fleets = obs0.fleets
         state[i].observation.next_fleet_id = obs0.next_fleet_id
         state[i].observation.comets = obs0.comets

--- a/kaggle_environments/envs/orbit_wars/test_orbit_wars.py
+++ b/kaggle_environments/envs/orbit_wars/test_orbit_wars.py
@@ -12,6 +12,12 @@ from kaggle_environments.envs.orbit_wars.orbit_wars import (
 
 class TestOrbitWars(unittest.TestCase):
 
+    def _advance_step_counter(self, state):
+        next_step = getattr(state[0].observation, "step", 0) + 1
+        for agent_state in state:
+            agent_state.observation.step = next_step
+        return state
+
     def test_symmetry(self):
         # Mock state for step 0
         state = [
@@ -149,6 +155,46 @@ class TestOrbitWars(unittest.TestCase):
         self.assertEqual(len(owned), 4)
         owners = set(p[1] for p in owned)
         self.assertEqual(owners, {0, 1, 2, 3})
+
+    def test_comet_spawn_keeps_initial_planets_synced_across_players(self):
+        state = [
+            SimpleNamespace(
+                observation=SimpleNamespace(step=0),
+                action=[],
+                status="ACTIVE",
+                reward=0,
+            )
+        ] + [
+            SimpleNamespace(
+                observation=SimpleNamespace(player=i),
+                action=[],
+                status="ACTIVE",
+                reward=0,
+            )
+            for i in range(1, 4)
+        ]
+        env = SimpleNamespace(
+            configuration=SimpleNamespace(shipSpeed=5, episodeSteps=120, cometSpeed=4),
+            done=False,
+        )
+
+        state = interpreter(state, env)
+        state = self._advance_step_counter(state)
+
+        for _ in range(49):
+            for agent_state in state:
+                agent_state.action = []
+            state = interpreter(state, env)
+            state = self._advance_step_counter(state)
+
+        obs0 = state[0].observation
+
+        self.assertTrue(obs0.comets)
+        self.assertEqual(len(obs0.initial_planets), len(obs0.planets))
+        for other_state in state[1:]:
+            other_obs = other_state.observation
+            self.assertEqual(obs0.comet_planet_ids, other_obs.comet_planet_ids)
+            self.assertEqual(obs0.initial_planets, other_obs.initial_planets)
 
     def test_generate_planets_has_diagonal_orbiting_group(self):
         # The y=x diagonal orbiting group should always be generated


### PR DESCRIPTION
## Summary

This fixes an observation sync gap in `orbit_wars` where `initial_planets` could diverge between player 0 and the other players after comet spawn or comet expiry.

`obs0.initial_planets` is updated during comet lifecycle handling, but the end-of-turn synchronization for `i > 0` was only copying:

- `planets`
- `fleets`
- `next_fleet_id`
- `comets`
- `comet_planet_ids`

As a result, non-zero players could keep a stale `initial_planets` view even though the rest of the comet-related observation was already synchronized.

## Changes

- include `initial_planets` in the per-player observation sync block at the end of `interpreter()`
- add a regression test that advances a seeded 4-player game through the first comet spawn and verifies that every `i > 0` player receives the same `initial_planets` and `comet_planet_ids` as player 0

## Testing

```bash
uv run python -m pytest kaggle_environments/envs/orbit_wars/test_orbit_wars.py -q
```
