### PR TITLE
Seed RNG in orbit_wars comet-spawn test to fix flake

### DIFF
--- a/kaggle_environments/envs/orbit_wars/test_orbit_wars.py
+++ b/kaggle_environments/envs/orbit_wars/test_orbit_wars.py
@@ -1,5 +1,6 @@
-import unittest
 import math
+import random
+import unittest
 from types import SimpleNamespace
 from kaggle_environments.envs.orbit_wars.orbit_wars import (
     interpreter,
@@ -157,6 +158,9 @@ class TestOrbitWars(unittest.TestCase):
         self.assertEqual(owners, {0, 1, 2, 3})
 
     def test_comet_spawn_keeps_initial_planets_synced_across_players(self):
+        # Comet spawning is RNG-driven; seed so the 49-step window is
+        # deterministic and reliably contains a spawn.
+        random.seed(0)
         state = [
             SimpleNamespace(
                 observation=SimpleNamespace(step=0),


### PR DESCRIPTION
test_comet_spawn_keeps_initial_planets_synced_across_players advances 49 no-op steps and asserts a comet has spawned. Comet spawning is RNG-driven, so this fails ~7% of CI runs (observed 2/30 locally).

Seed random.seed(0) at the top of the test so the spawn window is deterministic. Confirmed 0/50 failures in repeated local runs.