### PR TITLE
Amazons: surface model thoughts in side-panel game log

### DIFF
--- a/kaggle_environments/envs/open_spiel_env/games/amazons/visualizer/default/src/main.ts
+++ b/kaggle_environments/envs/open_spiel_env/games/amazons/visualizer/default/src/main.ts
@@ -1,5 +1,6 @@
 import { createReplayVisualizer, ReplayAdapter } from '@kaggle-environments/core';
 import { renderer } from './renderer';
+import { amazonsTransformer } from './transformers/amazonsTransformer';
 import './style.css';
 
 const app = document.getElementById('app');
@@ -17,5 +18,10 @@ createReplayVisualizer(
     gameName: 'open_spiel_amazons',
     renderer: renderer as any,
     ui: 'side-panel',
+    transformer: (replay) => ({
+      ...replay,
+      steps: amazonsTransformer(replay),
+      isTransformed: true,
+    }),
   })
 );

--- a/kaggle_environments/envs/open_spiel_env/games/amazons/visualizer/default/src/renderer.ts
+++ b/kaggle_environments/envs/open_spiel_env/games/amazons/visualizer/default/src/renderer.ts
@@ -1,18 +1,7 @@
 import type { RendererOptions } from '@kaggle-environments/core';
-import type { AmazonsStep } from './transformers/amazonsTransformer';
+import type { AmazonsBoardState, AmazonsCell, AmazonsStep } from './transformers/amazonsTransformer';
 
-type Cell = 'X' | 'O' | '#' | '.';
-type Board = Cell[][];
-
-interface AmazonsObservation {
-  board: Board;
-  board_size: number;
-  current_player: string;
-  phase: 'from' | 'to' | 'shoot' | null;
-  move_number: number;
-  is_terminal: boolean;
-  winner: string | null;
-}
+type Board = AmazonsCell[][];
 
 const INK = '#050001';
 const SOFT_INK = '#3c3b37';
@@ -24,9 +13,8 @@ const HIGHLIGHT_FROM = 'rgba(189, 238, 255, 0.55)';
 const HIGHLIGHT_TO = 'rgba(255, 215, 96, 0.65)';
 const HIGHLIGHT_SHOOT = 'rgba(154, 51, 36, 0.25)';
 
-function asObservation(step: AmazonsStep | undefined): AmazonsObservation | null {
-  if (!step?.boardState) return null;
-  return step.boardState as AmazonsObservation;
+function asObservation(step: AmazonsStep | undefined): AmazonsBoardState | null {
+  return step?.boardState ?? null;
 }
 
 interface BoardDiff {
@@ -68,7 +56,7 @@ function makePlayerCard(label: string, glyphClass: 'x' | 'o', active: boolean): 
   `;
 }
 
-function findPrevObservation(steps: AmazonsStep[], step: number): AmazonsObservation | null {
+function findPrevObservation(steps: AmazonsStep[], step: number): AmazonsBoardState | null {
   for (let i = step - 1; i >= 0; i--) {
     const obs = asObservation(steps[i]);
     if (obs) return obs;
@@ -80,7 +68,7 @@ function drawBoard(
   c: CanvasRenderingContext2D,
   width: number,
   height: number,
-  obs: AmazonsObservation,
+  obs: AmazonsBoardState,
   diff: BoardDiff
 ) {
   c.clearRect(0, 0, width, height);
@@ -174,7 +162,7 @@ function drawBoard(
   }
 }
 
-function describeStatus(obs: AmazonsObservation, diff: BoardDiff): { primary: string; annotation: string } {
+function describeStatus(obs: AmazonsBoardState, diff: BoardDiff): { primary: string; annotation: string } {
   if (obs.is_terminal) {
     if (obs.winner === 'draw') {
       return { primary: 'Draw', annotation: 'no legal moves remain' };

--- a/kaggle_environments/envs/open_spiel_env/games/amazons/visualizer/default/src/renderer.ts
+++ b/kaggle_environments/envs/open_spiel_env/games/amazons/visualizer/default/src/renderer.ts
@@ -1,4 +1,5 @@
 import type { RendererOptions } from '@kaggle-environments/core';
+import type { AmazonsStep } from './transformers/amazonsTransformer';
 
 type Cell = 'X' | 'O' | '#' | '.';
 type Board = Cell[][];
@@ -23,14 +24,9 @@ const HIGHLIGHT_FROM = 'rgba(189, 238, 255, 0.55)';
 const HIGHLIGHT_TO = 'rgba(255, 215, 96, 0.65)';
 const HIGHLIGHT_SHOOT = 'rgba(154, 51, 36, 0.25)';
 
-function parseObservation(rawStep: any): AmazonsObservation | null {
-  const raw = rawStep?.[0]?.observation?.observationString;
-  if (!raw) return null;
-  try {
-    return JSON.parse(raw) as AmazonsObservation;
-  } catch {
-    return null;
-  }
+function asObservation(step: AmazonsStep | undefined): AmazonsObservation | null {
+  if (!step?.boardState) return null;
+  return step.boardState as AmazonsObservation;
 }
 
 interface BoardDiff {
@@ -72,10 +68,10 @@ function makePlayerCard(label: string, glyphClass: 'x' | 'o', active: boolean): 
   `;
 }
 
-function findPrevStep(steps: any[], step: number): any | null {
+function findPrevObservation(steps: AmazonsStep[], step: number): AmazonsObservation | null {
   for (let i = step - 1; i >= 0; i--) {
-    const obs = parseObservation(steps[i]);
-    if (obs) return steps[i];
+    const obs = asObservation(steps[i]);
+    if (obs) return obs;
   }
   return null;
 }
@@ -209,9 +205,9 @@ function cellName([row, col]: [number, number]): string {
   return `${'abcdefghij'[col] ?? '?'}${row + 1}`;
 }
 
-export function renderer(options: RendererOptions) {
+export function renderer(options: RendererOptions<AmazonsStep[]>) {
   const { step, replay, parent } = options;
-  const steps = (replay?.steps ?? []) as any[];
+  const steps = (replay?.steps ?? []) as AmazonsStep[];
 
   parent.innerHTML = `
     <div class="renderer-container">
@@ -229,7 +225,7 @@ export function renderer(options: RendererOptions) {
   const annotation = parent.querySelector('.amazons-annotation') as HTMLDivElement;
   if (!canvas) return;
 
-  const obs = parseObservation(steps[step]);
+  const obs = asObservation(steps[step]);
 
   if (!obs) {
     header.innerHTML = `${makePlayerCard('Black (X)', 'x', false)}<span style="color:${SOFT_INK}">vs</span>${makePlayerCard('White (O)', 'o', false)}`;
@@ -255,8 +251,7 @@ export function renderer(options: RendererOptions) {
   if (!ctx) return;
   ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
 
-  const prevStep = findPrevStep(steps, step);
-  const prevObs = prevStep ? parseObservation(prevStep) : null;
+  const prevObs = findPrevObservation(steps, step);
   const diff = diffBoards(prevObs?.board ?? null, obs.board);
 
   drawBoard(ctx, rect.width, rect.height, obs, diff);

--- a/kaggle_environments/envs/open_spiel_env/games/amazons/visualizer/default/src/transformers/amazonsTransformer.ts
+++ b/kaggle_environments/envs/open_spiel_env/games/amazons/visualizer/default/src/transformers/amazonsTransformer.ts
@@ -1,0 +1,130 @@
+// Amazons replay transformer.
+//
+// Builds the per-step `players` array the side-panel UI needs. Each Amazons
+// turn is three sub-actions (from / to / shoot), and only the active player
+// produces an action in any given step — the inactive player just waits.
+//
+// We surface the LLM's `thoughts` (and `generate_returns`, when present, in
+// the Go-harness shape) so the right-hand Game Log can render reasoning.
+
+interface AmazonsAction {
+  submission?: number;
+  actionString?: string | null;
+  thoughts?: string | null;
+  status?: string | null;
+  generate_returns?: string[] | null;
+}
+
+interface AmazonsObservation {
+  observationString?: string;
+  isTerminal?: boolean;
+}
+
+interface AmazonsReplayPlayer {
+  action?: AmazonsAction;
+  reward: number;
+  observation: AmazonsObservation;
+  status?: string;
+}
+
+interface AmazonsPlayer {
+  id: number;
+  name: string;
+  thumbnail: string;
+  isTurn: boolean;
+  actionDisplayText: string;
+  thoughts: string;
+  reward: number;
+  generateReturns: string[] | null;
+}
+
+type Cell = 'X' | 'O' | '#' | '.';
+
+interface AmazonsBoardState {
+  board: Cell[][];
+  board_size: number;
+  current_player: string;
+  phase: 'from' | 'to' | 'shoot' | null;
+  move_number: number;
+  is_terminal: boolean;
+  winner: string | null;
+}
+
+export interface AmazonsStep {
+  step: number;
+  players: AmazonsPlayer[];
+  boardState: AmazonsBoardState | null;
+  isTerminal: boolean;
+  winner: string | null;
+}
+
+function parseThoughts(action?: AmazonsAction): string {
+  if (action?.generate_returns?.[0]) {
+    try {
+      const parsed = JSON.parse(action.generate_returns[0]);
+      if (parsed.main_response_and_thoughts) {
+        return parsed.main_response_and_thoughts;
+      }
+    } catch {
+      // fall through to action.thoughts
+    }
+  }
+  return action?.thoughts ?? '';
+}
+
+function parseBoardState(step: AmazonsReplayPlayer[]): AmazonsBoardState | null {
+  // Both agents see the same observationString; pick whichever is populated.
+  const raw = step?.[0]?.observation?.observationString ?? step?.[1]?.observation?.observationString;
+  if (!raw) return null;
+  try {
+    return JSON.parse(raw) as AmazonsBoardState;
+  } catch {
+    return null;
+  }
+}
+
+function deriveWinner(step: AmazonsReplayPlayer[]): string | null {
+  if (step.length < 2) return null;
+  const r0 = step[0].reward;
+  const r1 = step[1].reward;
+  if (r0 === r1) return 'Draw';
+  return r0 > r1 ? 'Black (X) wins!' : 'White (O) wins!';
+}
+
+export const amazonsTransformer = (environment: any): AmazonsStep[] => {
+  const teamNames: string[] = environment?.info?.TeamNames ?? ['Black (X)', 'White (O)'];
+  const rawSteps: AmazonsReplayPlayer[][] = environment?.steps ?? [];
+  const out: AmazonsStep[] = [];
+
+  rawSteps.forEach((step, index) => {
+    const players: AmazonsPlayer[] = step.map((p, i): AmazonsPlayer => {
+      const submission = p.action?.submission;
+      const isTurn = submission !== undefined && submission !== null && submission !== -1;
+      return {
+        id: i,
+        name: teamNames[i] ?? (i === 0 ? 'Black (X)' : 'White (O)'),
+        thumbnail: '',
+        isTurn,
+        actionDisplayText: p.action?.actionString ?? '',
+        thoughts: parseThoughts(p.action),
+        reward: p.reward ?? 0,
+        generateReturns: p.action?.generate_returns ?? null,
+      };
+    });
+
+    // Skip steps where neither player acted (e.g. the env's setup step where
+    // both submit -1). The side-panel uses isTurn to pick the active player.
+    if (!players.some((pl) => pl.isTurn)) return;
+
+    const isTerminal = !!step[0]?.observation?.isTerminal;
+    out.push({
+      step: index,
+      players,
+      boardState: parseBoardState(step),
+      isTerminal,
+      winner: isTerminal ? deriveWinner(step) : null,
+    });
+  });
+
+  return out;
+};

--- a/kaggle_environments/envs/open_spiel_env/games/amazons/visualizer/default/src/transformers/amazonsTransformer.ts
+++ b/kaggle_environments/envs/open_spiel_env/games/amazons/visualizer/default/src/transformers/amazonsTransformer.ts
@@ -38,10 +38,10 @@ interface AmazonsPlayer {
   generateReturns: string[] | null;
 }
 
-type Cell = 'X' | 'O' | '#' | '.';
+export type AmazonsCell = 'X' | 'O' | '#' | '.';
 
-interface AmazonsBoardState {
-  board: Cell[][];
+export interface AmazonsBoardState {
+  board: AmazonsCell[][];
   board_size: number;
   current_player: string;
   phase: 'from' | 'to' | 'shoot' | null;
@@ -59,6 +59,9 @@ export interface AmazonsStep {
 }
 
 function parseThoughts(action?: AmazonsAction): string {
+  // Prefer the Go-harness ``main_response_and_thoughts`` payload when
+  // generate_returns is populated; fall through to ``action.thoughts`` if
+  // generate_returns is missing, fails to parse, or doesn't carry the field.
   if (action?.generate_returns?.[0]) {
     try {
       const parsed = JSON.parse(action.generate_returns[0]);
@@ -99,7 +102,9 @@ export const amazonsTransformer = (environment: any): AmazonsStep[] => {
   rawSteps.forEach((step, index) => {
     const players: AmazonsPlayer[] = step.map((p, i): AmazonsPlayer => {
       const submission = p.action?.submission;
-      const isTurn = submission !== undefined && submission !== null && submission !== -1;
+      // Match Go: an action with submission undefined or -1 is a no-op
+      // (the env's setup step or the inactive player).
+      const isTurn = submission !== undefined && submission !== -1;
       return {
         id: i,
         name: teamNames[i] ?? (i === 0 ? 'Black (X)' : 'White (O)'),


### PR DESCRIPTION
The amazons visualizer used the side-panel UI but didn't supply a transformer, so the right-hand Game Log stayed empty even when agents returned thoughts. Add an amazonsTransformer mirroring the Go pattern: it builds per-step players carrying actionString/thoughts/generate_returns, and attaches the parsed boardState that the renderer now consumes.