### PR TITLE
Add Dark Hex (OpenSpiel) game and visualizer

### DIFF
--- a/kaggle_environments/envs/open_spiel_env/games/dark_hex/dark_hex_proxy.py
+++ b/kaggle_environments/envs/open_spiel_env/games/dark_hex/dark_hex_proxy.py
@@ -1,0 +1,88 @@
+"""Structured JSON observations for Dark Hex.
+
+Dark Hex is an imperfect-information variant of Hex: each player only sees
+their own pieces. When a player attempts to play on a cell occupied by the
+opponent, the move is rejected and the opponent's piece becomes visible at
+that cell -- the player then takes another turn. Player 0 ('x') connects
+top to bottom; player 1 ('o') connects left to right.
+"""
+
+import json
+from typing import Any
+
+import pyspiel
+
+from ... import proxy
+
+
+def _player_string(player: int) -> str:
+    if player < 0:
+        return pyspiel.PlayerId(player).name.lower()
+    if player == 0:
+        return "x"
+    if player == 1:
+        return "o"
+    raise ValueError(f"Invalid player: {player}")
+
+
+class DarkHexState(proxy.State):
+    """Dark Hex state proxy."""
+
+    def _board_from_observation(self, player: int) -> list[list[str]]:
+        raw = self.__wrapped__.observation_string(player)
+        return [list(row) for row in raw.split("\n") if row]
+
+    def state_dict(self, player: int | None = None) -> dict[str, Any]:
+        params = self.get_game().get_parameters()
+        num_rows = params.get("num_rows", params.get("board_size", 3))
+        num_cols = params.get("num_cols", params.get("board_size", 3))
+        winner = None
+        if self.is_terminal():
+            returns = self.returns()
+            if returns[0] > returns[1]:
+                winner = "x"
+            elif returns[1] > returns[0]:
+                winner = "o"
+            else:
+                winner = "draw"
+        result: dict[str, Any] = {
+            "current_player": _player_string(self.current_player()),
+            "is_terminal": self.is_terminal(),
+            "winner": winner,
+            "num_rows": num_rows,
+            "num_cols": num_cols,
+        }
+        if player is None:
+            result["board_player_x"] = self._board_from_observation(0)
+            result["board_player_o"] = self._board_from_observation(1)
+        else:
+            result["board"] = self._board_from_observation(player)
+        return result
+
+    def to_json(self, player: int | None = None) -> str:
+        return json.dumps(self.state_dict(player))
+
+    def observation_string(self, player: int) -> str:
+        return self.to_json(player)
+
+    def __str__(self) -> str:
+        return self.to_json()
+
+
+class DarkHexGame(proxy.Game):
+    """Dark Hex game proxy."""
+
+    def __init__(self, params: Any | None = None):
+        params = params or {}
+        wrapped = pyspiel.load_game("dark_hex", params)
+        super().__init__(
+            wrapped,
+            short_name="dark_hex_proxy",
+            long_name="Dark Hex (proxy)",
+        )
+
+    def new_initial_state(self, *args) -> DarkHexState:
+        return DarkHexState(self.__wrapped__.new_initial_state(*args), game=self)
+
+
+pyspiel.register_game(DarkHexGame().get_type(), DarkHexGame)

--- a/kaggle_environments/envs/open_spiel_env/games/dark_hex/visualizer/default/index.html
+++ b/kaggle_environments/envs/open_spiel_env/games/dark_hex/visualizer/default/index.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Dark Hex Visualizer</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=Mynerve&display=swap" rel="stylesheet" />
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="/src/main.ts"></script>
+  </body>
+</html>

--- a/kaggle_environments/envs/open_spiel_env/games/dark_hex/visualizer/default/package.json
+++ b/kaggle_environments/envs/open_spiel_env/games/dark_hex/visualizer/default/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@kaggle-environments/open-spiel-dark-hex-visualizer",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "dev-with-replay": "cross-env VITE_REPLAY_FILE=./replays/test-replay.json vite",
+    "build": "tsc && vite build",
+    "preview": "vite preview"
+  },
+  "devDependencies": {
+    "cross-env": "^10.1.0",
+    "typescript": "^5.0.0",
+    "vite": "^5.0.0"
+  },
+  "dependencies": {
+    "@kaggle-environments/core": "workspace:*"
+  }
+}

--- a/kaggle_environments/envs/open_spiel_env/games/dark_hex/visualizer/default/replays/test-replay.json
+++ b/kaggle_environments/envs/open_spiel_env/games/dark_hex/visualizer/default/replays/test-replay.json
@@ -1,0 +1,1093 @@
+{
+  "id": "7451fe8c-3f2c-11f1-96e9-122fb404ab4e",
+  "name": "open_spiel_dark_hex",
+  "title": "Open Spiel: dark_hex",
+  "description": "Kaggle environment wrapper for OpenSpiel games.\nFor game implementation details see:\nhttps://github.com/google-deepmind/open_spiel/tree/master/open_spiel/games",
+  "version": "0.1.0",
+  "module_version": "1.18.0",
+  "configuration": {
+    "includeLegalActions": true,
+    "episodeSteps": 117,
+    "actTimeout": 3600,
+    "runTimeout": 172800,
+    "openSpielGameString": "dark_hex_proxy(board_size=3,gameversion=cdh,num_cols=3,num_rows=3,obstype=reveal-nothing)",
+    "openSpielGameName": "dark_hex",
+    "openSpielGameParameters": {
+      "board_size": 3,
+      "gameversion": "cdh",
+      "num_cols": 3,
+      "num_rows": 3,
+      "obstype": "reveal-nothing"
+    },
+    "observationType": "observation",
+    "useOpenings": false,
+    "useImage": false,
+    "loadPresetHands": false,
+    "metadata": {}
+  },
+  "specification": {
+    "action": {
+      "description": "Action object MUST contain a field `submission`, and MAY contain arbitrary additional information.",
+      "type": "object",
+      "default": {
+        "submission": -1
+      }
+    },
+    "agents": [2],
+    "configuration": {
+      "episodeSteps": {
+        "description": "Maximum number of steps in the episode.",
+        "type": "integer",
+        "minimum": 1,
+        "default": 117
+      },
+      "actTimeout": {
+        "description": "Maximum runtime (seconds) to obtain an action from an agent.",
+        "type": "number",
+        "minimum": 0,
+        "default": 3600
+      },
+      "runTimeout": {
+        "description": "Maximum runtime (seconds) of an episode (not necessarily DONE).",
+        "type": "number",
+        "minimum": 0,
+        "default": 172800
+      },
+      "openSpielGameString": {
+        "description": "The full game string including parameters.",
+        "type": "string",
+        "default": "dark_hex_proxy(board_size=3,gameversion=cdh,num_cols=3,num_rows=3,obstype=reveal-nothing)"
+      },
+      "openSpielGameName": {
+        "description": "The short_name of the OpenSpiel game to load.",
+        "type": "string",
+        "default": "dark_hex"
+      },
+      "openSpielGameParameters": {
+        "description": "Game parameters for Open Spiel game.",
+        "type": "object",
+        "default": {
+          "board_size": 3,
+          "gameversion": "cdh",
+          "num_cols": 3,
+          "num_rows": 3,
+          "obstype": "reveal-nothing"
+        },
+        "properties": {}
+      },
+      "observationType": {
+        "description": "Type of observation string: 'observation' or 'information_state'.",
+        "type": "string",
+        "default": "observation"
+      },
+      "useOpenings": {
+        "description": "Whether to start from a position in an opening book.",
+        "type": "boolean",
+        "default": false
+      },
+      "useImage": {
+        "description": "If true, indicates the observation is intended to be rendered as an image. Note that currently the agent harness is responsible for the actual rendering; no image is passed in the observation.",
+        "type": "boolean",
+        "default": false
+      },
+      "includeLegalActions": {
+        "description": "If true, include legalActions and legalActionStrings in observations. Defaults to false since these can be derived from serializedGameAndState.",
+        "type": "boolean",
+        "default": false
+      },
+      "seed": {
+        "description": "Integer currently only used for selecting starting position.",
+        "type": "number"
+      },
+      "initialActions": {
+        "description": "Actions applied to initial state before play begins to set up starting position.",
+        "type": "array"
+      },
+      "loadPresetHands": {
+        "description": "Repeated poker only. Load preset hand chance actions from preset_hands.jsonl.",
+        "type": "boolean",
+        "default": false
+      },
+      "presetHands": {
+        "description": "Repeated poker only. List of per-hand chance action sequences to use instead of random chance.",
+        "type": "array"
+      },
+      "metadata": {
+        "description": "Arbitrary metadata.",
+        "type": "object",
+        "default": {},
+        "properties": {}
+      }
+    },
+    "info": {},
+    "observation": {
+      "remainingOverageTime": {
+        "description": "Total remaining banked time (seconds) that can be used in excess of per-step actTimeouts -- agent is disqualified with TIMEOUT status when this drops below 0.",
+        "shared": false,
+        "type": "number",
+        "minimum": 0,
+        "default": 12
+      },
+      "step": {
+        "description": "Current step within the episode.",
+        "type": "integer",
+        "shared": true,
+        "minimum": 0,
+        "default": 0
+      },
+      "properties": {
+        "openSpielGameString": {
+          "description": "Full game string including parameters.",
+          "type": "string",
+          "default": "dark_hex_proxy(board_size=3,gameversion=cdh,num_cols=3,num_rows=3,obstype=reveal-nothing)"
+        },
+        "openSpielGameName": {
+          "description": "Short name of the OpenSpiel game.",
+          "type": "string",
+          "default": "dark_hex"
+        },
+        "observationString": {
+          "description": "String representation of state.",
+          "type": "string"
+        },
+        "legalActions": {
+          "description": "List of OpenSpiel legal action integers. Only included if includeLegalActions is true.",
+          "type": "array"
+        },
+        "legalActionStrings": {
+          "description": "List of OpenSpiel legal action strings. Only included if includeLegalActions is true.",
+          "type": "array"
+        },
+        "currentPlayer": {
+          "description": "ID of player whose turn it is.",
+          "type": "integer"
+        },
+        "playerId": {
+          "description": "ID of the agent receiving this observation.",
+          "type": "integer"
+        },
+        "isTerminal": {
+          "description": "Boolean indicating game end.",
+          "type": "boolean"
+        },
+        "serializedGameAndState": {
+          "description": "Enables reconstructing the Game and State objects.",
+          "type": "string"
+        },
+        "remainingOverageTime": 60,
+        "step": 0
+      },
+      "default": {}
+    },
+    "reward": {
+      "type": ["number", "null"],
+      "default": 0.0
+    }
+  },
+  "steps": [
+    [
+      {
+        "action": {
+          "submission": -1
+        },
+        "reward": 0.0,
+        "info": {},
+        "observation": {
+          "remainingOverageTime": 12,
+          "step": 0
+        },
+        "status": "ACTIVE"
+      },
+      {
+        "action": {
+          "submission": -1
+        },
+        "reward": 0.0,
+        "info": {},
+        "observation": {
+          "remainingOverageTime": 12
+        },
+        "status": "ACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "submission": -1
+        },
+        "reward": null,
+        "info": {
+          "actionSubmitted": null,
+          "actionSubmittedToString": null,
+          "actionApplied": null,
+          "timeTaken": null,
+          "agentSelfReportedStatus": null
+        },
+        "observation": {
+          "remainingOverageTime": 12,
+          "step": 1,
+          "observationString": "{\"current_player\": \"x\", \"is_terminal\": false, \"winner\": null, \"num_rows\": 3, \"num_cols\": 3, \"board\": [[\".\", \".\", \".\"], [\".\", \".\", \".\"], [\".\", \".\", \".\"]]}",
+          "currentPlayer": 0,
+          "playerId": 0,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ndark_hex_proxy(board_size=3,gameversion=cdh,num_cols=3,num_rows=3,obstype=reveal-nothing)\n[State]\nhistory=\nmove_number=0\n__dict__=gASV4gAAAAAAAAB9lIwLX193cmFwcGVkX1+UjAdweXNwaWVslIwFU3RhdGWUk5QpgZSMtSMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmRhcmtfaGV4KGJvYXJkX3NpemU9MyxnYW1ldmVyc2lvbj1jZGgsbnVtX2NvbHM9MyxudW1fcm93cz0zLG9ic3R5cGU9cmV2ZWFsLW5vdGhpbmcpCltTdGF0ZV0KCgqUYnMu\n",
+          "legalActions": [0, 1, 2, 3, 4, 5, 6, 7, 8],
+          "legalActionStrings": [
+            "a1",
+            "b1",
+            "c1",
+            "a2",
+            "b2",
+            "c2",
+            "a3",
+            "b3",
+            "c3"
+          ]
+        },
+        "status": "ACTIVE"
+      },
+      {
+        "action": {
+          "submission": -1
+        },
+        "reward": null,
+        "info": {},
+        "observation": {
+          "remainingOverageTime": 12,
+          "observationString": "{\"current_player\": \"x\", \"is_terminal\": false, \"winner\": null, \"num_rows\": 3, \"num_cols\": 3, \"board\": [[\".\", \".\", \".\"], [\".\", \".\", \".\"], [\".\", \".\", \".\"]]}",
+          "currentPlayer": 0,
+          "playerId": 1,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ndark_hex_proxy(board_size=3,gameversion=cdh,num_cols=3,num_rows=3,obstype=reveal-nothing)\n[State]\nhistory=\nmove_number=0\n__dict__=gASV4gAAAAAAAAB9lIwLX193cmFwcGVkX1+UjAdweXNwaWVslIwFU3RhdGWUk5QpgZSMtSMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmRhcmtfaGV4KGJvYXJkX3NpemU9MyxnYW1ldmVyc2lvbj1jZGgsbnVtX2NvbHM9MyxudW1fcm93cz0zLG9ic3R5cGU9cmV2ZWFsLW5vdGhpbmcpCltTdGF0ZV0KCgqUYnMu\n",
+          "legalActions": [],
+          "legalActionStrings": []
+        },
+        "status": "INACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "submission": 2
+        },
+        "reward": null,
+        "info": {
+          "actionSubmitted": 2,
+          "actionSubmittedToString": "c1",
+          "actionApplied": 2,
+          "timeTaken": 0.0,
+          "agentSelfReportedStatus": null
+        },
+        "observation": {
+          "remainingOverageTime": 12,
+          "step": 2,
+          "observationString": "{\"current_player\": \"o\", \"is_terminal\": false, \"winner\": null, \"num_rows\": 3, \"num_cols\": 3, \"board\": [[\".\", \".\", \"x\"], [\".\", \".\", \".\"], [\".\", \".\", \".\"]]}",
+          "currentPlayer": 1,
+          "playerId": 0,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ndark_hex_proxy(board_size=3,gameversion=cdh,num_cols=3,num_rows=3,obstype=reveal-nothing)\n[State]\nhistory=0:2\nmove_number=1\n__dict__=gASV4wAAAAAAAAB9lIwLX193cmFwcGVkX1+UjAdweXNwaWVslIwFU3RhdGWUk5QpgZSMtiMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmRhcmtfaGV4KGJvYXJkX3NpemU9MyxnYW1ldmVyc2lvbj1jZGgsbnVtX2NvbHM9MyxudW1fcm93cz0zLG9ic3R5cGU9cmV2ZWFsLW5vdGhpbmcpCltTdGF0ZV0KMgoKlGJzLg==\n",
+          "legalActions": [],
+          "legalActionStrings": []
+        },
+        "status": "INACTIVE"
+      },
+      {
+        "action": {
+          "submission": -1
+        },
+        "reward": null,
+        "info": {},
+        "observation": {
+          "remainingOverageTime": 12,
+          "observationString": "{\"current_player\": \"o\", \"is_terminal\": false, \"winner\": null, \"num_rows\": 3, \"num_cols\": 3, \"board\": [[\".\", \".\", \".\"], [\".\", \".\", \".\"], [\".\", \".\", \".\"]]}",
+          "currentPlayer": 1,
+          "playerId": 1,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ndark_hex_proxy(board_size=3,gameversion=cdh,num_cols=3,num_rows=3,obstype=reveal-nothing)\n[State]\nhistory=0:2\nmove_number=1\n__dict__=gASV4wAAAAAAAAB9lIwLX193cmFwcGVkX1+UjAdweXNwaWVslIwFU3RhdGWUk5QpgZSMtiMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmRhcmtfaGV4KGJvYXJkX3NpemU9MyxnYW1ldmVyc2lvbj1jZGgsbnVtX2NvbHM9MyxudW1fcm93cz0zLG9ic3R5cGU9cmV2ZWFsLW5vdGhpbmcpCltTdGF0ZV0KMgoKlGJzLg==\n",
+          "legalActions": [0, 1, 2, 3, 4, 5, 6, 7, 8],
+          "legalActionStrings": [
+            "a1",
+            "b1",
+            "c1",
+            "a2",
+            "b2",
+            "c2",
+            "a3",
+            "b3",
+            "c3"
+          ]
+        },
+        "status": "ACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "submission": -1
+        },
+        "reward": null,
+        "info": {},
+        "observation": {
+          "remainingOverageTime": 12,
+          "step": 3,
+          "observationString": "{\"current_player\": \"o\", \"is_terminal\": false, \"winner\": null, \"num_rows\": 3, \"num_cols\": 3, \"board\": [[\".\", \".\", \"x\"], [\".\", \".\", \".\"], [\".\", \".\", \".\"]]}",
+          "currentPlayer": 1,
+          "playerId": 0,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ndark_hex_proxy(board_size=3,gameversion=cdh,num_cols=3,num_rows=3,obstype=reveal-nothing)\n[State]\nhistory=0:2,1:2\nmove_number=2\n__dict__=gASV5QAAAAAAAAB9lIwLX193cmFwcGVkX1+UjAdweXNwaWVslIwFU3RhdGWUk5QpgZSMuCMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmRhcmtfaGV4KGJvYXJkX3NpemU9MyxnYW1ldmVyc2lvbj1jZGgsbnVtX2NvbHM9MyxudW1fcm93cz0zLG9ic3R5cGU9cmV2ZWFsLW5vdGhpbmcpCltTdGF0ZV0KMgoyCgqUYnMu\n",
+          "legalActions": [],
+          "legalActionStrings": []
+        },
+        "status": "INACTIVE"
+      },
+      {
+        "action": {
+          "submission": 2
+        },
+        "reward": null,
+        "info": {
+          "actionSubmitted": 2,
+          "actionSubmittedToString": "c1",
+          "actionApplied": 2,
+          "timeTaken": 0.0,
+          "agentSelfReportedStatus": null
+        },
+        "observation": {
+          "remainingOverageTime": 12,
+          "observationString": "{\"current_player\": \"o\", \"is_terminal\": false, \"winner\": null, \"num_rows\": 3, \"num_cols\": 3, \"board\": [[\".\", \".\", \"x\"], [\".\", \".\", \".\"], [\".\", \".\", \".\"]]}",
+          "currentPlayer": 1,
+          "playerId": 1,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ndark_hex_proxy(board_size=3,gameversion=cdh,num_cols=3,num_rows=3,obstype=reveal-nothing)\n[State]\nhistory=0:2,1:2\nmove_number=2\n__dict__=gASV5QAAAAAAAAB9lIwLX193cmFwcGVkX1+UjAdweXNwaWVslIwFU3RhdGWUk5QpgZSMuCMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmRhcmtfaGV4KGJvYXJkX3NpemU9MyxnYW1ldmVyc2lvbj1jZGgsbnVtX2NvbHM9MyxudW1fcm93cz0zLG9ic3R5cGU9cmV2ZWFsLW5vdGhpbmcpCltTdGF0ZV0KMgoyCgqUYnMu\n",
+          "legalActions": [0, 1, 3, 4, 5, 6, 7, 8],
+          "legalActionStrings": ["a1", "b1", "a2", "b2", "c2", "a3", "b3", "c3"]
+        },
+        "status": "ACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "submission": -1
+        },
+        "reward": null,
+        "info": {},
+        "observation": {
+          "remainingOverageTime": 12,
+          "step": 4,
+          "observationString": "{\"current_player\": \"x\", \"is_terminal\": false, \"winner\": null, \"num_rows\": 3, \"num_cols\": 3, \"board\": [[\".\", \".\", \"x\"], [\".\", \".\", \".\"], [\".\", \".\", \".\"]]}",
+          "currentPlayer": 0,
+          "playerId": 0,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ndark_hex_proxy(board_size=3,gameversion=cdh,num_cols=3,num_rows=3,obstype=reveal-nothing)\n[State]\nhistory=0:2,1:2,1:7\nmove_number=3\n__dict__=gASV5wAAAAAAAAB9lIwLX193cmFwcGVkX1+UjAdweXNwaWVslIwFU3RhdGWUk5QpgZSMuiMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmRhcmtfaGV4KGJvYXJkX3NpemU9MyxnYW1ldmVyc2lvbj1jZGgsbnVtX2NvbHM9MyxudW1fcm93cz0zLG9ic3R5cGU9cmV2ZWFsLW5vdGhpbmcpCltTdGF0ZV0KMgoyCjcKCpRicy4=\n",
+          "legalActions": [0, 1, 3, 4, 5, 6, 7, 8],
+          "legalActionStrings": ["a1", "b1", "a2", "b2", "c2", "a3", "b3", "c3"]
+        },
+        "status": "ACTIVE"
+      },
+      {
+        "action": {
+          "submission": 7
+        },
+        "reward": null,
+        "info": {
+          "actionSubmitted": 7,
+          "actionSubmittedToString": "b3",
+          "actionApplied": 7,
+          "timeTaken": 0.0,
+          "agentSelfReportedStatus": null
+        },
+        "observation": {
+          "remainingOverageTime": 12,
+          "observationString": "{\"current_player\": \"x\", \"is_terminal\": false, \"winner\": null, \"num_rows\": 3, \"num_cols\": 3, \"board\": [[\".\", \".\", \"x\"], [\".\", \".\", \".\"], [\".\", \"o\", \".\"]]}",
+          "currentPlayer": 0,
+          "playerId": 1,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ndark_hex_proxy(board_size=3,gameversion=cdh,num_cols=3,num_rows=3,obstype=reveal-nothing)\n[State]\nhistory=0:2,1:2,1:7\nmove_number=3\n__dict__=gASV5wAAAAAAAAB9lIwLX193cmFwcGVkX1+UjAdweXNwaWVslIwFU3RhdGWUk5QpgZSMuiMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmRhcmtfaGV4KGJvYXJkX3NpemU9MyxnYW1ldmVyc2lvbj1jZGgsbnVtX2NvbHM9MyxudW1fcm93cz0zLG9ic3R5cGU9cmV2ZWFsLW5vdGhpbmcpCltTdGF0ZV0KMgoyCjcKCpRicy4=\n",
+          "legalActions": [],
+          "legalActionStrings": []
+        },
+        "status": "INACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "submission": 4
+        },
+        "reward": null,
+        "info": {
+          "actionSubmitted": 4,
+          "actionSubmittedToString": "b2",
+          "actionApplied": 4,
+          "timeTaken": 0.0,
+          "agentSelfReportedStatus": null
+        },
+        "observation": {
+          "remainingOverageTime": 12,
+          "step": 5,
+          "observationString": "{\"current_player\": \"o\", \"is_terminal\": false, \"winner\": null, \"num_rows\": 3, \"num_cols\": 3, \"board\": [[\".\", \".\", \"x\"], [\".\", \"x\", \".\"], [\".\", \".\", \".\"]]}",
+          "currentPlayer": 1,
+          "playerId": 0,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ndark_hex_proxy(board_size=3,gameversion=cdh,num_cols=3,num_rows=3,obstype=reveal-nothing)\n[State]\nhistory=0:2,1:2,1:7,0:4\nmove_number=4\n__dict__=gASV6QAAAAAAAAB9lIwLX193cmFwcGVkX1+UjAdweXNwaWVslIwFU3RhdGWUk5QpgZSMvCMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmRhcmtfaGV4KGJvYXJkX3NpemU9MyxnYW1ldmVyc2lvbj1jZGgsbnVtX2NvbHM9MyxudW1fcm93cz0zLG9ic3R5cGU9cmV2ZWFsLW5vdGhpbmcpCltTdGF0ZV0KMgoyCjcKNAoKlGJzLg==\n",
+          "legalActions": [],
+          "legalActionStrings": []
+        },
+        "status": "INACTIVE"
+      },
+      {
+        "action": {
+          "submission": -1
+        },
+        "reward": null,
+        "info": {},
+        "observation": {
+          "remainingOverageTime": 12,
+          "observationString": "{\"current_player\": \"o\", \"is_terminal\": false, \"winner\": null, \"num_rows\": 3, \"num_cols\": 3, \"board\": [[\".\", \".\", \"x\"], [\".\", \".\", \".\"], [\".\", \"o\", \".\"]]}",
+          "currentPlayer": 1,
+          "playerId": 1,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ndark_hex_proxy(board_size=3,gameversion=cdh,num_cols=3,num_rows=3,obstype=reveal-nothing)\n[State]\nhistory=0:2,1:2,1:7,0:4\nmove_number=4\n__dict__=gASV6QAAAAAAAAB9lIwLX193cmFwcGVkX1+UjAdweXNwaWVslIwFU3RhdGWUk5QpgZSMvCMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmRhcmtfaGV4KGJvYXJkX3NpemU9MyxnYW1ldmVyc2lvbj1jZGgsbnVtX2NvbHM9MyxudW1fcm93cz0zLG9ic3R5cGU9cmV2ZWFsLW5vdGhpbmcpCltTdGF0ZV0KMgoyCjcKNAoKlGJzLg==\n",
+          "legalActions": [0, 1, 3, 4, 5, 6, 8],
+          "legalActionStrings": ["a1", "b1", "a2", "b2", "c2", "a3", "c3"]
+        },
+        "status": "ACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "submission": -1
+        },
+        "reward": null,
+        "info": {},
+        "observation": {
+          "remainingOverageTime": 12,
+          "step": 6,
+          "observationString": "{\"current_player\": \"x\", \"is_terminal\": false, \"winner\": null, \"num_rows\": 3, \"num_cols\": 3, \"board\": [[\".\", \".\", \"x\"], [\".\", \"x\", \".\"], [\".\", \".\", \".\"]]}",
+          "currentPlayer": 0,
+          "playerId": 0,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ndark_hex_proxy(board_size=3,gameversion=cdh,num_cols=3,num_rows=3,obstype=reveal-nothing)\n[State]\nhistory=0:2,1:2,1:7,0:4,1:8\nmove_number=5\n__dict__=gASV6wAAAAAAAAB9lIwLX193cmFwcGVkX1+UjAdweXNwaWVslIwFU3RhdGWUk5QpgZSMviMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmRhcmtfaGV4KGJvYXJkX3NpemU9MyxnYW1ldmVyc2lvbj1jZGgsbnVtX2NvbHM9MyxudW1fcm93cz0zLG9ic3R5cGU9cmV2ZWFsLW5vdGhpbmcpCltTdGF0ZV0KMgoyCjcKNAo4CgqUYnMu\n",
+          "legalActions": [0, 1, 3, 5, 6, 7, 8],
+          "legalActionStrings": ["a1", "b1", "a2", "c2", "a3", "b3", "c3"]
+        },
+        "status": "ACTIVE"
+      },
+      {
+        "action": {
+          "submission": 8
+        },
+        "reward": null,
+        "info": {
+          "actionSubmitted": 8,
+          "actionSubmittedToString": "c3",
+          "actionApplied": 8,
+          "timeTaken": 0.0,
+          "agentSelfReportedStatus": null
+        },
+        "observation": {
+          "remainingOverageTime": 12,
+          "observationString": "{\"current_player\": \"x\", \"is_terminal\": false, \"winner\": null, \"num_rows\": 3, \"num_cols\": 3, \"board\": [[\".\", \".\", \"x\"], [\".\", \".\", \".\"], [\".\", \"o\", \"o\"]]}",
+          "currentPlayer": 0,
+          "playerId": 1,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ndark_hex_proxy(board_size=3,gameversion=cdh,num_cols=3,num_rows=3,obstype=reveal-nothing)\n[State]\nhistory=0:2,1:2,1:7,0:4,1:8\nmove_number=5\n__dict__=gASV6wAAAAAAAAB9lIwLX193cmFwcGVkX1+UjAdweXNwaWVslIwFU3RhdGWUk5QpgZSMviMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmRhcmtfaGV4KGJvYXJkX3NpemU9MyxnYW1ldmVyc2lvbj1jZGgsbnVtX2NvbHM9MyxudW1fcm93cz0zLG9ic3R5cGU9cmV2ZWFsLW5vdGhpbmcpCltTdGF0ZV0KMgoyCjcKNAo4CgqUYnMu\n",
+          "legalActions": [],
+          "legalActionStrings": []
+        },
+        "status": "INACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "submission": 8
+        },
+        "reward": null,
+        "info": {
+          "actionSubmitted": 8,
+          "actionSubmittedToString": "c3",
+          "actionApplied": 8,
+          "timeTaken": 0.0,
+          "agentSelfReportedStatus": null
+        },
+        "observation": {
+          "remainingOverageTime": 12,
+          "step": 7,
+          "observationString": "{\"current_player\": \"x\", \"is_terminal\": false, \"winner\": null, \"num_rows\": 3, \"num_cols\": 3, \"board\": [[\".\", \".\", \"x\"], [\".\", \"x\", \".\"], [\".\", \".\", \"o\"]]}",
+          "currentPlayer": 0,
+          "playerId": 0,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ndark_hex_proxy(board_size=3,gameversion=cdh,num_cols=3,num_rows=3,obstype=reveal-nothing)\n[State]\nhistory=0:2,1:2,1:7,0:4,1:8,0:8\nmove_number=6\n__dict__=gASV7QAAAAAAAAB9lIwLX193cmFwcGVkX1+UjAdweXNwaWVslIwFU3RhdGWUk5QpgZSMwCMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmRhcmtfaGV4KGJvYXJkX3NpemU9MyxnYW1ldmVyc2lvbj1jZGgsbnVtX2NvbHM9MyxudW1fcm93cz0zLG9ic3R5cGU9cmV2ZWFsLW5vdGhpbmcpCltTdGF0ZV0KMgoyCjcKNAo4CjgKCpRicy4=\n",
+          "legalActions": [0, 1, 3, 5, 6, 7],
+          "legalActionStrings": ["a1", "b1", "a2", "c2", "a3", "b3"]
+        },
+        "status": "ACTIVE"
+      },
+      {
+        "action": {
+          "submission": -1
+        },
+        "reward": null,
+        "info": {},
+        "observation": {
+          "remainingOverageTime": 12,
+          "observationString": "{\"current_player\": \"x\", \"is_terminal\": false, \"winner\": null, \"num_rows\": 3, \"num_cols\": 3, \"board\": [[\".\", \".\", \"x\"], [\".\", \".\", \".\"], [\".\", \"o\", \"o\"]]}",
+          "currentPlayer": 0,
+          "playerId": 1,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ndark_hex_proxy(board_size=3,gameversion=cdh,num_cols=3,num_rows=3,obstype=reveal-nothing)\n[State]\nhistory=0:2,1:2,1:7,0:4,1:8,0:8\nmove_number=6\n__dict__=gASV7QAAAAAAAAB9lIwLX193cmFwcGVkX1+UjAdweXNwaWVslIwFU3RhdGWUk5QpgZSMwCMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmRhcmtfaGV4KGJvYXJkX3NpemU9MyxnYW1ldmVyc2lvbj1jZGgsbnVtX2NvbHM9MyxudW1fcm93cz0zLG9ic3R5cGU9cmV2ZWFsLW5vdGhpbmcpCltTdGF0ZV0KMgoyCjcKNAo4CjgKCpRicy4=\n",
+          "legalActions": [],
+          "legalActionStrings": []
+        },
+        "status": "INACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "submission": 3
+        },
+        "reward": null,
+        "info": {
+          "actionSubmitted": 3,
+          "actionSubmittedToString": "a2",
+          "actionApplied": 3,
+          "timeTaken": 0.0,
+          "agentSelfReportedStatus": null
+        },
+        "observation": {
+          "remainingOverageTime": 12,
+          "step": 8,
+          "observationString": "{\"current_player\": \"o\", \"is_terminal\": false, \"winner\": null, \"num_rows\": 3, \"num_cols\": 3, \"board\": [[\".\", \".\", \"x\"], [\"x\", \"x\", \".\"], [\".\", \".\", \"o\"]]}",
+          "currentPlayer": 1,
+          "playerId": 0,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ndark_hex_proxy(board_size=3,gameversion=cdh,num_cols=3,num_rows=3,obstype=reveal-nothing)\n[State]\nhistory=0:2,1:2,1:7,0:4,1:8,0:8,0:3\nmove_number=7\n__dict__=gASV7wAAAAAAAAB9lIwLX193cmFwcGVkX1+UjAdweXNwaWVslIwFU3RhdGWUk5QpgZSMwiMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmRhcmtfaGV4KGJvYXJkX3NpemU9MyxnYW1ldmVyc2lvbj1jZGgsbnVtX2NvbHM9MyxudW1fcm93cz0zLG9ic3R5cGU9cmV2ZWFsLW5vdGhpbmcpCltTdGF0ZV0KMgoyCjcKNAo4CjgKMwoKlGJzLg==\n",
+          "legalActions": [],
+          "legalActionStrings": []
+        },
+        "status": "INACTIVE"
+      },
+      {
+        "action": {
+          "submission": -1
+        },
+        "reward": null,
+        "info": {},
+        "observation": {
+          "remainingOverageTime": 12,
+          "observationString": "{\"current_player\": \"o\", \"is_terminal\": false, \"winner\": null, \"num_rows\": 3, \"num_cols\": 3, \"board\": [[\".\", \".\", \"x\"], [\".\", \".\", \".\"], [\".\", \"o\", \"o\"]]}",
+          "currentPlayer": 1,
+          "playerId": 1,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ndark_hex_proxy(board_size=3,gameversion=cdh,num_cols=3,num_rows=3,obstype=reveal-nothing)\n[State]\nhistory=0:2,1:2,1:7,0:4,1:8,0:8,0:3\nmove_number=7\n__dict__=gASV7wAAAAAAAAB9lIwLX193cmFwcGVkX1+UjAdweXNwaWVslIwFU3RhdGWUk5QpgZSMwiMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmRhcmtfaGV4KGJvYXJkX3NpemU9MyxnYW1ldmVyc2lvbj1jZGgsbnVtX2NvbHM9MyxudW1fcm93cz0zLG9ic3R5cGU9cmV2ZWFsLW5vdGhpbmcpCltTdGF0ZV0KMgoyCjcKNAo4CjgKMwoKlGJzLg==\n",
+          "legalActions": [0, 1, 3, 4, 5, 6],
+          "legalActionStrings": ["a1", "b1", "a2", "b2", "c2", "a3"]
+        },
+        "status": "ACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "submission": -1
+        },
+        "reward": null,
+        "info": {},
+        "observation": {
+          "remainingOverageTime": 12,
+          "step": 9,
+          "observationString": "{\"current_player\": \"x\", \"is_terminal\": false, \"winner\": null, \"num_rows\": 3, \"num_cols\": 3, \"board\": [[\".\", \".\", \"x\"], [\"x\", \"x\", \".\"], [\".\", \".\", \"o\"]]}",
+          "currentPlayer": 0,
+          "playerId": 0,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ndark_hex_proxy(board_size=3,gameversion=cdh,num_cols=3,num_rows=3,obstype=reveal-nothing)\n[State]\nhistory=0:2,1:2,1:7,0:4,1:8,0:8,0:3,1:1\nmove_number=8\n__dict__=gASV8QAAAAAAAAB9lIwLX193cmFwcGVkX1+UjAdweXNwaWVslIwFU3RhdGWUk5QpgZSMxCMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmRhcmtfaGV4KGJvYXJkX3NpemU9MyxnYW1ldmVyc2lvbj1jZGgsbnVtX2NvbHM9MyxudW1fcm93cz0zLG9ic3R5cGU9cmV2ZWFsLW5vdGhpbmcpCltTdGF0ZV0KMgoyCjcKNAo4CjgKMwoxCgqUYnMu\n",
+          "legalActions": [0, 1, 5, 6, 7],
+          "legalActionStrings": ["a1", "b1", "c2", "a3", "b3"]
+        },
+        "status": "ACTIVE"
+      },
+      {
+        "action": {
+          "submission": 1
+        },
+        "reward": null,
+        "info": {
+          "actionSubmitted": 1,
+          "actionSubmittedToString": "b1",
+          "actionApplied": 1,
+          "timeTaken": 0.0,
+          "agentSelfReportedStatus": null
+        },
+        "observation": {
+          "remainingOverageTime": 12,
+          "observationString": "{\"current_player\": \"x\", \"is_terminal\": false, \"winner\": null, \"num_rows\": 3, \"num_cols\": 3, \"board\": [[\".\", \"o\", \"x\"], [\".\", \".\", \".\"], [\".\", \"o\", \"o\"]]}",
+          "currentPlayer": 0,
+          "playerId": 1,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ndark_hex_proxy(board_size=3,gameversion=cdh,num_cols=3,num_rows=3,obstype=reveal-nothing)\n[State]\nhistory=0:2,1:2,1:7,0:4,1:8,0:8,0:3,1:1\nmove_number=8\n__dict__=gASV8QAAAAAAAAB9lIwLX193cmFwcGVkX1+UjAdweXNwaWVslIwFU3RhdGWUk5QpgZSMxCMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmRhcmtfaGV4KGJvYXJkX3NpemU9MyxnYW1ldmVyc2lvbj1jZGgsbnVtX2NvbHM9MyxudW1fcm93cz0zLG9ic3R5cGU9cmV2ZWFsLW5vdGhpbmcpCltTdGF0ZV0KMgoyCjcKNAo4CjgKMwoxCgqUYnMu\n",
+          "legalActions": [],
+          "legalActionStrings": []
+        },
+        "status": "INACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "submission": 1
+        },
+        "reward": null,
+        "info": {
+          "actionSubmitted": 1,
+          "actionSubmittedToString": "b1",
+          "actionApplied": 1,
+          "timeTaken": 0.0,
+          "agentSelfReportedStatus": null
+        },
+        "observation": {
+          "remainingOverageTime": 12,
+          "step": 10,
+          "observationString": "{\"current_player\": \"x\", \"is_terminal\": false, \"winner\": null, \"num_rows\": 3, \"num_cols\": 3, \"board\": [[\".\", \"o\", \"x\"], [\"x\", \"x\", \".\"], [\".\", \".\", \"o\"]]}",
+          "currentPlayer": 0,
+          "playerId": 0,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ndark_hex_proxy(board_size=3,gameversion=cdh,num_cols=3,num_rows=3,obstype=reveal-nothing)\n[State]\nhistory=0:2,1:2,1:7,0:4,1:8,0:8,0:3,1:1,0:1\nmove_number=9\n__dict__=gASV8wAAAAAAAAB9lIwLX193cmFwcGVkX1+UjAdweXNwaWVslIwFU3RhdGWUk5QpgZSMxiMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmRhcmtfaGV4KGJvYXJkX3NpemU9MyxnYW1ldmVyc2lvbj1jZGgsbnVtX2NvbHM9MyxudW1fcm93cz0zLG9ic3R5cGU9cmV2ZWFsLW5vdGhpbmcpCltTdGF0ZV0KMgoyCjcKNAo4CjgKMwoxCjEKCpRicy4=\n",
+          "legalActions": [0, 5, 6, 7],
+          "legalActionStrings": ["a1", "c2", "a3", "b3"]
+        },
+        "status": "ACTIVE"
+      },
+      {
+        "action": {
+          "submission": -1
+        },
+        "reward": null,
+        "info": {},
+        "observation": {
+          "remainingOverageTime": 12,
+          "observationString": "{\"current_player\": \"x\", \"is_terminal\": false, \"winner\": null, \"num_rows\": 3, \"num_cols\": 3, \"board\": [[\".\", \"o\", \"x\"], [\".\", \".\", \".\"], [\".\", \"o\", \"o\"]]}",
+          "currentPlayer": 0,
+          "playerId": 1,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ndark_hex_proxy(board_size=3,gameversion=cdh,num_cols=3,num_rows=3,obstype=reveal-nothing)\n[State]\nhistory=0:2,1:2,1:7,0:4,1:8,0:8,0:3,1:1,0:1\nmove_number=9\n__dict__=gASV8wAAAAAAAAB9lIwLX193cmFwcGVkX1+UjAdweXNwaWVslIwFU3RhdGWUk5QpgZSMxiMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmRhcmtfaGV4KGJvYXJkX3NpemU9MyxnYW1ldmVyc2lvbj1jZGgsbnVtX2NvbHM9MyxudW1fcm93cz0zLG9ic3R5cGU9cmV2ZWFsLW5vdGhpbmcpCltTdGF0ZV0KMgoyCjcKNAo4CjgKMwoxCjEKCpRicy4=\n",
+          "legalActions": [],
+          "legalActionStrings": []
+        },
+        "status": "INACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "submission": 7
+        },
+        "reward": null,
+        "info": {
+          "actionSubmitted": 7,
+          "actionSubmittedToString": "b3",
+          "actionApplied": 7,
+          "timeTaken": 0.0,
+          "agentSelfReportedStatus": null
+        },
+        "observation": {
+          "remainingOverageTime": 12,
+          "step": 11,
+          "observationString": "{\"current_player\": \"x\", \"is_terminal\": false, \"winner\": null, \"num_rows\": 3, \"num_cols\": 3, \"board\": [[\".\", \"o\", \"x\"], [\"x\", \"x\", \".\"], [\".\", \"o\", \"o\"]]}",
+          "currentPlayer": 0,
+          "playerId": 0,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ndark_hex_proxy(board_size=3,gameversion=cdh,num_cols=3,num_rows=3,obstype=reveal-nothing)\n[State]\nhistory=0:2,1:2,1:7,0:4,1:8,0:8,0:3,1:1,0:1,0:7\nmove_number=10\n__dict__=gASV9QAAAAAAAAB9lIwLX193cmFwcGVkX1+UjAdweXNwaWVslIwFU3RhdGWUk5QpgZSMyCMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmRhcmtfaGV4KGJvYXJkX3NpemU9MyxnYW1ldmVyc2lvbj1jZGgsbnVtX2NvbHM9MyxudW1fcm93cz0zLG9ic3R5cGU9cmV2ZWFsLW5vdGhpbmcpCltTdGF0ZV0KMgoyCjcKNAo4CjgKMwoxCjEKNwoKlGJzLg==\n",
+          "legalActions": [0, 5, 6],
+          "legalActionStrings": ["a1", "c2", "a3"]
+        },
+        "status": "ACTIVE"
+      },
+      {
+        "action": {
+          "submission": -1
+        },
+        "reward": null,
+        "info": {},
+        "observation": {
+          "remainingOverageTime": 12,
+          "observationString": "{\"current_player\": \"x\", \"is_terminal\": false, \"winner\": null, \"num_rows\": 3, \"num_cols\": 3, \"board\": [[\".\", \"o\", \"x\"], [\".\", \".\", \".\"], [\".\", \"o\", \"o\"]]}",
+          "currentPlayer": 0,
+          "playerId": 1,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ndark_hex_proxy(board_size=3,gameversion=cdh,num_cols=3,num_rows=3,obstype=reveal-nothing)\n[State]\nhistory=0:2,1:2,1:7,0:4,1:8,0:8,0:3,1:1,0:1,0:7\nmove_number=10\n__dict__=gASV9QAAAAAAAAB9lIwLX193cmFwcGVkX1+UjAdweXNwaWVslIwFU3RhdGWUk5QpgZSMyCMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmRhcmtfaGV4KGJvYXJkX3NpemU9MyxnYW1ldmVyc2lvbj1jZGgsbnVtX2NvbHM9MyxudW1fcm93cz0zLG9ic3R5cGU9cmV2ZWFsLW5vdGhpbmcpCltTdGF0ZV0KMgoyCjcKNAo4CjgKMwoxCjEKNwoKlGJzLg==\n",
+          "legalActions": [],
+          "legalActionStrings": []
+        },
+        "status": "INACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "submission": 5
+        },
+        "reward": null,
+        "info": {
+          "actionSubmitted": 5,
+          "actionSubmittedToString": "c2",
+          "actionApplied": 5,
+          "timeTaken": 0.0,
+          "agentSelfReportedStatus": null
+        },
+        "observation": {
+          "remainingOverageTime": 12,
+          "step": 12,
+          "observationString": "{\"current_player\": \"o\", \"is_terminal\": false, \"winner\": null, \"num_rows\": 3, \"num_cols\": 3, \"board\": [[\".\", \"o\", \"x\"], [\"x\", \"x\", \"x\"], [\".\", \"o\", \"o\"]]}",
+          "currentPlayer": 1,
+          "playerId": 0,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ndark_hex_proxy(board_size=3,gameversion=cdh,num_cols=3,num_rows=3,obstype=reveal-nothing)\n[State]\nhistory=0:2,1:2,1:7,0:4,1:8,0:8,0:3,1:1,0:1,0:7,0:5\nmove_number=11\n__dict__=gASV9wAAAAAAAAB9lIwLX193cmFwcGVkX1+UjAdweXNwaWVslIwFU3RhdGWUk5QpgZSMyiMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmRhcmtfaGV4KGJvYXJkX3NpemU9MyxnYW1ldmVyc2lvbj1jZGgsbnVtX2NvbHM9MyxudW1fcm93cz0zLG9ic3R5cGU9cmV2ZWFsLW5vdGhpbmcpCltTdGF0ZV0KMgoyCjcKNAo4CjgKMwoxCjEKNwo1CgqUYnMu\n",
+          "legalActions": [],
+          "legalActionStrings": []
+        },
+        "status": "INACTIVE"
+      },
+      {
+        "action": {
+          "submission": -1
+        },
+        "reward": null,
+        "info": {},
+        "observation": {
+          "remainingOverageTime": 12,
+          "observationString": "{\"current_player\": \"o\", \"is_terminal\": false, \"winner\": null, \"num_rows\": 3, \"num_cols\": 3, \"board\": [[\".\", \"o\", \"x\"], [\".\", \".\", \".\"], [\".\", \"o\", \"o\"]]}",
+          "currentPlayer": 1,
+          "playerId": 1,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ndark_hex_proxy(board_size=3,gameversion=cdh,num_cols=3,num_rows=3,obstype=reveal-nothing)\n[State]\nhistory=0:2,1:2,1:7,0:4,1:8,0:8,0:3,1:1,0:1,0:7,0:5\nmove_number=11\n__dict__=gASV9wAAAAAAAAB9lIwLX193cmFwcGVkX1+UjAdweXNwaWVslIwFU3RhdGWUk5QpgZSMyiMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmRhcmtfaGV4KGJvYXJkX3NpemU9MyxnYW1ldmVyc2lvbj1jZGgsbnVtX2NvbHM9MyxudW1fcm93cz0zLG9ic3R5cGU9cmV2ZWFsLW5vdGhpbmcpCltTdGF0ZV0KMgoyCjcKNAo4CjgKMwoxCjEKNwo1CgqUYnMu\n",
+          "legalActions": [0, 3, 4, 5, 6],
+          "legalActionStrings": ["a1", "a2", "b2", "c2", "a3"]
+        },
+        "status": "ACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "submission": -1
+        },
+        "reward": null,
+        "info": {},
+        "observation": {
+          "remainingOverageTime": 12,
+          "step": 13,
+          "observationString": "{\"current_player\": \"o\", \"is_terminal\": false, \"winner\": null, \"num_rows\": 3, \"num_cols\": 3, \"board\": [[\".\", \"o\", \"x\"], [\"x\", \"x\", \"x\"], [\".\", \"o\", \"o\"]]}",
+          "currentPlayer": 1,
+          "playerId": 0,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ndark_hex_proxy(board_size=3,gameversion=cdh,num_cols=3,num_rows=3,obstype=reveal-nothing)\n[State]\nhistory=0:2,1:2,1:7,0:4,1:8,0:8,0:3,1:1,0:1,0:7,0:5,1:4\nmove_number=12\n__dict__=gASV+QAAAAAAAAB9lIwLX193cmFwcGVkX1+UjAdweXNwaWVslIwFU3RhdGWUk5QpgZSMzCMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmRhcmtfaGV4KGJvYXJkX3NpemU9MyxnYW1ldmVyc2lvbj1jZGgsbnVtX2NvbHM9MyxudW1fcm93cz0zLG9ic3R5cGU9cmV2ZWFsLW5vdGhpbmcpCltTdGF0ZV0KMgoyCjcKNAo4CjgKMwoxCjEKNwo1CjQKCpRicy4=\n",
+          "legalActions": [],
+          "legalActionStrings": []
+        },
+        "status": "INACTIVE"
+      },
+      {
+        "action": {
+          "submission": 4
+        },
+        "reward": null,
+        "info": {
+          "actionSubmitted": 4,
+          "actionSubmittedToString": "b2",
+          "actionApplied": 4,
+          "timeTaken": 0.0,
+          "agentSelfReportedStatus": null
+        },
+        "observation": {
+          "remainingOverageTime": 12,
+          "observationString": "{\"current_player\": \"o\", \"is_terminal\": false, \"winner\": null, \"num_rows\": 3, \"num_cols\": 3, \"board\": [[\".\", \"o\", \"x\"], [\".\", \"x\", \".\"], [\".\", \"o\", \"o\"]]}",
+          "currentPlayer": 1,
+          "playerId": 1,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ndark_hex_proxy(board_size=3,gameversion=cdh,num_cols=3,num_rows=3,obstype=reveal-nothing)\n[State]\nhistory=0:2,1:2,1:7,0:4,1:8,0:8,0:3,1:1,0:1,0:7,0:5,1:4\nmove_number=12\n__dict__=gASV+QAAAAAAAAB9lIwLX193cmFwcGVkX1+UjAdweXNwaWVslIwFU3RhdGWUk5QpgZSMzCMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmRhcmtfaGV4KGJvYXJkX3NpemU9MyxnYW1ldmVyc2lvbj1jZGgsbnVtX2NvbHM9MyxudW1fcm93cz0zLG9ic3R5cGU9cmV2ZWFsLW5vdGhpbmcpCltTdGF0ZV0KMgoyCjcKNAo4CjgKMwoxCjEKNwo1CjQKCpRicy4=\n",
+          "legalActions": [0, 3, 5, 6],
+          "legalActionStrings": ["a1", "a2", "c2", "a3"]
+        },
+        "status": "ACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "submission": -1
+        },
+        "reward": null,
+        "info": {},
+        "observation": {
+          "remainingOverageTime": 12,
+          "step": 14,
+          "observationString": "{\"current_player\": \"o\", \"is_terminal\": false, \"winner\": null, \"num_rows\": 3, \"num_cols\": 3, \"board\": [[\".\", \"o\", \"x\"], [\"x\", \"x\", \"x\"], [\".\", \"o\", \"o\"]]}",
+          "currentPlayer": 1,
+          "playerId": 0,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ndark_hex_proxy(board_size=3,gameversion=cdh,num_cols=3,num_rows=3,obstype=reveal-nothing)\n[State]\nhistory=0:2,1:2,1:7,0:4,1:8,0:8,0:3,1:1,0:1,0:7,0:5,1:4,1:3\nmove_number=13\n__dict__=gASV+wAAAAAAAAB9lIwLX193cmFwcGVkX1+UjAdweXNwaWVslIwFU3RhdGWUk5QpgZSMziMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmRhcmtfaGV4KGJvYXJkX3NpemU9MyxnYW1ldmVyc2lvbj1jZGgsbnVtX2NvbHM9MyxudW1fcm93cz0zLG9ic3R5cGU9cmV2ZWFsLW5vdGhpbmcpCltTdGF0ZV0KMgoyCjcKNAo4CjgKMwoxCjEKNwo1CjQKMwoKlGJzLg==\n",
+          "legalActions": [],
+          "legalActionStrings": []
+        },
+        "status": "INACTIVE"
+      },
+      {
+        "action": {
+          "submission": 3
+        },
+        "reward": null,
+        "info": {
+          "actionSubmitted": 3,
+          "actionSubmittedToString": "a2",
+          "actionApplied": 3,
+          "timeTaken": 0.0,
+          "agentSelfReportedStatus": null
+        },
+        "observation": {
+          "remainingOverageTime": 12,
+          "observationString": "{\"current_player\": \"o\", \"is_terminal\": false, \"winner\": null, \"num_rows\": 3, \"num_cols\": 3, \"board\": [[\".\", \"o\", \"x\"], [\"x\", \"x\", \".\"], [\".\", \"o\", \"o\"]]}",
+          "currentPlayer": 1,
+          "playerId": 1,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ndark_hex_proxy(board_size=3,gameversion=cdh,num_cols=3,num_rows=3,obstype=reveal-nothing)\n[State]\nhistory=0:2,1:2,1:7,0:4,1:8,0:8,0:3,1:1,0:1,0:7,0:5,1:4,1:3\nmove_number=13\n__dict__=gASV+wAAAAAAAAB9lIwLX193cmFwcGVkX1+UjAdweXNwaWVslIwFU3RhdGWUk5QpgZSMziMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmRhcmtfaGV4KGJvYXJkX3NpemU9MyxnYW1ldmVyc2lvbj1jZGgsbnVtX2NvbHM9MyxudW1fcm93cz0zLG9ic3R5cGU9cmV2ZWFsLW5vdGhpbmcpCltTdGF0ZV0KMgoyCjcKNAo4CjgKMwoxCjEKNwo1CjQKMwoKlGJzLg==\n",
+          "legalActions": [0, 5, 6],
+          "legalActionStrings": ["a1", "c2", "a3"]
+        },
+        "status": "ACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "submission": -1
+        },
+        "reward": null,
+        "info": {},
+        "observation": {
+          "remainingOverageTime": 12,
+          "step": 15,
+          "observationString": "{\"current_player\": \"o\", \"is_terminal\": false, \"winner\": null, \"num_rows\": 3, \"num_cols\": 3, \"board\": [[\".\", \"o\", \"x\"], [\"x\", \"x\", \"x\"], [\".\", \"o\", \"o\"]]}",
+          "currentPlayer": 1,
+          "playerId": 0,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ndark_hex_proxy(board_size=3,gameversion=cdh,num_cols=3,num_rows=3,obstype=reveal-nothing)\n[State]\nhistory=0:2,1:2,1:7,0:4,1:8,0:8,0:3,1:1,0:1,0:7,0:5,1:4,1:3,1:5\nmove_number=14\n__dict__=gASV/QAAAAAAAAB9lIwLX193cmFwcGVkX1+UjAdweXNwaWVslIwFU3RhdGWUk5QpgZSM0CMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmRhcmtfaGV4KGJvYXJkX3NpemU9MyxnYW1ldmVyc2lvbj1jZGgsbnVtX2NvbHM9MyxudW1fcm93cz0zLG9ic3R5cGU9cmV2ZWFsLW5vdGhpbmcpCltTdGF0ZV0KMgoyCjcKNAo4CjgKMwoxCjEKNwo1CjQKMwo1CgqUYnMu\n",
+          "legalActions": [],
+          "legalActionStrings": []
+        },
+        "status": "INACTIVE"
+      },
+      {
+        "action": {
+          "submission": 5
+        },
+        "reward": null,
+        "info": {
+          "actionSubmitted": 5,
+          "actionSubmittedToString": "c2",
+          "actionApplied": 5,
+          "timeTaken": 0.0,
+          "agentSelfReportedStatus": null
+        },
+        "observation": {
+          "remainingOverageTime": 12,
+          "observationString": "{\"current_player\": \"o\", \"is_terminal\": false, \"winner\": null, \"num_rows\": 3, \"num_cols\": 3, \"board\": [[\".\", \"o\", \"x\"], [\"x\", \"x\", \"x\"], [\".\", \"o\", \"o\"]]}",
+          "currentPlayer": 1,
+          "playerId": 1,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ndark_hex_proxy(board_size=3,gameversion=cdh,num_cols=3,num_rows=3,obstype=reveal-nothing)\n[State]\nhistory=0:2,1:2,1:7,0:4,1:8,0:8,0:3,1:1,0:1,0:7,0:5,1:4,1:3,1:5\nmove_number=14\n__dict__=gASV/QAAAAAAAAB9lIwLX193cmFwcGVkX1+UjAdweXNwaWVslIwFU3RhdGWUk5QpgZSM0CMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmRhcmtfaGV4KGJvYXJkX3NpemU9MyxnYW1ldmVyc2lvbj1jZGgsbnVtX2NvbHM9MyxudW1fcm93cz0zLG9ic3R5cGU9cmV2ZWFsLW5vdGhpbmcpCltTdGF0ZV0KMgoyCjcKNAo4CjgKMwoxCjEKNwo1CjQKMwo1CgqUYnMu\n",
+          "legalActions": [0, 6],
+          "legalActionStrings": ["a1", "a3"]
+        },
+        "status": "ACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "submission": -1
+        },
+        "reward": null,
+        "info": {},
+        "observation": {
+          "remainingOverageTime": 12,
+          "step": 16,
+          "observationString": "{\"current_player\": \"x\", \"is_terminal\": false, \"winner\": null, \"num_rows\": 3, \"num_cols\": 3, \"board\": [[\".\", \"o\", \"x\"], [\"x\", \"x\", \"x\"], [\".\", \"o\", \"o\"]]}",
+          "currentPlayer": 0,
+          "playerId": 0,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ndark_hex_proxy(board_size=3,gameversion=cdh,num_cols=3,num_rows=3,obstype=reveal-nothing)\n[State]\nhistory=0:2,1:2,1:7,0:4,1:8,0:8,0:3,1:1,0:1,0:7,0:5,1:4,1:3,1:5,1:0\nmove_number=15\n__dict__=gASV/wAAAAAAAAB9lIwLX193cmFwcGVkX1+UjAdweXNwaWVslIwFU3RhdGWUk5QpgZSM0iMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmRhcmtfaGV4KGJvYXJkX3NpemU9MyxnYW1ldmVyc2lvbj1jZGgsbnVtX2NvbHM9MyxudW1fcm93cz0zLG9ic3R5cGU9cmV2ZWFsLW5vdGhpbmcpCltTdGF0ZV0KMgoyCjcKNAo4CjgKMwoxCjEKNwo1CjQKMwo1CjAKCpRicy4=\n",
+          "legalActions": [0, 6],
+          "legalActionStrings": ["a1", "a3"]
+        },
+        "status": "ACTIVE"
+      },
+      {
+        "action": {
+          "submission": 0
+        },
+        "reward": null,
+        "info": {
+          "actionSubmitted": 0,
+          "actionSubmittedToString": "a1",
+          "actionApplied": 0,
+          "timeTaken": 0.0,
+          "agentSelfReportedStatus": null
+        },
+        "observation": {
+          "remainingOverageTime": 12,
+          "observationString": "{\"current_player\": \"x\", \"is_terminal\": false, \"winner\": null, \"num_rows\": 3, \"num_cols\": 3, \"board\": [[\"o\", \"o\", \"x\"], [\"x\", \"x\", \"x\"], [\".\", \"o\", \"o\"]]}",
+          "currentPlayer": 0,
+          "playerId": 1,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ndark_hex_proxy(board_size=3,gameversion=cdh,num_cols=3,num_rows=3,obstype=reveal-nothing)\n[State]\nhistory=0:2,1:2,1:7,0:4,1:8,0:8,0:3,1:1,0:1,0:7,0:5,1:4,1:3,1:5,1:0\nmove_number=15\n__dict__=gASV/wAAAAAAAAB9lIwLX193cmFwcGVkX1+UjAdweXNwaWVslIwFU3RhdGWUk5QpgZSM0iMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmRhcmtfaGV4KGJvYXJkX3NpemU9MyxnYW1ldmVyc2lvbj1jZGgsbnVtX2NvbHM9MyxudW1fcm93cz0zLG9ic3R5cGU9cmV2ZWFsLW5vdGhpbmcpCltTdGF0ZV0KMgoyCjcKNAo4CjgKMwoxCjEKNwo1CjQKMwo1CjAKCpRicy4=\n",
+          "legalActions": [],
+          "legalActionStrings": []
+        },
+        "status": "INACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "submission": 0
+        },
+        "reward": null,
+        "info": {
+          "actionSubmitted": 0,
+          "actionSubmittedToString": "a1",
+          "actionApplied": 0,
+          "timeTaken": 0.0,
+          "agentSelfReportedStatus": null
+        },
+        "observation": {
+          "remainingOverageTime": 12,
+          "step": 17,
+          "observationString": "{\"current_player\": \"x\", \"is_terminal\": false, \"winner\": null, \"num_rows\": 3, \"num_cols\": 3, \"board\": [[\"o\", \"o\", \"x\"], [\"x\", \"x\", \"x\"], [\".\", \"o\", \"o\"]]}",
+          "currentPlayer": 0,
+          "playerId": 0,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ndark_hex_proxy(board_size=3,gameversion=cdh,num_cols=3,num_rows=3,obstype=reveal-nothing)\n[State]\nhistory=0:2,1:2,1:7,0:4,1:8,0:8,0:3,1:1,0:1,0:7,0:5,1:4,1:3,1:5,1:0,0:0\nmove_number=16\n__dict__=gASVAQEAAAAAAAB9lIwLX193cmFwcGVkX1+UjAdweXNwaWVslIwFU3RhdGWUk5QpgZSM1CMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmRhcmtfaGV4KGJvYXJkX3NpemU9MyxnYW1ldmVyc2lvbj1jZGgsbnVtX2NvbHM9MyxudW1fcm93cz0zLG9ic3R5cGU9cmV2ZWFsLW5vdGhpbmcpCltTdGF0ZV0KMgoyCjcKNAo4CjgKMwoxCjEKNwo1CjQKMwo1CjAKMAoKlGJzLg==\n",
+          "legalActions": [6],
+          "legalActionStrings": ["a3"]
+        },
+        "status": "ACTIVE"
+      },
+      {
+        "action": {
+          "submission": -1
+        },
+        "reward": null,
+        "info": {},
+        "observation": {
+          "remainingOverageTime": 12,
+          "observationString": "{\"current_player\": \"x\", \"is_terminal\": false, \"winner\": null, \"num_rows\": 3, \"num_cols\": 3, \"board\": [[\"o\", \"o\", \"x\"], [\"x\", \"x\", \"x\"], [\".\", \"o\", \"o\"]]}",
+          "currentPlayer": 0,
+          "playerId": 1,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ndark_hex_proxy(board_size=3,gameversion=cdh,num_cols=3,num_rows=3,obstype=reveal-nothing)\n[State]\nhistory=0:2,1:2,1:7,0:4,1:8,0:8,0:3,1:1,0:1,0:7,0:5,1:4,1:3,1:5,1:0,0:0\nmove_number=16\n__dict__=gASVAQEAAAAAAAB9lIwLX193cmFwcGVkX1+UjAdweXNwaWVslIwFU3RhdGWUk5QpgZSM1CMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmRhcmtfaGV4KGJvYXJkX3NpemU9MyxnYW1ldmVyc2lvbj1jZGgsbnVtX2NvbHM9MyxudW1fcm93cz0zLG9ic3R5cGU9cmV2ZWFsLW5vdGhpbmcpCltTdGF0ZV0KMgoyCjcKNAo4CjgKMwoxCjEKNwo1CjQKMwo1CjAKMAoKlGJzLg==\n",
+          "legalActions": [],
+          "legalActionStrings": []
+        },
+        "status": "INACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "submission": 6
+        },
+        "reward": 1.0,
+        "info": {
+          "actionSubmitted": 6,
+          "actionSubmittedToString": "a3",
+          "actionApplied": 6,
+          "timeTaken": 0.0,
+          "agentSelfReportedStatus": null
+        },
+        "observation": {
+          "remainingOverageTime": 12,
+          "step": 18,
+          "observationString": "{\"current_player\": \"terminal\", \"is_terminal\": true, \"winner\": \"x\", \"num_rows\": 3, \"num_cols\": 3, \"board\": [[\"o\", \"o\", \"x\"], [\"x\", \"x\", \"x\"], [\"x\", \"o\", \"o\"]]}",
+          "currentPlayer": -4,
+          "playerId": 0,
+          "isTerminal": true,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ndark_hex_proxy(board_size=3,gameversion=cdh,num_cols=3,num_rows=3,obstype=reveal-nothing)\n[State]\nhistory=0:2,1:2,1:7,0:4,1:8,0:8,0:3,1:1,0:1,0:7,0:5,1:4,1:3,1:5,1:0,0:0,0:6\nmove_number=17\n__dict__=gASVAwEAAAAAAAB9lIwLX193cmFwcGVkX1+UjAdweXNwaWVslIwFU3RhdGWUk5QpgZSM1iMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmRhcmtfaGV4KGJvYXJkX3NpemU9MyxnYW1ldmVyc2lvbj1jZGgsbnVtX2NvbHM9MyxudW1fcm93cz0zLG9ic3R5cGU9cmV2ZWFsLW5vdGhpbmcpCltTdGF0ZV0KMgoyCjcKNAo4CjgKMwoxCjEKNwo1CjQKMwo1CjAKMAo2CgqUYnMu\n",
+          "legalActions": [],
+          "legalActionStrings": []
+        },
+        "status": "DONE"
+      },
+      {
+        "action": {
+          "submission": -1
+        },
+        "reward": -1.0,
+        "info": {},
+        "observation": {
+          "remainingOverageTime": 12,
+          "observationString": "{\"current_player\": \"terminal\", \"is_terminal\": true, \"winner\": \"x\", \"num_rows\": 3, \"num_cols\": 3, \"board\": [[\"o\", \"o\", \"x\"], [\"x\", \"x\", \"x\"], [\".\", \"o\", \"o\"]]}",
+          "currentPlayer": -4,
+          "playerId": 1,
+          "isTerminal": true,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ndark_hex_proxy(board_size=3,gameversion=cdh,num_cols=3,num_rows=3,obstype=reveal-nothing)\n[State]\nhistory=0:2,1:2,1:7,0:4,1:8,0:8,0:3,1:1,0:1,0:7,0:5,1:4,1:3,1:5,1:0,0:0,0:6\nmove_number=17\n__dict__=gASVAwEAAAAAAAB9lIwLX193cmFwcGVkX1+UjAdweXNwaWVslIwFU3RhdGWUk5QpgZSM1iMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmRhcmtfaGV4KGJvYXJkX3NpemU9MyxnYW1ldmVyc2lvbj1jZGgsbnVtX2NvbHM9MyxudW1fcm93cz0zLG9ic3R5cGU9cmV2ZWFsLW5vdGhpbmcpCltTdGF0ZV0KMgoyCjcKNAo4CjgKMwoxCjEKNwo1CjQKMwo1CjAKMAo2CgqUYnMu\n",
+          "legalActions": [],
+          "legalActionStrings": []
+        },
+        "status": "DONE"
+      }
+    ]
+  ],
+  "rewards": [1.0, -1.0],
+  "statuses": ["DONE", "DONE"],
+  "schema_version": 1,
+  "info": {
+    "openSpielGameStringResolved": "dark_hex_proxy(board_size=3,gameversion=cdh,num_cols=3,num_rows=3,obstype=reveal-nothing)",
+    "stateHistory": [
+      "{\"current_player\": \"x\", \"is_terminal\": false, \"winner\": null, \"num_rows\": 3, \"num_cols\": 3, \"board_player_x\": [[\".\", \".\", \".\"], [\".\", \".\", \".\"], [\".\", \".\", \".\"]], \"board_player_o\": [[\".\", \".\", \".\"], [\".\", \".\", \".\"], [\".\", \".\", \".\"]]}",
+      "{\"current_player\": \"o\", \"is_terminal\": false, \"winner\": null, \"num_rows\": 3, \"num_cols\": 3, \"board_player_x\": [[\".\", \".\", \"x\"], [\".\", \".\", \".\"], [\".\", \".\", \".\"]], \"board_player_o\": [[\".\", \".\", \".\"], [\".\", \".\", \".\"], [\".\", \".\", \".\"]]}",
+      "{\"current_player\": \"o\", \"is_terminal\": false, \"winner\": null, \"num_rows\": 3, \"num_cols\": 3, \"board_player_x\": [[\".\", \".\", \"x\"], [\".\", \".\", \".\"], [\".\", \".\", \".\"]], \"board_player_o\": [[\".\", \".\", \"x\"], [\".\", \".\", \".\"], [\".\", \".\", \".\"]]}",
+      "{\"current_player\": \"x\", \"is_terminal\": false, \"winner\": null, \"num_rows\": 3, \"num_cols\": 3, \"board_player_x\": [[\".\", \".\", \"x\"], [\".\", \".\", \".\"], [\".\", \".\", \".\"]], \"board_player_o\": [[\".\", \".\", \"x\"], [\".\", \".\", \".\"], [\".\", \"o\", \".\"]]}",
+      "{\"current_player\": \"o\", \"is_terminal\": false, \"winner\": null, \"num_rows\": 3, \"num_cols\": 3, \"board_player_x\": [[\".\", \".\", \"x\"], [\".\", \"x\", \".\"], [\".\", \".\", \".\"]], \"board_player_o\": [[\".\", \".\", \"x\"], [\".\", \".\", \".\"], [\".\", \"o\", \".\"]]}",
+      "{\"current_player\": \"x\", \"is_terminal\": false, \"winner\": null, \"num_rows\": 3, \"num_cols\": 3, \"board_player_x\": [[\".\", \".\", \"x\"], [\".\", \"x\", \".\"], [\".\", \".\", \".\"]], \"board_player_o\": [[\".\", \".\", \"x\"], [\".\", \".\", \".\"], [\".\", \"o\", \"o\"]]}",
+      "{\"current_player\": \"x\", \"is_terminal\": false, \"winner\": null, \"num_rows\": 3, \"num_cols\": 3, \"board_player_x\": [[\".\", \".\", \"x\"], [\".\", \"x\", \".\"], [\".\", \".\", \"o\"]], \"board_player_o\": [[\".\", \".\", \"x\"], [\".\", \".\", \".\"], [\".\", \"o\", \"o\"]]}",
+      "{\"current_player\": \"o\", \"is_terminal\": false, \"winner\": null, \"num_rows\": 3, \"num_cols\": 3, \"board_player_x\": [[\".\", \".\", \"x\"], [\"x\", \"x\", \".\"], [\".\", \".\", \"o\"]], \"board_player_o\": [[\".\", \".\", \"x\"], [\".\", \".\", \".\"], [\".\", \"o\", \"o\"]]}",
+      "{\"current_player\": \"x\", \"is_terminal\": false, \"winner\": null, \"num_rows\": 3, \"num_cols\": 3, \"board_player_x\": [[\".\", \".\", \"x\"], [\"x\", \"x\", \".\"], [\".\", \".\", \"o\"]], \"board_player_o\": [[\".\", \"o\", \"x\"], [\".\", \".\", \".\"], [\".\", \"o\", \"o\"]]}",
+      "{\"current_player\": \"x\", \"is_terminal\": false, \"winner\": null, \"num_rows\": 3, \"num_cols\": 3, \"board_player_x\": [[\".\", \"o\", \"x\"], [\"x\", \"x\", \".\"], [\".\", \".\", \"o\"]], \"board_player_o\": [[\".\", \"o\", \"x\"], [\".\", \".\", \".\"], [\".\", \"o\", \"o\"]]}",
+      "{\"current_player\": \"x\", \"is_terminal\": false, \"winner\": null, \"num_rows\": 3, \"num_cols\": 3, \"board_player_x\": [[\".\", \"o\", \"x\"], [\"x\", \"x\", \".\"], [\".\", \"o\", \"o\"]], \"board_player_o\": [[\".\", \"o\", \"x\"], [\".\", \".\", \".\"], [\".\", \"o\", \"o\"]]}",
+      "{\"current_player\": \"o\", \"is_terminal\": false, \"winner\": null, \"num_rows\": 3, \"num_cols\": 3, \"board_player_x\": [[\".\", \"o\", \"x\"], [\"x\", \"x\", \"x\"], [\".\", \"o\", \"o\"]], \"board_player_o\": [[\".\", \"o\", \"x\"], [\".\", \".\", \".\"], [\".\", \"o\", \"o\"]]}",
+      "{\"current_player\": \"o\", \"is_terminal\": false, \"winner\": null, \"num_rows\": 3, \"num_cols\": 3, \"board_player_x\": [[\".\", \"o\", \"x\"], [\"x\", \"x\", \"x\"], [\".\", \"o\", \"o\"]], \"board_player_o\": [[\".\", \"o\", \"x\"], [\".\", \"x\", \".\"], [\".\", \"o\", \"o\"]]}",
+      "{\"current_player\": \"o\", \"is_terminal\": false, \"winner\": null, \"num_rows\": 3, \"num_cols\": 3, \"board_player_x\": [[\".\", \"o\", \"x\"], [\"x\", \"x\", \"x\"], [\".\", \"o\", \"o\"]], \"board_player_o\": [[\".\", \"o\", \"x\"], [\"x\", \"x\", \".\"], [\".\", \"o\", \"o\"]]}",
+      "{\"current_player\": \"o\", \"is_terminal\": false, \"winner\": null, \"num_rows\": 3, \"num_cols\": 3, \"board_player_x\": [[\".\", \"o\", \"x\"], [\"x\", \"x\", \"x\"], [\".\", \"o\", \"o\"]], \"board_player_o\": [[\".\", \"o\", \"x\"], [\"x\", \"x\", \"x\"], [\".\", \"o\", \"o\"]]}",
+      "{\"current_player\": \"x\", \"is_terminal\": false, \"winner\": null, \"num_rows\": 3, \"num_cols\": 3, \"board_player_x\": [[\".\", \"o\", \"x\"], [\"x\", \"x\", \"x\"], [\".\", \"o\", \"o\"]], \"board_player_o\": [[\"o\", \"o\", \"x\"], [\"x\", \"x\", \"x\"], [\".\", \"o\", \"o\"]]}",
+      "{\"current_player\": \"x\", \"is_terminal\": false, \"winner\": null, \"num_rows\": 3, \"num_cols\": 3, \"board_player_x\": [[\"o\", \"o\", \"x\"], [\"x\", \"x\", \"x\"], [\".\", \"o\", \"o\"]], \"board_player_o\": [[\"o\", \"o\", \"x\"], [\"x\", \"x\", \"x\"], [\".\", \"o\", \"o\"]]}",
+      "{\"current_player\": \"terminal\", \"is_terminal\": true, \"winner\": \"x\", \"num_rows\": 3, \"num_cols\": 3, \"board_player_x\": [[\"o\", \"o\", \"x\"], [\"x\", \"x\", \"x\"], [\"x\", \"o\", \"o\"]], \"board_player_o\": [[\"o\", \"o\", \"x\"], [\"x\", \"x\", \"x\"], [\".\", \"o\", \"o\"]]}"
+    ],
+    "actionHistory": [
+      "2",
+      "2",
+      "7",
+      "4",
+      "8",
+      "8",
+      "3",
+      "1",
+      "1",
+      "7",
+      "5",
+      "4",
+      "3",
+      "5",
+      "0",
+      "0",
+      "6"
+    ],
+    "moveDurations": [
+      0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+      0.0, 0.0
+    ]
+  }
+}

--- a/kaggle_environments/envs/open_spiel_env/games/dark_hex/visualizer/default/src/main.ts
+++ b/kaggle_environments/envs/open_spiel_env/games/dark_hex/visualizer/default/src/main.ts
@@ -1,0 +1,21 @@
+import { createReplayVisualizer, ReplayAdapter } from '@kaggle-environments/core';
+import { renderer } from './renderer';
+import './style.css';
+
+const app = document.getElementById('app');
+if (!app) {
+  throw new Error('Could not find app element');
+}
+
+if (import.meta.env?.DEV && import.meta.hot) {
+  import.meta.hot.accept();
+}
+
+createReplayVisualizer(
+  app,
+  new ReplayAdapter({
+    gameName: 'open_spiel_dark_hex',
+    renderer: renderer as any,
+    ui: 'side-panel',
+  })
+);

--- a/kaggle_environments/envs/open_spiel_env/games/dark_hex/visualizer/default/src/renderer.ts
+++ b/kaggle_environments/envs/open_spiel_env/games/dark_hex/visualizer/default/src/renderer.ts
@@ -1,0 +1,322 @@
+import type { RendererOptions } from '@kaggle-environments/core';
+
+interface DarkHexObservation {
+  board: string[][];
+  current_player: string;
+  is_terminal: boolean;
+  winner: string | null;
+  num_rows: number;
+  num_cols: number;
+}
+
+const PLAYER_X_COLOR = '#1f77b4';
+const PLAYER_O_COLOR = '#d62728';
+const CELL_FILL = '#fbf7e8';
+const SECONDARY_TEXT = '#444343';
+const SKETCH_STROKE = '#3c3b37';
+
+const SQRT3 = Math.sqrt(3);
+
+function parseObservation(step: any, playerIdx: number): DarkHexObservation | null {
+  const raw = step?.[playerIdx]?.observation?.observationString;
+  if (!raw) return null;
+  try {
+    return JSON.parse(raw);
+  } catch {
+    return null;
+  }
+}
+
+function actionToCoords(action: number, numCols: number): { row: number; col: number } {
+  return { row: Math.floor(action / numCols), col: action % numCols };
+}
+
+function colLabel(col: number): string {
+  return String.fromCharCode('a'.charCodeAt(0) + col);
+}
+
+function actionString(action: number, numCols: number): string {
+  const { row, col } = actionToCoords(action, numCols);
+  return `${colLabel(col)}${row + 1}`;
+}
+
+function getPlayerName(replay: any, idx: number): string {
+  const info = replay?.info?.TeamNames?.[idx];
+  if (info) return info;
+  const fromAgent = replay?.agents?.[idx]?.name;
+  if (fromAgent) return fromAgent;
+  return idx === 0 ? 'Player X' : 'Player O';
+}
+
+function drawHexBoard(
+  ctx: CanvasRenderingContext2D,
+  width: number,
+  height: number,
+  board: string[][],
+  numRows: number,
+  numCols: number,
+  highlightCell: { row: number; col: number } | null,
+  highlightColor: string
+) {
+  ctx.clearRect(0, 0, width, height);
+
+  const padding = 28;
+  const innerW = Math.max(0, width - padding * 2);
+  const innerH = Math.max(0, height - padding * 2);
+  const totalUnitsW = numCols + (numRows - 1) / 2;
+  const totalUnitsH = (numRows - 1) * 1.5 + 2;
+  const sizeFromW = innerW / (totalUnitsW * SQRT3);
+  const sizeFromH = innerH / totalUnitsH;
+  const size = Math.max(8, Math.min(sizeFromW, sizeFromH));
+  const hexW = SQRT3 * size;
+  const hexH = 2 * size;
+  const boardW = totalUnitsW * hexW;
+  const boardH = (numRows - 1) * 1.5 * size + hexH;
+  const xOffset = (width - boardW) / 2;
+  const yOffset = (height - boardH) / 2;
+
+  const centerOf = (row: number, col: number) => ({
+    x: xOffset + (col + row * 0.5 + 0.5) * hexW,
+    y: yOffset + size + row * 1.5 * size,
+  });
+
+  const hexPath = (cx: number, cy: number, s: number) => {
+    ctx.beginPath();
+    for (let i = 0; i < 6; i++) {
+      const angle = (Math.PI / 3) * i + Math.PI / 6;
+      const x = cx + s * Math.cos(angle);
+      const y = cy + s * Math.sin(angle);
+      if (i === 0) ctx.moveTo(x, y);
+      else ctx.lineTo(x, y);
+    }
+    ctx.closePath();
+  };
+
+  // Draw colored edge guides for the connection goals.
+  // Player X (0) connects top↔bottom (rows). Player O (1) connects left↔right (cols).
+  const edgeWidth = Math.max(3, size * 0.18);
+  ctx.lineWidth = edgeWidth;
+  ctx.lineCap = 'round';
+
+  // Top edge (X)
+  ctx.strokeStyle = PLAYER_X_COLOR;
+  let topL = centerOf(0, 0);
+  let topR = centerOf(0, numCols - 1);
+  ctx.beginPath();
+  ctx.moveTo(topL.x - hexW / 2, topL.y - size * 0.6);
+  ctx.lineTo(topR.x + hexW / 2, topR.y - size * 0.6);
+  ctx.stroke();
+
+  // Bottom edge (X)
+  let botL = centerOf(numRows - 1, 0);
+  let botR = centerOf(numRows - 1, numCols - 1);
+  ctx.beginPath();
+  ctx.moveTo(botL.x - hexW / 2, botL.y + size * 0.6);
+  ctx.lineTo(botR.x + hexW / 2, botR.y + size * 0.6);
+  ctx.stroke();
+
+  // Left edge (O) -- zigzag along left side
+  ctx.strokeStyle = PLAYER_O_COLOR;
+  ctx.beginPath();
+  for (let r = 0; r < numRows; r++) {
+    const c = centerOf(r, 0);
+    const x = c.x - hexW / 2 - size * 0.15;
+    if (r === 0) ctx.moveTo(x, c.y - size * 0.5);
+    else ctx.lineTo(x, c.y - size * 0.5);
+    ctx.lineTo(x, c.y + size * 0.5);
+  }
+  ctx.stroke();
+
+  // Right edge (O)
+  ctx.beginPath();
+  for (let r = 0; r < numRows; r++) {
+    const c = centerOf(r, numCols - 1);
+    const x = c.x + hexW / 2 + size * 0.15;
+    if (r === 0) ctx.moveTo(x, c.y - size * 0.5);
+    else ctx.lineTo(x, c.y - size * 0.5);
+    ctx.lineTo(x, c.y + size * 0.5);
+  }
+  ctx.stroke();
+
+  // Draw hex cells
+  ctx.font = `${Math.round(size * 0.7)}px 'Inter', sans-serif`;
+  ctx.textAlign = 'center';
+  ctx.textBaseline = 'middle';
+
+  for (let r = 0; r < numRows; r++) {
+    for (let c = 0; c < numCols; c++) {
+      const { x, y } = centerOf(r, c);
+      const cell = board?.[r]?.[c] ?? '.';
+
+      hexPath(x, y, size * 0.95);
+      ctx.fillStyle = CELL_FILL;
+      ctx.fill();
+      ctx.lineWidth = 1.25;
+      ctx.setLineDash([3, 3]);
+      ctx.strokeStyle = SKETCH_STROKE;
+      ctx.stroke();
+      ctx.setLineDash([]);
+
+      if (cell === 'x') {
+        ctx.fillStyle = PLAYER_X_COLOR;
+        ctx.fillText('X', x, y + size * 0.04);
+      } else if (cell === 'o') {
+        ctx.fillStyle = PLAYER_O_COLOR;
+        ctx.fillText('O', x, y + size * 0.04);
+      }
+    }
+  }
+
+  // Highlight the most recent move on this board
+  if (highlightCell) {
+    const { x, y } = centerOf(highlightCell.row, highlightCell.col);
+    hexPath(x, y, size * 0.95);
+    ctx.lineWidth = Math.max(2.5, size * 0.12);
+    ctx.setLineDash([]);
+    ctx.strokeStyle = highlightColor;
+    ctx.stroke();
+  }
+
+  // Coordinate labels
+  ctx.font = `${Math.round(size * 0.32)}px 'Inter', sans-serif`;
+  ctx.fillStyle = SECONDARY_TEXT;
+  for (let c = 0; c < numCols; c++) {
+    const top = centerOf(0, c);
+    ctx.fillText(colLabel(c), top.x, top.y - size - size * 0.25);
+  }
+  for (let r = 0; r < numRows; r++) {
+    const left = centerOf(r, 0);
+    ctx.fillText(`${r + 1}`, left.x - hexW * 0.55 - size * 0.25, left.y);
+  }
+}
+
+function buildBoardCard(label: string, color: string): HTMLDivElement {
+  const card = document.createElement('div');
+  card.className = 'board-card';
+  const labelEl = document.createElement('div');
+  labelEl.className = 'board-label';
+  labelEl.style.color = color;
+  labelEl.textContent = label;
+  const canvas = document.createElement('canvas');
+  card.appendChild(labelEl);
+  card.appendChild(canvas);
+  return card;
+}
+
+export function renderer(options: RendererOptions) {
+  const { parent, replay, step } = options;
+  const steps = (replay?.steps ?? []) as any[];
+  if (!steps.length) return;
+
+  parent.innerHTML = `
+    <div class="renderer-container">
+      <div class="header"></div>
+      <div class="boards"></div>
+      <div class="status-container sketched-border"></div>
+    </div>
+  `;
+  const header = parent.querySelector('.header') as HTMLDivElement;
+  const boards = parent.querySelector('.boards') as HTMLDivElement;
+  const statusContainer = parent.querySelector('.status-container') as HTMLDivElement;
+
+  const currentStep = steps[step];
+
+  const obsX = parseObservation(currentStep, 0);
+  const obsO = parseObservation(currentStep, 1);
+  const observation = obsX ?? obsO;
+  if (!observation) {
+    statusContainer.textContent = 'Waiting for first observation...';
+    return;
+  }
+
+  const numCols = observation.num_cols;
+  const isTerminal = observation.is_terminal;
+  const currentPlayer = observation.current_player;
+
+  const playerNames = [getPlayerName(replay, 0), getPlayerName(replay, 1)];
+  const activeIdx = isTerminal ? -1 : currentPlayer === 'x' ? 0 : currentPlayer === 'o' ? 1 : -1;
+
+  header.innerHTML = `
+    <span class="player sketched-border ${activeIdx === 0 ? 'active' : ''}" style="color: ${PLAYER_X_COLOR};">
+      ${playerNames[0]} <span style="opacity: 0.7;">(X)</span>
+    </span>
+    <span class="vs">vs</span>
+    <span class="player sketched-border ${activeIdx === 1 ? 'active' : ''}" style="color: ${PLAYER_O_COLOR};">
+      ${playerNames[1]} <span style="opacity: 0.7;">(O)</span>
+    </span>
+  `;
+
+  // Detect last move: at step k, the submission that produced the visible state is in step k itself.
+  let lastAction: number | null = null;
+  let lastActor: number | null = null;
+  for (let i = 0; i < currentStep.length; i++) {
+    const sub = currentStep[i]?.action?.submission;
+    if (typeof sub === 'number' && sub >= 0) {
+      lastAction = sub;
+      lastActor = i;
+      break;
+    }
+  }
+  const lastCell = lastAction !== null ? actionToCoords(lastAction, numCols) : null;
+
+  // Build two board cards.
+  boards.innerHTML = '';
+  const xCard = buildBoardCard("X's view", PLAYER_X_COLOR);
+  const oCard = buildBoardCard("O's view", PLAYER_O_COLOR);
+  boards.appendChild(xCard);
+  boards.appendChild(oCard);
+
+  const drawCard = (card: HTMLDivElement, obs: DarkHexObservation | null, ownerIdx: number) => {
+    const canvas = card.querySelector('canvas') as HTMLCanvasElement;
+    canvas.width = 0;
+    canvas.height = 0;
+    const rect = canvas.getBoundingClientRect();
+    canvas.width = Math.max(1, Math.floor(rect.width));
+    canvas.height = Math.max(1, Math.floor(rect.height));
+    const ctx = canvas.getContext('2d');
+    if (!ctx || !obs) return;
+
+    const board = obs.board;
+    // The actor always sees the result of their own action (a placed piece on success, or the
+    // opponent's revealed piece on a collision). The opponent only learns about the action when
+    // their own piece was the collision target -- which is the same cell, already showing their
+    // own piece in their view.
+    let highlight: { row: number; col: number } | null = null;
+    const highlightColor = lastActor === 0 ? PLAYER_X_COLOR : PLAYER_O_COLOR;
+    if (lastCell && ownerIdx === lastActor) {
+      const cellInThisView = board?.[lastCell.row]?.[lastCell.col];
+      if (cellInThisView === 'x' || cellInThisView === 'o') {
+        highlight = lastCell;
+      }
+    }
+    drawHexBoard(ctx, canvas.width, canvas.height, board, obs.num_rows, obs.num_cols, highlight, highlightColor);
+  };
+
+  // Defer to next frame so layout sizes are settled.
+  requestAnimationFrame(() => {
+    drawCard(xCard, obsX, 0);
+    drawCard(oCard, obsO, 1);
+  });
+
+  // Status footer.
+  let statusHTML = '';
+  if (isTerminal) {
+    if (observation.winner === 'x') {
+      statusHTML = `<span style="color: ${PLAYER_X_COLOR};">${playerNames[0]} (X) wins!</span>`;
+    } else if (observation.winner === 'o') {
+      statusHTML = `<span style="color: ${PLAYER_O_COLOR};">${playerNames[1]} (O) wins!</span>`;
+    } else {
+      statusHTML = `<span>Game over: ${observation.winner ?? 'finished'}</span>`;
+    }
+  } else {
+    const turnColor = activeIdx === 0 ? PLAYER_X_COLOR : PLAYER_O_COLOR;
+    const turnName = activeIdx >= 0 ? playerNames[activeIdx] : '';
+    statusHTML = `<span>Turn: <span style="color: ${turnColor}; font-weight: 700;">${turnName}</span></span>`;
+  }
+  if (lastAction !== null && lastActor !== null) {
+    const moveStr = actionString(lastAction, numCols);
+    const moverColor = lastActor === 0 ? PLAYER_X_COLOR : PLAYER_O_COLOR;
+    statusHTML += `<span class="annotation">last move: <span style="color: ${moverColor}; font-weight: 600;">${moveStr}</span></span>`;
+  }
+  statusContainer.innerHTML = statusHTML;
+}

--- a/kaggle_environments/envs/open_spiel_env/games/dark_hex/visualizer/default/src/style.css
+++ b/kaggle_environments/envs/open_spiel_env/games/dark_hex/visualizer/default/src/style.css
@@ -1,0 +1,127 @@
+@import url('https://fonts.googleapis.com/css2?family=Inter:ital,opsz,wght@0,14..32,100..900;1,14..32,100..900&display=swap');
+
+html,
+body,
+#app {
+  width: 100%;
+  height: 100%;
+  margin: 0;
+  padding: 0;
+  overflow: hidden;
+}
+
+.renderer-container {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  width: 100%;
+  height: 100%;
+  min-height: 0;
+  background-color: #f5f1e2;
+  overflow: hidden;
+  font-family: 'Inter', sans-serif;
+  color: #050001;
+  container-type: inline-size;
+}
+
+.sketched-border {
+  border: 1px dashed #3c3b37;
+}
+
+.header {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 16px;
+  padding: 8px 0;
+  font-size: 1.1rem;
+  font-weight: 600;
+  flex-shrink: 0;
+}
+
+.header .player {
+  padding: 4px 12px;
+  background-color: white;
+  transition: scale 300ms, background-color 300ms;
+  white-space: nowrap;
+}
+
+.header .player.active {
+  background-color: #bdeeff;
+  scale: 1.1;
+}
+
+.header .vs {
+  color: #444343;
+  font-weight: 500;
+}
+
+.boards {
+  display: flex;
+  flex: 1 1 0;
+  flex-direction: row;
+  align-items: center;
+  justify-content: center;
+  gap: 24px;
+  width: 100%;
+  min-height: 0;
+  padding: 8px 0;
+  overflow: hidden;
+}
+
+@container (max-width: 680px) {
+  .boards {
+    flex-direction: column;
+    gap: 12px;
+  }
+}
+
+.board-card {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  flex: 1 1 0;
+  min-width: 0;
+  min-height: 0;
+  max-width: 420px;
+}
+
+.board-card .board-label {
+  font-size: 0.95rem;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+  flex-shrink: 0;
+}
+
+.board-card canvas {
+  position: relative;
+  width: 100%;
+  height: auto;
+  aspect-ratio: 1.4 / 1;
+  max-height: 100%;
+  background: transparent;
+}
+
+.status-container {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+  padding: 5px 16px;
+  background-color: white;
+  font-size: 0.9rem;
+  font-weight: 600;
+  min-height: 18px;
+  min-width: 240px;
+  margin: 8px 0 12px;
+  flex-shrink: 0;
+  text-align: center;
+}
+
+.status-container .annotation {
+  font-family: 'Mynerve', cursive;
+  font-weight: 400;
+  color: #444343;
+}

--- a/kaggle_environments/envs/open_spiel_env/games/dark_hex/visualizer/default/tsconfig.json
+++ b/kaggle_environments/envs/open_spiel_env/games/dark_hex/visualizer/default/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../../../../../../web/tsconfig.base.json",
+  "include": ["src"],
+  "compilerOptions": {
+    "allowJs": true
+  }
+}

--- a/kaggle_environments/envs/open_spiel_env/games/dark_hex/visualizer/default/vite.config.ts
+++ b/kaggle_environments/envs/open_spiel_env/games/dark_hex/visualizer/default/vite.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig, mergeConfig } from 'vite';
+import baseConfig from '../../../../../../../web/vite.config.base';
+
+export default mergeConfig(
+  baseConfig,
+  defineConfig({
+    publicDir: 'replays',
+  })
+);

--- a/kaggle_environments/envs/open_spiel_env/open_spiel_env.py
+++ b/kaggle_environments/envs/open_spiel_env/open_spiel_env.py
@@ -852,6 +852,7 @@ GAMES_LIST = [
     "checkers",
     "chess",
     "connect_four",
+    "dark_hex",
     "gin_rummy",
     "go(board_size=9)",
     "goofspiel(num_cards=4,points_order=descending,returns_type=total_points)",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -333,6 +333,22 @@ importers:
         specifier: ^5.0.0
         version: 5.4.21(@types/node@25.2.1)
 
+  kaggle_environments/envs/open_spiel_env/games/dark_hex/visualizer/default:
+    dependencies:
+      '@kaggle-environments/core':
+        specifier: workspace:*
+        version: link:../../../../../../../web/core
+    devDependencies:
+      cross-env:
+        specifier: ^10.1.0
+        version: 10.1.0
+      typescript:
+        specifier: ^5.0.0
+        version: 5.9.3
+      vite:
+        specifier: ^5.0.0
+        version: 5.4.21(@types/node@25.2.1)
+
   kaggle_environments/envs/open_spiel_env/games/go/visualizer/default:
     dependencies:
       '@kaggle-environments/core':
@@ -1152,79 +1168,66 @@ packages:
     resolution: {integrity: sha512-F8sWbhZ7tyuEfsmOxwc2giKDQzN3+kuBLPwwZGyVkLlKGdV1nvnNwYD0fKQ8+XS6hp9nY7B+ZeK01EBUE7aHaw==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.57.1':
     resolution: {integrity: sha512-rGfNUfn0GIeXtBP1wL5MnzSj98+PZe/AXaGBCRmT0ts80lU5CATYGxXukeTX39XBKsxzFpEeK+Mrp9faXOlmrw==}
     cpu: [arm]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.57.1':
     resolution: {integrity: sha512-MMtej3YHWeg/0klK2Qodf3yrNzz6CGjo2UntLvk2RSPlhzgLvYEB3frRvbEF2wRKh1Z2fDIg9KRPe1fawv7C+g==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.57.1':
     resolution: {integrity: sha512-1a/qhaaOXhqXGpMFMET9VqwZakkljWHLmZOX48R0I/YLbhdxr1m4gtG1Hq7++VhVUmf+L3sTAf9op4JlhQ5u1Q==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.57.1':
     resolution: {integrity: sha512-QWO6RQTZ/cqYtJMtxhkRkidoNGXc7ERPbZN7dVW5SdURuLeVU7lwKMpo18XdcmpWYd0qsP1bwKPf7DNSUinhvA==}
     cpu: [loong64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.57.1':
     resolution: {integrity: sha512-xpObYIf+8gprgWaPP32xiN5RVTi/s5FCR+XMXSKmhfoJjrpRAjCuuqQXyxUa/eJTdAE6eJ+KDKaoEqjZQxh3Gw==}
     cpu: [loong64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.57.1':
     resolution: {integrity: sha512-4BrCgrpZo4hvzMDKRqEaW1zeecScDCR+2nZ86ATLhAoJ5FQ+lbHVD3ttKe74/c7tNT9c6F2viwB3ufwp01Oh2w==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.57.1':
     resolution: {integrity: sha512-NOlUuzesGauESAyEYFSe3QTUguL+lvrN1HtwEEsU2rOwdUDeTMJdO5dUYl/2hKf9jWydJrO9OL/XSSf65R5+Xw==}
     cpu: [ppc64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.57.1':
     resolution: {integrity: sha512-ptA88htVp0AwUUqhVghwDIKlvJMD/fmL/wrQj99PRHFRAG6Z5nbWoWG4o81Nt9FT+IuqUQi+L31ZKAFeJ5Is+A==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.57.1':
     resolution: {integrity: sha512-S51t7aMMTNdmAMPpBg7OOsTdn4tySRQvklmL3RpDRyknk87+Sp3xaumlatU+ppQ+5raY7sSTcC2beGgvhENfuw==}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.57.1':
     resolution: {integrity: sha512-Bl00OFnVFkL82FHbEqy3k5CUCKH6OEJL54KCyx2oqsmZnFTR8IoNqBF+mjQVcRCT5sB6yOvK8A37LNm/kPJiZg==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.57.1':
     resolution: {integrity: sha512-ABca4ceT4N+Tv/GtotnWAeXZUZuM/9AQyCyKYyKnpk4yoA7QIAuBt6Hkgpw8kActYlew2mvckXkvx0FfoInnLg==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.57.1':
     resolution: {integrity: sha512-HFps0JeGtuOR2convgRRkHCekD7j+gdAuXM+/i6kGzQtFhlCtQkpwtNzkNj6QhCDp7DRJ7+qC/1Vg2jt5iSOFw==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.57.1':
     resolution: {integrity: sha512-H+hXEv9gdVQuDTgnqD+SQffoWoc0Of59AStSzTEj/feWTBAnSfSD3+Dql1ZruJQxmykT/JVY0dE8Ka7z0DH1hw==}

--- a/tests/envs/open_spiel_env/test_open_spiel_env.py
+++ b/tests/envs/open_spiel_env/test_open_spiel_env.py
@@ -25,6 +25,61 @@ class OpenSpielEnvTest(absltest.TestCase):
         envs = open_spiel_env._register_game_envs([game_type.short_name for game_type in pyspiel.registered_games()])
         self.assertTrue(len(envs) > _REGISTERED_GAMES_THRESHOLD)
 
+    def test_dark_hex_agent_playthrough(self):
+        env = make(
+            "open_spiel_dark_hex",
+            configuration={"includeLegalActions": True},
+            debug=True,
+        )
+        env.run(["random", "random"])
+        playthrough = env.toJSON()
+        self.assertEqual(playthrough["name"], "open_spiel_dark_hex")
+        self.assertTrue(all(status == "DONE" for status in playthrough["statuses"]))
+        rewards = playthrough["rewards"]
+        self.assertEqual(sorted(rewards), [-1.0, 1.0])
+
+    def test_dark_hex_manual_playthrough(self):
+        env = make("open_spiel_dark_hex", debug=True)
+        env.reset()
+        env.step([{"submission": -1}, {"submission": -1}])  # Initial setup step.
+        env.step([{"submission": 1}, {"submission": -1}])  # p0: b1
+        env.step([{"submission": -1}, {"submission": 0}])  # p1: a1
+        env.step([{"submission": 4}, {"submission": -1}])  # p0: b2
+        env.step([{"submission": -1}, {"submission": 3}])  # p1: a2
+        env.step([{"submission": 7}, {"submission": -1}])  # p0: b3 (wins)
+        self.assertTrue(env.done)
+        self.assertEqual(env.toJSON()["rewards"], [1, -1])
+        final_obs = json.loads(env.state[0]["observation"]["observationString"])
+        self.assertTrue(final_obs["is_terminal"])
+        self.assertEqual(final_obs["winner"], "x")
+
+    def test_dark_hex_observation_hides_opponent(self):
+        env = make("open_spiel_dark_hex", debug=True)
+        env.reset()
+        env.step([{"submission": -1}, {"submission": -1}])  # Initial setup step.
+        env.step([{"submission": 4}, {"submission": -1}])  # p0: b2 (center)
+        # After p0's move, p1's view should not see the new x piece.
+        obs_p1 = json.loads(env.state[1]["observation"]["observationString"])
+        self.assertEqual(obs_p1["board"], [["."] * 3] * 3)
+        # p0's view should see their own x piece.
+        obs_p0 = json.loads(env.state[0]["observation"]["observationString"])
+        self.assertEqual(obs_p0["board"][1][1], "x")
+
+    def test_dark_hex_invalid_action(self):
+        env = make("open_spiel_dark_hex", debug=True)
+        env.reset()
+        env.step([{"submission": -1}, {"submission": -1}])  # Initial setup step.
+        env.step([{"submission": 999}, {"submission": -1}])  # Invalid action.
+        self.assertTrue(env.done)
+        playthrough = env.toJSON()
+        self.assertEqual(
+            playthrough["rewards"],
+            [
+                open_spiel_env.DEFAULT_INVALID_ACTION_REWARD,
+                -open_spiel_env.DEFAULT_INVALID_ACTION_REWARD,
+            ],
+        )
+
     def test_tic_tac_toe_agent_playthrough(self):
         env = make("open_spiel_tic_tac_toe", debug=True)
         env.run(["random", "random"])
@@ -484,13 +539,10 @@ class OpenSpielEnvTest(absltest.TestCase):
         self.assertIsNotNone(obs.legalActionStrings)
         self.assertEqual(len(obs.legalActions), 9)  # All 9 squares available
 
-
     # --- Simultaneous move game tests ---
 
     def test_goofspiel_agent_playthrough(self):
-        open_spiel_env._register_game_envs(
-            ["goofspiel(num_cards=4,points_order=descending,returns_type=total_points)"]
-        )
+        open_spiel_env._register_game_envs(["goofspiel(num_cards=4,points_order=descending,returns_type=total_points)"])
         env = make("open_spiel_goofspiel", debug=True)
         env.run(["random", "random"])
         json = env.toJSON()
@@ -501,9 +553,7 @@ class OpenSpielEnvTest(absltest.TestCase):
         self.assertTrue(all(r is not None for r in json["rewards"]))
 
     def test_goofspiel_manual_playthrough(self):
-        open_spiel_env._register_game_envs(
-            ["goofspiel(num_cards=4,points_order=descending,returns_type=total_points)"]
-        )
+        open_spiel_env._register_game_envs(["goofspiel(num_cards=4,points_order=descending,returns_type=total_points)"])
         env = make("open_spiel_goofspiel", debug=True)
         env.reset()
         # Initial setup step.
@@ -523,9 +573,7 @@ class OpenSpielEnvTest(absltest.TestCase):
         self.assertTrue(all([status == "DONE" for status in json["statuses"]]))
 
     def test_simultaneous_invalid_action(self):
-        open_spiel_env._register_game_envs(
-            ["goofspiel(num_cards=4,points_order=descending,returns_type=total_points)"]
-        )
+        open_spiel_env._register_game_envs(["goofspiel(num_cards=4,points_order=descending,returns_type=total_points)"])
         env = make("open_spiel_goofspiel", debug=True)
         env.reset()
         env.step([{"submission": -1}, {"submission": -1}])  # Setup step.
@@ -616,16 +664,16 @@ class OpenSpielEnvTest(absltest.TestCase):
         self.assertEqual(json["rewards"], [0.0, 100.0])
 
     def test_simultaneous_agent_error(self):
-        open_spiel_env._register_game_envs(
-            ["goofspiel(num_cards=4,points_order=descending,returns_type=total_points)"]
-        )
+        open_spiel_env._register_game_envs(["goofspiel(num_cards=4,points_order=descending,returns_type=total_points)"])
         env = make("open_spiel_goofspiel", debug=True)
         env.reset()
         env.step([{"submission": -1}, {"submission": -1}])  # Setup step.
-        env.step([
-            {"submission": open_spiel_env.AGENT_ERROR_ACTION},
-            {"submission": 0},
-        ])
+        env.step(
+            [
+                {"submission": open_spiel_env.AGENT_ERROR_ACTION},
+                {"submission": 0},
+            ]
+        )
         self.assertTrue(env.done)
         json = env.toJSON()
         self.assertEqual(json["rewards"], [None, None])


### PR DESCRIPTION
Adds dark_hex to the OpenSpiel game list with a JSON-emitting proxy that preserves the imperfect-information property: each player only sees their own pieces plus opponent pieces revealed via collisions.

Includes a hex-board visualizer that renders both players' views side by side with colored edge guides for the connection goals (X: top-bottom, O: left-right) and a last-move highlight on the actor's own board.