### PR TITLE
Add Y (OpenSpiel) game and visualizer

### DIFF
--- a/kaggle_environments/envs/open_spiel_env/games/y/visualizer/default/index.html
+++ b/kaggle_environments/envs/open_spiel_env/games/y/visualizer/default/index.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Y Visualizer</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=Mynerve&display=swap" rel="stylesheet" />
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="/src/main.ts"></script>
+  </body>
+</html>

--- a/kaggle_environments/envs/open_spiel_env/games/y/visualizer/default/package.json
+++ b/kaggle_environments/envs/open_spiel_env/games/y/visualizer/default/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@kaggle-environments/open-spiel-y-visualizer",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "dev-with-replay": "cross-env VITE_REPLAY_FILE=./replays/test-replay.json vite",
+    "build": "tsc && vite build",
+    "preview": "vite preview"
+  },
+  "devDependencies": {
+    "cross-env": "^10.1.0",
+    "typescript": "^5.0.0",
+    "vite": "^5.0.0"
+  },
+  "dependencies": {
+    "@kaggle-environments/core": "workspace:*"
+  }
+}

--- a/kaggle_environments/envs/open_spiel_env/games/y/visualizer/default/replays/test-replay.json
+++ b/kaggle_environments/envs/open_spiel_env/games/y/visualizer/default/replays/test-replay.json
@@ -1,0 +1,2154 @@
+{
+  "id": "ac9b78fa-3f8f-11f1-b37d-122fb404ab4e",
+  "name": "open_spiel_y",
+  "title": "Open Spiel: y",
+  "description": "Kaggle environment wrapper for OpenSpiel games.\nFor game implementation details see:\nhttps://github.com/google-deepmind/open_spiel/tree/master/open_spiel/games",
+  "version": "0.1.0",
+  "module_version": "1.18.0",
+  "configuration": {
+    "includeLegalActions": true,
+    "episodeSteps": 136,
+    "actTimeout": 3600,
+    "runTimeout": 172800,
+    "openSpielGameString": "y_proxy(ansi_color_output=False,board_size=8)",
+    "openSpielGameName": "y",
+    "openSpielGameParameters": {
+      "ansi_color_output": false,
+      "board_size": 8
+    },
+    "observationType": "observation",
+    "useOpenings": false,
+    "useImage": false,
+    "loadPresetHands": false,
+    "metadata": {}
+  },
+  "specification": {
+    "action": {
+      "description": "Action object MUST contain a field `submission`, and MAY contain arbitrary additional information.",
+      "type": "object",
+      "default": {
+        "submission": -1
+      }
+    },
+    "agents": [2],
+    "configuration": {
+      "episodeSteps": {
+        "description": "Maximum number of steps in the episode.",
+        "type": "integer",
+        "minimum": 1,
+        "default": 136
+      },
+      "actTimeout": {
+        "description": "Maximum runtime (seconds) to obtain an action from an agent.",
+        "type": "number",
+        "minimum": 0,
+        "default": 3600
+      },
+      "runTimeout": {
+        "description": "Maximum runtime (seconds) of an episode (not necessarily DONE).",
+        "type": "number",
+        "minimum": 0,
+        "default": 172800
+      },
+      "openSpielGameString": {
+        "description": "The full game string including parameters.",
+        "type": "string",
+        "default": "y_proxy(ansi_color_output=False,board_size=8)"
+      },
+      "openSpielGameName": {
+        "description": "The short_name of the OpenSpiel game to load.",
+        "type": "string",
+        "default": "y"
+      },
+      "openSpielGameParameters": {
+        "description": "Game parameters for Open Spiel game.",
+        "type": "object",
+        "default": {
+          "ansi_color_output": false,
+          "board_size": 8
+        },
+        "properties": {}
+      },
+      "observationType": {
+        "description": "Type of observation string: 'observation' or 'information_state'.",
+        "type": "string",
+        "default": "observation"
+      },
+      "useOpenings": {
+        "description": "Whether to start from a position in an opening book.",
+        "type": "boolean",
+        "default": false
+      },
+      "useImage": {
+        "description": "If true, indicates the observation is intended to be rendered as an image. Note that currently the agent harness is responsible for the actual rendering; no image is passed in the observation.",
+        "type": "boolean",
+        "default": false
+      },
+      "includeLegalActions": {
+        "description": "If true, include legalActions and legalActionStrings in observations. Defaults to false since these can be derived from serializedGameAndState.",
+        "type": "boolean",
+        "default": false
+      },
+      "seed": {
+        "description": "Integer currently only used for selecting starting position.",
+        "type": "number"
+      },
+      "initialActions": {
+        "description": "Actions applied to initial state before play begins to set up starting position.",
+        "type": "array"
+      },
+      "loadPresetHands": {
+        "description": "Repeated poker only. Load preset hand chance actions from preset_hands.jsonl.",
+        "type": "boolean",
+        "default": false
+      },
+      "presetHands": {
+        "description": "Repeated poker only. List of per-hand chance action sequences to use instead of random chance.",
+        "type": "array"
+      },
+      "metadata": {
+        "description": "Arbitrary metadata.",
+        "type": "object",
+        "default": {},
+        "properties": {}
+      }
+    },
+    "info": {},
+    "observation": {
+      "remainingOverageTime": {
+        "description": "Total remaining banked time (seconds) that can be used in excess of per-step actTimeouts -- agent is disqualified with TIMEOUT status when this drops below 0.",
+        "shared": false,
+        "type": "number",
+        "minimum": 0,
+        "default": 12
+      },
+      "step": {
+        "description": "Current step within the episode.",
+        "type": "integer",
+        "shared": true,
+        "minimum": 0,
+        "default": 0
+      },
+      "properties": {
+        "openSpielGameString": {
+          "description": "Full game string including parameters.",
+          "type": "string",
+          "default": "y_proxy(ansi_color_output=False,board_size=8)"
+        },
+        "openSpielGameName": {
+          "description": "Short name of the OpenSpiel game.",
+          "type": "string",
+          "default": "y"
+        },
+        "observationString": {
+          "description": "String representation of state.",
+          "type": "string"
+        },
+        "legalActions": {
+          "description": "List of OpenSpiel legal action integers. Only included if includeLegalActions is true.",
+          "type": "array"
+        },
+        "legalActionStrings": {
+          "description": "List of OpenSpiel legal action strings. Only included if includeLegalActions is true.",
+          "type": "array"
+        },
+        "currentPlayer": {
+          "description": "ID of player whose turn it is.",
+          "type": "integer"
+        },
+        "playerId": {
+          "description": "ID of the agent receiving this observation.",
+          "type": "integer"
+        },
+        "isTerminal": {
+          "description": "Boolean indicating game end.",
+          "type": "boolean"
+        },
+        "serializedGameAndState": {
+          "description": "Enables reconstructing the Game and State objects.",
+          "type": "string"
+        },
+        "remainingOverageTime": 60,
+        "step": 0
+      },
+      "default": {}
+    },
+    "reward": {
+      "type": ["number", "null"],
+      "default": 0.0
+    }
+  },
+  "steps": [
+    [
+      {
+        "action": {
+          "submission": -1
+        },
+        "reward": 0.0,
+        "info": {},
+        "observation": {
+          "remainingOverageTime": 12,
+          "step": 0
+        },
+        "status": "ACTIVE"
+      },
+      {
+        "action": {
+          "submission": -1
+        },
+        "reward": 0.0,
+        "info": {},
+        "observation": {
+          "remainingOverageTime": 12
+        },
+        "status": "ACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "submission": -1
+        },
+        "reward": null,
+        "info": {
+          "actionSubmitted": null,
+          "actionSubmittedToString": null,
+          "actionApplied": null,
+          "timeTaken": null,
+          "agentSelfReportedStatus": null
+        },
+        "observation": {
+          "remainingOverageTime": 12,
+          "step": 1,
+          "observationString": "{\"board\": [[null, null, null, null, null, null, null, null], [null, null, null, null, null, null, null], [null, null, null, null, null, null], [null, null, null, null, null], [null, null, null, null], [null, null, null], [null, null], [null]], \"board_size\": 8, \"current_player\": \"x\", \"is_terminal\": false, \"winner\": null, \"last_move\": null, \"move_number\": 0}",
+          "currentPlayer": 0,
+          "playerId": 0,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ny_proxy(ansi_color_output=False,board_size=8)\n[State]\nhistory=\nmove_number=0\n__dict__=gASVtgAAAAAAAAB9lIwLX193cmFwcGVkX1+UjAdweXNwaWVslIwFU3RhdGWUk5QpgZSMiSMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCnkoYW5zaV9jb2xvcl9vdXRwdXQ9RmFsc2UsYm9hcmRfc2l6ZT04KQpbU3RhdGVdCgoKlGJzLg==\n",
+          "legalActions": [
+            0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 16, 17, 18, 19,
+            20, 21, 24, 25, 26, 27, 28, 32, 33, 34, 35, 40, 41, 42, 48, 49, 56
+          ],
+          "legalActionStrings": [
+            "a1",
+            "b1",
+            "c1",
+            "d1",
+            "e1",
+            "f1",
+            "g1",
+            "h1",
+            "a2",
+            "b2",
+            "c2",
+            "d2",
+            "e2",
+            "f2",
+            "g2",
+            "a3",
+            "b3",
+            "c3",
+            "d3",
+            "e3",
+            "f3",
+            "a4",
+            "b4",
+            "c4",
+            "d4",
+            "e4",
+            "a5",
+            "b5",
+            "c5",
+            "d5",
+            "a6",
+            "b6",
+            "c6",
+            "a7",
+            "b7",
+            "a8"
+          ]
+        },
+        "status": "ACTIVE"
+      },
+      {
+        "action": {
+          "submission": -1
+        },
+        "reward": null,
+        "info": {},
+        "observation": {
+          "remainingOverageTime": 12,
+          "observationString": "{\"board\": [[null, null, null, null, null, null, null, null], [null, null, null, null, null, null, null], [null, null, null, null, null, null], [null, null, null, null, null], [null, null, null, null], [null, null, null], [null, null], [null]], \"board_size\": 8, \"current_player\": \"x\", \"is_terminal\": false, \"winner\": null, \"last_move\": null, \"move_number\": 0}",
+          "currentPlayer": 0,
+          "playerId": 1,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ny_proxy(ansi_color_output=False,board_size=8)\n[State]\nhistory=\nmove_number=0\n__dict__=gASVtgAAAAAAAAB9lIwLX193cmFwcGVkX1+UjAdweXNwaWVslIwFU3RhdGWUk5QpgZSMiSMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCnkoYW5zaV9jb2xvcl9vdXRwdXQ9RmFsc2UsYm9hcmRfc2l6ZT04KQpbU3RhdGVdCgoKlGJzLg==\n",
+          "legalActions": [],
+          "legalActionStrings": []
+        },
+        "status": "INACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "submission": 11,
+          "thoughts": "explore zeta tau nu alpha psi iota mu"
+        },
+        "reward": null,
+        "info": {
+          "actionSubmitted": 11,
+          "actionSubmittedToString": "d2",
+          "actionApplied": 11,
+          "timeTaken": 0.0,
+          "agentSelfReportedStatus": null
+        },
+        "observation": {
+          "remainingOverageTime": 12,
+          "step": 2,
+          "observationString": "{\"board\": [[null, null, null, null, null, null, null, null], [null, null, null, \"x\", null, null, null], [null, null, null, null, null, null], [null, null, null, null, null], [null, null, null, null], [null, null, null], [null, null], [null]], \"board_size\": 8, \"current_player\": \"o\", \"is_terminal\": false, \"winner\": null, \"last_move\": \"d2\", \"move_number\": 1}",
+          "currentPlayer": 1,
+          "playerId": 0,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ny_proxy(ansi_color_output=False,board_size=8)\n[State]\nhistory=0:11\nmove_number=1\n__dict__=gASVuAAAAAAAAAB9lIwLX193cmFwcGVkX1+UjAdweXNwaWVslIwFU3RhdGWUk5QpgZSMiyMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCnkoYW5zaV9jb2xvcl9vdXRwdXQ9RmFsc2UsYm9hcmRfc2l6ZT04KQpbU3RhdGVdCjExCgqUYnMu\n",
+          "legalActions": [],
+          "legalActionStrings": []
+        },
+        "status": "INACTIVE"
+      },
+      {
+        "action": {
+          "submission": -1
+        },
+        "reward": null,
+        "info": {},
+        "observation": {
+          "remainingOverageTime": 12,
+          "observationString": "{\"board\": [[null, null, null, null, null, null, null, null], [null, null, null, \"x\", null, null, null], [null, null, null, null, null, null], [null, null, null, null, null], [null, null, null, null], [null, null, null], [null, null], [null]], \"board_size\": 8, \"current_player\": \"o\", \"is_terminal\": false, \"winner\": null, \"last_move\": \"d2\", \"move_number\": 1}",
+          "currentPlayer": 1,
+          "playerId": 1,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ny_proxy(ansi_color_output=False,board_size=8)\n[State]\nhistory=0:11\nmove_number=1\n__dict__=gASVuAAAAAAAAAB9lIwLX193cmFwcGVkX1+UjAdweXNwaWVslIwFU3RhdGWUk5QpgZSMiyMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCnkoYW5zaV9jb2xvcl9vdXRwdXQ9RmFsc2UsYm9hcmRfc2l6ZT04KQpbU3RhdGVdCjExCgqUYnMu\n",
+          "legalActions": [
+            0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 12, 13, 14, 16, 17, 18, 19, 20,
+            21, 24, 25, 26, 27, 28, 32, 33, 34, 35, 40, 41, 42, 48, 49, 56
+          ],
+          "legalActionStrings": [
+            "a1",
+            "b1",
+            "c1",
+            "d1",
+            "e1",
+            "f1",
+            "g1",
+            "h1",
+            "a2",
+            "b2",
+            "c2",
+            "e2",
+            "f2",
+            "g2",
+            "a3",
+            "b3",
+            "c3",
+            "d3",
+            "e3",
+            "f3",
+            "a4",
+            "b4",
+            "c4",
+            "d4",
+            "e4",
+            "a5",
+            "b5",
+            "c5",
+            "d5",
+            "a6",
+            "b6",
+            "c6",
+            "a7",
+            "b7",
+            "a8"
+          ]
+        },
+        "status": "ACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "submission": -1
+        },
+        "reward": null,
+        "info": {},
+        "observation": {
+          "remainingOverageTime": 12,
+          "step": 3,
+          "observationString": "{\"board\": [[null, null, null, null, null, null, null, null], [null, null, null, \"x\", null, null, null], [null, null, null, null, null, null], [null, null, null, null, null], [null, null, null, \"o\"], [null, null, null], [null, null], [null]], \"board_size\": 8, \"current_player\": \"x\", \"is_terminal\": false, \"winner\": null, \"last_move\": \"d5\", \"move_number\": 2}",
+          "currentPlayer": 0,
+          "playerId": 0,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ny_proxy(ansi_color_output=False,board_size=8)\n[State]\nhistory=0:11,1:35\nmove_number=2\n__dict__=gASVuwAAAAAAAAB9lIwLX193cmFwcGVkX1+UjAdweXNwaWVslIwFU3RhdGWUk5QpgZSMjiMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCnkoYW5zaV9jb2xvcl9vdXRwdXQ9RmFsc2UsYm9hcmRfc2l6ZT04KQpbU3RhdGVdCjExCjM1CgqUYnMu\n",
+          "legalActions": [
+            0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 12, 13, 14, 16, 17, 18, 19, 20,
+            21, 24, 25, 26, 27, 28, 32, 33, 34, 40, 41, 42, 48, 49, 56
+          ],
+          "legalActionStrings": [
+            "a1",
+            "b1",
+            "c1",
+            "d1",
+            "e1",
+            "f1",
+            "g1",
+            "h1",
+            "a2",
+            "b2",
+            "c2",
+            "e2",
+            "f2",
+            "g2",
+            "a3",
+            "b3",
+            "c3",
+            "d3",
+            "e3",
+            "f3",
+            "a4",
+            "b4",
+            "c4",
+            "d4",
+            "e4",
+            "a5",
+            "b5",
+            "c5",
+            "a6",
+            "b6",
+            "c6",
+            "a7",
+            "b7",
+            "a8"
+          ]
+        },
+        "status": "ACTIVE"
+      },
+      {
+        "action": {
+          "submission": 35,
+          "thoughts": "wonder psi eta theta iota gamma rho zeta"
+        },
+        "reward": null,
+        "info": {
+          "actionSubmitted": 35,
+          "actionSubmittedToString": "d5",
+          "actionApplied": 35,
+          "timeTaken": 0.0,
+          "agentSelfReportedStatus": null
+        },
+        "observation": {
+          "remainingOverageTime": 12,
+          "observationString": "{\"board\": [[null, null, null, null, null, null, null, null], [null, null, null, \"x\", null, null, null], [null, null, null, null, null, null], [null, null, null, null, null], [null, null, null, \"o\"], [null, null, null], [null, null], [null]], \"board_size\": 8, \"current_player\": \"x\", \"is_terminal\": false, \"winner\": null, \"last_move\": \"d5\", \"move_number\": 2}",
+          "currentPlayer": 0,
+          "playerId": 1,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ny_proxy(ansi_color_output=False,board_size=8)\n[State]\nhistory=0:11,1:35\nmove_number=2\n__dict__=gASVuwAAAAAAAAB9lIwLX193cmFwcGVkX1+UjAdweXNwaWVslIwFU3RhdGWUk5QpgZSMjiMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCnkoYW5zaV9jb2xvcl9vdXRwdXQ9RmFsc2UsYm9hcmRfc2l6ZT04KQpbU3RhdGVdCjExCjM1CgqUYnMu\n",
+          "legalActions": [],
+          "legalActionStrings": []
+        },
+        "status": "INACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "submission": 56,
+          "thoughts": "ponder phi mu explore lambda nu lantern iota"
+        },
+        "reward": null,
+        "info": {
+          "actionSubmitted": 56,
+          "actionSubmittedToString": "a8",
+          "actionApplied": 56,
+          "timeTaken": 0.0,
+          "agentSelfReportedStatus": null
+        },
+        "observation": {
+          "remainingOverageTime": 12,
+          "step": 4,
+          "observationString": "{\"board\": [[null, null, null, null, null, null, null, null], [null, null, null, \"x\", null, null, null], [null, null, null, null, null, null], [null, null, null, null, null], [null, null, null, \"o\"], [null, null, null], [null, null], [\"x\"]], \"board_size\": 8, \"current_player\": \"o\", \"is_terminal\": false, \"winner\": null, \"last_move\": \"a8\", \"move_number\": 3}",
+          "currentPlayer": 1,
+          "playerId": 0,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ny_proxy(ansi_color_output=False,board_size=8)\n[State]\nhistory=0:11,1:35,0:56\nmove_number=3\n__dict__=gASVvgAAAAAAAAB9lIwLX193cmFwcGVkX1+UjAdweXNwaWVslIwFU3RhdGWUk5QpgZSMkSMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCnkoYW5zaV9jb2xvcl9vdXRwdXQ9RmFsc2UsYm9hcmRfc2l6ZT04KQpbU3RhdGVdCjExCjM1CjU2CgqUYnMu\n",
+          "legalActions": [],
+          "legalActionStrings": []
+        },
+        "status": "INACTIVE"
+      },
+      {
+        "action": {
+          "submission": -1
+        },
+        "reward": null,
+        "info": {},
+        "observation": {
+          "remainingOverageTime": 12,
+          "observationString": "{\"board\": [[null, null, null, null, null, null, null, null], [null, null, null, \"x\", null, null, null], [null, null, null, null, null, null], [null, null, null, null, null], [null, null, null, \"o\"], [null, null, null], [null, null], [\"x\"]], \"board_size\": 8, \"current_player\": \"o\", \"is_terminal\": false, \"winner\": null, \"last_move\": \"a8\", \"move_number\": 3}",
+          "currentPlayer": 1,
+          "playerId": 1,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ny_proxy(ansi_color_output=False,board_size=8)\n[State]\nhistory=0:11,1:35,0:56\nmove_number=3\n__dict__=gASVvgAAAAAAAAB9lIwLX193cmFwcGVkX1+UjAdweXNwaWVslIwFU3RhdGWUk5QpgZSMkSMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCnkoYW5zaV9jb2xvcl9vdXRwdXQ9RmFsc2UsYm9hcmRfc2l6ZT04KQpbU3RhdGVdCjExCjM1CjU2CgqUYnMu\n",
+          "legalActions": [
+            0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 12, 13, 14, 16, 17, 18, 19, 20,
+            21, 24, 25, 26, 27, 28, 32, 33, 34, 40, 41, 42, 48, 49
+          ],
+          "legalActionStrings": [
+            "a1",
+            "b1",
+            "c1",
+            "d1",
+            "e1",
+            "f1",
+            "g1",
+            "h1",
+            "a2",
+            "b2",
+            "c2",
+            "e2",
+            "f2",
+            "g2",
+            "a3",
+            "b3",
+            "c3",
+            "d3",
+            "e3",
+            "f3",
+            "a4",
+            "b4",
+            "c4",
+            "d4",
+            "e4",
+            "a5",
+            "b5",
+            "c5",
+            "a6",
+            "b6",
+            "c6",
+            "a7",
+            "b7"
+          ]
+        },
+        "status": "ACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "submission": -1
+        },
+        "reward": null,
+        "info": {},
+        "observation": {
+          "remainingOverageTime": 12,
+          "step": 5,
+          "observationString": "{\"board\": [[null, null, null, null, null, null, null, null], [null, null, null, \"x\", null, null, null], [null, null, null, null, null, null], [null, null, null, null, null], [null, null, null, \"o\"], [\"o\", null, null], [null, null], [\"x\"]], \"board_size\": 8, \"current_player\": \"x\", \"is_terminal\": false, \"winner\": null, \"last_move\": \"a6\", \"move_number\": 4}",
+          "currentPlayer": 0,
+          "playerId": 0,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ny_proxy(ansi_color_output=False,board_size=8)\n[State]\nhistory=0:11,1:35,0:56,1:40\nmove_number=4\n__dict__=gASVwQAAAAAAAAB9lIwLX193cmFwcGVkX1+UjAdweXNwaWVslIwFU3RhdGWUk5QpgZSMlCMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCnkoYW5zaV9jb2xvcl9vdXRwdXQ9RmFsc2UsYm9hcmRfc2l6ZT04KQpbU3RhdGVdCjExCjM1CjU2CjQwCgqUYnMu\n",
+          "legalActions": [
+            0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 12, 13, 14, 16, 17, 18, 19, 20,
+            21, 24, 25, 26, 27, 28, 32, 33, 34, 41, 42, 48, 49
+          ],
+          "legalActionStrings": [
+            "a1",
+            "b1",
+            "c1",
+            "d1",
+            "e1",
+            "f1",
+            "g1",
+            "h1",
+            "a2",
+            "b2",
+            "c2",
+            "e2",
+            "f2",
+            "g2",
+            "a3",
+            "b3",
+            "c3",
+            "d3",
+            "e3",
+            "f3",
+            "a4",
+            "b4",
+            "c4",
+            "d4",
+            "e4",
+            "a5",
+            "b5",
+            "c5",
+            "b6",
+            "c6",
+            "a7",
+            "b7"
+          ]
+        },
+        "status": "ACTIVE"
+      },
+      {
+        "action": {
+          "submission": 40,
+          "thoughts": "chi kappa rho kappa lantern zeta cascade omega"
+        },
+        "reward": null,
+        "info": {
+          "actionSubmitted": 40,
+          "actionSubmittedToString": "a6",
+          "actionApplied": 40,
+          "timeTaken": 0.0,
+          "agentSelfReportedStatus": null
+        },
+        "observation": {
+          "remainingOverageTime": 12,
+          "observationString": "{\"board\": [[null, null, null, null, null, null, null, null], [null, null, null, \"x\", null, null, null], [null, null, null, null, null, null], [null, null, null, null, null], [null, null, null, \"o\"], [\"o\", null, null], [null, null], [\"x\"]], \"board_size\": 8, \"current_player\": \"x\", \"is_terminal\": false, \"winner\": null, \"last_move\": \"a6\", \"move_number\": 4}",
+          "currentPlayer": 0,
+          "playerId": 1,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ny_proxy(ansi_color_output=False,board_size=8)\n[State]\nhistory=0:11,1:35,0:56,1:40\nmove_number=4\n__dict__=gASVwQAAAAAAAAB9lIwLX193cmFwcGVkX1+UjAdweXNwaWVslIwFU3RhdGWUk5QpgZSMlCMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCnkoYW5zaV9jb2xvcl9vdXRwdXQ9RmFsc2UsYm9hcmRfc2l6ZT04KQpbU3RhdGVdCjExCjM1CjU2CjQwCgqUYnMu\n",
+          "legalActions": [],
+          "legalActionStrings": []
+        },
+        "status": "INACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "submission": 20,
+          "thoughts": "rho shadow pi rho echo delta xi phi"
+        },
+        "reward": null,
+        "info": {
+          "actionSubmitted": 20,
+          "actionSubmittedToString": "e3",
+          "actionApplied": 20,
+          "timeTaken": 0.0,
+          "agentSelfReportedStatus": null
+        },
+        "observation": {
+          "remainingOverageTime": 12,
+          "step": 6,
+          "observationString": "{\"board\": [[null, null, null, null, null, null, null, null], [null, null, null, \"x\", null, null, null], [null, null, null, null, \"x\", null], [null, null, null, null, null], [null, null, null, \"o\"], [\"o\", null, null], [null, null], [\"x\"]], \"board_size\": 8, \"current_player\": \"o\", \"is_terminal\": false, \"winner\": null, \"last_move\": \"e3\", \"move_number\": 5}",
+          "currentPlayer": 1,
+          "playerId": 0,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ny_proxy(ansi_color_output=False,board_size=8)\n[State]\nhistory=0:11,1:35,0:56,1:40,0:20\nmove_number=5\n__dict__=gASVxAAAAAAAAAB9lIwLX193cmFwcGVkX1+UjAdweXNwaWVslIwFU3RhdGWUk5QpgZSMlyMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCnkoYW5zaV9jb2xvcl9vdXRwdXQ9RmFsc2UsYm9hcmRfc2l6ZT04KQpbU3RhdGVdCjExCjM1CjU2CjQwCjIwCgqUYnMu\n",
+          "legalActions": [],
+          "legalActionStrings": []
+        },
+        "status": "INACTIVE"
+      },
+      {
+        "action": {
+          "submission": -1
+        },
+        "reward": null,
+        "info": {},
+        "observation": {
+          "remainingOverageTime": 12,
+          "observationString": "{\"board\": [[null, null, null, null, null, null, null, null], [null, null, null, \"x\", null, null, null], [null, null, null, null, \"x\", null], [null, null, null, null, null], [null, null, null, \"o\"], [\"o\", null, null], [null, null], [\"x\"]], \"board_size\": 8, \"current_player\": \"o\", \"is_terminal\": false, \"winner\": null, \"last_move\": \"e3\", \"move_number\": 5}",
+          "currentPlayer": 1,
+          "playerId": 1,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ny_proxy(ansi_color_output=False,board_size=8)\n[State]\nhistory=0:11,1:35,0:56,1:40,0:20\nmove_number=5\n__dict__=gASVxAAAAAAAAAB9lIwLX193cmFwcGVkX1+UjAdweXNwaWVslIwFU3RhdGWUk5QpgZSMlyMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCnkoYW5zaV9jb2xvcl9vdXRwdXQ9RmFsc2UsYm9hcmRfc2l6ZT04KQpbU3RhdGVdCjExCjM1CjU2CjQwCjIwCgqUYnMu\n",
+          "legalActions": [
+            0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 12, 13, 14, 16, 17, 18, 19, 21,
+            24, 25, 26, 27, 28, 32, 33, 34, 41, 42, 48, 49
+          ],
+          "legalActionStrings": [
+            "a1",
+            "b1",
+            "c1",
+            "d1",
+            "e1",
+            "f1",
+            "g1",
+            "h1",
+            "a2",
+            "b2",
+            "c2",
+            "e2",
+            "f2",
+            "g2",
+            "a3",
+            "b3",
+            "c3",
+            "d3",
+            "f3",
+            "a4",
+            "b4",
+            "c4",
+            "d4",
+            "e4",
+            "a5",
+            "b5",
+            "c5",
+            "b6",
+            "c6",
+            "a7",
+            "b7"
+          ]
+        },
+        "status": "ACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "submission": -1
+        },
+        "reward": null,
+        "info": {},
+        "observation": {
+          "remainingOverageTime": 12,
+          "step": 7,
+          "observationString": "{\"board\": [[null, null, null, null, null, null, null, null], [null, null, null, \"x\", null, null, null], [null, null, null, null, \"x\", null], [null, null, null, \"o\", null], [null, null, null, \"o\"], [\"o\", null, null], [null, null], [\"x\"]], \"board_size\": 8, \"current_player\": \"x\", \"is_terminal\": false, \"winner\": null, \"last_move\": \"d4\", \"move_number\": 6}",
+          "currentPlayer": 0,
+          "playerId": 0,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ny_proxy(ansi_color_output=False,board_size=8)\n[State]\nhistory=0:11,1:35,0:56,1:40,0:20,1:27\nmove_number=6\n__dict__=gASVxwAAAAAAAAB9lIwLX193cmFwcGVkX1+UjAdweXNwaWVslIwFU3RhdGWUk5QpgZSMmiMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCnkoYW5zaV9jb2xvcl9vdXRwdXQ9RmFsc2UsYm9hcmRfc2l6ZT04KQpbU3RhdGVdCjExCjM1CjU2CjQwCjIwCjI3CgqUYnMu\n",
+          "legalActions": [
+            0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 12, 13, 14, 16, 17, 18, 19, 21,
+            24, 25, 26, 28, 32, 33, 34, 41, 42, 48, 49
+          ],
+          "legalActionStrings": [
+            "a1",
+            "b1",
+            "c1",
+            "d1",
+            "e1",
+            "f1",
+            "g1",
+            "h1",
+            "a2",
+            "b2",
+            "c2",
+            "e2",
+            "f2",
+            "g2",
+            "a3",
+            "b3",
+            "c3",
+            "d3",
+            "f3",
+            "a4",
+            "b4",
+            "c4",
+            "e4",
+            "a5",
+            "b5",
+            "c5",
+            "b6",
+            "c6",
+            "a7",
+            "b7"
+          ]
+        },
+        "status": "ACTIVE"
+      },
+      {
+        "action": {
+          "submission": 27,
+          "thoughts": "nu phi muse reflect theta explore omega tau"
+        },
+        "reward": null,
+        "info": {
+          "actionSubmitted": 27,
+          "actionSubmittedToString": "d4",
+          "actionApplied": 27,
+          "timeTaken": 0.0,
+          "agentSelfReportedStatus": null
+        },
+        "observation": {
+          "remainingOverageTime": 12,
+          "observationString": "{\"board\": [[null, null, null, null, null, null, null, null], [null, null, null, \"x\", null, null, null], [null, null, null, null, \"x\", null], [null, null, null, \"o\", null], [null, null, null, \"o\"], [\"o\", null, null], [null, null], [\"x\"]], \"board_size\": 8, \"current_player\": \"x\", \"is_terminal\": false, \"winner\": null, \"last_move\": \"d4\", \"move_number\": 6}",
+          "currentPlayer": 0,
+          "playerId": 1,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ny_proxy(ansi_color_output=False,board_size=8)\n[State]\nhistory=0:11,1:35,0:56,1:40,0:20,1:27\nmove_number=6\n__dict__=gASVxwAAAAAAAAB9lIwLX193cmFwcGVkX1+UjAdweXNwaWVslIwFU3RhdGWUk5QpgZSMmiMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCnkoYW5zaV9jb2xvcl9vdXRwdXQ9RmFsc2UsYm9hcmRfc2l6ZT04KQpbU3RhdGVdCjExCjM1CjU2CjQwCjIwCjI3CgqUYnMu\n",
+          "legalActions": [],
+          "legalActionStrings": []
+        },
+        "status": "INACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "submission": 25,
+          "thoughts": "rho ponder spark consider ember sigma rho eta"
+        },
+        "reward": null,
+        "info": {
+          "actionSubmitted": 25,
+          "actionSubmittedToString": "b4",
+          "actionApplied": 25,
+          "timeTaken": 0.0,
+          "agentSelfReportedStatus": null
+        },
+        "observation": {
+          "remainingOverageTime": 12,
+          "step": 8,
+          "observationString": "{\"board\": [[null, null, null, null, null, null, null, null], [null, null, null, \"x\", null, null, null], [null, null, null, null, \"x\", null], [null, \"x\", null, \"o\", null], [null, null, null, \"o\"], [\"o\", null, null], [null, null], [\"x\"]], \"board_size\": 8, \"current_player\": \"o\", \"is_terminal\": false, \"winner\": null, \"last_move\": \"b4\", \"move_number\": 7}",
+          "currentPlayer": 1,
+          "playerId": 0,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ny_proxy(ansi_color_output=False,board_size=8)\n[State]\nhistory=0:11,1:35,0:56,1:40,0:20,1:27,0:25\nmove_number=7\n__dict__=gASVygAAAAAAAAB9lIwLX193cmFwcGVkX1+UjAdweXNwaWVslIwFU3RhdGWUk5QpgZSMnSMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCnkoYW5zaV9jb2xvcl9vdXRwdXQ9RmFsc2UsYm9hcmRfc2l6ZT04KQpbU3RhdGVdCjExCjM1CjU2CjQwCjIwCjI3CjI1CgqUYnMu\n",
+          "legalActions": [],
+          "legalActionStrings": []
+        },
+        "status": "INACTIVE"
+      },
+      {
+        "action": {
+          "submission": -1
+        },
+        "reward": null,
+        "info": {},
+        "observation": {
+          "remainingOverageTime": 12,
+          "observationString": "{\"board\": [[null, null, null, null, null, null, null, null], [null, null, null, \"x\", null, null, null], [null, null, null, null, \"x\", null], [null, \"x\", null, \"o\", null], [null, null, null, \"o\"], [\"o\", null, null], [null, null], [\"x\"]], \"board_size\": 8, \"current_player\": \"o\", \"is_terminal\": false, \"winner\": null, \"last_move\": \"b4\", \"move_number\": 7}",
+          "currentPlayer": 1,
+          "playerId": 1,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ny_proxy(ansi_color_output=False,board_size=8)\n[State]\nhistory=0:11,1:35,0:56,1:40,0:20,1:27,0:25\nmove_number=7\n__dict__=gASVygAAAAAAAAB9lIwLX193cmFwcGVkX1+UjAdweXNwaWVslIwFU3RhdGWUk5QpgZSMnSMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCnkoYW5zaV9jb2xvcl9vdXRwdXQ9RmFsc2UsYm9hcmRfc2l6ZT04KQpbU3RhdGVdCjExCjM1CjU2CjQwCjIwCjI3CjI1CgqUYnMu\n",
+          "legalActions": [
+            0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 12, 13, 14, 16, 17, 18, 19, 21,
+            24, 26, 28, 32, 33, 34, 41, 42, 48, 49
+          ],
+          "legalActionStrings": [
+            "a1",
+            "b1",
+            "c1",
+            "d1",
+            "e1",
+            "f1",
+            "g1",
+            "h1",
+            "a2",
+            "b2",
+            "c2",
+            "e2",
+            "f2",
+            "g2",
+            "a3",
+            "b3",
+            "c3",
+            "d3",
+            "f3",
+            "a4",
+            "c4",
+            "e4",
+            "a5",
+            "b5",
+            "c5",
+            "b6",
+            "c6",
+            "a7",
+            "b7"
+          ]
+        },
+        "status": "ACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "submission": -1
+        },
+        "reward": null,
+        "info": {},
+        "observation": {
+          "remainingOverageTime": 12,
+          "step": 9,
+          "observationString": "{\"board\": [[null, null, null, null, null, null, null, null], [null, null, \"o\", \"x\", null, null, null], [null, null, null, null, \"x\", null], [null, \"x\", null, \"o\", null], [null, null, null, \"o\"], [\"o\", null, null], [null, null], [\"x\"]], \"board_size\": 8, \"current_player\": \"x\", \"is_terminal\": false, \"winner\": null, \"last_move\": \"c2\", \"move_number\": 8}",
+          "currentPlayer": 0,
+          "playerId": 0,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ny_proxy(ansi_color_output=False,board_size=8)\n[State]\nhistory=0:11,1:35,0:56,1:40,0:20,1:27,0:25,1:10\nmove_number=8\n__dict__=gASVzQAAAAAAAAB9lIwLX193cmFwcGVkX1+UjAdweXNwaWVslIwFU3RhdGWUk5QpgZSMoCMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCnkoYW5zaV9jb2xvcl9vdXRwdXQ9RmFsc2UsYm9hcmRfc2l6ZT04KQpbU3RhdGVdCjExCjM1CjU2CjQwCjIwCjI3CjI1CjEwCgqUYnMu\n",
+          "legalActions": [
+            0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 12, 13, 14, 16, 17, 18, 19, 21, 24,
+            26, 28, 32, 33, 34, 41, 42, 48, 49
+          ],
+          "legalActionStrings": [
+            "a1",
+            "b1",
+            "c1",
+            "d1",
+            "e1",
+            "f1",
+            "g1",
+            "h1",
+            "a2",
+            "b2",
+            "e2",
+            "f2",
+            "g2",
+            "a3",
+            "b3",
+            "c3",
+            "d3",
+            "f3",
+            "a4",
+            "c4",
+            "e4",
+            "a5",
+            "b5",
+            "c5",
+            "b6",
+            "c6",
+            "a7",
+            "b7"
+          ]
+        },
+        "status": "ACTIVE"
+      },
+      {
+        "action": {
+          "submission": 10,
+          "thoughts": "chi explore nu lambda chi muse wonder consider"
+        },
+        "reward": null,
+        "info": {
+          "actionSubmitted": 10,
+          "actionSubmittedToString": "c2",
+          "actionApplied": 10,
+          "timeTaken": 0.0,
+          "agentSelfReportedStatus": null
+        },
+        "observation": {
+          "remainingOverageTime": 12,
+          "observationString": "{\"board\": [[null, null, null, null, null, null, null, null], [null, null, \"o\", \"x\", null, null, null], [null, null, null, null, \"x\", null], [null, \"x\", null, \"o\", null], [null, null, null, \"o\"], [\"o\", null, null], [null, null], [\"x\"]], \"board_size\": 8, \"current_player\": \"x\", \"is_terminal\": false, \"winner\": null, \"last_move\": \"c2\", \"move_number\": 8}",
+          "currentPlayer": 0,
+          "playerId": 1,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ny_proxy(ansi_color_output=False,board_size=8)\n[State]\nhistory=0:11,1:35,0:56,1:40,0:20,1:27,0:25,1:10\nmove_number=8\n__dict__=gASVzQAAAAAAAAB9lIwLX193cmFwcGVkX1+UjAdweXNwaWVslIwFU3RhdGWUk5QpgZSMoCMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCnkoYW5zaV9jb2xvcl9vdXRwdXQ9RmFsc2UsYm9hcmRfc2l6ZT04KQpbU3RhdGVdCjExCjM1CjU2CjQwCjIwCjI3CjI1CjEwCgqUYnMu\n",
+          "legalActions": [],
+          "legalActionStrings": []
+        },
+        "status": "INACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "submission": 17,
+          "thoughts": "alpha delta wonder omicron consider upsilon epsilon cascade"
+        },
+        "reward": null,
+        "info": {
+          "actionSubmitted": 17,
+          "actionSubmittedToString": "b3",
+          "actionApplied": 17,
+          "timeTaken": 0.0,
+          "agentSelfReportedStatus": null
+        },
+        "observation": {
+          "remainingOverageTime": 12,
+          "step": 10,
+          "observationString": "{\"board\": [[null, null, null, null, null, null, null, null], [null, null, \"o\", \"x\", null, null, null], [null, \"x\", null, null, \"x\", null], [null, \"x\", null, \"o\", null], [null, null, null, \"o\"], [\"o\", null, null], [null, null], [\"x\"]], \"board_size\": 8, \"current_player\": \"o\", \"is_terminal\": false, \"winner\": null, \"last_move\": \"b3\", \"move_number\": 9}",
+          "currentPlayer": 1,
+          "playerId": 0,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ny_proxy(ansi_color_output=False,board_size=8)\n[State]\nhistory=0:11,1:35,0:56,1:40,0:20,1:27,0:25,1:10,0:17\nmove_number=9\n__dict__=gASV0AAAAAAAAAB9lIwLX193cmFwcGVkX1+UjAdweXNwaWVslIwFU3RhdGWUk5QpgZSMoyMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCnkoYW5zaV9jb2xvcl9vdXRwdXQ9RmFsc2UsYm9hcmRfc2l6ZT04KQpbU3RhdGVdCjExCjM1CjU2CjQwCjIwCjI3CjI1CjEwCjE3CgqUYnMu\n",
+          "legalActions": [],
+          "legalActionStrings": []
+        },
+        "status": "INACTIVE"
+      },
+      {
+        "action": {
+          "submission": -1
+        },
+        "reward": null,
+        "info": {},
+        "observation": {
+          "remainingOverageTime": 12,
+          "observationString": "{\"board\": [[null, null, null, null, null, null, null, null], [null, null, \"o\", \"x\", null, null, null], [null, \"x\", null, null, \"x\", null], [null, \"x\", null, \"o\", null], [null, null, null, \"o\"], [\"o\", null, null], [null, null], [\"x\"]], \"board_size\": 8, \"current_player\": \"o\", \"is_terminal\": false, \"winner\": null, \"last_move\": \"b3\", \"move_number\": 9}",
+          "currentPlayer": 1,
+          "playerId": 1,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ny_proxy(ansi_color_output=False,board_size=8)\n[State]\nhistory=0:11,1:35,0:56,1:40,0:20,1:27,0:25,1:10,0:17\nmove_number=9\n__dict__=gASV0AAAAAAAAAB9lIwLX193cmFwcGVkX1+UjAdweXNwaWVslIwFU3RhdGWUk5QpgZSMoyMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCnkoYW5zaV9jb2xvcl9vdXRwdXQ9RmFsc2UsYm9hcmRfc2l6ZT04KQpbU3RhdGVdCjExCjM1CjU2CjQwCjIwCjI3CjI1CjEwCjE3CgqUYnMu\n",
+          "legalActions": [
+            0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 12, 13, 14, 16, 18, 19, 21, 24, 26,
+            28, 32, 33, 34, 41, 42, 48, 49
+          ],
+          "legalActionStrings": [
+            "a1",
+            "b1",
+            "c1",
+            "d1",
+            "e1",
+            "f1",
+            "g1",
+            "h1",
+            "a2",
+            "b2",
+            "e2",
+            "f2",
+            "g2",
+            "a3",
+            "c3",
+            "d3",
+            "f3",
+            "a4",
+            "c4",
+            "e4",
+            "a5",
+            "b5",
+            "c5",
+            "b6",
+            "c6",
+            "a7",
+            "b7"
+          ]
+        },
+        "status": "ACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "submission": -1
+        },
+        "reward": null,
+        "info": {},
+        "observation": {
+          "remainingOverageTime": 12,
+          "step": 11,
+          "observationString": "{\"board\": [[null, \"o\", null, null, null, null, null, null], [null, null, \"o\", \"x\", null, null, null], [null, \"x\", null, null, \"x\", null], [null, \"x\", null, \"o\", null], [null, null, null, \"o\"], [\"o\", null, null], [null, null], [\"x\"]], \"board_size\": 8, \"current_player\": \"x\", \"is_terminal\": false, \"winner\": null, \"last_move\": \"b1\", \"move_number\": 10}",
+          "currentPlayer": 0,
+          "playerId": 0,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ny_proxy(ansi_color_output=False,board_size=8)\n[State]\nhistory=0:11,1:35,0:56,1:40,0:20,1:27,0:25,1:10,0:17,1:1\nmove_number=10\n__dict__=gASV0gAAAAAAAAB9lIwLX193cmFwcGVkX1+UjAdweXNwaWVslIwFU3RhdGWUk5QpgZSMpSMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCnkoYW5zaV9jb2xvcl9vdXRwdXQ9RmFsc2UsYm9hcmRfc2l6ZT04KQpbU3RhdGVdCjExCjM1CjU2CjQwCjIwCjI3CjI1CjEwCjE3CjEKCpRicy4=\n",
+          "legalActions": [
+            0, 2, 3, 4, 5, 6, 7, 8, 9, 12, 13, 14, 16, 18, 19, 21, 24, 26, 28,
+            32, 33, 34, 41, 42, 48, 49
+          ],
+          "legalActionStrings": [
+            "a1",
+            "c1",
+            "d1",
+            "e1",
+            "f1",
+            "g1",
+            "h1",
+            "a2",
+            "b2",
+            "e2",
+            "f2",
+            "g2",
+            "a3",
+            "c3",
+            "d3",
+            "f3",
+            "a4",
+            "c4",
+            "e4",
+            "a5",
+            "b5",
+            "c5",
+            "b6",
+            "c6",
+            "a7",
+            "b7"
+          ]
+        },
+        "status": "ACTIVE"
+      },
+      {
+        "action": {
+          "submission": 1,
+          "thoughts": "consider theta omicron chi theta ponder eta delta"
+        },
+        "reward": null,
+        "info": {
+          "actionSubmitted": 1,
+          "actionSubmittedToString": "b1",
+          "actionApplied": 1,
+          "timeTaken": 0.0,
+          "agentSelfReportedStatus": null
+        },
+        "observation": {
+          "remainingOverageTime": 12,
+          "observationString": "{\"board\": [[null, \"o\", null, null, null, null, null, null], [null, null, \"o\", \"x\", null, null, null], [null, \"x\", null, null, \"x\", null], [null, \"x\", null, \"o\", null], [null, null, null, \"o\"], [\"o\", null, null], [null, null], [\"x\"]], \"board_size\": 8, \"current_player\": \"x\", \"is_terminal\": false, \"winner\": null, \"last_move\": \"b1\", \"move_number\": 10}",
+          "currentPlayer": 0,
+          "playerId": 1,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ny_proxy(ansi_color_output=False,board_size=8)\n[State]\nhistory=0:11,1:35,0:56,1:40,0:20,1:27,0:25,1:10,0:17,1:1\nmove_number=10\n__dict__=gASV0gAAAAAAAAB9lIwLX193cmFwcGVkX1+UjAdweXNwaWVslIwFU3RhdGWUk5QpgZSMpSMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCnkoYW5zaV9jb2xvcl9vdXRwdXQ9RmFsc2UsYm9hcmRfc2l6ZT04KQpbU3RhdGVdCjExCjM1CjU2CjQwCjIwCjI3CjI1CjEwCjE3CjEKCpRicy4=\n",
+          "legalActions": [],
+          "legalActionStrings": []
+        },
+        "status": "INACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "submission": 28,
+          "thoughts": "ember xi drift mu explore xi epsilon phi"
+        },
+        "reward": null,
+        "info": {
+          "actionSubmitted": 28,
+          "actionSubmittedToString": "e4",
+          "actionApplied": 28,
+          "timeTaken": 0.0,
+          "agentSelfReportedStatus": null
+        },
+        "observation": {
+          "remainingOverageTime": 12,
+          "step": 12,
+          "observationString": "{\"board\": [[null, \"o\", null, null, null, null, null, null], [null, null, \"o\", \"x\", null, null, null], [null, \"x\", null, null, \"x\", null], [null, \"x\", null, \"o\", \"x\"], [null, null, null, \"o\"], [\"o\", null, null], [null, null], [\"x\"]], \"board_size\": 8, \"current_player\": \"o\", \"is_terminal\": false, \"winner\": null, \"last_move\": \"e4\", \"move_number\": 11}",
+          "currentPlayer": 1,
+          "playerId": 0,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ny_proxy(ansi_color_output=False,board_size=8)\n[State]\nhistory=0:11,1:35,0:56,1:40,0:20,1:27,0:25,1:10,0:17,1:1,0:28\nmove_number=11\n__dict__=gASV1QAAAAAAAAB9lIwLX193cmFwcGVkX1+UjAdweXNwaWVslIwFU3RhdGWUk5QpgZSMqCMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCnkoYW5zaV9jb2xvcl9vdXRwdXQ9RmFsc2UsYm9hcmRfc2l6ZT04KQpbU3RhdGVdCjExCjM1CjU2CjQwCjIwCjI3CjI1CjEwCjE3CjEKMjgKCpRicy4=\n",
+          "legalActions": [],
+          "legalActionStrings": []
+        },
+        "status": "INACTIVE"
+      },
+      {
+        "action": {
+          "submission": -1
+        },
+        "reward": null,
+        "info": {},
+        "observation": {
+          "remainingOverageTime": 12,
+          "observationString": "{\"board\": [[null, \"o\", null, null, null, null, null, null], [null, null, \"o\", \"x\", null, null, null], [null, \"x\", null, null, \"x\", null], [null, \"x\", null, \"o\", \"x\"], [null, null, null, \"o\"], [\"o\", null, null], [null, null], [\"x\"]], \"board_size\": 8, \"current_player\": \"o\", \"is_terminal\": false, \"winner\": null, \"last_move\": \"e4\", \"move_number\": 11}",
+          "currentPlayer": 1,
+          "playerId": 1,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ny_proxy(ansi_color_output=False,board_size=8)\n[State]\nhistory=0:11,1:35,0:56,1:40,0:20,1:27,0:25,1:10,0:17,1:1,0:28\nmove_number=11\n__dict__=gASV1QAAAAAAAAB9lIwLX193cmFwcGVkX1+UjAdweXNwaWVslIwFU3RhdGWUk5QpgZSMqCMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCnkoYW5zaV9jb2xvcl9vdXRwdXQ9RmFsc2UsYm9hcmRfc2l6ZT04KQpbU3RhdGVdCjExCjM1CjU2CjQwCjIwCjI3CjI1CjEwCjE3CjEKMjgKCpRicy4=\n",
+          "legalActions": [
+            0, 2, 3, 4, 5, 6, 7, 8, 9, 12, 13, 14, 16, 18, 19, 21, 24, 26, 32,
+            33, 34, 41, 42, 48, 49
+          ],
+          "legalActionStrings": [
+            "a1",
+            "c1",
+            "d1",
+            "e1",
+            "f1",
+            "g1",
+            "h1",
+            "a2",
+            "b2",
+            "e2",
+            "f2",
+            "g2",
+            "a3",
+            "c3",
+            "d3",
+            "f3",
+            "a4",
+            "c4",
+            "a5",
+            "b5",
+            "c5",
+            "b6",
+            "c6",
+            "a7",
+            "b7"
+          ]
+        },
+        "status": "ACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "submission": -1
+        },
+        "reward": null,
+        "info": {},
+        "observation": {
+          "remainingOverageTime": 12,
+          "step": 13,
+          "observationString": "{\"board\": [[null, \"o\", null, null, null, null, null, null], [null, null, \"o\", \"x\", null, null, null], [null, \"x\", null, \"o\", \"x\", null], [null, \"x\", null, \"o\", \"x\"], [null, null, null, \"o\"], [\"o\", null, null], [null, null], [\"x\"]], \"board_size\": 8, \"current_player\": \"x\", \"is_terminal\": false, \"winner\": null, \"last_move\": \"d3\", \"move_number\": 12}",
+          "currentPlayer": 0,
+          "playerId": 0,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ny_proxy(ansi_color_output=False,board_size=8)\n[State]\nhistory=0:11,1:35,0:56,1:40,0:20,1:27,0:25,1:10,0:17,1:1,0:28,1:19\nmove_number=12\n__dict__=gASV2AAAAAAAAAB9lIwLX193cmFwcGVkX1+UjAdweXNwaWVslIwFU3RhdGWUk5QpgZSMqyMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCnkoYW5zaV9jb2xvcl9vdXRwdXQ9RmFsc2UsYm9hcmRfc2l6ZT04KQpbU3RhdGVdCjExCjM1CjU2CjQwCjIwCjI3CjI1CjEwCjE3CjEKMjgKMTkKCpRicy4=\n",
+          "legalActions": [
+            0, 2, 3, 4, 5, 6, 7, 8, 9, 12, 13, 14, 16, 18, 21, 24, 26, 32, 33,
+            34, 41, 42, 48, 49
+          ],
+          "legalActionStrings": [
+            "a1",
+            "c1",
+            "d1",
+            "e1",
+            "f1",
+            "g1",
+            "h1",
+            "a2",
+            "b2",
+            "e2",
+            "f2",
+            "g2",
+            "a3",
+            "c3",
+            "f3",
+            "a4",
+            "c4",
+            "a5",
+            "b5",
+            "c5",
+            "b6",
+            "c6",
+            "a7",
+            "b7"
+          ]
+        },
+        "status": "ACTIVE"
+      },
+      {
+        "action": {
+          "submission": 19,
+          "thoughts": "wonder echo shadow ponder spark shadow horizon ripple"
+        },
+        "reward": null,
+        "info": {
+          "actionSubmitted": 19,
+          "actionSubmittedToString": "d3",
+          "actionApplied": 19,
+          "timeTaken": 0.0,
+          "agentSelfReportedStatus": null
+        },
+        "observation": {
+          "remainingOverageTime": 12,
+          "observationString": "{\"board\": [[null, \"o\", null, null, null, null, null, null], [null, null, \"o\", \"x\", null, null, null], [null, \"x\", null, \"o\", \"x\", null], [null, \"x\", null, \"o\", \"x\"], [null, null, null, \"o\"], [\"o\", null, null], [null, null], [\"x\"]], \"board_size\": 8, \"current_player\": \"x\", \"is_terminal\": false, \"winner\": null, \"last_move\": \"d3\", \"move_number\": 12}",
+          "currentPlayer": 0,
+          "playerId": 1,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ny_proxy(ansi_color_output=False,board_size=8)\n[State]\nhistory=0:11,1:35,0:56,1:40,0:20,1:27,0:25,1:10,0:17,1:1,0:28,1:19\nmove_number=12\n__dict__=gASV2AAAAAAAAAB9lIwLX193cmFwcGVkX1+UjAdweXNwaWVslIwFU3RhdGWUk5QpgZSMqyMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCnkoYW5zaV9jb2xvcl9vdXRwdXQ9RmFsc2UsYm9hcmRfc2l6ZT04KQpbU3RhdGVdCjExCjM1CjU2CjQwCjIwCjI3CjI1CjEwCjE3CjEKMjgKMTkKCpRicy4=\n",
+          "legalActions": [],
+          "legalActionStrings": []
+        },
+        "status": "INACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "submission": 13,
+          "thoughts": "psi iota upsilon mu iota eta consider rho"
+        },
+        "reward": null,
+        "info": {
+          "actionSubmitted": 13,
+          "actionSubmittedToString": "f2",
+          "actionApplied": 13,
+          "timeTaken": 0.0,
+          "agentSelfReportedStatus": null
+        },
+        "observation": {
+          "remainingOverageTime": 12,
+          "step": 14,
+          "observationString": "{\"board\": [[null, \"o\", null, null, null, null, null, null], [null, null, \"o\", \"x\", null, \"x\", null], [null, \"x\", null, \"o\", \"x\", null], [null, \"x\", null, \"o\", \"x\"], [null, null, null, \"o\"], [\"o\", null, null], [null, null], [\"x\"]], \"board_size\": 8, \"current_player\": \"o\", \"is_terminal\": false, \"winner\": null, \"last_move\": \"f2\", \"move_number\": 13}",
+          "currentPlayer": 1,
+          "playerId": 0,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ny_proxy(ansi_color_output=False,board_size=8)\n[State]\nhistory=0:11,1:35,0:56,1:40,0:20,1:27,0:25,1:10,0:17,1:1,0:28,1:19,0:13\nmove_number=13\n__dict__=gASV2wAAAAAAAAB9lIwLX193cmFwcGVkX1+UjAdweXNwaWVslIwFU3RhdGWUk5QpgZSMriMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCnkoYW5zaV9jb2xvcl9vdXRwdXQ9RmFsc2UsYm9hcmRfc2l6ZT04KQpbU3RhdGVdCjExCjM1CjU2CjQwCjIwCjI3CjI1CjEwCjE3CjEKMjgKMTkKMTMKCpRicy4=\n",
+          "legalActions": [],
+          "legalActionStrings": []
+        },
+        "status": "INACTIVE"
+      },
+      {
+        "action": {
+          "submission": -1
+        },
+        "reward": null,
+        "info": {},
+        "observation": {
+          "remainingOverageTime": 12,
+          "observationString": "{\"board\": [[null, \"o\", null, null, null, null, null, null], [null, null, \"o\", \"x\", null, \"x\", null], [null, \"x\", null, \"o\", \"x\", null], [null, \"x\", null, \"o\", \"x\"], [null, null, null, \"o\"], [\"o\", null, null], [null, null], [\"x\"]], \"board_size\": 8, \"current_player\": \"o\", \"is_terminal\": false, \"winner\": null, \"last_move\": \"f2\", \"move_number\": 13}",
+          "currentPlayer": 1,
+          "playerId": 1,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ny_proxy(ansi_color_output=False,board_size=8)\n[State]\nhistory=0:11,1:35,0:56,1:40,0:20,1:27,0:25,1:10,0:17,1:1,0:28,1:19,0:13\nmove_number=13\n__dict__=gASV2wAAAAAAAAB9lIwLX193cmFwcGVkX1+UjAdweXNwaWVslIwFU3RhdGWUk5QpgZSMriMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCnkoYW5zaV9jb2xvcl9vdXRwdXQ9RmFsc2UsYm9hcmRfc2l6ZT04KQpbU3RhdGVdCjExCjM1CjU2CjQwCjIwCjI3CjI1CjEwCjE3CjEKMjgKMTkKMTMKCpRicy4=\n",
+          "legalActions": [
+            0, 2, 3, 4, 5, 6, 7, 8, 9, 12, 14, 16, 18, 21, 24, 26, 32, 33, 34,
+            41, 42, 48, 49
+          ],
+          "legalActionStrings": [
+            "a1",
+            "c1",
+            "d1",
+            "e1",
+            "f1",
+            "g1",
+            "h1",
+            "a2",
+            "b2",
+            "e2",
+            "g2",
+            "a3",
+            "c3",
+            "f3",
+            "a4",
+            "c4",
+            "a5",
+            "b5",
+            "c5",
+            "b6",
+            "c6",
+            "a7",
+            "b7"
+          ]
+        },
+        "status": "ACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "submission": -1
+        },
+        "reward": null,
+        "info": {},
+        "observation": {
+          "remainingOverageTime": 12,
+          "step": 15,
+          "observationString": "{\"board\": [[\"o\", \"o\", null, null, null, null, null, null], [null, null, \"o\", \"x\", null, \"x\", null], [null, \"x\", null, \"o\", \"x\", null], [null, \"x\", null, \"o\", \"x\"], [null, null, null, \"o\"], [\"o\", null, null], [null, null], [\"x\"]], \"board_size\": 8, \"current_player\": \"x\", \"is_terminal\": false, \"winner\": null, \"last_move\": \"a1\", \"move_number\": 14}",
+          "currentPlayer": 0,
+          "playerId": 0,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ny_proxy(ansi_color_output=False,board_size=8)\n[State]\nhistory=0:11,1:35,0:56,1:40,0:20,1:27,0:25,1:10,0:17,1:1,0:28,1:19,0:13,1:0\nmove_number=14\n__dict__=gASV3QAAAAAAAAB9lIwLX193cmFwcGVkX1+UjAdweXNwaWVslIwFU3RhdGWUk5QpgZSMsCMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCnkoYW5zaV9jb2xvcl9vdXRwdXQ9RmFsc2UsYm9hcmRfc2l6ZT04KQpbU3RhdGVdCjExCjM1CjU2CjQwCjIwCjI3CjI1CjEwCjE3CjEKMjgKMTkKMTMKMAoKlGJzLg==\n",
+          "legalActions": [
+            2, 3, 4, 5, 6, 7, 8, 9, 12, 14, 16, 18, 21, 24, 26, 32, 33, 34, 41,
+            42, 48, 49
+          ],
+          "legalActionStrings": [
+            "c1",
+            "d1",
+            "e1",
+            "f1",
+            "g1",
+            "h1",
+            "a2",
+            "b2",
+            "e2",
+            "g2",
+            "a3",
+            "c3",
+            "f3",
+            "a4",
+            "c4",
+            "a5",
+            "b5",
+            "c5",
+            "b6",
+            "c6",
+            "a7",
+            "b7"
+          ]
+        },
+        "status": "ACTIVE"
+      },
+      {
+        "action": {
+          "submission": 0,
+          "thoughts": "muse lambda eta ponder beta iota nu horizon"
+        },
+        "reward": null,
+        "info": {
+          "actionSubmitted": 0,
+          "actionSubmittedToString": "a1",
+          "actionApplied": 0,
+          "timeTaken": 0.0,
+          "agentSelfReportedStatus": null
+        },
+        "observation": {
+          "remainingOverageTime": 12,
+          "observationString": "{\"board\": [[\"o\", \"o\", null, null, null, null, null, null], [null, null, \"o\", \"x\", null, \"x\", null], [null, \"x\", null, \"o\", \"x\", null], [null, \"x\", null, \"o\", \"x\"], [null, null, null, \"o\"], [\"o\", null, null], [null, null], [\"x\"]], \"board_size\": 8, \"current_player\": \"x\", \"is_terminal\": false, \"winner\": null, \"last_move\": \"a1\", \"move_number\": 14}",
+          "currentPlayer": 0,
+          "playerId": 1,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ny_proxy(ansi_color_output=False,board_size=8)\n[State]\nhistory=0:11,1:35,0:56,1:40,0:20,1:27,0:25,1:10,0:17,1:1,0:28,1:19,0:13,1:0\nmove_number=14\n__dict__=gASV3QAAAAAAAAB9lIwLX193cmFwcGVkX1+UjAdweXNwaWVslIwFU3RhdGWUk5QpgZSMsCMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCnkoYW5zaV9jb2xvcl9vdXRwdXQ9RmFsc2UsYm9hcmRfc2l6ZT04KQpbU3RhdGVdCjExCjM1CjU2CjQwCjIwCjI3CjI1CjEwCjE3CjEKMjgKMTkKMTMKMAoKlGJzLg==\n",
+          "legalActions": [],
+          "legalActionStrings": []
+        },
+        "status": "INACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "submission": 5,
+          "thoughts": "rho lambda shadow shadow nu nu lambda cascade"
+        },
+        "reward": null,
+        "info": {
+          "actionSubmitted": 5,
+          "actionSubmittedToString": "f1",
+          "actionApplied": 5,
+          "timeTaken": 0.0,
+          "agentSelfReportedStatus": null
+        },
+        "observation": {
+          "remainingOverageTime": 12,
+          "step": 16,
+          "observationString": "{\"board\": [[\"o\", \"o\", null, null, null, \"x\", null, null], [null, null, \"o\", \"x\", null, \"x\", null], [null, \"x\", null, \"o\", \"x\", null], [null, \"x\", null, \"o\", \"x\"], [null, null, null, \"o\"], [\"o\", null, null], [null, null], [\"x\"]], \"board_size\": 8, \"current_player\": \"o\", \"is_terminal\": false, \"winner\": null, \"last_move\": \"f1\", \"move_number\": 15}",
+          "currentPlayer": 1,
+          "playerId": 0,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ny_proxy(ansi_color_output=False,board_size=8)\n[State]\nhistory=0:11,1:35,0:56,1:40,0:20,1:27,0:25,1:10,0:17,1:1,0:28,1:19,0:13,1:0,0:5\nmove_number=15\n__dict__=gASV3wAAAAAAAAB9lIwLX193cmFwcGVkX1+UjAdweXNwaWVslIwFU3RhdGWUk5QpgZSMsiMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCnkoYW5zaV9jb2xvcl9vdXRwdXQ9RmFsc2UsYm9hcmRfc2l6ZT04KQpbU3RhdGVdCjExCjM1CjU2CjQwCjIwCjI3CjI1CjEwCjE3CjEKMjgKMTkKMTMKMAo1CgqUYnMu\n",
+          "legalActions": [],
+          "legalActionStrings": []
+        },
+        "status": "INACTIVE"
+      },
+      {
+        "action": {
+          "submission": -1
+        },
+        "reward": null,
+        "info": {},
+        "observation": {
+          "remainingOverageTime": 12,
+          "observationString": "{\"board\": [[\"o\", \"o\", null, null, null, \"x\", null, null], [null, null, \"o\", \"x\", null, \"x\", null], [null, \"x\", null, \"o\", \"x\", null], [null, \"x\", null, \"o\", \"x\"], [null, null, null, \"o\"], [\"o\", null, null], [null, null], [\"x\"]], \"board_size\": 8, \"current_player\": \"o\", \"is_terminal\": false, \"winner\": null, \"last_move\": \"f1\", \"move_number\": 15}",
+          "currentPlayer": 1,
+          "playerId": 1,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ny_proxy(ansi_color_output=False,board_size=8)\n[State]\nhistory=0:11,1:35,0:56,1:40,0:20,1:27,0:25,1:10,0:17,1:1,0:28,1:19,0:13,1:0,0:5\nmove_number=15\n__dict__=gASV3wAAAAAAAAB9lIwLX193cmFwcGVkX1+UjAdweXNwaWVslIwFU3RhdGWUk5QpgZSMsiMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCnkoYW5zaV9jb2xvcl9vdXRwdXQ9RmFsc2UsYm9hcmRfc2l6ZT04KQpbU3RhdGVdCjExCjM1CjU2CjQwCjIwCjI3CjI1CjEwCjE3CjEKMjgKMTkKMTMKMAo1CgqUYnMu\n",
+          "legalActions": [
+            2, 3, 4, 6, 7, 8, 9, 12, 14, 16, 18, 21, 24, 26, 32, 33, 34, 41, 42,
+            48, 49
+          ],
+          "legalActionStrings": [
+            "c1",
+            "d1",
+            "e1",
+            "g1",
+            "h1",
+            "a2",
+            "b2",
+            "e2",
+            "g2",
+            "a3",
+            "c3",
+            "f3",
+            "a4",
+            "c4",
+            "a5",
+            "b5",
+            "c5",
+            "b6",
+            "c6",
+            "a7",
+            "b7"
+          ]
+        },
+        "status": "ACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "submission": -1
+        },
+        "reward": null,
+        "info": {},
+        "observation": {
+          "remainingOverageTime": 12,
+          "step": 17,
+          "observationString": "{\"board\": [[\"o\", \"o\", null, null, null, \"x\", null, null], [null, null, \"o\", \"x\", null, \"x\", \"o\"], [null, \"x\", null, \"o\", \"x\", null], [null, \"x\", null, \"o\", \"x\"], [null, null, null, \"o\"], [\"o\", null, null], [null, null], [\"x\"]], \"board_size\": 8, \"current_player\": \"x\", \"is_terminal\": false, \"winner\": null, \"last_move\": \"g2\", \"move_number\": 16}",
+          "currentPlayer": 0,
+          "playerId": 0,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ny_proxy(ansi_color_output=False,board_size=8)\n[State]\nhistory=0:11,1:35,0:56,1:40,0:20,1:27,0:25,1:10,0:17,1:1,0:28,1:19,0:13,1:0,0:5,1:14\nmove_number=16\n__dict__=gASV4gAAAAAAAAB9lIwLX193cmFwcGVkX1+UjAdweXNwaWVslIwFU3RhdGWUk5QpgZSMtSMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCnkoYW5zaV9jb2xvcl9vdXRwdXQ9RmFsc2UsYm9hcmRfc2l6ZT04KQpbU3RhdGVdCjExCjM1CjU2CjQwCjIwCjI3CjI1CjEwCjE3CjEKMjgKMTkKMTMKMAo1CjE0CgqUYnMu\n",
+          "legalActions": [
+            2, 3, 4, 6, 7, 8, 9, 12, 16, 18, 21, 24, 26, 32, 33, 34, 41, 42, 48,
+            49
+          ],
+          "legalActionStrings": [
+            "c1",
+            "d1",
+            "e1",
+            "g1",
+            "h1",
+            "a2",
+            "b2",
+            "e2",
+            "a3",
+            "c3",
+            "f3",
+            "a4",
+            "c4",
+            "a5",
+            "b5",
+            "c5",
+            "b6",
+            "c6",
+            "a7",
+            "b7"
+          ]
+        },
+        "status": "ACTIVE"
+      },
+      {
+        "action": {
+          "submission": 14,
+          "thoughts": "eta ripple shadow explore omega beta chi imagine"
+        },
+        "reward": null,
+        "info": {
+          "actionSubmitted": 14,
+          "actionSubmittedToString": "g2",
+          "actionApplied": 14,
+          "timeTaken": 0.0,
+          "agentSelfReportedStatus": null
+        },
+        "observation": {
+          "remainingOverageTime": 12,
+          "observationString": "{\"board\": [[\"o\", \"o\", null, null, null, \"x\", null, null], [null, null, \"o\", \"x\", null, \"x\", \"o\"], [null, \"x\", null, \"o\", \"x\", null], [null, \"x\", null, \"o\", \"x\"], [null, null, null, \"o\"], [\"o\", null, null], [null, null], [\"x\"]], \"board_size\": 8, \"current_player\": \"x\", \"is_terminal\": false, \"winner\": null, \"last_move\": \"g2\", \"move_number\": 16}",
+          "currentPlayer": 0,
+          "playerId": 1,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ny_proxy(ansi_color_output=False,board_size=8)\n[State]\nhistory=0:11,1:35,0:56,1:40,0:20,1:27,0:25,1:10,0:17,1:1,0:28,1:19,0:13,1:0,0:5,1:14\nmove_number=16\n__dict__=gASV4gAAAAAAAAB9lIwLX193cmFwcGVkX1+UjAdweXNwaWVslIwFU3RhdGWUk5QpgZSMtSMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCnkoYW5zaV9jb2xvcl9vdXRwdXQ9RmFsc2UsYm9hcmRfc2l6ZT04KQpbU3RhdGVdCjExCjM1CjU2CjQwCjIwCjI3CjI1CjEwCjE3CjEKMjgKMTkKMTMKMAo1CjE0CgqUYnMu\n",
+          "legalActions": [],
+          "legalActionStrings": []
+        },
+        "status": "INACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "submission": 8,
+          "thoughts": "lambda eta xi beta omega iota eta tau"
+        },
+        "reward": null,
+        "info": {
+          "actionSubmitted": 8,
+          "actionSubmittedToString": "a2",
+          "actionApplied": 8,
+          "timeTaken": 0.0,
+          "agentSelfReportedStatus": null
+        },
+        "observation": {
+          "remainingOverageTime": 12,
+          "step": 18,
+          "observationString": "{\"board\": [[\"o\", \"o\", null, null, null, \"x\", null, null], [\"x\", null, \"o\", \"x\", null, \"x\", \"o\"], [null, \"x\", null, \"o\", \"x\", null], [null, \"x\", null, \"o\", \"x\"], [null, null, null, \"o\"], [\"o\", null, null], [null, null], [\"x\"]], \"board_size\": 8, \"current_player\": \"o\", \"is_terminal\": false, \"winner\": null, \"last_move\": \"a2\", \"move_number\": 17}",
+          "currentPlayer": 1,
+          "playerId": 0,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ny_proxy(ansi_color_output=False,board_size=8)\n[State]\nhistory=0:11,1:35,0:56,1:40,0:20,1:27,0:25,1:10,0:17,1:1,0:28,1:19,0:13,1:0,0:5,1:14,0:8\nmove_number=17\n__dict__=gASV5AAAAAAAAAB9lIwLX193cmFwcGVkX1+UjAdweXNwaWVslIwFU3RhdGWUk5QpgZSMtyMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCnkoYW5zaV9jb2xvcl9vdXRwdXQ9RmFsc2UsYm9hcmRfc2l6ZT04KQpbU3RhdGVdCjExCjM1CjU2CjQwCjIwCjI3CjI1CjEwCjE3CjEKMjgKMTkKMTMKMAo1CjE0CjgKCpRicy4=\n",
+          "legalActions": [],
+          "legalActionStrings": []
+        },
+        "status": "INACTIVE"
+      },
+      {
+        "action": {
+          "submission": -1
+        },
+        "reward": null,
+        "info": {},
+        "observation": {
+          "remainingOverageTime": 12,
+          "observationString": "{\"board\": [[\"o\", \"o\", null, null, null, \"x\", null, null], [\"x\", null, \"o\", \"x\", null, \"x\", \"o\"], [null, \"x\", null, \"o\", \"x\", null], [null, \"x\", null, \"o\", \"x\"], [null, null, null, \"o\"], [\"o\", null, null], [null, null], [\"x\"]], \"board_size\": 8, \"current_player\": \"o\", \"is_terminal\": false, \"winner\": null, \"last_move\": \"a2\", \"move_number\": 17}",
+          "currentPlayer": 1,
+          "playerId": 1,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ny_proxy(ansi_color_output=False,board_size=8)\n[State]\nhistory=0:11,1:35,0:56,1:40,0:20,1:27,0:25,1:10,0:17,1:1,0:28,1:19,0:13,1:0,0:5,1:14,0:8\nmove_number=17\n__dict__=gASV5AAAAAAAAAB9lIwLX193cmFwcGVkX1+UjAdweXNwaWVslIwFU3RhdGWUk5QpgZSMtyMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCnkoYW5zaV9jb2xvcl9vdXRwdXQ9RmFsc2UsYm9hcmRfc2l6ZT04KQpbU3RhdGVdCjExCjM1CjU2CjQwCjIwCjI3CjI1CjEwCjE3CjEKMjgKMTkKMTMKMAo1CjE0CjgKCpRicy4=\n",
+          "legalActions": [
+            2, 3, 4, 6, 7, 9, 12, 16, 18, 21, 24, 26, 32, 33, 34, 41, 42, 48, 49
+          ],
+          "legalActionStrings": [
+            "c1",
+            "d1",
+            "e1",
+            "g1",
+            "h1",
+            "b2",
+            "e2",
+            "a3",
+            "c3",
+            "f3",
+            "a4",
+            "c4",
+            "a5",
+            "b5",
+            "c5",
+            "b6",
+            "c6",
+            "a7",
+            "b7"
+          ]
+        },
+        "status": "ACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "submission": -1
+        },
+        "reward": null,
+        "info": {},
+        "observation": {
+          "remainingOverageTime": 12,
+          "step": 19,
+          "observationString": "{\"board\": [[\"o\", \"o\", null, null, \"o\", \"x\", null, null], [\"x\", null, \"o\", \"x\", null, \"x\", \"o\"], [null, \"x\", null, \"o\", \"x\", null], [null, \"x\", null, \"o\", \"x\"], [null, null, null, \"o\"], [\"o\", null, null], [null, null], [\"x\"]], \"board_size\": 8, \"current_player\": \"x\", \"is_terminal\": false, \"winner\": null, \"last_move\": \"e1\", \"move_number\": 18}",
+          "currentPlayer": 0,
+          "playerId": 0,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ny_proxy(ansi_color_output=False,board_size=8)\n[State]\nhistory=0:11,1:35,0:56,1:40,0:20,1:27,0:25,1:10,0:17,1:1,0:28,1:19,0:13,1:0,0:5,1:14,0:8,1:4\nmove_number=18\n__dict__=gASV5gAAAAAAAAB9lIwLX193cmFwcGVkX1+UjAdweXNwaWVslIwFU3RhdGWUk5QpgZSMuSMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCnkoYW5zaV9jb2xvcl9vdXRwdXQ9RmFsc2UsYm9hcmRfc2l6ZT04KQpbU3RhdGVdCjExCjM1CjU2CjQwCjIwCjI3CjI1CjEwCjE3CjEKMjgKMTkKMTMKMAo1CjE0CjgKNAoKlGJzLg==\n",
+          "legalActions": [
+            2, 3, 6, 7, 9, 12, 16, 18, 21, 24, 26, 32, 33, 34, 41, 42, 48, 49
+          ],
+          "legalActionStrings": [
+            "c1",
+            "d1",
+            "g1",
+            "h1",
+            "b2",
+            "e2",
+            "a3",
+            "c3",
+            "f3",
+            "a4",
+            "c4",
+            "a5",
+            "b5",
+            "c5",
+            "b6",
+            "c6",
+            "a7",
+            "b7"
+          ]
+        },
+        "status": "ACTIVE"
+      },
+      {
+        "action": {
+          "submission": 4,
+          "thoughts": "phi shadow ember spark imagine pi consider xi"
+        },
+        "reward": null,
+        "info": {
+          "actionSubmitted": 4,
+          "actionSubmittedToString": "e1",
+          "actionApplied": 4,
+          "timeTaken": 0.0,
+          "agentSelfReportedStatus": null
+        },
+        "observation": {
+          "remainingOverageTime": 12,
+          "observationString": "{\"board\": [[\"o\", \"o\", null, null, \"o\", \"x\", null, null], [\"x\", null, \"o\", \"x\", null, \"x\", \"o\"], [null, \"x\", null, \"o\", \"x\", null], [null, \"x\", null, \"o\", \"x\"], [null, null, null, \"o\"], [\"o\", null, null], [null, null], [\"x\"]], \"board_size\": 8, \"current_player\": \"x\", \"is_terminal\": false, \"winner\": null, \"last_move\": \"e1\", \"move_number\": 18}",
+          "currentPlayer": 0,
+          "playerId": 1,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ny_proxy(ansi_color_output=False,board_size=8)\n[State]\nhistory=0:11,1:35,0:56,1:40,0:20,1:27,0:25,1:10,0:17,1:1,0:28,1:19,0:13,1:0,0:5,1:14,0:8,1:4\nmove_number=18\n__dict__=gASV5gAAAAAAAAB9lIwLX193cmFwcGVkX1+UjAdweXNwaWVslIwFU3RhdGWUk5QpgZSMuSMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCnkoYW5zaV9jb2xvcl9vdXRwdXQ9RmFsc2UsYm9hcmRfc2l6ZT04KQpbU3RhdGVdCjExCjM1CjU2CjQwCjIwCjI3CjI1CjEwCjE3CjEKMjgKMTkKMTMKMAo1CjE0CjgKNAoKlGJzLg==\n",
+          "legalActions": [],
+          "legalActionStrings": []
+        },
+        "status": "INACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "submission": 18,
+          "thoughts": "pi consider theta imagine nu lantern lambda muse"
+        },
+        "reward": null,
+        "info": {
+          "actionSubmitted": 18,
+          "actionSubmittedToString": "c3",
+          "actionApplied": 18,
+          "timeTaken": 0.0,
+          "agentSelfReportedStatus": null
+        },
+        "observation": {
+          "remainingOverageTime": 12,
+          "step": 20,
+          "observationString": "{\"board\": [[\"o\", \"o\", null, null, \"o\", \"x\", null, null], [\"x\", null, \"o\", \"x\", null, \"x\", \"o\"], [null, \"x\", \"x\", \"o\", \"x\", null], [null, \"x\", null, \"o\", \"x\"], [null, null, null, \"o\"], [\"o\", null, null], [null, null], [\"x\"]], \"board_size\": 8, \"current_player\": \"o\", \"is_terminal\": false, \"winner\": null, \"last_move\": \"c3\", \"move_number\": 19}",
+          "currentPlayer": 1,
+          "playerId": 0,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ny_proxy(ansi_color_output=False,board_size=8)\n[State]\nhistory=0:11,1:35,0:56,1:40,0:20,1:27,0:25,1:10,0:17,1:1,0:28,1:19,0:13,1:0,0:5,1:14,0:8,1:4,0:18\nmove_number=19\n__dict__=gASV6QAAAAAAAAB9lIwLX193cmFwcGVkX1+UjAdweXNwaWVslIwFU3RhdGWUk5QpgZSMvCMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCnkoYW5zaV9jb2xvcl9vdXRwdXQ9RmFsc2UsYm9hcmRfc2l6ZT04KQpbU3RhdGVdCjExCjM1CjU2CjQwCjIwCjI3CjI1CjEwCjE3CjEKMjgKMTkKMTMKMAo1CjE0CjgKNAoxOAoKlGJzLg==\n",
+          "legalActions": [],
+          "legalActionStrings": []
+        },
+        "status": "INACTIVE"
+      },
+      {
+        "action": {
+          "submission": -1
+        },
+        "reward": null,
+        "info": {},
+        "observation": {
+          "remainingOverageTime": 12,
+          "observationString": "{\"board\": [[\"o\", \"o\", null, null, \"o\", \"x\", null, null], [\"x\", null, \"o\", \"x\", null, \"x\", \"o\"], [null, \"x\", \"x\", \"o\", \"x\", null], [null, \"x\", null, \"o\", \"x\"], [null, null, null, \"o\"], [\"o\", null, null], [null, null], [\"x\"]], \"board_size\": 8, \"current_player\": \"o\", \"is_terminal\": false, \"winner\": null, \"last_move\": \"c3\", \"move_number\": 19}",
+          "currentPlayer": 1,
+          "playerId": 1,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ny_proxy(ansi_color_output=False,board_size=8)\n[State]\nhistory=0:11,1:35,0:56,1:40,0:20,1:27,0:25,1:10,0:17,1:1,0:28,1:19,0:13,1:0,0:5,1:14,0:8,1:4,0:18\nmove_number=19\n__dict__=gASV6QAAAAAAAAB9lIwLX193cmFwcGVkX1+UjAdweXNwaWVslIwFU3RhdGWUk5QpgZSMvCMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCnkoYW5zaV9jb2xvcl9vdXRwdXQ9RmFsc2UsYm9hcmRfc2l6ZT04KQpbU3RhdGVdCjExCjM1CjU2CjQwCjIwCjI3CjI1CjEwCjE3CjEKMjgKMTkKMTMKMAo1CjE0CjgKNAoxOAoKlGJzLg==\n",
+          "legalActions": [
+            2, 3, 6, 7, 9, 12, 16, 21, 24, 26, 32, 33, 34, 41, 42, 48, 49
+          ],
+          "legalActionStrings": [
+            "c1",
+            "d1",
+            "g1",
+            "h1",
+            "b2",
+            "e2",
+            "a3",
+            "f3",
+            "a4",
+            "c4",
+            "a5",
+            "b5",
+            "c5",
+            "b6",
+            "c6",
+            "a7",
+            "b7"
+          ]
+        },
+        "status": "ACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "submission": -1
+        },
+        "reward": null,
+        "info": {},
+        "observation": {
+          "remainingOverageTime": 12,
+          "step": 21,
+          "observationString": "{\"board\": [[\"o\", \"o\", null, null, \"o\", \"x\", null, null], [\"x\", null, \"o\", \"x\", null, \"x\", \"o\"], [null, \"x\", \"x\", \"o\", \"x\", null], [null, \"x\", null, \"o\", \"x\"], [null, null, null, \"o\"], [\"o\", null, \"o\"], [null, null], [\"x\"]], \"board_size\": 8, \"current_player\": \"x\", \"is_terminal\": false, \"winner\": null, \"last_move\": \"c6\", \"move_number\": 20}",
+          "currentPlayer": 0,
+          "playerId": 0,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ny_proxy(ansi_color_output=False,board_size=8)\n[State]\nhistory=0:11,1:35,0:56,1:40,0:20,1:27,0:25,1:10,0:17,1:1,0:28,1:19,0:13,1:0,0:5,1:14,0:8,1:4,0:18,1:42\nmove_number=20\n__dict__=gASV7AAAAAAAAAB9lIwLX193cmFwcGVkX1+UjAdweXNwaWVslIwFU3RhdGWUk5QpgZSMvyMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCnkoYW5zaV9jb2xvcl9vdXRwdXQ9RmFsc2UsYm9hcmRfc2l6ZT04KQpbU3RhdGVdCjExCjM1CjU2CjQwCjIwCjI3CjI1CjEwCjE3CjEKMjgKMTkKMTMKMAo1CjE0CjgKNAoxOAo0MgoKlGJzLg==\n",
+          "legalActions": [
+            2, 3, 6, 7, 9, 12, 16, 21, 24, 26, 32, 33, 34, 41, 48, 49
+          ],
+          "legalActionStrings": [
+            "c1",
+            "d1",
+            "g1",
+            "h1",
+            "b2",
+            "e2",
+            "a3",
+            "f3",
+            "a4",
+            "c4",
+            "a5",
+            "b5",
+            "c5",
+            "b6",
+            "a7",
+            "b7"
+          ]
+        },
+        "status": "ACTIVE"
+      },
+      {
+        "action": {
+          "submission": 42,
+          "thoughts": "psi sigma nu ember epsilon drift psi phi"
+        },
+        "reward": null,
+        "info": {
+          "actionSubmitted": 42,
+          "actionSubmittedToString": "c6",
+          "actionApplied": 42,
+          "timeTaken": 0.0,
+          "agentSelfReportedStatus": null
+        },
+        "observation": {
+          "remainingOverageTime": 12,
+          "observationString": "{\"board\": [[\"o\", \"o\", null, null, \"o\", \"x\", null, null], [\"x\", null, \"o\", \"x\", null, \"x\", \"o\"], [null, \"x\", \"x\", \"o\", \"x\", null], [null, \"x\", null, \"o\", \"x\"], [null, null, null, \"o\"], [\"o\", null, \"o\"], [null, null], [\"x\"]], \"board_size\": 8, \"current_player\": \"x\", \"is_terminal\": false, \"winner\": null, \"last_move\": \"c6\", \"move_number\": 20}",
+          "currentPlayer": 0,
+          "playerId": 1,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ny_proxy(ansi_color_output=False,board_size=8)\n[State]\nhistory=0:11,1:35,0:56,1:40,0:20,1:27,0:25,1:10,0:17,1:1,0:28,1:19,0:13,1:0,0:5,1:14,0:8,1:4,0:18,1:42\nmove_number=20\n__dict__=gASV7AAAAAAAAAB9lIwLX193cmFwcGVkX1+UjAdweXNwaWVslIwFU3RhdGWUk5QpgZSMvyMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCnkoYW5zaV9jb2xvcl9vdXRwdXQ9RmFsc2UsYm9hcmRfc2l6ZT04KQpbU3RhdGVdCjExCjM1CjU2CjQwCjIwCjI3CjI1CjEwCjE3CjEKMjgKMTkKMTMKMAo1CjE0CjgKNAoxOAo0MgoKlGJzLg==\n",
+          "legalActions": [],
+          "legalActionStrings": []
+        },
+        "status": "INACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "submission": 49,
+          "thoughts": "upsilon lambda nu rho lantern xi ripple delta"
+        },
+        "reward": null,
+        "info": {
+          "actionSubmitted": 49,
+          "actionSubmittedToString": "b7",
+          "actionApplied": 49,
+          "timeTaken": 0.0,
+          "agentSelfReportedStatus": null
+        },
+        "observation": {
+          "remainingOverageTime": 12,
+          "step": 22,
+          "observationString": "{\"board\": [[\"o\", \"o\", null, null, \"o\", \"x\", null, null], [\"x\", null, \"o\", \"x\", null, \"x\", \"o\"], [null, \"x\", \"x\", \"o\", \"x\", null], [null, \"x\", null, \"o\", \"x\"], [null, null, null, \"o\"], [\"o\", null, \"o\"], [null, \"x\"], [\"x\"]], \"board_size\": 8, \"current_player\": \"o\", \"is_terminal\": false, \"winner\": null, \"last_move\": \"b7\", \"move_number\": 21}",
+          "currentPlayer": 1,
+          "playerId": 0,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ny_proxy(ansi_color_output=False,board_size=8)\n[State]\nhistory=0:11,1:35,0:56,1:40,0:20,1:27,0:25,1:10,0:17,1:1,0:28,1:19,0:13,1:0,0:5,1:14,0:8,1:4,0:18,1:42,0:49\nmove_number=21\n__dict__=gASV7wAAAAAAAAB9lIwLX193cmFwcGVkX1+UjAdweXNwaWVslIwFU3RhdGWUk5QpgZSMwiMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCnkoYW5zaV9jb2xvcl9vdXRwdXQ9RmFsc2UsYm9hcmRfc2l6ZT04KQpbU3RhdGVdCjExCjM1CjU2CjQwCjIwCjI3CjI1CjEwCjE3CjEKMjgKMTkKMTMKMAo1CjE0CjgKNAoxOAo0Mgo0OQoKlGJzLg==\n",
+          "legalActions": [],
+          "legalActionStrings": []
+        },
+        "status": "INACTIVE"
+      },
+      {
+        "action": {
+          "submission": -1
+        },
+        "reward": null,
+        "info": {},
+        "observation": {
+          "remainingOverageTime": 12,
+          "observationString": "{\"board\": [[\"o\", \"o\", null, null, \"o\", \"x\", null, null], [\"x\", null, \"o\", \"x\", null, \"x\", \"o\"], [null, \"x\", \"x\", \"o\", \"x\", null], [null, \"x\", null, \"o\", \"x\"], [null, null, null, \"o\"], [\"o\", null, \"o\"], [null, \"x\"], [\"x\"]], \"board_size\": 8, \"current_player\": \"o\", \"is_terminal\": false, \"winner\": null, \"last_move\": \"b7\", \"move_number\": 21}",
+          "currentPlayer": 1,
+          "playerId": 1,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ny_proxy(ansi_color_output=False,board_size=8)\n[State]\nhistory=0:11,1:35,0:56,1:40,0:20,1:27,0:25,1:10,0:17,1:1,0:28,1:19,0:13,1:0,0:5,1:14,0:8,1:4,0:18,1:42,0:49\nmove_number=21\n__dict__=gASV7wAAAAAAAAB9lIwLX193cmFwcGVkX1+UjAdweXNwaWVslIwFU3RhdGWUk5QpgZSMwiMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCnkoYW5zaV9jb2xvcl9vdXRwdXQ9RmFsc2UsYm9hcmRfc2l6ZT04KQpbU3RhdGVdCjExCjM1CjU2CjQwCjIwCjI3CjI1CjEwCjE3CjEKMjgKMTkKMTMKMAo1CjE0CjgKNAoxOAo0Mgo0OQoKlGJzLg==\n",
+          "legalActions": [
+            2, 3, 6, 7, 9, 12, 16, 21, 24, 26, 32, 33, 34, 41, 48
+          ],
+          "legalActionStrings": [
+            "c1",
+            "d1",
+            "g1",
+            "h1",
+            "b2",
+            "e2",
+            "a3",
+            "f3",
+            "a4",
+            "c4",
+            "a5",
+            "b5",
+            "c5",
+            "b6",
+            "a7"
+          ]
+        },
+        "status": "ACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "submission": -1
+        },
+        "reward": null,
+        "info": {},
+        "observation": {
+          "remainingOverageTime": 12,
+          "step": 23,
+          "observationString": "{\"board\": [[\"o\", \"o\", null, null, \"o\", \"x\", null, null], [\"x\", null, \"o\", \"x\", null, \"x\", \"o\"], [null, \"x\", \"x\", \"o\", \"x\", \"o\"], [null, \"x\", null, \"o\", \"x\"], [null, null, null, \"o\"], [\"o\", null, \"o\"], [null, \"x\"], [\"x\"]], \"board_size\": 8, \"current_player\": \"x\", \"is_terminal\": false, \"winner\": null, \"last_move\": \"f3\", \"move_number\": 22}",
+          "currentPlayer": 0,
+          "playerId": 0,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ny_proxy(ansi_color_output=False,board_size=8)\n[State]\nhistory=0:11,1:35,0:56,1:40,0:20,1:27,0:25,1:10,0:17,1:1,0:28,1:19,0:13,1:0,0:5,1:14,0:8,1:4,0:18,1:42,0:49,1:21\nmove_number=22\n__dict__=gASV8gAAAAAAAAB9lIwLX193cmFwcGVkX1+UjAdweXNwaWVslIwFU3RhdGWUk5QpgZSMxSMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCnkoYW5zaV9jb2xvcl9vdXRwdXQ9RmFsc2UsYm9hcmRfc2l6ZT04KQpbU3RhdGVdCjExCjM1CjU2CjQwCjIwCjI3CjI1CjEwCjE3CjEKMjgKMTkKMTMKMAo1CjE0CjgKNAoxOAo0Mgo0OQoyMQoKlGJzLg==\n",
+          "legalActions": [2, 3, 6, 7, 9, 12, 16, 24, 26, 32, 33, 34, 41, 48],
+          "legalActionStrings": [
+            "c1",
+            "d1",
+            "g1",
+            "h1",
+            "b2",
+            "e2",
+            "a3",
+            "a4",
+            "c4",
+            "a5",
+            "b5",
+            "c5",
+            "b6",
+            "a7"
+          ]
+        },
+        "status": "ACTIVE"
+      },
+      {
+        "action": {
+          "submission": 21,
+          "thoughts": "cascade ripple iota explore iota epsilon spark muse"
+        },
+        "reward": null,
+        "info": {
+          "actionSubmitted": 21,
+          "actionSubmittedToString": "f3",
+          "actionApplied": 21,
+          "timeTaken": 0.0,
+          "agentSelfReportedStatus": null
+        },
+        "observation": {
+          "remainingOverageTime": 12,
+          "observationString": "{\"board\": [[\"o\", \"o\", null, null, \"o\", \"x\", null, null], [\"x\", null, \"o\", \"x\", null, \"x\", \"o\"], [null, \"x\", \"x\", \"o\", \"x\", \"o\"], [null, \"x\", null, \"o\", \"x\"], [null, null, null, \"o\"], [\"o\", null, \"o\"], [null, \"x\"], [\"x\"]], \"board_size\": 8, \"current_player\": \"x\", \"is_terminal\": false, \"winner\": null, \"last_move\": \"f3\", \"move_number\": 22}",
+          "currentPlayer": 0,
+          "playerId": 1,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ny_proxy(ansi_color_output=False,board_size=8)\n[State]\nhistory=0:11,1:35,0:56,1:40,0:20,1:27,0:25,1:10,0:17,1:1,0:28,1:19,0:13,1:0,0:5,1:14,0:8,1:4,0:18,1:42,0:49,1:21\nmove_number=22\n__dict__=gASV8gAAAAAAAAB9lIwLX193cmFwcGVkX1+UjAdweXNwaWVslIwFU3RhdGWUk5QpgZSMxSMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCnkoYW5zaV9jb2xvcl9vdXRwdXQ9RmFsc2UsYm9hcmRfc2l6ZT04KQpbU3RhdGVdCjExCjM1CjU2CjQwCjIwCjI3CjI1CjEwCjE3CjEKMjgKMTkKMTMKMAo1CjE0CjgKNAoxOAo0Mgo0OQoyMQoKlGJzLg==\n",
+          "legalActions": [],
+          "legalActionStrings": []
+        },
+        "status": "INACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "submission": 12,
+          "thoughts": "gamma nu rho zeta rho alpha echo phi"
+        },
+        "reward": null,
+        "info": {
+          "actionSubmitted": 12,
+          "actionSubmittedToString": "e2",
+          "actionApplied": 12,
+          "timeTaken": 0.0,
+          "agentSelfReportedStatus": null
+        },
+        "observation": {
+          "remainingOverageTime": 12,
+          "step": 24,
+          "observationString": "{\"board\": [[\"o\", \"o\", null, null, \"o\", \"x\", null, null], [\"x\", null, \"o\", \"x\", \"x\", \"x\", \"o\"], [null, \"x\", \"x\", \"o\", \"x\", \"o\"], [null, \"x\", null, \"o\", \"x\"], [null, null, null, \"o\"], [\"o\", null, \"o\"], [null, \"x\"], [\"x\"]], \"board_size\": 8, \"current_player\": \"o\", \"is_terminal\": false, \"winner\": null, \"last_move\": \"e2\", \"move_number\": 23}",
+          "currentPlayer": 1,
+          "playerId": 0,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ny_proxy(ansi_color_output=False,board_size=8)\n[State]\nhistory=0:11,1:35,0:56,1:40,0:20,1:27,0:25,1:10,0:17,1:1,0:28,1:19,0:13,1:0,0:5,1:14,0:8,1:4,0:18,1:42,0:49,1:21,0:12\nmove_number=23\n__dict__=gASV9QAAAAAAAAB9lIwLX193cmFwcGVkX1+UjAdweXNwaWVslIwFU3RhdGWUk5QpgZSMyCMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCnkoYW5zaV9jb2xvcl9vdXRwdXQ9RmFsc2UsYm9hcmRfc2l6ZT04KQpbU3RhdGVdCjExCjM1CjU2CjQwCjIwCjI3CjI1CjEwCjE3CjEKMjgKMTkKMTMKMAo1CjE0CjgKNAoxOAo0Mgo0OQoyMQoxMgoKlGJzLg==\n",
+          "legalActions": [],
+          "legalActionStrings": []
+        },
+        "status": "INACTIVE"
+      },
+      {
+        "action": {
+          "submission": -1
+        },
+        "reward": null,
+        "info": {},
+        "observation": {
+          "remainingOverageTime": 12,
+          "observationString": "{\"board\": [[\"o\", \"o\", null, null, \"o\", \"x\", null, null], [\"x\", null, \"o\", \"x\", \"x\", \"x\", \"o\"], [null, \"x\", \"x\", \"o\", \"x\", \"o\"], [null, \"x\", null, \"o\", \"x\"], [null, null, null, \"o\"], [\"o\", null, \"o\"], [null, \"x\"], [\"x\"]], \"board_size\": 8, \"current_player\": \"o\", \"is_terminal\": false, \"winner\": null, \"last_move\": \"e2\", \"move_number\": 23}",
+          "currentPlayer": 1,
+          "playerId": 1,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ny_proxy(ansi_color_output=False,board_size=8)\n[State]\nhistory=0:11,1:35,0:56,1:40,0:20,1:27,0:25,1:10,0:17,1:1,0:28,1:19,0:13,1:0,0:5,1:14,0:8,1:4,0:18,1:42,0:49,1:21,0:12\nmove_number=23\n__dict__=gASV9QAAAAAAAAB9lIwLX193cmFwcGVkX1+UjAdweXNwaWVslIwFU3RhdGWUk5QpgZSMyCMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCnkoYW5zaV9jb2xvcl9vdXRwdXQ9RmFsc2UsYm9hcmRfc2l6ZT04KQpbU3RhdGVdCjExCjM1CjU2CjQwCjIwCjI3CjI1CjEwCjE3CjEKMjgKMTkKMTMKMAo1CjE0CjgKNAoxOAo0Mgo0OQoyMQoxMgoKlGJzLg==\n",
+          "legalActions": [2, 3, 6, 7, 9, 16, 24, 26, 32, 33, 34, 41, 48],
+          "legalActionStrings": [
+            "c1",
+            "d1",
+            "g1",
+            "h1",
+            "b2",
+            "a3",
+            "a4",
+            "c4",
+            "a5",
+            "b5",
+            "c5",
+            "b6",
+            "a7"
+          ]
+        },
+        "status": "ACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "submission": -1
+        },
+        "reward": null,
+        "info": {},
+        "observation": {
+          "remainingOverageTime": 12,
+          "step": 25,
+          "observationString": "{\"board\": [[\"o\", \"o\", null, null, \"o\", \"x\", null, null], [\"x\", null, \"o\", \"x\", \"x\", \"x\", \"o\"], [null, \"x\", \"x\", \"o\", \"x\", \"o\"], [\"o\", \"x\", null, \"o\", \"x\"], [null, null, null, \"o\"], [\"o\", null, \"o\"], [null, \"x\"], [\"x\"]], \"board_size\": 8, \"current_player\": \"x\", \"is_terminal\": false, \"winner\": null, \"last_move\": \"a4\", \"move_number\": 24}",
+          "currentPlayer": 0,
+          "playerId": 0,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ny_proxy(ansi_color_output=False,board_size=8)\n[State]\nhistory=0:11,1:35,0:56,1:40,0:20,1:27,0:25,1:10,0:17,1:1,0:28,1:19,0:13,1:0,0:5,1:14,0:8,1:4,0:18,1:42,0:49,1:21,0:12,1:24\nmove_number=24\n__dict__=gASV+AAAAAAAAAB9lIwLX193cmFwcGVkX1+UjAdweXNwaWVslIwFU3RhdGWUk5QpgZSMyyMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCnkoYW5zaV9jb2xvcl9vdXRwdXQ9RmFsc2UsYm9hcmRfc2l6ZT04KQpbU3RhdGVdCjExCjM1CjU2CjQwCjIwCjI3CjI1CjEwCjE3CjEKMjgKMTkKMTMKMAo1CjE0CjgKNAoxOAo0Mgo0OQoyMQoxMgoyNAoKlGJzLg==\n",
+          "legalActions": [2, 3, 6, 7, 9, 16, 26, 32, 33, 34, 41, 48],
+          "legalActionStrings": [
+            "c1",
+            "d1",
+            "g1",
+            "h1",
+            "b2",
+            "a3",
+            "c4",
+            "a5",
+            "b5",
+            "c5",
+            "b6",
+            "a7"
+          ]
+        },
+        "status": "ACTIVE"
+      },
+      {
+        "action": {
+          "submission": 24,
+          "thoughts": "tau psi gamma kappa mu psi iota beta"
+        },
+        "reward": null,
+        "info": {
+          "actionSubmitted": 24,
+          "actionSubmittedToString": "a4",
+          "actionApplied": 24,
+          "timeTaken": 0.0,
+          "agentSelfReportedStatus": null
+        },
+        "observation": {
+          "remainingOverageTime": 12,
+          "observationString": "{\"board\": [[\"o\", \"o\", null, null, \"o\", \"x\", null, null], [\"x\", null, \"o\", \"x\", \"x\", \"x\", \"o\"], [null, \"x\", \"x\", \"o\", \"x\", \"o\"], [\"o\", \"x\", null, \"o\", \"x\"], [null, null, null, \"o\"], [\"o\", null, \"o\"], [null, \"x\"], [\"x\"]], \"board_size\": 8, \"current_player\": \"x\", \"is_terminal\": false, \"winner\": null, \"last_move\": \"a4\", \"move_number\": 24}",
+          "currentPlayer": 0,
+          "playerId": 1,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ny_proxy(ansi_color_output=False,board_size=8)\n[State]\nhistory=0:11,1:35,0:56,1:40,0:20,1:27,0:25,1:10,0:17,1:1,0:28,1:19,0:13,1:0,0:5,1:14,0:8,1:4,0:18,1:42,0:49,1:21,0:12,1:24\nmove_number=24\n__dict__=gASV+AAAAAAAAAB9lIwLX193cmFwcGVkX1+UjAdweXNwaWVslIwFU3RhdGWUk5QpgZSMyyMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCnkoYW5zaV9jb2xvcl9vdXRwdXQ9RmFsc2UsYm9hcmRfc2l6ZT04KQpbU3RhdGVdCjExCjM1CjU2CjQwCjIwCjI3CjI1CjEwCjE3CjEKMjgKMTkKMTMKMAo1CjE0CjgKNAoxOAo0Mgo0OQoyMQoxMgoyNAoKlGJzLg==\n",
+          "legalActions": [],
+          "legalActionStrings": []
+        },
+        "status": "INACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "submission": 16,
+          "thoughts": "epsilon alpha chi horizon gamma phi sigma pi"
+        },
+        "reward": 1.0,
+        "info": {
+          "actionSubmitted": 16,
+          "actionSubmittedToString": "a3",
+          "actionApplied": 16,
+          "timeTaken": 0.0,
+          "agentSelfReportedStatus": null
+        },
+        "observation": {
+          "remainingOverageTime": 12,
+          "step": 26,
+          "observationString": "{\"board\": [[\"o\", \"o\", null, null, \"o\", \"x\", null, null], [\"x\", null, \"o\", \"x\", \"x\", \"x\", \"o\"], [\"x\", \"x\", \"x\", \"o\", \"x\", \"o\"], [\"o\", \"x\", null, \"o\", \"x\"], [null, null, null, \"o\"], [\"o\", null, \"o\"], [null, \"x\"], [\"x\"]], \"board_size\": 8, \"current_player\": \"terminal\", \"is_terminal\": true, \"winner\": \"x\", \"last_move\": \"a3\", \"move_number\": 25}",
+          "currentPlayer": -4,
+          "playerId": 0,
+          "isTerminal": true,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ny_proxy(ansi_color_output=False,board_size=8)\n[State]\nhistory=0:11,1:35,0:56,1:40,0:20,1:27,0:25,1:10,0:17,1:1,0:28,1:19,0:13,1:0,0:5,1:14,0:8,1:4,0:18,1:42,0:49,1:21,0:12,1:24,0:16\nmove_number=25\n__dict__=gASV+wAAAAAAAAB9lIwLX193cmFwcGVkX1+UjAdweXNwaWVslIwFU3RhdGWUk5QpgZSMziMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCnkoYW5zaV9jb2xvcl9vdXRwdXQ9RmFsc2UsYm9hcmRfc2l6ZT04KQpbU3RhdGVdCjExCjM1CjU2CjQwCjIwCjI3CjI1CjEwCjE3CjEKMjgKMTkKMTMKMAo1CjE0CjgKNAoxOAo0Mgo0OQoyMQoxMgoyNAoxNgoKlGJzLg==\n",
+          "legalActions": [],
+          "legalActionStrings": []
+        },
+        "status": "DONE"
+      },
+      {
+        "action": {
+          "submission": -1
+        },
+        "reward": -1.0,
+        "info": {},
+        "observation": {
+          "remainingOverageTime": 12,
+          "observationString": "{\"board\": [[\"o\", \"o\", null, null, \"o\", \"x\", null, null], [\"x\", null, \"o\", \"x\", \"x\", \"x\", \"o\"], [\"x\", \"x\", \"x\", \"o\", \"x\", \"o\"], [\"o\", \"x\", null, \"o\", \"x\"], [null, null, null, \"o\"], [\"o\", null, \"o\"], [null, \"x\"], [\"x\"]], \"board_size\": 8, \"current_player\": \"terminal\", \"is_terminal\": true, \"winner\": \"x\", \"last_move\": \"a3\", \"move_number\": 25}",
+          "currentPlayer": -4,
+          "playerId": 1,
+          "isTerminal": true,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ny_proxy(ansi_color_output=False,board_size=8)\n[State]\nhistory=0:11,1:35,0:56,1:40,0:20,1:27,0:25,1:10,0:17,1:1,0:28,1:19,0:13,1:0,0:5,1:14,0:8,1:4,0:18,1:42,0:49,1:21,0:12,1:24,0:16\nmove_number=25\n__dict__=gASV+wAAAAAAAAB9lIwLX193cmFwcGVkX1+UjAdweXNwaWVslIwFU3RhdGWUk5QpgZSMziMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCnkoYW5zaV9jb2xvcl9vdXRwdXQ9RmFsc2UsYm9hcmRfc2l6ZT04KQpbU3RhdGVdCjExCjM1CjU2CjQwCjIwCjI3CjI1CjEwCjE3CjEKMjgKMTkKMTMKMAo1CjE0CjgKNAoxOAo0Mgo0OQoyMQoxMgoyNAoxNgoKlGJzLg==\n",
+          "legalActions": [],
+          "legalActionStrings": []
+        },
+        "status": "DONE"
+      }
+    ]
+  ],
+  "rewards": [1.0, -1.0],
+  "statuses": ["DONE", "DONE"],
+  "schema_version": 1,
+  "info": {
+    "openSpielGameStringResolved": "y_proxy(ansi_color_output=False,board_size=8)",
+    "stateHistory": [
+      "{\"board\": [[null, null, null, null, null, null, null, null], [null, null, null, null, null, null, null], [null, null, null, null, null, null], [null, null, null, null, null], [null, null, null, null], [null, null, null], [null, null], [null]], \"board_size\": 8, \"current_player\": \"x\", \"is_terminal\": false, \"winner\": null, \"last_move\": null, \"move_number\": 0}",
+      "{\"board\": [[null, null, null, null, null, null, null, null], [null, null, null, \"x\", null, null, null], [null, null, null, null, null, null], [null, null, null, null, null], [null, null, null, null], [null, null, null], [null, null], [null]], \"board_size\": 8, \"current_player\": \"o\", \"is_terminal\": false, \"winner\": null, \"last_move\": \"d2\", \"move_number\": 1}",
+      "{\"board\": [[null, null, null, null, null, null, null, null], [null, null, null, \"x\", null, null, null], [null, null, null, null, null, null], [null, null, null, null, null], [null, null, null, \"o\"], [null, null, null], [null, null], [null]], \"board_size\": 8, \"current_player\": \"x\", \"is_terminal\": false, \"winner\": null, \"last_move\": \"d5\", \"move_number\": 2}",
+      "{\"board\": [[null, null, null, null, null, null, null, null], [null, null, null, \"x\", null, null, null], [null, null, null, null, null, null], [null, null, null, null, null], [null, null, null, \"o\"], [null, null, null], [null, null], [\"x\"]], \"board_size\": 8, \"current_player\": \"o\", \"is_terminal\": false, \"winner\": null, \"last_move\": \"a8\", \"move_number\": 3}",
+      "{\"board\": [[null, null, null, null, null, null, null, null], [null, null, null, \"x\", null, null, null], [null, null, null, null, null, null], [null, null, null, null, null], [null, null, null, \"o\"], [\"o\", null, null], [null, null], [\"x\"]], \"board_size\": 8, \"current_player\": \"x\", \"is_terminal\": false, \"winner\": null, \"last_move\": \"a6\", \"move_number\": 4}",
+      "{\"board\": [[null, null, null, null, null, null, null, null], [null, null, null, \"x\", null, null, null], [null, null, null, null, \"x\", null], [null, null, null, null, null], [null, null, null, \"o\"], [\"o\", null, null], [null, null], [\"x\"]], \"board_size\": 8, \"current_player\": \"o\", \"is_terminal\": false, \"winner\": null, \"last_move\": \"e3\", \"move_number\": 5}",
+      "{\"board\": [[null, null, null, null, null, null, null, null], [null, null, null, \"x\", null, null, null], [null, null, null, null, \"x\", null], [null, null, null, \"o\", null], [null, null, null, \"o\"], [\"o\", null, null], [null, null], [\"x\"]], \"board_size\": 8, \"current_player\": \"x\", \"is_terminal\": false, \"winner\": null, \"last_move\": \"d4\", \"move_number\": 6}",
+      "{\"board\": [[null, null, null, null, null, null, null, null], [null, null, null, \"x\", null, null, null], [null, null, null, null, \"x\", null], [null, \"x\", null, \"o\", null], [null, null, null, \"o\"], [\"o\", null, null], [null, null], [\"x\"]], \"board_size\": 8, \"current_player\": \"o\", \"is_terminal\": false, \"winner\": null, \"last_move\": \"b4\", \"move_number\": 7}",
+      "{\"board\": [[null, null, null, null, null, null, null, null], [null, null, \"o\", \"x\", null, null, null], [null, null, null, null, \"x\", null], [null, \"x\", null, \"o\", null], [null, null, null, \"o\"], [\"o\", null, null], [null, null], [\"x\"]], \"board_size\": 8, \"current_player\": \"x\", \"is_terminal\": false, \"winner\": null, \"last_move\": \"c2\", \"move_number\": 8}",
+      "{\"board\": [[null, null, null, null, null, null, null, null], [null, null, \"o\", \"x\", null, null, null], [null, \"x\", null, null, \"x\", null], [null, \"x\", null, \"o\", null], [null, null, null, \"o\"], [\"o\", null, null], [null, null], [\"x\"]], \"board_size\": 8, \"current_player\": \"o\", \"is_terminal\": false, \"winner\": null, \"last_move\": \"b3\", \"move_number\": 9}",
+      "{\"board\": [[null, \"o\", null, null, null, null, null, null], [null, null, \"o\", \"x\", null, null, null], [null, \"x\", null, null, \"x\", null], [null, \"x\", null, \"o\", null], [null, null, null, \"o\"], [\"o\", null, null], [null, null], [\"x\"]], \"board_size\": 8, \"current_player\": \"x\", \"is_terminal\": false, \"winner\": null, \"last_move\": \"b1\", \"move_number\": 10}",
+      "{\"board\": [[null, \"o\", null, null, null, null, null, null], [null, null, \"o\", \"x\", null, null, null], [null, \"x\", null, null, \"x\", null], [null, \"x\", null, \"o\", \"x\"], [null, null, null, \"o\"], [\"o\", null, null], [null, null], [\"x\"]], \"board_size\": 8, \"current_player\": \"o\", \"is_terminal\": false, \"winner\": null, \"last_move\": \"e4\", \"move_number\": 11}",
+      "{\"board\": [[null, \"o\", null, null, null, null, null, null], [null, null, \"o\", \"x\", null, null, null], [null, \"x\", null, \"o\", \"x\", null], [null, \"x\", null, \"o\", \"x\"], [null, null, null, \"o\"], [\"o\", null, null], [null, null], [\"x\"]], \"board_size\": 8, \"current_player\": \"x\", \"is_terminal\": false, \"winner\": null, \"last_move\": \"d3\", \"move_number\": 12}",
+      "{\"board\": [[null, \"o\", null, null, null, null, null, null], [null, null, \"o\", \"x\", null, \"x\", null], [null, \"x\", null, \"o\", \"x\", null], [null, \"x\", null, \"o\", \"x\"], [null, null, null, \"o\"], [\"o\", null, null], [null, null], [\"x\"]], \"board_size\": 8, \"current_player\": \"o\", \"is_terminal\": false, \"winner\": null, \"last_move\": \"f2\", \"move_number\": 13}",
+      "{\"board\": [[\"o\", \"o\", null, null, null, null, null, null], [null, null, \"o\", \"x\", null, \"x\", null], [null, \"x\", null, \"o\", \"x\", null], [null, \"x\", null, \"o\", \"x\"], [null, null, null, \"o\"], [\"o\", null, null], [null, null], [\"x\"]], \"board_size\": 8, \"current_player\": \"x\", \"is_terminal\": false, \"winner\": null, \"last_move\": \"a1\", \"move_number\": 14}",
+      "{\"board\": [[\"o\", \"o\", null, null, null, \"x\", null, null], [null, null, \"o\", \"x\", null, \"x\", null], [null, \"x\", null, \"o\", \"x\", null], [null, \"x\", null, \"o\", \"x\"], [null, null, null, \"o\"], [\"o\", null, null], [null, null], [\"x\"]], \"board_size\": 8, \"current_player\": \"o\", \"is_terminal\": false, \"winner\": null, \"last_move\": \"f1\", \"move_number\": 15}",
+      "{\"board\": [[\"o\", \"o\", null, null, null, \"x\", null, null], [null, null, \"o\", \"x\", null, \"x\", \"o\"], [null, \"x\", null, \"o\", \"x\", null], [null, \"x\", null, \"o\", \"x\"], [null, null, null, \"o\"], [\"o\", null, null], [null, null], [\"x\"]], \"board_size\": 8, \"current_player\": \"x\", \"is_terminal\": false, \"winner\": null, \"last_move\": \"g2\", \"move_number\": 16}",
+      "{\"board\": [[\"o\", \"o\", null, null, null, \"x\", null, null], [\"x\", null, \"o\", \"x\", null, \"x\", \"o\"], [null, \"x\", null, \"o\", \"x\", null], [null, \"x\", null, \"o\", \"x\"], [null, null, null, \"o\"], [\"o\", null, null], [null, null], [\"x\"]], \"board_size\": 8, \"current_player\": \"o\", \"is_terminal\": false, \"winner\": null, \"last_move\": \"a2\", \"move_number\": 17}",
+      "{\"board\": [[\"o\", \"o\", null, null, \"o\", \"x\", null, null], [\"x\", null, \"o\", \"x\", null, \"x\", \"o\"], [null, \"x\", null, \"o\", \"x\", null], [null, \"x\", null, \"o\", \"x\"], [null, null, null, \"o\"], [\"o\", null, null], [null, null], [\"x\"]], \"board_size\": 8, \"current_player\": \"x\", \"is_terminal\": false, \"winner\": null, \"last_move\": \"e1\", \"move_number\": 18}",
+      "{\"board\": [[\"o\", \"o\", null, null, \"o\", \"x\", null, null], [\"x\", null, \"o\", \"x\", null, \"x\", \"o\"], [null, \"x\", \"x\", \"o\", \"x\", null], [null, \"x\", null, \"o\", \"x\"], [null, null, null, \"o\"], [\"o\", null, null], [null, null], [\"x\"]], \"board_size\": 8, \"current_player\": \"o\", \"is_terminal\": false, \"winner\": null, \"last_move\": \"c3\", \"move_number\": 19}",
+      "{\"board\": [[\"o\", \"o\", null, null, \"o\", \"x\", null, null], [\"x\", null, \"o\", \"x\", null, \"x\", \"o\"], [null, \"x\", \"x\", \"o\", \"x\", null], [null, \"x\", null, \"o\", \"x\"], [null, null, null, \"o\"], [\"o\", null, \"o\"], [null, null], [\"x\"]], \"board_size\": 8, \"current_player\": \"x\", \"is_terminal\": false, \"winner\": null, \"last_move\": \"c6\", \"move_number\": 20}",
+      "{\"board\": [[\"o\", \"o\", null, null, \"o\", \"x\", null, null], [\"x\", null, \"o\", \"x\", null, \"x\", \"o\"], [null, \"x\", \"x\", \"o\", \"x\", null], [null, \"x\", null, \"o\", \"x\"], [null, null, null, \"o\"], [\"o\", null, \"o\"], [null, \"x\"], [\"x\"]], \"board_size\": 8, \"current_player\": \"o\", \"is_terminal\": false, \"winner\": null, \"last_move\": \"b7\", \"move_number\": 21}",
+      "{\"board\": [[\"o\", \"o\", null, null, \"o\", \"x\", null, null], [\"x\", null, \"o\", \"x\", null, \"x\", \"o\"], [null, \"x\", \"x\", \"o\", \"x\", \"o\"], [null, \"x\", null, \"o\", \"x\"], [null, null, null, \"o\"], [\"o\", null, \"o\"], [null, \"x\"], [\"x\"]], \"board_size\": 8, \"current_player\": \"x\", \"is_terminal\": false, \"winner\": null, \"last_move\": \"f3\", \"move_number\": 22}",
+      "{\"board\": [[\"o\", \"o\", null, null, \"o\", \"x\", null, null], [\"x\", null, \"o\", \"x\", \"x\", \"x\", \"o\"], [null, \"x\", \"x\", \"o\", \"x\", \"o\"], [null, \"x\", null, \"o\", \"x\"], [null, null, null, \"o\"], [\"o\", null, \"o\"], [null, \"x\"], [\"x\"]], \"board_size\": 8, \"current_player\": \"o\", \"is_terminal\": false, \"winner\": null, \"last_move\": \"e2\", \"move_number\": 23}",
+      "{\"board\": [[\"o\", \"o\", null, null, \"o\", \"x\", null, null], [\"x\", null, \"o\", \"x\", \"x\", \"x\", \"o\"], [null, \"x\", \"x\", \"o\", \"x\", \"o\"], [\"o\", \"x\", null, \"o\", \"x\"], [null, null, null, \"o\"], [\"o\", null, \"o\"], [null, \"x\"], [\"x\"]], \"board_size\": 8, \"current_player\": \"x\", \"is_terminal\": false, \"winner\": null, \"last_move\": \"a4\", \"move_number\": 24}",
+      "{\"board\": [[\"o\", \"o\", null, null, \"o\", \"x\", null, null], [\"x\", null, \"o\", \"x\", \"x\", \"x\", \"o\"], [\"x\", \"x\", \"x\", \"o\", \"x\", \"o\"], [\"o\", \"x\", null, \"o\", \"x\"], [null, null, null, \"o\"], [\"o\", null, \"o\"], [null, \"x\"], [\"x\"]], \"board_size\": 8, \"current_player\": \"terminal\", \"is_terminal\": true, \"winner\": \"x\", \"last_move\": \"a3\", \"move_number\": 25}"
+    ],
+    "actionHistory": [
+      "11",
+      "35",
+      "56",
+      "40",
+      "20",
+      "27",
+      "25",
+      "10",
+      "17",
+      "1",
+      "28",
+      "19",
+      "13",
+      "0",
+      "5",
+      "14",
+      "8",
+      "4",
+      "18",
+      "42",
+      "49",
+      "21",
+      "12",
+      "24",
+      "16"
+    ],
+    "moveDurations": [
+      0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+      0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0
+    ]
+  }
+}

--- a/kaggle_environments/envs/open_spiel_env/games/y/visualizer/default/src/main.ts
+++ b/kaggle_environments/envs/open_spiel_env/games/y/visualizer/default/src/main.ts
@@ -1,0 +1,27 @@
+import { createReplayVisualizer, ReplayAdapter } from '@kaggle-environments/core';
+import { renderer } from './renderer';
+import { yTransformer } from './transformers/yTransformer';
+import './style.css';
+
+const app = document.getElementById('app');
+if (!app) {
+  throw new Error('Could not find app element');
+}
+
+if (import.meta.env?.DEV && import.meta.hot) {
+  import.meta.hot.accept();
+}
+
+createReplayVisualizer(
+  app,
+  new ReplayAdapter({
+    gameName: 'open_spiel_y',
+    renderer: renderer as any,
+    ui: 'side-panel',
+    transformer: (replay) => ({
+      ...replay,
+      steps: yTransformer(replay),
+      isTransformed: true,
+    }),
+  })
+);

--- a/kaggle_environments/envs/open_spiel_env/games/y/visualizer/default/src/renderer.ts
+++ b/kaggle_environments/envs/open_spiel_env/games/y/visualizer/default/src/renderer.ts
@@ -1,0 +1,239 @@
+import type { RendererOptions } from '@kaggle-environments/core';
+import type { YBoardState, YStep } from './transformers/yTransformer';
+
+const PLAYER_X_COLOR = '#1f77b4';
+const PLAYER_O_COLOR = '#d62728';
+const CELL_FILL = '#fbf7e8';
+const SECONDARY_TEXT = '#444343';
+const SKETCH_STROKE = '#3c3b37';
+
+const SQRT3 = Math.sqrt(3);
+
+function colLabel(col: number): string {
+  return String.fromCharCode('a'.charCodeAt(0) + col);
+}
+
+function getPlayerName(replay: any, idx: number): string {
+  const info = replay?.info?.TeamNames?.[idx];
+  if (info) return info;
+  const fromAgent = replay?.agents?.[idx]?.name;
+  if (fromAgent) return fromAgent;
+  return idx === 0 ? 'Player X' : 'Player O';
+}
+
+function drawYBoard(
+  ctx: CanvasRenderingContext2D,
+  width: number,
+  height: number,
+  board: (string | null)[][],
+  boardSize: number,
+  highlightCell: { row: number; col: number } | null,
+  highlightColor: string
+) {
+  ctx.clearRect(0, 0, width, height);
+
+  const padding = 28;
+  const innerW = Math.max(0, width - padding * 2);
+  const innerH = Math.max(0, height - padding * 2);
+  // The triangle bounding box: width = boardSize * hexW, height = ((boardSize-1)*1.5 + 2) * size.
+  const totalUnitsH = (boardSize - 1) * 1.5 + 2;
+  const sizeFromW = innerW / (boardSize * SQRT3);
+  const sizeFromH = innerH / totalUnitsH;
+  const size = Math.max(6, Math.min(sizeFromW, sizeFromH));
+  const hexW = SQRT3 * size;
+  const boardW = boardSize * hexW;
+  const boardH = (boardSize - 1) * 1.5 * size + 2 * size;
+  const xOffset = (width - boardW) / 2;
+  const yOffset = (height - boardH) / 2;
+
+  const centerOf = (row: number, col: number) => ({
+    x: xOffset + (col + row * 0.5 + 0.5) * hexW,
+    y: yOffset + size + row * 1.5 * size,
+  });
+
+  const hexPath = (cx: number, cy: number, s: number) => {
+    ctx.beginPath();
+    for (let i = 0; i < 6; i++) {
+      const angle = (Math.PI / 3) * i + Math.PI / 6;
+      const x = cx + s * Math.cos(angle);
+      const y = cy + s * Math.sin(angle);
+      if (i === 0) ctx.moveTo(x, y);
+      else ctx.lineTo(x, y);
+    }
+    ctx.closePath();
+  };
+
+  // Three sides of the triangle. In Y, a player wins by linking all three.
+  const edgeWidth = Math.max(3, size * 0.18);
+  ctx.lineWidth = edgeWidth;
+  ctx.lineCap = 'round';
+  ctx.setLineDash([]);
+
+  const topL = centerOf(0, 0);
+  const topR = centerOf(0, boardSize - 1);
+  ctx.strokeStyle = PLAYER_X_COLOR;
+  ctx.beginPath();
+  ctx.moveTo(topL.x - hexW / 2, topL.y - size * 0.6);
+  ctx.lineTo(topR.x + hexW / 2, topR.y - size * 0.6);
+  ctx.stroke();
+
+  const botCorner = centerOf(boardSize - 1, 0);
+  ctx.strokeStyle = PLAYER_O_COLOR;
+  ctx.beginPath();
+  ctx.moveTo(topL.x - hexW / 2, topL.y - size * 0.5);
+  ctx.lineTo(botCorner.x - hexW / 2, botCorner.y + size * 0.5);
+  ctx.stroke();
+
+  ctx.strokeStyle = '#7c7c7c';
+  ctx.beginPath();
+  ctx.moveTo(topR.x + hexW / 2, topR.y - size * 0.5);
+  ctx.lineTo(botCorner.x + hexW / 2, botCorner.y + size * 0.5);
+  ctx.stroke();
+
+  // Cells.
+  ctx.font = `${Math.round(size * 0.7)}px 'Inter', sans-serif`;
+  ctx.textAlign = 'center';
+  ctx.textBaseline = 'middle';
+
+  for (let r = 0; r < boardSize; r++) {
+    const rowLen = boardSize - r;
+    for (let c = 0; c < rowLen; c++) {
+      const { x, y } = centerOf(r, c);
+      const cell = board?.[r]?.[c] ?? null;
+
+      hexPath(x, y, size * 0.95);
+      ctx.fillStyle = CELL_FILL;
+      ctx.fill();
+      ctx.lineWidth = 1.25;
+      ctx.setLineDash([3, 3]);
+      ctx.strokeStyle = SKETCH_STROKE;
+      ctx.stroke();
+      ctx.setLineDash([]);
+
+      if (cell === 'x') {
+        ctx.fillStyle = PLAYER_X_COLOR;
+        ctx.fillText('X', x, y + size * 0.04);
+      } else if (cell === 'o') {
+        ctx.fillStyle = PLAYER_O_COLOR;
+        ctx.fillText('O', x, y + size * 0.04);
+      }
+    }
+  }
+
+  if (highlightCell) {
+    const { x, y } = centerOf(highlightCell.row, highlightCell.col);
+    hexPath(x, y, size * 0.95);
+    ctx.lineWidth = Math.max(2.5, size * 0.12);
+    ctx.setLineDash([]);
+    ctx.strokeStyle = highlightColor;
+    ctx.stroke();
+  }
+
+  // Coordinate labels.
+  ctx.font = `${Math.round(size * 0.32)}px 'Inter', sans-serif`;
+  ctx.fillStyle = SECONDARY_TEXT;
+  for (let c = 0; c < boardSize; c++) {
+    const top = centerOf(0, c);
+    ctx.fillText(colLabel(c), top.x, top.y - size - size * 0.25);
+  }
+  for (let r = 0; r < boardSize; r++) {
+    const left = centerOf(r, 0);
+    ctx.fillText(`${r + 1}`, left.x - hexW * 0.55 - size * 0.25, left.y);
+  }
+}
+
+export function renderer(options: RendererOptions<YStep[]>) {
+  const { parent, replay, step } = options;
+  const steps = (replay?.steps ?? []) as YStep[];
+  if (!steps.length) return;
+
+  parent.innerHTML = `
+    <div class="renderer-container">
+      <div class="header"></div>
+      <div class="board-wrap"><canvas></canvas></div>
+      <div class="status-container sketched-border"></div>
+    </div>
+  `;
+  const header = parent.querySelector('.header') as HTMLDivElement;
+  const wrap = parent.querySelector('.board-wrap') as HTMLDivElement;
+  const canvas = wrap.querySelector('canvas') as HTMLCanvasElement;
+  const statusContainer = parent.querySelector('.status-container') as HTMLDivElement;
+
+  const currentStep = steps[step];
+  const observation: YBoardState | null = currentStep?.boardState ?? null;
+  if (!observation) {
+    statusContainer.textContent = 'Waiting for first observation...';
+    return;
+  }
+
+  const boardSize = observation.board_size;
+  const isTerminal = observation.is_terminal;
+  const currentPlayer = observation.current_player;
+
+  const playerNames = [getPlayerName(replay, 0), getPlayerName(replay, 1)];
+  const activeIdx = isTerminal ? -1 : currentPlayer === 'x' ? 0 : currentPlayer === 'o' ? 1 : -1;
+
+  header.innerHTML = `
+    <span class="player sketched-border ${activeIdx === 0 ? 'active' : ''}" style="color: ${PLAYER_X_COLOR};">
+      ${playerNames[0]} <span style="opacity: 0.7;">(X)</span>
+    </span>
+    <span class="vs">vs</span>
+    <span class="player sketched-border ${activeIdx === 1 ? 'active' : ''}" style="color: ${PLAYER_O_COLOR};">
+      ${playerNames[1]} <span style="opacity: 0.7;">(O)</span>
+    </span>
+  `;
+
+  // The proxy puts the most recent move on the board state itself.
+  // Move parity tells us who placed it: even-index → x (player 0), odd → o.
+  const lastActor = observation.move_number > 0 ? (observation.move_number - 1) % 2 : null;
+  let lastCell: { row: number; col: number } | null = null;
+  if (observation.last_move) {
+    const colChar = observation.last_move.charCodeAt(0) - 'a'.charCodeAt(0);
+    const rowNum = parseInt(observation.last_move.slice(1), 10) - 1;
+    if (colChar >= 0 && rowNum >= 0) lastCell = { row: rowNum, col: colChar };
+  }
+  const highlightColor = lastActor === 0 ? PLAYER_X_COLOR : PLAYER_O_COLOR;
+
+  const aspect = (boardSize * SQRT3) / ((boardSize - 1) * 1.5 + 2);
+
+  const sizeAndDraw = () => {
+    const wrapRect = wrap.getBoundingClientRect();
+    const availW = wrapRect.width;
+    const availH = wrapRect.height;
+    if (availW <= 0 || availH <= 0) return;
+    let cssW = Math.min(availW, availH * aspect);
+    let cssH = cssW / aspect;
+    cssW = Math.max(1, Math.floor(cssW));
+    cssH = Math.max(1, Math.floor(cssH));
+    canvas.style.width = `${cssW}px`;
+    canvas.style.height = `${cssH}px`;
+    canvas.width = cssW;
+    canvas.height = cssH;
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return;
+    drawYBoard(ctx, cssW, cssH, observation.board, boardSize, lastCell, highlightColor);
+  };
+
+  requestAnimationFrame(sizeAndDraw);
+
+  let statusHTML = '';
+  if (isTerminal) {
+    if (observation.winner === 'x') {
+      statusHTML = `<span style="color: ${PLAYER_X_COLOR};">${playerNames[0]} (X) wins!</span>`;
+    } else if (observation.winner === 'o') {
+      statusHTML = `<span style="color: ${PLAYER_O_COLOR};">${playerNames[1]} (O) wins!</span>`;
+    } else {
+      statusHTML = `<span>Game over: ${observation.winner ?? 'finished'}</span>`;
+    }
+  } else {
+    const turnColor = activeIdx === 0 ? PLAYER_X_COLOR : PLAYER_O_COLOR;
+    const turnName = activeIdx >= 0 ? playerNames[activeIdx] : '';
+    statusHTML = `<span>Turn: <span style="color: ${turnColor}; font-weight: 700;">${turnName}</span></span>`;
+  }
+  if (observation.last_move) {
+    const moverColor = lastActor === 0 ? PLAYER_X_COLOR : PLAYER_O_COLOR;
+    statusHTML += `<span class="annotation">last move: <span style="color: ${moverColor}; font-weight: 600;">${observation.last_move}</span></span>`;
+  }
+  statusHTML += `<span class="annotation">move ${observation.move_number}</span>`;
+  statusContainer.innerHTML = statusHTML;
+}

--- a/kaggle_environments/envs/open_spiel_env/games/y/visualizer/default/src/style.css
+++ b/kaggle_environments/envs/open_spiel_env/games/y/visualizer/default/src/style.css
@@ -1,0 +1,101 @@
+@import url('https://fonts.googleapis.com/css2?family=Inter:ital,opsz,wght@0,14..32,100..900;1,14..32,100..900&display=swap');
+
+html,
+body,
+#app {
+  width: 100%;
+  height: 100%;
+  margin: 0;
+  padding: 0;
+  overflow: hidden;
+}
+
+.renderer-container {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  width: 100%;
+  height: 100%;
+  min-height: 0;
+  background-color: #f5f1e2;
+  overflow: hidden;
+  font-family: 'Inter', sans-serif;
+  color: #050001;
+  container-type: inline-size;
+  box-sizing: border-box;
+  padding: 12px;
+}
+
+.sketched-border {
+  border: 1px dashed #3c3b37;
+}
+
+.header {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 16px;
+  padding: 8px 0;
+  font-size: 1.1rem;
+  font-weight: 600;
+  flex-shrink: 0;
+}
+
+.header .player {
+  padding: 4px 12px;
+  background-color: white;
+  transition: scale 300ms, background-color 300ms;
+  white-space: nowrap;
+}
+
+.header .player.active {
+  background-color: #bdeeff;
+  scale: 1.1;
+}
+
+.header .vs {
+  color: #444343;
+  font-weight: 500;
+}
+
+.board-wrap {
+  display: flex;
+  flex: 1 1 0;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  min-height: 0;
+  padding: 8px 0;
+  overflow: hidden;
+}
+
+.board-wrap canvas {
+  /* Override .viewer canvas { position: absolute; ... } from web/core. */
+  position: relative;
+  display: block;
+  max-width: 100%;
+  max-height: 100%;
+  background: transparent;
+}
+
+.status-container {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+  padding: 5px 16px;
+  background-color: white;
+  font-size: 0.9rem;
+  font-weight: 600;
+  min-height: 18px;
+  min-width: 240px;
+  margin: 8px 0 4px;
+  flex-shrink: 0;
+  text-align: center;
+}
+
+.status-container .annotation {
+  font-family: 'Mynerve', cursive;
+  font-weight: 400;
+  color: #444343;
+}

--- a/kaggle_environments/envs/open_spiel_env/games/y/visualizer/default/src/transformers/yTransformer.ts
+++ b/kaggle_environments/envs/open_spiel_env/games/y/visualizer/default/src/transformers/yTransformer.ts
@@ -1,0 +1,128 @@
+// Y replay transformer.
+//
+// Builds the per-step `players` array the side-panel UI needs. Y is a
+// sequential game: only the active player produces a real action in any
+// given step; the inactive player just submits -1.
+//
+// We surface the LLM's `thoughts` (and `generate_returns`, when present, in
+// the Go-harness shape) so the right-hand Game Log can render reasoning.
+
+interface YAction {
+  submission?: number;
+  actionString?: string | null;
+  thoughts?: string | null;
+  status?: string | null;
+  generate_returns?: string[] | null;
+}
+
+interface YObservation {
+  observationString?: string;
+  isTerminal?: boolean;
+}
+
+interface YReplayPlayer {
+  action?: YAction;
+  reward: number;
+  observation: YObservation;
+  status?: string;
+}
+
+interface YPlayer {
+  id: number;
+  name: string;
+  thumbnail: string;
+  isTurn: boolean;
+  actionDisplayText: string;
+  thoughts: string;
+  reward: number;
+  generateReturns: string[] | null;
+}
+
+export type YCell = 'x' | 'o' | null;
+
+export interface YBoardState {
+  board: YCell[][];
+  board_size: number;
+  current_player: string;
+  is_terminal: boolean;
+  winner: string | null;
+  last_move: string | null;
+  move_number: number;
+}
+
+export interface YStep {
+  step: number;
+  players: YPlayer[];
+  boardState: YBoardState | null;
+  isTerminal: boolean;
+  winner: string | null;
+}
+
+function parseThoughts(action?: YAction): string {
+  if (action?.generate_returns?.[0]) {
+    try {
+      const parsed = JSON.parse(action.generate_returns[0]);
+      if (parsed.main_response_and_thoughts) {
+        return parsed.main_response_and_thoughts;
+      }
+    } catch {
+      // fall through to action.thoughts
+    }
+  }
+  return action?.thoughts ?? '';
+}
+
+function parseBoardState(step: YReplayPlayer[]): YBoardState | null {
+  const raw = step?.[0]?.observation?.observationString ?? step?.[1]?.observation?.observationString;
+  if (!raw) return null;
+  try {
+    return JSON.parse(raw) as YBoardState;
+  } catch {
+    return null;
+  }
+}
+
+function deriveWinner(step: YReplayPlayer[]): string | null {
+  if (step.length < 2) return null;
+  const r0 = step[0].reward;
+  const r1 = step[1].reward;
+  if (r0 === r1) return 'Draw';
+  return r0 > r1 ? 'Player X wins!' : 'Player O wins!';
+}
+
+export const yTransformer = (environment: any): YStep[] => {
+  const teamNames: string[] = environment?.info?.TeamNames ?? ['Player X', 'Player O'];
+  const rawSteps: YReplayPlayer[][] = environment?.steps ?? [];
+  const out: YStep[] = [];
+
+  rawSteps.forEach((step, index) => {
+    const players: YPlayer[] = step.map((p, i): YPlayer => {
+      const submission = p.action?.submission;
+      const isTurn = submission !== undefined && submission !== -1;
+      return {
+        id: i,
+        name: teamNames[i] ?? (i === 0 ? 'Player X' : 'Player O'),
+        thumbnail: '',
+        isTurn,
+        actionDisplayText: p.action?.actionString ?? '',
+        thoughts: parseThoughts(p.action),
+        reward: p.reward ?? 0,
+        generateReturns: p.action?.generate_returns ?? null,
+      };
+    });
+
+    // Skip the env's setup step where both players submit -1.
+    if (!players.some((pl) => pl.isTurn)) return;
+
+    const isTerminal = !!step[0]?.observation?.isTerminal;
+    out.push({
+      step: index,
+      players,
+      boardState: parseBoardState(step),
+      isTerminal,
+      winner: isTerminal ? deriveWinner(step) : null,
+    });
+  });
+
+  return out;
+};

--- a/kaggle_environments/envs/open_spiel_env/games/y/visualizer/default/tsconfig.json
+++ b/kaggle_environments/envs/open_spiel_env/games/y/visualizer/default/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../../../../../../web/tsconfig.base.json",
+  "include": ["src"],
+  "compilerOptions": {
+    "allowJs": true
+  }
+}

--- a/kaggle_environments/envs/open_spiel_env/games/y/visualizer/default/vite.config.ts
+++ b/kaggle_environments/envs/open_spiel_env/games/y/visualizer/default/vite.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig, mergeConfig } from 'vite';
+import baseConfig from '../../../../../../../web/vite.config.base';
+
+export default mergeConfig(
+  baseConfig,
+  defineConfig({
+    publicDir: 'replays',
+  })
+);

--- a/kaggle_environments/envs/open_spiel_env/games/y/y_proxy.py
+++ b/kaggle_environments/envs/open_spiel_env/games/y/y_proxy.py
@@ -1,0 +1,96 @@
+"""Structured JSON observations for Y.
+
+Y is a connection game on a triangular board. Player 0 ('x') and player 1 ('o')
+take turns placing stones. A player wins by connecting all three sides of the
+triangle with a single chain of their stones. Actions are encoded as
+``row * board_size + col`` (both 0-indexed). On a board of size N, row r has
+N - r playable cells, indexed by columns 0..N-r-1.
+"""
+
+import json
+from typing import Any
+
+import pyspiel
+
+from ... import proxy
+
+
+def _player_string(player: int) -> str:
+    if player < 0:
+        return pyspiel.PlayerId(player).name.lower()
+    if player == 0:
+        return "x"
+    if player == 1:
+        return "o"
+    raise ValueError(f"Invalid player: {player}")
+
+
+def _action_to_coord(action: int, board_size: int) -> str:
+    row = action // board_size
+    col = action % board_size
+    return f"{chr(ord('a') + col)}{row + 1}"
+
+
+class YState(proxy.State):
+    """Y state proxy."""
+
+    def _board_from_history(self, board_size: int) -> list[list[str | None]]:
+        board: list[list[str | None]] = [[None] * (board_size - r) for r in range(board_size)]
+        for move_index, action in enumerate(self.history()):
+            row = action // board_size
+            col = action % board_size
+            board[row][col] = "x" if move_index % 2 == 0 else "o"
+        return board
+
+    def state_dict(self, player: int | None = None) -> dict[str, Any]:
+        del player
+        params = self.get_game().get_parameters()
+        board_size = params.get("board_size", 19)
+        history = self.history()
+        last_move = _action_to_coord(history[-1], board_size) if history else None
+        winner = None
+        if self.is_terminal():
+            returns = self.returns()
+            if returns[0] > returns[1]:
+                winner = "x"
+            elif returns[1] > returns[0]:
+                winner = "o"
+            else:
+                winner = "draw"
+        return {
+            "board": self._board_from_history(board_size),
+            "board_size": board_size,
+            "current_player": _player_string(self.current_player()),
+            "is_terminal": self.is_terminal(),
+            "winner": winner,
+            "last_move": last_move,
+            "move_number": len(history),
+        }
+
+    def to_json(self, player: int | None = None) -> str:
+        return json.dumps(self.state_dict(player))
+
+    def observation_string(self, player: int) -> str:
+        return self.to_json(player)
+
+    def __str__(self) -> str:
+        return self.to_json()
+
+
+class YGame(proxy.Game):
+    """Y game proxy."""
+
+    def __init__(self, params: Any | None = None):
+        params = params or {}
+        wrapped = pyspiel.load_game("y", params)
+        super().__init__(
+            wrapped,
+            short_name="y_proxy",
+            long_name="Y (proxy)",
+        )
+
+    def new_initial_state(self, *args) -> YState:
+        return YState(self.__wrapped__.new_initial_state(*args), game=self)
+
+
+pyspiel.register_game(YGame().get_type(), YGame)

--- a/kaggle_environments/envs/open_spiel_env/open_spiel_env.py
+++ b/kaggle_environments/envs/open_spiel_env/open_spiel_env.py
@@ -874,6 +874,7 @@ GAMES_LIST = [
     "repeated_game(stage_game=matrix_pd(),num_repetitions=100)",
     "tic_tac_toe",
     "snake",
+    "y(board_size=8)",
     DEFAULT_UNIVERSAL_POKER_GAME_STRING,
     DEFAULT_REPEATED_POKER_GAME_STRING,
     DEFAULT_REPEATED_POKERKIT_GAME_STRING,

--- a/kaggle_environments/envs/open_spiel_env/open_spiel_env.py
+++ b/kaggle_environments/envs/open_spiel_env/open_spiel_env.py
@@ -874,7 +874,7 @@ GAMES_LIST = [
     "repeated_game(stage_game=matrix_pd(),num_repetitions=100)",
     "tic_tac_toe",
     "snake",
-    "y(board_size=8)",
+    "y",
     DEFAULT_UNIVERSAL_POKER_GAME_STRING,
     DEFAULT_REPEATED_POKER_GAME_STRING,
     DEFAULT_REPEATED_POKERKIT_GAME_STRING,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -432,6 +432,22 @@ importers:
         specifier: ^5.0.0
         version: 5.4.21(@types/node@25.2.1)
 
+  kaggle_environments/envs/open_spiel_env/games/y/visualizer/default:
+    dependencies:
+      '@kaggle-environments/core':
+        specifier: workspace:*
+        version: link:../../../../../../../web/core
+    devDependencies:
+      cross-env:
+        specifier: ^10.1.0
+        version: 10.1.0
+      typescript:
+        specifier: ^5.0.0
+        version: 5.9.3
+      vite:
+        specifier: ^5.0.0
+        version: 5.4.21(@types/node@25.2.1)
+
   kaggle_environments/envs/orbit_wars/visualizer/default:
     dependencies:
       '@kaggle-environments/core':

--- a/tests/envs/open_spiel_env/test_open_spiel_env.py
+++ b/tests/envs/open_spiel_env/test_open_spiel_env.py
@@ -95,7 +95,11 @@ class OpenSpielEnvTest(absltest.TestCase):
         self.assertEqual(sorted(rewards), [-1.0, 1.0])
 
     def test_y_manual_playthrough(self):
-        env = make("open_spiel_y", debug=True)
+        env = make(
+            "open_spiel_y",
+            configuration={"openSpielGameParameters": {"board_size": 8}},
+            debug=True,
+        )
         env.reset()
         env.step([{"submission": -1}, {"submission": -1}])  # Initial setup step.
         # P0 connects the left column (a1..a8), touching all three sides.

--- a/tests/envs/open_spiel_env/test_open_spiel_env.py
+++ b/tests/envs/open_spiel_env/test_open_spiel_env.py
@@ -81,6 +81,56 @@ class OpenSpielEnvTest(absltest.TestCase):
             ],
         )
 
+    def test_y_agent_playthrough(self):
+        env = make(
+            "open_spiel_y",
+            configuration={"includeLegalActions": True},
+            debug=True,
+        )
+        env.run(["random", "random"])
+        playthrough = env.toJSON()
+        self.assertEqual(playthrough["name"], "open_spiel_y")
+        self.assertTrue(all(status == "DONE" for status in playthrough["statuses"]))
+        rewards = playthrough["rewards"]
+        self.assertEqual(sorted(rewards), [-1.0, 1.0])
+
+    def test_y_manual_playthrough(self):
+        env = make("open_spiel_y", debug=True)
+        env.reset()
+        env.step([{"submission": -1}, {"submission": -1}])  # Initial setup step.
+        # P0 connects the left column (a1..a8), touching all three sides.
+        # Action encoding: row * 8 + col, with rows/cols 0-indexed.
+        moves = [0, 1, 8, 2, 16, 3, 24, 4, 32, 5, 40, 6, 48, 7, 56]
+        for i, action in enumerate(moves):
+            if i % 2 == 0:
+                env.step([{"submission": action}, {"submission": -1}])
+            else:
+                env.step([{"submission": -1}, {"submission": action}])
+        self.assertTrue(env.done)
+        self.assertEqual(env.toJSON()["rewards"], [1, -1])
+        final_obs = json.loads(env.state[0]["observation"]["observationString"])
+        self.assertTrue(final_obs["is_terminal"])
+        self.assertEqual(final_obs["winner"], "x")
+        self.assertEqual(final_obs["board_size"], 8)
+        self.assertEqual(final_obs["last_move"], "a8")
+        self.assertEqual(final_obs["board"][0][0], "x")
+        self.assertEqual(final_obs["board"][7][0], "x")
+
+    def test_y_invalid_action(self):
+        env = make("open_spiel_y", debug=True)
+        env.reset()
+        env.step([{"submission": -1}, {"submission": -1}])  # Initial setup step.
+        env.step([{"submission": 999}, {"submission": -1}])  # Invalid action.
+        self.assertTrue(env.done)
+        playthrough = env.toJSON()
+        self.assertEqual(
+            playthrough["rewards"],
+            [
+                open_spiel_env.DEFAULT_INVALID_ACTION_REWARD,
+                -open_spiel_env.DEFAULT_INVALID_ACTION_REWARD,
+            ],
+        )
+
     def test_tic_tac_toe_agent_playthrough(self):
         env = make("open_spiel_tic_tac_toe", debug=True)
         env.run(["random", "random"])


### PR DESCRIPTION
Onboards the OpenSpiel triangular connection game "Y" as open_spiel_y(board_size=8). Adds a proxy that emits structured JSON observations (board, current_player, is_terminal, winner, last_move, move_number) and a Vite/canvas visualizer with a side-panel transformer so model thoughts surface in the Game Log.