### PR TITLE
Add Gin Rummy (OpenSpiel) game and visualizer

### DIFF
--- a/kaggle_environments/envs/open_spiel_env/games/gin_rummy/gin_rummy_proxy.py
+++ b/kaggle_environments/envs/open_spiel_env/games/gin_rummy/gin_rummy_proxy.py
@@ -1,0 +1,152 @@
+"""Structured JSON observations for Gin Rummy.
+
+OpenSpiel's default observation_string for gin_rummy is multi-line ASCII art
+with header fields, two boxed hand displays, the upcard, and the discard pile.
+This proxy parses that text into a structured JSON object that agents can
+consume directly.
+
+Cards use OpenSpiel's two-character notation: rank in {A,2-9,T,J,Q,K} followed
+by suit in {s,c,d,h}. Each player only sees their own hand; the opponent's
+hand appears as an empty list.
+"""
+
+import json
+import re
+from typing import Any
+
+import pyspiel
+
+from ... import proxy
+
+_CARD_RE = re.compile(r"[A23456789TJQK][scdh]")
+_HEADER_RE = re.compile(r"^(Knock card|Prev upcard|Repeated move|Current player|Phase): ?(.*)$")
+_STOCK_RE = re.compile(r"^Stock size: (\d+)\s+Upcard: (\S+)\s*$")
+_DISCARD_RE = re.compile(r"^Discard pile: ?(.*)$")
+_PLAYER_DEADWOOD_RE = re.compile(r"^Player(\d): Deadwood=(\d+)\s*$")
+_PLAYER_RE = re.compile(r"^Player(\d):\s*$")
+
+
+def _parse_card(token: str) -> str | None:
+    if token == "XX" or not token:
+        return None
+    return token
+
+
+def _parse_observation(text: str) -> dict[str, Any]:
+    """Parse the OpenSpiel gin_rummy observation_string into a dict."""
+    lines = text.split("\n")
+    result: dict[str, Any] = {
+        "knock_card": None,
+        "prev_upcard": None,
+        "repeated_move": 0,
+        "phase": None,
+        "stock_size": 0,
+        "upcard": None,
+        "discard_pile": [],
+        "hands": {"0": [], "1": []},
+        "deadwood": {"0": None, "1": None},
+    }
+    current_hand: int | None = None
+    for line in lines:
+        m = _HEADER_RE.match(line)
+        if m:
+            key = m.group(1).lower().replace(" ", "_")
+            value = m.group(2).strip()
+            if key == "knock_card":
+                result["knock_card"] = int(value) if value.isdigit() else (value or None)
+            elif key == "prev_upcard":
+                result["prev_upcard"] = _parse_card(value)
+            elif key == "repeated_move":
+                result["repeated_move"] = int(value)
+            elif key == "phase":
+                result["phase"] = value
+            # current_player from header is redundant with state.current_player()
+            continue
+        m = _STOCK_RE.match(line)
+        if m:
+            result["stock_size"] = int(m.group(1))
+            result["upcard"] = _parse_card(m.group(2))
+            continue
+        m = _DISCARD_RE.match(line)
+        if m:
+            result["discard_pile"] = _CARD_RE.findall(m.group(1))
+            continue
+        m = _PLAYER_DEADWOOD_RE.match(line)
+        if m:
+            current_hand = int(m.group(1))
+            result["deadwood"][str(current_hand)] = int(m.group(2))
+            continue
+        m = _PLAYER_RE.match(line)
+        if m:
+            current_hand = int(m.group(1))
+            continue
+        if current_hand is not None and line.startswith("|") and line.endswith("|"):
+            result["hands"][str(current_hand)].extend(_CARD_RE.findall(line))
+    return result
+
+
+class GinRummyState(proxy.State):
+    """Gin Rummy state proxy with structured JSON observations."""
+
+    def state_dict(self, player: int | None = None) -> dict[str, Any]:
+        # Use player 0's view as the source for shared fields; the opponent's
+        # hand is hidden in player 0's observation, and we mask the requesting
+        # player's opponent below.
+        observer = player if player is not None else 0
+        parsed = _parse_observation(self.__wrapped__.observation_string(observer))
+
+        winner: int | str | None = None
+        returns_list: list[float] = []
+        if self.is_terminal():
+            returns_list = list(self.returns())
+            if returns_list[0] > returns_list[1]:
+                winner = 0
+            elif returns_list[1] > returns_list[0]:
+                winner = 1
+            else:
+                winner = "draw"
+
+        result: dict[str, Any] = {
+            "phase": parsed["phase"],
+            "current_player": self.current_player(),
+            "is_terminal": self.is_terminal(),
+            "winner": winner,
+            "returns": returns_list,
+            "knock_card": parsed["knock_card"],
+            "prev_upcard": parsed["prev_upcard"],
+            "upcard": parsed["upcard"],
+            "stock_size": parsed["stock_size"],
+            "discard_pile": parsed["discard_pile"],
+            "hands": parsed["hands"],
+            "deadwood": parsed["deadwood"],
+            "repeated_move": parsed["repeated_move"],
+        }
+        return result
+
+    def to_json(self, player: int | None = None) -> str:
+        return json.dumps(self.state_dict(player))
+
+    def observation_string(self, player: int) -> str:
+        return self.to_json(player)
+
+    def __str__(self) -> str:
+        return self.to_json()
+
+
+class GinRummyGame(proxy.Game):
+    """Gin Rummy game proxy."""
+
+    def __init__(self, params: Any | None = None):
+        params = params or {}
+        wrapped = pyspiel.load_game("gin_rummy", params)
+        super().__init__(
+            wrapped,
+            short_name="gin_rummy_proxy",
+            long_name="Gin Rummy (proxy)",
+        )
+
+    def new_initial_state(self, *args) -> GinRummyState:
+        return GinRummyState(self.__wrapped__.new_initial_state(*args), game=self)
+
+
+pyspiel.register_game(GinRummyGame().get_type(), GinRummyGame)

--- a/kaggle_environments/envs/open_spiel_env/games/gin_rummy/visualizer/default/index.html
+++ b/kaggle_environments/envs/open_spiel_env/games/gin_rummy/visualizer/default/index.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Gin Rummy Visualizer</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=Mynerve&display=swap" rel="stylesheet" />
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="/src/main.ts"></script>
+  </body>
+</html>

--- a/kaggle_environments/envs/open_spiel_env/games/gin_rummy/visualizer/default/package.json
+++ b/kaggle_environments/envs/open_spiel_env/games/gin_rummy/visualizer/default/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@kaggle-environments/open-spiel-gin-rummy-visualizer",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "dev-with-replay": "cross-env VITE_REPLAY_FILE=./replays/test-replay.json vite",
+    "build": "tsc && vite build",
+    "preview": "vite preview"
+  },
+  "devDependencies": {
+    "cross-env": "^10.1.0",
+    "typescript": "^5.0.0",
+    "vite": "^5.0.0"
+  },
+  "dependencies": {
+    "@kaggle-environments/core": "workspace:*"
+  }
+}

--- a/kaggle_environments/envs/open_spiel_env/games/gin_rummy/visualizer/default/replays/test-replay.json
+++ b/kaggle_environments/envs/open_spiel_env/games/gin_rummy/visualizer/default/replays/test-replay.json
@@ -1,0 +1,7531 @@
+{
+  "id": "31b44558-3f90-11f1-8c54-122fb404ab4e",
+  "name": "open_spiel_gin_rummy",
+  "title": "Open Spiel: gin_rummy",
+  "description": "Kaggle environment wrapper for OpenSpiel games.\nFor game implementation details see:\nhttps://github.com/google-deepmind/open_spiel/tree/master/open_spiel/games",
+  "version": "0.1.0",
+  "module_version": "1.27.4",
+  "configuration": {
+    "includeLegalActions": true,
+    "episodeSteps": 450,
+    "actTimeout": 3600,
+    "runTimeout": 172800,
+    "openSpielGameString": "gin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)",
+    "openSpielGameName": "gin_rummy",
+    "openSpielGameParameters": {
+      "gin_bonus": 25,
+      "hand_size": 10,
+      "knock_card": 10,
+      "num_ranks": 13,
+      "num_suits": 4,
+      "oklahoma": false,
+      "undercut_bonus": 25
+    },
+    "observationType": "observation",
+    "useOpenings": false,
+    "useImage": false,
+    "loadPresetHands": false,
+    "metadata": {}
+  },
+  "specification": {
+    "action": {
+      "description": "Action object MUST contain a field `submission`, and MAY contain arbitrary additional information.",
+      "type": "object",
+      "default": {
+        "submission": -1
+      }
+    },
+    "agents": [2],
+    "configuration": {
+      "episodeSteps": {
+        "description": "Maximum number of steps in the episode.",
+        "type": "integer",
+        "minimum": 1,
+        "default": 450
+      },
+      "actTimeout": {
+        "description": "Maximum runtime (seconds) to obtain an action from an agent.",
+        "type": "number",
+        "minimum": 0,
+        "default": 3600
+      },
+      "runTimeout": {
+        "description": "Maximum runtime (seconds) of an episode (not necessarily DONE).",
+        "type": "number",
+        "minimum": 0,
+        "default": 172800
+      },
+      "openSpielGameString": {
+        "description": "The full game string including parameters.",
+        "type": "string",
+        "default": "gin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)"
+      },
+      "openSpielGameName": {
+        "description": "The short_name of the OpenSpiel game to load.",
+        "type": "string",
+        "default": "gin_rummy"
+      },
+      "openSpielGameParameters": {
+        "description": "Game parameters for Open Spiel game.",
+        "type": "object",
+        "default": {
+          "gin_bonus": 25,
+          "hand_size": 10,
+          "knock_card": 10,
+          "num_ranks": 13,
+          "num_suits": 4,
+          "oklahoma": false,
+          "undercut_bonus": 25
+        },
+        "properties": {}
+      },
+      "observationType": {
+        "description": "Type of observation string: 'observation' or 'information_state'.",
+        "type": "string",
+        "default": "observation"
+      },
+      "useOpenings": {
+        "description": "Whether to start from a position in an opening book.",
+        "type": "boolean",
+        "default": false
+      },
+      "useImage": {
+        "description": "If true, indicates the observation is intended to be rendered as an image. Note that currently the agent harness is responsible for the actual rendering; no image is passed in the observation.",
+        "type": "boolean",
+        "default": false
+      },
+      "includeLegalActions": {
+        "description": "If true, include legalActions and legalActionStrings in observations. Defaults to false since these can be derived from serializedGameAndState.",
+        "type": "boolean",
+        "default": false
+      },
+      "seed": {
+        "description": "Integer currently only used for selecting starting position.",
+        "type": "number"
+      },
+      "initialActions": {
+        "description": "Actions applied to initial state before play begins to set up starting position.",
+        "type": "array"
+      },
+      "loadPresetHands": {
+        "description": "Repeated poker only. Load preset hand chance actions from preset_hands.jsonl.",
+        "type": "boolean",
+        "default": false
+      },
+      "presetHands": {
+        "description": "Repeated poker only. List of per-hand chance action sequences to use instead of random chance.",
+        "type": "array"
+      },
+      "metadata": {
+        "description": "Arbitrary metadata.",
+        "type": "object",
+        "default": {},
+        "properties": {}
+      }
+    },
+    "info": {},
+    "observation": {
+      "remainingOverageTime": {
+        "description": "Total remaining banked time (seconds) that can be used in excess of per-step actTimeouts -- agent is disqualified with TIMEOUT status when this drops below 0.",
+        "shared": false,
+        "type": "number",
+        "minimum": 0,
+        "default": 12
+      },
+      "step": {
+        "description": "Current step within the episode.",
+        "type": "integer",
+        "shared": true,
+        "minimum": 0,
+        "default": 0
+      },
+      "properties": {
+        "openSpielGameString": {
+          "description": "Full game string including parameters.",
+          "type": "string",
+          "default": "gin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)"
+        },
+        "openSpielGameName": {
+          "description": "Short name of the OpenSpiel game.",
+          "type": "string",
+          "default": "gin_rummy"
+        },
+        "observationString": {
+          "description": "String representation of state.",
+          "type": "string"
+        },
+        "legalActions": {
+          "description": "List of OpenSpiel legal action integers. Only included if includeLegalActions is true.",
+          "type": "array"
+        },
+        "legalActionStrings": {
+          "description": "List of OpenSpiel legal action strings. Only included if includeLegalActions is true.",
+          "type": "array"
+        },
+        "currentPlayer": {
+          "description": "ID of player whose turn it is.",
+          "type": "integer"
+        },
+        "playerId": {
+          "description": "ID of the agent receiving this observation.",
+          "type": "integer"
+        },
+        "isTerminal": {
+          "description": "Boolean indicating game end.",
+          "type": "boolean"
+        },
+        "serializedGameAndState": {
+          "description": "Enables reconstructing the Game and State objects.",
+          "type": "string"
+        },
+        "remainingOverageTime": 60,
+        "step": 0
+      },
+      "default": {}
+    },
+    "reward": {
+      "type": ["number", "null"],
+      "default": 0.0
+    }
+  },
+  "steps": [
+    [
+      {
+        "action": {
+          "submission": -1
+        },
+        "reward": 0.0,
+        "info": {},
+        "observation": {
+          "remainingOverageTime": 12,
+          "step": 0
+        },
+        "status": "ACTIVE"
+      },
+      {
+        "action": {
+          "submission": -1
+        },
+        "reward": 0.0,
+        "info": {},
+        "observation": {
+          "remainingOverageTime": 12
+        },
+        "status": "ACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "submission": -1
+        },
+        "reward": null,
+        "info": {},
+        "observation": {
+          "remainingOverageTime": 12,
+          "step": 1,
+          "observationString": "{\"phase\": \"FirstUpcard\", \"current_player\": 0, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": null, \"upcard\": \"2c\", \"stock_size\": 31, \"discard_pile\": [], \"hands\": {\"0\": [\"6s\", \"8s\", \"Ac\", \"6c\", \"3d\", \"6d\", \"5h\", \"9h\", \"Jh\", \"Qh\"], \"1\": []}, \"deadwood\": {\"0\": 46, \"1\": null}, \"repeated_move\": 0}",
+          "currentPlayer": 0,
+          "playerId": 0,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14\nmove_number=21\n__dict__=gASVSQEAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRYBwEAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAoKlGJzLg==\n",
+          "legalActions": [52, 54],
+          "legalActionStrings": [
+            "Player: 0 Action: Draw upcard",
+            "Player: 0 Action: Pass"
+          ]
+        },
+        "status": "ACTIVE"
+      },
+      {
+        "action": {
+          "submission": -1
+        },
+        "reward": null,
+        "info": {},
+        "observation": {
+          "remainingOverageTime": 12,
+          "observationString": "{\"phase\": \"FirstUpcard\", \"current_player\": 0, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": null, \"upcard\": \"2c\", \"stock_size\": 31, \"discard_pile\": [], \"hands\": {\"0\": [], \"1\": [\"4s\", \"5s\", \"7s\", \"Qs\", \"9c\", \"Kc\", \"7d\", \"Kd\", \"Th\", \"Kh\"]}, \"deadwood\": {\"0\": null, \"1\": 52}, \"repeated_move\": 0}",
+          "currentPlayer": 0,
+          "playerId": 1,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14\nmove_number=21\n__dict__=gASVSQEAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRYBwEAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAoKlGJzLg==\n",
+          "legalActions": [],
+          "legalActionStrings": []
+        },
+        "status": "INACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "submission": 52,
+          "thoughts": "reflect ember ponder imagine beta lantern iota xi"
+        },
+        "reward": null,
+        "info": {
+          "actionSubmitted": 52,
+          "actionSubmittedToString": "Player: 0 Action: Draw upcard",
+          "actionApplied": 52,
+          "timeTaken": 0.0,
+          "agentSelfReportedStatus": null
+        },
+        "observation": {
+          "remainingOverageTime": 12,
+          "step": 2,
+          "observationString": "{\"phase\": \"Discard\", \"current_player\": 0, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"2c\", \"upcard\": null, \"stock_size\": 31, \"discard_pile\": [], \"hands\": {\"0\": [\"6s\", \"8s\", \"Ac\", \"2c\", \"6c\", \"3d\", \"6d\", \"5h\", \"9h\", \"Jh\", \"Qh\"], \"1\": []}, \"deadwood\": {\"0\": 38, \"1\": null}, \"repeated_move\": 0}",
+          "currentPlayer": 0,
+          "playerId": 0,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14,0:52\nmove_number=22\n__dict__=gASVTAEAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRYCgEAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAo1MgoKlGJzLg==\n",
+          "legalActions": [5, 7, 13, 14, 18, 28, 31, 43, 47, 49, 50],
+          "legalActionStrings": [
+            "Player: 0 Action: 6s",
+            "Player: 0 Action: 8s",
+            "Player: 0 Action: Ac",
+            "Player: 0 Action: 2c",
+            "Player: 0 Action: 6c",
+            "Player: 0 Action: 3d",
+            "Player: 0 Action: 6d",
+            "Player: 0 Action: 5h",
+            "Player: 0 Action: 9h",
+            "Player: 0 Action: Jh",
+            "Player: 0 Action: Qh"
+          ]
+        },
+        "status": "ACTIVE"
+      },
+      {
+        "action": {
+          "submission": -1
+        },
+        "reward": null,
+        "info": {},
+        "observation": {
+          "remainingOverageTime": 12,
+          "observationString": "{\"phase\": \"Discard\", \"current_player\": 0, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"2c\", \"upcard\": null, \"stock_size\": 31, \"discard_pile\": [], \"hands\": {\"0\": [], \"1\": [\"4s\", \"5s\", \"7s\", \"Qs\", \"9c\", \"Kc\", \"7d\", \"Kd\", \"Th\", \"Kh\"]}, \"deadwood\": {\"0\": null, \"1\": 52}, \"repeated_move\": 0}",
+          "currentPlayer": 0,
+          "playerId": 1,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14,0:52\nmove_number=22\n__dict__=gASVTAEAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRYCgEAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAo1MgoKlGJzLg==\n",
+          "legalActions": [],
+          "legalActionStrings": []
+        },
+        "status": "INACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "submission": 49,
+          "thoughts": "mu nu lantern shadow sigma delta omicron omicron"
+        },
+        "reward": null,
+        "info": {
+          "actionSubmitted": 49,
+          "actionSubmittedToString": "Player: 0 Action: Jh",
+          "actionApplied": 49,
+          "timeTaken": 0.0,
+          "agentSelfReportedStatus": null
+        },
+        "observation": {
+          "remainingOverageTime": 12,
+          "step": 3,
+          "observationString": "{\"phase\": \"Draw\", \"current_player\": 1, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"2c\", \"upcard\": \"Jh\", \"stock_size\": 31, \"discard_pile\": [], \"hands\": {\"0\": [\"6s\", \"8s\", \"Ac\", \"2c\", \"6c\", \"3d\", \"6d\", \"5h\", \"9h\", \"Qh\"], \"1\": []}, \"deadwood\": {\"0\": 38, \"1\": null}, \"repeated_move\": 0}",
+          "currentPlayer": 1,
+          "playerId": 0,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14,0:52,0:49\nmove_number=23\n__dict__=gASVTwEAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRYDQEAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAo1Mgo0OQoKlGJzLg==\n",
+          "legalActions": [],
+          "legalActionStrings": []
+        },
+        "status": "INACTIVE"
+      },
+      {
+        "action": {
+          "submission": -1
+        },
+        "reward": null,
+        "info": {},
+        "observation": {
+          "remainingOverageTime": 12,
+          "observationString": "{\"phase\": \"Draw\", \"current_player\": 1, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"2c\", \"upcard\": \"Jh\", \"stock_size\": 31, \"discard_pile\": [], \"hands\": {\"0\": [], \"1\": [\"4s\", \"5s\", \"7s\", \"Qs\", \"9c\", \"Kc\", \"7d\", \"Kd\", \"Th\", \"Kh\"]}, \"deadwood\": {\"0\": null, \"1\": 52}, \"repeated_move\": 0}",
+          "currentPlayer": 1,
+          "playerId": 1,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14,0:52,0:49\nmove_number=23\n__dict__=gASVTwEAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRYDQEAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAo1Mgo0OQoKlGJzLg==\n",
+          "legalActions": [52, 53],
+          "legalActionStrings": [
+            "Player: 1 Action: Draw upcard",
+            "Player: 1 Action: Draw stock"
+          ]
+        },
+        "status": "ACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "submission": -1
+        },
+        "reward": null,
+        "info": {},
+        "observation": {
+          "remainingOverageTime": 12,
+          "step": 4,
+          "observationString": "{\"phase\": \"Discard\", \"current_player\": 1, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"Jh\", \"upcard\": null, \"stock_size\": 31, \"discard_pile\": [], \"hands\": {\"0\": [\"6s\", \"8s\", \"Ac\", \"2c\", \"6c\", \"3d\", \"6d\", \"5h\", \"9h\", \"Qh\"], \"1\": []}, \"deadwood\": {\"0\": 38, \"1\": null}, \"repeated_move\": 0}",
+          "currentPlayer": 1,
+          "playerId": 0,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14,0:52,0:49,1:52\nmove_number=24\n__dict__=gASVUgEAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRYEAEAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAo1Mgo0OQo1MgoKlGJzLg==\n",
+          "legalActions": [],
+          "legalActionStrings": []
+        },
+        "status": "INACTIVE"
+      },
+      {
+        "action": {
+          "submission": 52,
+          "thoughts": "muse consider lambda cascade phi cascade omicron eta"
+        },
+        "reward": null,
+        "info": {
+          "actionSubmitted": 52,
+          "actionSubmittedToString": "Player: 1 Action: Draw upcard",
+          "actionApplied": 52,
+          "timeTaken": 0.0,
+          "agentSelfReportedStatus": null
+        },
+        "observation": {
+          "remainingOverageTime": 12,
+          "observationString": "{\"phase\": \"Discard\", \"current_player\": 1, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"Jh\", \"upcard\": null, \"stock_size\": 31, \"discard_pile\": [], \"hands\": {\"0\": [], \"1\": [\"4s\", \"5s\", \"7s\", \"Qs\", \"9c\", \"Kc\", \"7d\", \"Kd\", \"Th\", \"Jh\", \"Kh\"]}, \"deadwood\": {\"0\": null, \"1\": 52}, \"repeated_move\": 0}",
+          "currentPlayer": 1,
+          "playerId": 1,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14,0:52,0:49,1:52\nmove_number=24\n__dict__=gASVUgEAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRYEAEAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAo1Mgo0OQo1MgoKlGJzLg==\n",
+          "legalActions": [3, 4, 6, 11, 21, 25, 32, 38, 48, 49, 51],
+          "legalActionStrings": [
+            "Player: 1 Action: 4s",
+            "Player: 1 Action: 5s",
+            "Player: 1 Action: 7s",
+            "Player: 1 Action: Qs",
+            "Player: 1 Action: 9c",
+            "Player: 1 Action: Kc",
+            "Player: 1 Action: 7d",
+            "Player: 1 Action: Kd",
+            "Player: 1 Action: Th",
+            "Player: 1 Action: Jh",
+            "Player: 1 Action: Kh"
+          ]
+        },
+        "status": "ACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "submission": -1
+        },
+        "reward": null,
+        "info": {},
+        "observation": {
+          "remainingOverageTime": 12,
+          "step": 5,
+          "observationString": "{\"phase\": \"Draw\", \"current_player\": 0, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"Jh\", \"upcard\": \"7s\", \"stock_size\": 31, \"discard_pile\": [], \"hands\": {\"0\": [\"6s\", \"8s\", \"Ac\", \"2c\", \"6c\", \"3d\", \"6d\", \"5h\", \"9h\", \"Qh\"], \"1\": []}, \"deadwood\": {\"0\": 38, \"1\": null}, \"repeated_move\": 0}",
+          "currentPlayer": 0,
+          "playerId": 0,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14,0:52,0:49,1:52,1:6\nmove_number=25\n__dict__=gASVVAEAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRYEgEAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAo1Mgo0OQo1Mgo2CgqUYnMu\n",
+          "legalActions": [52, 53],
+          "legalActionStrings": [
+            "Player: 0 Action: Draw upcard",
+            "Player: 0 Action: Draw stock"
+          ]
+        },
+        "status": "ACTIVE"
+      },
+      {
+        "action": {
+          "submission": 6,
+          "thoughts": "theta horizon mu theta ripple rho zeta reflect"
+        },
+        "reward": null,
+        "info": {
+          "actionSubmitted": 6,
+          "actionSubmittedToString": "Player: 1 Action: 7s",
+          "actionApplied": 6,
+          "timeTaken": 0.0,
+          "agentSelfReportedStatus": null
+        },
+        "observation": {
+          "remainingOverageTime": 12,
+          "observationString": "{\"phase\": \"Draw\", \"current_player\": 0, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"Jh\", \"upcard\": \"7s\", \"stock_size\": 31, \"discard_pile\": [], \"hands\": {\"0\": [], \"1\": [\"4s\", \"5s\", \"Qs\", \"9c\", \"Kc\", \"7d\", \"Kd\", \"Th\", \"Jh\", \"Kh\"]}, \"deadwood\": {\"0\": null, \"1\": 55}, \"repeated_move\": 0}",
+          "currentPlayer": 0,
+          "playerId": 1,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14,0:52,0:49,1:52,1:6\nmove_number=25\n__dict__=gASVVAEAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRYEgEAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAo1Mgo0OQo1Mgo2CgqUYnMu\n",
+          "legalActions": [],
+          "legalActionStrings": []
+        },
+        "status": "INACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "submission": 52,
+          "thoughts": "upsilon alpha mu xi cascade lantern imagine zeta"
+        },
+        "reward": null,
+        "info": {
+          "actionSubmitted": 52,
+          "actionSubmittedToString": "Player: 0 Action: Draw upcard",
+          "actionApplied": 52,
+          "timeTaken": 0.0,
+          "agentSelfReportedStatus": null
+        },
+        "observation": {
+          "remainingOverageTime": 12,
+          "step": 6,
+          "observationString": "{\"phase\": \"Discard\", \"current_player\": 0, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"7s\", \"upcard\": null, \"stock_size\": 31, \"discard_pile\": [], \"hands\": {\"0\": [\"6s\", \"7s\", \"8s\", \"Ac\", \"2c\", \"6c\", \"3d\", \"6d\", \"5h\", \"9h\", \"Qh\"], \"1\": []}, \"deadwood\": {\"0\": 32, \"1\": null}, \"repeated_move\": 0}",
+          "currentPlayer": 0,
+          "playerId": 0,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14,0:52,0:49,1:52,1:6,0:52\nmove_number=26\n__dict__=gASVVwEAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRYFQEAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAo1Mgo0OQo1Mgo2CjUyCgqUYnMu\n",
+          "legalActions": [5, 6, 7, 13, 14, 18, 28, 31, 43, 47, 50],
+          "legalActionStrings": [
+            "Player: 0 Action: 6s",
+            "Player: 0 Action: 7s",
+            "Player: 0 Action: 8s",
+            "Player: 0 Action: Ac",
+            "Player: 0 Action: 2c",
+            "Player: 0 Action: 6c",
+            "Player: 0 Action: 3d",
+            "Player: 0 Action: 6d",
+            "Player: 0 Action: 5h",
+            "Player: 0 Action: 9h",
+            "Player: 0 Action: Qh"
+          ]
+        },
+        "status": "ACTIVE"
+      },
+      {
+        "action": {
+          "submission": -1
+        },
+        "reward": null,
+        "info": {},
+        "observation": {
+          "remainingOverageTime": 12,
+          "observationString": "{\"phase\": \"Discard\", \"current_player\": 0, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"7s\", \"upcard\": null, \"stock_size\": 31, \"discard_pile\": [], \"hands\": {\"0\": [], \"1\": [\"4s\", \"5s\", \"Qs\", \"9c\", \"Kc\", \"7d\", \"Kd\", \"Th\", \"Jh\", \"Kh\"]}, \"deadwood\": {\"0\": null, \"1\": 55}, \"repeated_move\": 0}",
+          "currentPlayer": 0,
+          "playerId": 1,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14,0:52,0:49,1:52,1:6,0:52\nmove_number=26\n__dict__=gASVVwEAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRYFQEAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAo1Mgo0OQo1Mgo2CjUyCgqUYnMu\n",
+          "legalActions": [],
+          "legalActionStrings": []
+        },
+        "status": "INACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "submission": 14,
+          "thoughts": "alpha explore omega mu kappa consider wonder spark"
+        },
+        "reward": null,
+        "info": {
+          "actionSubmitted": 14,
+          "actionSubmittedToString": "Player: 0 Action: 2c",
+          "actionApplied": 14,
+          "timeTaken": 0.0,
+          "agentSelfReportedStatus": null
+        },
+        "observation": {
+          "remainingOverageTime": 12,
+          "step": 7,
+          "observationString": "{\"phase\": \"Draw\", \"current_player\": 1, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"7s\", \"upcard\": \"2c\", \"stock_size\": 31, \"discard_pile\": [], \"hands\": {\"0\": [\"6s\", \"7s\", \"8s\", \"Ac\", \"6c\", \"3d\", \"6d\", \"5h\", \"9h\", \"Qh\"], \"1\": []}, \"deadwood\": {\"0\": 40, \"1\": null}, \"repeated_move\": 0}",
+          "currentPlayer": 1,
+          "playerId": 0,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14,0:52,0:49,1:52,1:6,0:52,0:14\nmove_number=27\n__dict__=gASVWgEAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRYGAEAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAo1Mgo0OQo1Mgo2CjUyCjE0CgqUYnMu\n",
+          "legalActions": [],
+          "legalActionStrings": []
+        },
+        "status": "INACTIVE"
+      },
+      {
+        "action": {
+          "submission": -1
+        },
+        "reward": null,
+        "info": {},
+        "observation": {
+          "remainingOverageTime": 12,
+          "observationString": "{\"phase\": \"Draw\", \"current_player\": 1, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"7s\", \"upcard\": \"2c\", \"stock_size\": 31, \"discard_pile\": [], \"hands\": {\"0\": [], \"1\": [\"4s\", \"5s\", \"Qs\", \"9c\", \"Kc\", \"7d\", \"Kd\", \"Th\", \"Jh\", \"Kh\"]}, \"deadwood\": {\"0\": null, \"1\": 55}, \"repeated_move\": 0}",
+          "currentPlayer": 1,
+          "playerId": 1,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14,0:52,0:49,1:52,1:6,0:52,0:14\nmove_number=27\n__dict__=gASVWgEAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRYGAEAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAo1Mgo0OQo1Mgo2CjUyCjE0CgqUYnMu\n",
+          "legalActions": [52, 53],
+          "legalActionStrings": [
+            "Player: 1 Action: Draw upcard",
+            "Player: 1 Action: Draw stock"
+          ]
+        },
+        "status": "ACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "submission": -1
+        },
+        "reward": null,
+        "info": {},
+        "observation": {
+          "remainingOverageTime": 12,
+          "step": 8,
+          "observationString": "{\"phase\": \"Discard\", \"current_player\": 1, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"2c\", \"upcard\": null, \"stock_size\": 31, \"discard_pile\": [], \"hands\": {\"0\": [\"6s\", \"7s\", \"8s\", \"Ac\", \"6c\", \"3d\", \"6d\", \"5h\", \"9h\", \"Qh\"], \"1\": []}, \"deadwood\": {\"0\": 40, \"1\": null}, \"repeated_move\": 0}",
+          "currentPlayer": 1,
+          "playerId": 0,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14,0:52,0:49,1:52,1:6,0:52,0:14,1:52\nmove_number=28\n__dict__=gASVXQEAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRYGwEAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAo1Mgo0OQo1Mgo2CjUyCjE0CjUyCgqUYnMu\n",
+          "legalActions": [],
+          "legalActionStrings": []
+        },
+        "status": "INACTIVE"
+      },
+      {
+        "action": {
+          "submission": 52,
+          "thoughts": "iota chi iota phi xi shadow lambda alpha"
+        },
+        "reward": null,
+        "info": {
+          "actionSubmitted": 52,
+          "actionSubmittedToString": "Player: 1 Action: Draw upcard",
+          "actionApplied": 52,
+          "timeTaken": 0.0,
+          "agentSelfReportedStatus": null
+        },
+        "observation": {
+          "remainingOverageTime": 12,
+          "observationString": "{\"phase\": \"Discard\", \"current_player\": 1, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"2c\", \"upcard\": null, \"stock_size\": 31, \"discard_pile\": [], \"hands\": {\"0\": [], \"1\": [\"4s\", \"5s\", \"Qs\", \"2c\", \"9c\", \"Kc\", \"7d\", \"Kd\", \"Th\", \"Jh\", \"Kh\"]}, \"deadwood\": {\"0\": null, \"1\": 47}, \"repeated_move\": 0}",
+          "currentPlayer": 1,
+          "playerId": 1,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14,0:52,0:49,1:52,1:6,0:52,0:14,1:52\nmove_number=28\n__dict__=gASVXQEAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRYGwEAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAo1Mgo0OQo1Mgo2CjUyCjE0CjUyCgqUYnMu\n",
+          "legalActions": [3, 4, 11, 14, 21, 25, 32, 38, 48, 49, 51],
+          "legalActionStrings": [
+            "Player: 1 Action: 4s",
+            "Player: 1 Action: 5s",
+            "Player: 1 Action: Qs",
+            "Player: 1 Action: 2c",
+            "Player: 1 Action: 9c",
+            "Player: 1 Action: Kc",
+            "Player: 1 Action: 7d",
+            "Player: 1 Action: Kd",
+            "Player: 1 Action: Th",
+            "Player: 1 Action: Jh",
+            "Player: 1 Action: Kh"
+          ]
+        },
+        "status": "ACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "submission": -1
+        },
+        "reward": null,
+        "info": {},
+        "observation": {
+          "remainingOverageTime": 12,
+          "step": 9,
+          "observationString": "{\"phase\": \"Draw\", \"current_player\": 0, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"2c\", \"upcard\": \"7d\", \"stock_size\": 31, \"discard_pile\": [], \"hands\": {\"0\": [\"6s\", \"7s\", \"8s\", \"Ac\", \"6c\", \"3d\", \"6d\", \"5h\", \"9h\", \"Qh\"], \"1\": []}, \"deadwood\": {\"0\": 40, \"1\": null}, \"repeated_move\": 0}",
+          "currentPlayer": 0,
+          "playerId": 0,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14,0:52,0:49,1:52,1:6,0:52,0:14,1:52,1:32\nmove_number=29\n__dict__=gASVYAEAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRYHgEAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAo1Mgo0OQo1Mgo2CjUyCjE0CjUyCjMyCgqUYnMu\n",
+          "legalActions": [52, 53],
+          "legalActionStrings": [
+            "Player: 0 Action: Draw upcard",
+            "Player: 0 Action: Draw stock"
+          ]
+        },
+        "status": "ACTIVE"
+      },
+      {
+        "action": {
+          "submission": 32,
+          "thoughts": "lantern explore upsilon wonder lambda alpha omega rho"
+        },
+        "reward": null,
+        "info": {
+          "actionSubmitted": 32,
+          "actionSubmittedToString": "Player: 1 Action: 7d",
+          "actionApplied": 32,
+          "timeTaken": 0.0,
+          "agentSelfReportedStatus": null
+        },
+        "observation": {
+          "remainingOverageTime": 12,
+          "observationString": "{\"phase\": \"Draw\", \"current_player\": 0, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"2c\", \"upcard\": \"7d\", \"stock_size\": 31, \"discard_pile\": [], \"hands\": {\"0\": [], \"1\": [\"4s\", \"5s\", \"Qs\", \"2c\", \"9c\", \"Kc\", \"Kd\", \"Th\", \"Jh\", \"Kh\"]}, \"deadwood\": {\"0\": null, \"1\": 50}, \"repeated_move\": 0}",
+          "currentPlayer": 0,
+          "playerId": 1,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14,0:52,0:49,1:52,1:6,0:52,0:14,1:52,1:32\nmove_number=29\n__dict__=gASVYAEAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRYHgEAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAo1Mgo0OQo1Mgo2CjUyCjE0CjUyCjMyCgqUYnMu\n",
+          "legalActions": [],
+          "legalActionStrings": []
+        },
+        "status": "INACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "submission": 52,
+          "thoughts": "alpha eta muse phi xi ripple ripple ripple"
+        },
+        "reward": null,
+        "info": {
+          "actionSubmitted": 52,
+          "actionSubmittedToString": "Player: 0 Action: Draw upcard",
+          "actionApplied": 52,
+          "timeTaken": 0.0,
+          "agentSelfReportedStatus": null
+        },
+        "observation": {
+          "remainingOverageTime": 12,
+          "step": 10,
+          "observationString": "{\"phase\": \"Discard\", \"current_player\": 0, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"7d\", \"upcard\": null, \"stock_size\": 31, \"discard_pile\": [], \"hands\": {\"0\": [\"6s\", \"7s\", \"8s\", \"Ac\", \"6c\", \"3d\", \"6d\", \"7d\", \"5h\", \"9h\", \"Qh\"], \"1\": []}, \"deadwood\": {\"0\": 37, \"1\": null}, \"repeated_move\": 0}",
+          "currentPlayer": 0,
+          "playerId": 0,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14,0:52,0:49,1:52,1:6,0:52,0:14,1:52,1:32,0:52\nmove_number=30\n__dict__=gASVYwEAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRYIQEAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAo1Mgo0OQo1Mgo2CjUyCjE0CjUyCjMyCjUyCgqUYnMu\n",
+          "legalActions": [5, 6, 7, 13, 18, 28, 31, 32, 43, 47, 50],
+          "legalActionStrings": [
+            "Player: 0 Action: 6s",
+            "Player: 0 Action: 7s",
+            "Player: 0 Action: 8s",
+            "Player: 0 Action: Ac",
+            "Player: 0 Action: 6c",
+            "Player: 0 Action: 3d",
+            "Player: 0 Action: 6d",
+            "Player: 0 Action: 7d",
+            "Player: 0 Action: 5h",
+            "Player: 0 Action: 9h",
+            "Player: 0 Action: Qh"
+          ]
+        },
+        "status": "ACTIVE"
+      },
+      {
+        "action": {
+          "submission": -1
+        },
+        "reward": null,
+        "info": {},
+        "observation": {
+          "remainingOverageTime": 12,
+          "observationString": "{\"phase\": \"Discard\", \"current_player\": 0, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"7d\", \"upcard\": null, \"stock_size\": 31, \"discard_pile\": [], \"hands\": {\"0\": [], \"1\": [\"4s\", \"5s\", \"Qs\", \"2c\", \"9c\", \"Kc\", \"Kd\", \"Th\", \"Jh\", \"Kh\"]}, \"deadwood\": {\"0\": null, \"1\": 50}, \"repeated_move\": 0}",
+          "currentPlayer": 0,
+          "playerId": 1,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14,0:52,0:49,1:52,1:6,0:52,0:14,1:52,1:32,0:52\nmove_number=30\n__dict__=gASVYwEAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRYIQEAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAo1Mgo0OQo1Mgo2CjUyCjE0CjUyCjMyCjUyCgqUYnMu\n",
+          "legalActions": [],
+          "legalActionStrings": []
+        },
+        "status": "INACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "submission": 47,
+          "thoughts": "iota rho omega cascade horizon ponder spark ember"
+        },
+        "reward": null,
+        "info": {
+          "actionSubmitted": 47,
+          "actionSubmittedToString": "Player: 0 Action: 9h",
+          "actionApplied": 47,
+          "timeTaken": 0.0,
+          "agentSelfReportedStatus": null
+        },
+        "observation": {
+          "remainingOverageTime": 12,
+          "step": 11,
+          "observationString": "{\"phase\": \"Draw\", \"current_player\": 1, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"7d\", \"upcard\": \"9h\", \"stock_size\": 31, \"discard_pile\": [], \"hands\": {\"0\": [\"6s\", \"7s\", \"8s\", \"Ac\", \"6c\", \"3d\", \"6d\", \"7d\", \"5h\", \"Qh\"], \"1\": []}, \"deadwood\": {\"0\": 38, \"1\": null}, \"repeated_move\": 0}",
+          "currentPlayer": 1,
+          "playerId": 0,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14,0:52,0:49,1:52,1:6,0:52,0:14,1:52,1:32,0:52,0:47\nmove_number=31\n__dict__=gASVZgEAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRYJAEAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAo1Mgo0OQo1Mgo2CjUyCjE0CjUyCjMyCjUyCjQ3CgqUYnMu\n",
+          "legalActions": [],
+          "legalActionStrings": []
+        },
+        "status": "INACTIVE"
+      },
+      {
+        "action": {
+          "submission": -1
+        },
+        "reward": null,
+        "info": {},
+        "observation": {
+          "remainingOverageTime": 12,
+          "observationString": "{\"phase\": \"Draw\", \"current_player\": 1, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"7d\", \"upcard\": \"9h\", \"stock_size\": 31, \"discard_pile\": [], \"hands\": {\"0\": [], \"1\": [\"4s\", \"5s\", \"Qs\", \"2c\", \"9c\", \"Kc\", \"Kd\", \"Th\", \"Jh\", \"Kh\"]}, \"deadwood\": {\"0\": null, \"1\": 50}, \"repeated_move\": 0}",
+          "currentPlayer": 1,
+          "playerId": 1,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14,0:52,0:49,1:52,1:6,0:52,0:14,1:52,1:32,0:52,0:47\nmove_number=31\n__dict__=gASVZgEAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRYJAEAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAo1Mgo0OQo1Mgo2CjUyCjE0CjUyCjMyCjUyCjQ3CgqUYnMu\n",
+          "legalActions": [52, 53],
+          "legalActionStrings": [
+            "Player: 1 Action: Draw upcard",
+            "Player: 1 Action: Draw stock"
+          ]
+        },
+        "status": "ACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "submission": -1
+        },
+        "reward": null,
+        "info": {},
+        "observation": {
+          "remainingOverageTime": 12,
+          "step": 12,
+          "observationString": "{\"phase\": \"Discard\", \"current_player\": 1, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"9h\", \"upcard\": null, \"stock_size\": 31, \"discard_pile\": [], \"hands\": {\"0\": [\"6s\", \"7s\", \"8s\", \"Ac\", \"6c\", \"3d\", \"6d\", \"7d\", \"5h\", \"Qh\"], \"1\": []}, \"deadwood\": {\"0\": 38, \"1\": null}, \"repeated_move\": 0}",
+          "currentPlayer": 1,
+          "playerId": 0,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14,0:52,0:49,1:52,1:6,0:52,0:14,1:52,1:32,0:52,0:47,1:52\nmove_number=32\n__dict__=gASVaQEAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRYJwEAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAo1Mgo0OQo1Mgo2CjUyCjE0CjUyCjMyCjUyCjQ3CjUyCgqUYnMu\n",
+          "legalActions": [],
+          "legalActionStrings": []
+        },
+        "status": "INACTIVE"
+      },
+      {
+        "action": {
+          "submission": 52,
+          "thoughts": "upsilon alpha cascade cascade muse lantern imagine lantern"
+        },
+        "reward": null,
+        "info": {
+          "actionSubmitted": 52,
+          "actionSubmittedToString": "Player: 1 Action: Draw upcard",
+          "actionApplied": 52,
+          "timeTaken": 0.0,
+          "agentSelfReportedStatus": null
+        },
+        "observation": {
+          "remainingOverageTime": 12,
+          "observationString": "{\"phase\": \"Discard\", \"current_player\": 1, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"9h\", \"upcard\": null, \"stock_size\": 31, \"discard_pile\": [], \"hands\": {\"0\": [], \"1\": [\"4s\", \"5s\", \"Qs\", \"2c\", \"9c\", \"Kc\", \"Kd\", \"9h\", \"Th\", \"Jh\", \"Kh\"]}, \"deadwood\": {\"0\": null, \"1\": 20}, \"repeated_move\": 0}",
+          "currentPlayer": 1,
+          "playerId": 1,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14,0:52,0:49,1:52,1:6,0:52,0:14,1:52,1:32,0:52,0:47,1:52\nmove_number=32\n__dict__=gASVaQEAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRYJwEAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAo1Mgo0OQo1Mgo2CjUyCjE0CjUyCjMyCjUyCjQ3CjUyCgqUYnMu\n",
+          "legalActions": [3, 4, 11, 14, 21, 25, 38, 47, 48, 49, 51],
+          "legalActionStrings": [
+            "Player: 1 Action: 4s",
+            "Player: 1 Action: 5s",
+            "Player: 1 Action: Qs",
+            "Player: 1 Action: 2c",
+            "Player: 1 Action: 9c",
+            "Player: 1 Action: Kc",
+            "Player: 1 Action: Kd",
+            "Player: 1 Action: 9h",
+            "Player: 1 Action: Th",
+            "Player: 1 Action: Jh",
+            "Player: 1 Action: Kh"
+          ]
+        },
+        "status": "ACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "submission": -1
+        },
+        "reward": null,
+        "info": {},
+        "observation": {
+          "remainingOverageTime": 12,
+          "step": 13,
+          "observationString": "{\"phase\": \"Draw\", \"current_player\": 0, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"9h\", \"upcard\": \"Th\", \"stock_size\": 31, \"discard_pile\": [], \"hands\": {\"0\": [\"6s\", \"7s\", \"8s\", \"Ac\", \"6c\", \"3d\", \"6d\", \"7d\", \"5h\", \"Qh\"], \"1\": []}, \"deadwood\": {\"0\": 38, \"1\": null}, \"repeated_move\": 0}",
+          "currentPlayer": 0,
+          "playerId": 0,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14,0:52,0:49,1:52,1:6,0:52,0:14,1:52,1:32,0:52,0:47,1:52,1:48\nmove_number=33\n__dict__=gASVbAEAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRYKgEAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAo1Mgo0OQo1Mgo2CjUyCjE0CjUyCjMyCjUyCjQ3CjUyCjQ4CgqUYnMu\n",
+          "legalActions": [52, 53],
+          "legalActionStrings": [
+            "Player: 0 Action: Draw upcard",
+            "Player: 0 Action: Draw stock"
+          ]
+        },
+        "status": "ACTIVE"
+      },
+      {
+        "action": {
+          "submission": 48,
+          "thoughts": "echo shadow cascade psi eta xi omicron zeta"
+        },
+        "reward": null,
+        "info": {
+          "actionSubmitted": 48,
+          "actionSubmittedToString": "Player: 1 Action: Th",
+          "actionApplied": 48,
+          "timeTaken": 0.0,
+          "agentSelfReportedStatus": null
+        },
+        "observation": {
+          "remainingOverageTime": 12,
+          "observationString": "{\"phase\": \"Draw\", \"current_player\": 0, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"9h\", \"upcard\": \"Th\", \"stock_size\": 31, \"discard_pile\": [], \"hands\": {\"0\": [], \"1\": [\"4s\", \"5s\", \"Qs\", \"2c\", \"9c\", \"Kc\", \"Kd\", \"9h\", \"Jh\", \"Kh\"]}, \"deadwood\": {\"0\": null, \"1\": 49}, \"repeated_move\": 0}",
+          "currentPlayer": 0,
+          "playerId": 1,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14,0:52,0:49,1:52,1:6,0:52,0:14,1:52,1:32,0:52,0:47,1:52,1:48\nmove_number=33\n__dict__=gASVbAEAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRYKgEAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAo1Mgo0OQo1Mgo2CjUyCjE0CjUyCjMyCjUyCjQ3CjUyCjQ4CgqUYnMu\n",
+          "legalActions": [],
+          "legalActionStrings": []
+        },
+        "status": "INACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "submission": 52,
+          "thoughts": "consider phi sigma rho horizon nu ripple nu"
+        },
+        "reward": null,
+        "info": {
+          "actionSubmitted": 52,
+          "actionSubmittedToString": "Player: 0 Action: Draw upcard",
+          "actionApplied": 52,
+          "timeTaken": 0.0,
+          "agentSelfReportedStatus": null
+        },
+        "observation": {
+          "remainingOverageTime": 12,
+          "step": 14,
+          "observationString": "{\"phase\": \"Discard\", \"current_player\": 0, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"Th\", \"upcard\": null, \"stock_size\": 31, \"discard_pile\": [], \"hands\": {\"0\": [\"6s\", \"7s\", \"8s\", \"Ac\", \"6c\", \"3d\", \"6d\", \"7d\", \"5h\", \"Th\", \"Qh\"], \"1\": []}, \"deadwood\": {\"0\": 38, \"1\": null}, \"repeated_move\": 0}",
+          "currentPlayer": 0,
+          "playerId": 0,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14,0:52,0:49,1:52,1:6,0:52,0:14,1:52,1:32,0:52,0:47,1:52,1:48,0:52\nmove_number=34\n__dict__=gASVbwEAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRYLQEAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAo1Mgo0OQo1Mgo2CjUyCjE0CjUyCjMyCjUyCjQ3CjUyCjQ4CjUyCgqUYnMu\n",
+          "legalActions": [5, 6, 7, 13, 18, 28, 31, 32, 43, 48, 50],
+          "legalActionStrings": [
+            "Player: 0 Action: 6s",
+            "Player: 0 Action: 7s",
+            "Player: 0 Action: 8s",
+            "Player: 0 Action: Ac",
+            "Player: 0 Action: 6c",
+            "Player: 0 Action: 3d",
+            "Player: 0 Action: 6d",
+            "Player: 0 Action: 7d",
+            "Player: 0 Action: 5h",
+            "Player: 0 Action: Th",
+            "Player: 0 Action: Qh"
+          ]
+        },
+        "status": "ACTIVE"
+      },
+      {
+        "action": {
+          "submission": -1
+        },
+        "reward": null,
+        "info": {},
+        "observation": {
+          "remainingOverageTime": 12,
+          "observationString": "{\"phase\": \"Discard\", \"current_player\": 0, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"Th\", \"upcard\": null, \"stock_size\": 31, \"discard_pile\": [], \"hands\": {\"0\": [], \"1\": [\"4s\", \"5s\", \"Qs\", \"2c\", \"9c\", \"Kc\", \"Kd\", \"9h\", \"Jh\", \"Kh\"]}, \"deadwood\": {\"0\": null, \"1\": 49}, \"repeated_move\": 0}",
+          "currentPlayer": 0,
+          "playerId": 1,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14,0:52,0:49,1:52,1:6,0:52,0:14,1:52,1:32,0:52,0:47,1:52,1:48,0:52\nmove_number=34\n__dict__=gASVbwEAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRYLQEAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAo1Mgo0OQo1Mgo2CjUyCjE0CjUyCjMyCjUyCjQ3CjUyCjQ4CjUyCgqUYnMu\n",
+          "legalActions": [],
+          "legalActionStrings": []
+        },
+        "status": "INACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "submission": 13,
+          "thoughts": "psi rho muse imagine ripple gamma muse horizon"
+        },
+        "reward": null,
+        "info": {
+          "actionSubmitted": 13,
+          "actionSubmittedToString": "Player: 0 Action: Ac",
+          "actionApplied": 13,
+          "timeTaken": 0.0,
+          "agentSelfReportedStatus": null
+        },
+        "observation": {
+          "remainingOverageTime": 12,
+          "step": 15,
+          "observationString": "{\"phase\": \"Draw\", \"current_player\": 1, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"Th\", \"upcard\": \"Ac\", \"stock_size\": 31, \"discard_pile\": [], \"hands\": {\"0\": [\"6s\", \"7s\", \"8s\", \"6c\", \"3d\", \"6d\", \"7d\", \"5h\", \"Th\", \"Qh\"], \"1\": []}, \"deadwood\": {\"0\": 47, \"1\": null}, \"repeated_move\": 0}",
+          "currentPlayer": 1,
+          "playerId": 0,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14,0:52,0:49,1:52,1:6,0:52,0:14,1:52,1:32,0:52,0:47,1:52,1:48,0:52,0:13\nmove_number=35\n__dict__=gASVcgEAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRYMAEAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAo1Mgo0OQo1Mgo2CjUyCjE0CjUyCjMyCjUyCjQ3CjUyCjQ4CjUyCjEzCgqUYnMu\n",
+          "legalActions": [],
+          "legalActionStrings": []
+        },
+        "status": "INACTIVE"
+      },
+      {
+        "action": {
+          "submission": -1
+        },
+        "reward": null,
+        "info": {},
+        "observation": {
+          "remainingOverageTime": 12,
+          "observationString": "{\"phase\": \"Draw\", \"current_player\": 1, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"Th\", \"upcard\": \"Ac\", \"stock_size\": 31, \"discard_pile\": [], \"hands\": {\"0\": [], \"1\": [\"4s\", \"5s\", \"Qs\", \"2c\", \"9c\", \"Kc\", \"Kd\", \"9h\", \"Jh\", \"Kh\"]}, \"deadwood\": {\"0\": null, \"1\": 49}, \"repeated_move\": 0}",
+          "currentPlayer": 1,
+          "playerId": 1,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14,0:52,0:49,1:52,1:6,0:52,0:14,1:52,1:32,0:52,0:47,1:52,1:48,0:52,0:13\nmove_number=35\n__dict__=gASVcgEAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRYMAEAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAo1Mgo0OQo1Mgo2CjUyCjE0CjUyCjMyCjUyCjQ3CjUyCjQ4CjUyCjEzCgqUYnMu\n",
+          "legalActions": [52, 53],
+          "legalActionStrings": [
+            "Player: 1 Action: Draw upcard",
+            "Player: 1 Action: Draw stock"
+          ]
+        },
+        "status": "ACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "submission": -1
+        },
+        "reward": null,
+        "info": {},
+        "observation": {
+          "remainingOverageTime": 12,
+          "step": 16,
+          "observationString": "{\"phase\": \"Discard\", \"current_player\": 1, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"Ac\", \"upcard\": null, \"stock_size\": 30, \"discard_pile\": [\"Ac\"], \"hands\": {\"0\": [\"6s\", \"7s\", \"8s\", \"6c\", \"3d\", \"6d\", \"7d\", \"5h\", \"Th\", \"Qh\"], \"1\": []}, \"deadwood\": {\"0\": 47, \"1\": null}, \"repeated_move\": 0}",
+          "currentPlayer": 1,
+          "playerId": 0,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14,0:52,0:49,1:52,1:6,0:52,0:14,1:52,1:32,0:52,0:47,1:52,1:48,0:52,0:13,1:53,-1:19\nmove_number=37\n__dict__=gASVeAEAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRYNgEAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAo1Mgo0OQo1Mgo2CjUyCjE0CjUyCjMyCjUyCjQ3CjUyCjQ4CjUyCjEzCjUzCjE5CgqUYnMu\n",
+          "legalActions": [],
+          "legalActionStrings": []
+        },
+        "status": "INACTIVE"
+      },
+      {
+        "action": {
+          "submission": 53,
+          "thoughts": "zeta delta omega epsilon xi ember ponder eta"
+        },
+        "reward": null,
+        "info": {
+          "actionSubmitted": 53,
+          "actionSubmittedToString": "Player: 1 Action: Draw stock",
+          "actionApplied": 53,
+          "timeTaken": 0.0,
+          "agentSelfReportedStatus": null
+        },
+        "observation": {
+          "remainingOverageTime": 12,
+          "observationString": "{\"phase\": \"Discard\", \"current_player\": 1, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"Ac\", \"upcard\": null, \"stock_size\": 30, \"discard_pile\": [\"Ac\"], \"hands\": {\"0\": [], \"1\": [\"4s\", \"5s\", \"Qs\", \"2c\", \"7c\", \"9c\", \"Kc\", \"Kd\", \"9h\", \"Jh\", \"Kh\"]}, \"deadwood\": {\"0\": null, \"1\": 46}, \"repeated_move\": 0}",
+          "currentPlayer": 1,
+          "playerId": 1,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14,0:52,0:49,1:52,1:6,0:52,0:14,1:52,1:32,0:52,0:47,1:52,1:48,0:52,0:13,1:53,-1:19\nmove_number=37\n__dict__=gASVeAEAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRYNgEAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAo1Mgo0OQo1Mgo2CjUyCjE0CjUyCjMyCjUyCjQ3CjUyCjQ4CjUyCjEzCjUzCjE5CgqUYnMu\n",
+          "legalActions": [3, 4, 11, 14, 19, 21, 25, 38, 47, 49, 51],
+          "legalActionStrings": [
+            "Player: 1 Action: 4s",
+            "Player: 1 Action: 5s",
+            "Player: 1 Action: Qs",
+            "Player: 1 Action: 2c",
+            "Player: 1 Action: 7c",
+            "Player: 1 Action: 9c",
+            "Player: 1 Action: Kc",
+            "Player: 1 Action: Kd",
+            "Player: 1 Action: 9h",
+            "Player: 1 Action: Jh",
+            "Player: 1 Action: Kh"
+          ]
+        },
+        "status": "ACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "submission": -1
+        },
+        "reward": null,
+        "info": {},
+        "observation": {
+          "remainingOverageTime": 12,
+          "step": 17,
+          "observationString": "{\"phase\": \"Draw\", \"current_player\": 0, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"Ac\", \"upcard\": \"4s\", \"stock_size\": 30, \"discard_pile\": [\"Ac\"], \"hands\": {\"0\": [\"6s\", \"7s\", \"8s\", \"6c\", \"3d\", \"6d\", \"7d\", \"5h\", \"Th\", \"Qh\"], \"1\": []}, \"deadwood\": {\"0\": 47, \"1\": null}, \"repeated_move\": 0}",
+          "currentPlayer": 0,
+          "playerId": 0,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14,0:52,0:49,1:52,1:6,0:52,0:14,1:52,1:32,0:52,0:47,1:52,1:48,0:52,0:13,1:53,-1:19,1:3\nmove_number=38\n__dict__=gASVegEAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRYOAEAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAo1Mgo0OQo1Mgo2CjUyCjE0CjUyCjMyCjUyCjQ3CjUyCjQ4CjUyCjEzCjUzCjE5CjMKCpRicy4=\n",
+          "legalActions": [52, 53],
+          "legalActionStrings": [
+            "Player: 0 Action: Draw upcard",
+            "Player: 0 Action: Draw stock"
+          ]
+        },
+        "status": "ACTIVE"
+      },
+      {
+        "action": {
+          "submission": 3,
+          "thoughts": "sigma phi beta consider explore rho imagine alpha"
+        },
+        "reward": null,
+        "info": {
+          "actionSubmitted": 3,
+          "actionSubmittedToString": "Player: 1 Action: 4s",
+          "actionApplied": 3,
+          "timeTaken": 0.0,
+          "agentSelfReportedStatus": null
+        },
+        "observation": {
+          "remainingOverageTime": 12,
+          "observationString": "{\"phase\": \"Draw\", \"current_player\": 0, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"Ac\", \"upcard\": \"4s\", \"stock_size\": 30, \"discard_pile\": [\"Ac\"], \"hands\": {\"0\": [], \"1\": [\"5s\", \"Qs\", \"2c\", \"7c\", \"9c\", \"Kc\", \"Kd\", \"9h\", \"Jh\", \"Kh\"]}, \"deadwood\": {\"0\": null, \"1\": 52}, \"repeated_move\": 0}",
+          "currentPlayer": 0,
+          "playerId": 1,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14,0:52,0:49,1:52,1:6,0:52,0:14,1:52,1:32,0:52,0:47,1:52,1:48,0:52,0:13,1:53,-1:19,1:3\nmove_number=38\n__dict__=gASVegEAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRYOAEAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAo1Mgo0OQo1Mgo2CjUyCjE0CjUyCjMyCjUyCjQ3CjUyCjQ4CjUyCjEzCjUzCjE5CjMKCpRicy4=\n",
+          "legalActions": [],
+          "legalActionStrings": []
+        },
+        "status": "INACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "submission": 53,
+          "thoughts": "mu epsilon explore iota rho spark spark delta"
+        },
+        "reward": null,
+        "info": {
+          "actionSubmitted": 53,
+          "actionSubmittedToString": "Player: 0 Action: Draw stock",
+          "actionApplied": 53,
+          "timeTaken": 0.0,
+          "agentSelfReportedStatus": null
+        },
+        "observation": {
+          "remainingOverageTime": 12,
+          "step": 18,
+          "observationString": "{\"phase\": \"Discard\", \"current_player\": 0, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"4s\", \"upcard\": null, \"stock_size\": 29, \"discard_pile\": [\"Ac\", \"4s\"], \"hands\": {\"0\": [\"6s\", \"7s\", \"8s\", \"6c\", \"3d\", \"6d\", \"7d\", \"9d\", \"5h\", \"Th\", \"Qh\"], \"1\": []}, \"deadwood\": {\"0\": 46, \"1\": null}, \"repeated_move\": 0}",
+          "currentPlayer": 0,
+          "playerId": 0,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14,0:52,0:49,1:52,1:6,0:52,0:14,1:52,1:32,0:52,0:47,1:52,1:48,0:52,0:13,1:53,-1:19,1:3,0:53,-1:34\nmove_number=40\n__dict__=gASVgAEAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRYPgEAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAo1Mgo0OQo1Mgo2CjUyCjE0CjUyCjMyCjUyCjQ3CjUyCjQ4CjUyCjEzCjUzCjE5CjMKNTMKMzQKCpRicy4=\n",
+          "legalActions": [5, 6, 7, 18, 28, 31, 32, 34, 43, 48, 50],
+          "legalActionStrings": [
+            "Player: 0 Action: 6s",
+            "Player: 0 Action: 7s",
+            "Player: 0 Action: 8s",
+            "Player: 0 Action: 6c",
+            "Player: 0 Action: 3d",
+            "Player: 0 Action: 6d",
+            "Player: 0 Action: 7d",
+            "Player: 0 Action: 9d",
+            "Player: 0 Action: 5h",
+            "Player: 0 Action: Th",
+            "Player: 0 Action: Qh"
+          ]
+        },
+        "status": "ACTIVE"
+      },
+      {
+        "action": {
+          "submission": -1
+        },
+        "reward": null,
+        "info": {},
+        "observation": {
+          "remainingOverageTime": 12,
+          "observationString": "{\"phase\": \"Discard\", \"current_player\": 0, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"4s\", \"upcard\": null, \"stock_size\": 29, \"discard_pile\": [\"Ac\", \"4s\"], \"hands\": {\"0\": [], \"1\": [\"5s\", \"Qs\", \"2c\", \"7c\", \"9c\", \"Kc\", \"Kd\", \"9h\", \"Jh\", \"Kh\"]}, \"deadwood\": {\"0\": null, \"1\": 52}, \"repeated_move\": 0}",
+          "currentPlayer": 0,
+          "playerId": 1,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14,0:52,0:49,1:52,1:6,0:52,0:14,1:52,1:32,0:52,0:47,1:52,1:48,0:52,0:13,1:53,-1:19,1:3,0:53,-1:34\nmove_number=40\n__dict__=gASVgAEAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRYPgEAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAo1Mgo0OQo1Mgo2CjUyCjE0CjUyCjMyCjUyCjQ3CjUyCjQ4CjUyCjEzCjUzCjE5CjMKNTMKMzQKCpRicy4=\n",
+          "legalActions": [],
+          "legalActionStrings": []
+        },
+        "status": "INACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "submission": 48,
+          "thoughts": "spark echo ripple sigma explore ember epsilon alpha"
+        },
+        "reward": null,
+        "info": {
+          "actionSubmitted": 48,
+          "actionSubmittedToString": "Player: 0 Action: Th",
+          "actionApplied": 48,
+          "timeTaken": 0.0,
+          "agentSelfReportedStatus": null
+        },
+        "observation": {
+          "remainingOverageTime": 12,
+          "step": 19,
+          "observationString": "{\"phase\": \"Draw\", \"current_player\": 1, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"4s\", \"upcard\": \"Th\", \"stock_size\": 29, \"discard_pile\": [\"Ac\", \"4s\"], \"hands\": {\"0\": [\"6s\", \"7s\", \"8s\", \"6c\", \"3d\", \"6d\", \"7d\", \"9d\", \"5h\", \"Qh\"], \"1\": []}, \"deadwood\": {\"0\": 46, \"1\": null}, \"repeated_move\": 0}",
+          "currentPlayer": 1,
+          "playerId": 0,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14,0:52,0:49,1:52,1:6,0:52,0:14,1:52,1:32,0:52,0:47,1:52,1:48,0:52,0:13,1:53,-1:19,1:3,0:53,-1:34,0:48\nmove_number=41\n__dict__=gASVgwEAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRYQQEAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAo1Mgo0OQo1Mgo2CjUyCjE0CjUyCjMyCjUyCjQ3CjUyCjQ4CjUyCjEzCjUzCjE5CjMKNTMKMzQKNDgKCpRicy4=\n",
+          "legalActions": [],
+          "legalActionStrings": []
+        },
+        "status": "INACTIVE"
+      },
+      {
+        "action": {
+          "submission": -1
+        },
+        "reward": null,
+        "info": {},
+        "observation": {
+          "remainingOverageTime": 12,
+          "observationString": "{\"phase\": \"Draw\", \"current_player\": 1, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"4s\", \"upcard\": \"Th\", \"stock_size\": 29, \"discard_pile\": [\"Ac\", \"4s\"], \"hands\": {\"0\": [], \"1\": [\"5s\", \"Qs\", \"2c\", \"7c\", \"9c\", \"Kc\", \"Kd\", \"9h\", \"Jh\", \"Kh\"]}, \"deadwood\": {\"0\": null, \"1\": 52}, \"repeated_move\": 0}",
+          "currentPlayer": 1,
+          "playerId": 1,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14,0:52,0:49,1:52,1:6,0:52,0:14,1:52,1:32,0:52,0:47,1:52,1:48,0:52,0:13,1:53,-1:19,1:3,0:53,-1:34,0:48\nmove_number=41\n__dict__=gASVgwEAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRYQQEAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAo1Mgo0OQo1Mgo2CjUyCjE0CjUyCjMyCjUyCjQ3CjUyCjQ4CjUyCjEzCjUzCjE5CjMKNTMKMzQKNDgKCpRicy4=\n",
+          "legalActions": [52, 53],
+          "legalActionStrings": [
+            "Player: 1 Action: Draw upcard",
+            "Player: 1 Action: Draw stock"
+          ]
+        },
+        "status": "ACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "submission": -1
+        },
+        "reward": null,
+        "info": {},
+        "observation": {
+          "remainingOverageTime": 12,
+          "step": 20,
+          "observationString": "{\"phase\": \"Discard\", \"current_player\": 1, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"Th\", \"upcard\": null, \"stock_size\": 29, \"discard_pile\": [\"Ac\", \"4s\"], \"hands\": {\"0\": [\"6s\", \"7s\", \"8s\", \"6c\", \"3d\", \"6d\", \"7d\", \"9d\", \"5h\", \"Qh\"], \"1\": []}, \"deadwood\": {\"0\": 46, \"1\": null}, \"repeated_move\": 0}",
+          "currentPlayer": 1,
+          "playerId": 0,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14,0:52,0:49,1:52,1:6,0:52,0:14,1:52,1:32,0:52,0:47,1:52,1:48,0:52,0:13,1:53,-1:19,1:3,0:53,-1:34,0:48,1:52\nmove_number=42\n__dict__=gASVhgEAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRYRAEAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAo1Mgo0OQo1Mgo2CjUyCjE0CjUyCjMyCjUyCjQ3CjUyCjQ4CjUyCjEzCjUzCjE5CjMKNTMKMzQKNDgKNTIKCpRicy4=\n",
+          "legalActions": [],
+          "legalActionStrings": []
+        },
+        "status": "INACTIVE"
+      },
+      {
+        "action": {
+          "submission": 52,
+          "thoughts": "beta muse kappa pi theta ripple omicron reflect"
+        },
+        "reward": null,
+        "info": {
+          "actionSubmitted": 52,
+          "actionSubmittedToString": "Player: 1 Action: Draw upcard",
+          "actionApplied": 52,
+          "timeTaken": 0.0,
+          "agentSelfReportedStatus": null
+        },
+        "observation": {
+          "remainingOverageTime": 12,
+          "observationString": "{\"phase\": \"Discard\", \"current_player\": 1, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"Th\", \"upcard\": null, \"stock_size\": 29, \"discard_pile\": [\"Ac\", \"4s\"], \"hands\": {\"0\": [], \"1\": [\"5s\", \"Qs\", \"2c\", \"7c\", \"9c\", \"Kc\", \"Kd\", \"9h\", \"Th\", \"Jh\", \"Kh\"]}, \"deadwood\": {\"0\": null, \"1\": 23}, \"repeated_move\": 0}",
+          "currentPlayer": 1,
+          "playerId": 1,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14,0:52,0:49,1:52,1:6,0:52,0:14,1:52,1:32,0:52,0:47,1:52,1:48,0:52,0:13,1:53,-1:19,1:3,0:53,-1:34,0:48,1:52\nmove_number=42\n__dict__=gASVhgEAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRYRAEAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAo1Mgo0OQo1Mgo2CjUyCjE0CjUyCjMyCjUyCjQ3CjUyCjQ4CjUyCjEzCjUzCjE5CjMKNTMKMzQKNDgKNTIKCpRicy4=\n",
+          "legalActions": [4, 11, 14, 19, 21, 25, 38, 47, 48, 49, 51],
+          "legalActionStrings": [
+            "Player: 1 Action: 5s",
+            "Player: 1 Action: Qs",
+            "Player: 1 Action: 2c",
+            "Player: 1 Action: 7c",
+            "Player: 1 Action: 9c",
+            "Player: 1 Action: Kc",
+            "Player: 1 Action: Kd",
+            "Player: 1 Action: 9h",
+            "Player: 1 Action: Th",
+            "Player: 1 Action: Jh",
+            "Player: 1 Action: Kh"
+          ]
+        },
+        "status": "ACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "submission": -1
+        },
+        "reward": null,
+        "info": {},
+        "observation": {
+          "remainingOverageTime": 12,
+          "step": 21,
+          "observationString": "{\"phase\": \"Draw\", \"current_player\": 0, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"Th\", \"upcard\": \"Jh\", \"stock_size\": 29, \"discard_pile\": [\"Ac\", \"4s\"], \"hands\": {\"0\": [\"6s\", \"7s\", \"8s\", \"6c\", \"3d\", \"6d\", \"7d\", \"9d\", \"5h\", \"Qh\"], \"1\": []}, \"deadwood\": {\"0\": 46, \"1\": null}, \"repeated_move\": 0}",
+          "currentPlayer": 0,
+          "playerId": 0,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14,0:52,0:49,1:52,1:6,0:52,0:14,1:52,1:32,0:52,0:47,1:52,1:48,0:52,0:13,1:53,-1:19,1:3,0:53,-1:34,0:48,1:52,1:49\nmove_number=43\n__dict__=gASViQEAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRYRwEAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAo1Mgo0OQo1Mgo2CjUyCjE0CjUyCjMyCjUyCjQ3CjUyCjQ4CjUyCjEzCjUzCjE5CjMKNTMKMzQKNDgKNTIKNDkKCpRicy4=\n",
+          "legalActions": [52, 53],
+          "legalActionStrings": [
+            "Player: 0 Action: Draw upcard",
+            "Player: 0 Action: Draw stock"
+          ]
+        },
+        "status": "ACTIVE"
+      },
+      {
+        "action": {
+          "submission": 49,
+          "thoughts": "delta iota iota nu lambda psi sigma consider"
+        },
+        "reward": null,
+        "info": {
+          "actionSubmitted": 49,
+          "actionSubmittedToString": "Player: 1 Action: Jh",
+          "actionApplied": 49,
+          "timeTaken": 0.0,
+          "agentSelfReportedStatus": null
+        },
+        "observation": {
+          "remainingOverageTime": 12,
+          "observationString": "{\"phase\": \"Draw\", \"current_player\": 0, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"Th\", \"upcard\": \"Jh\", \"stock_size\": 29, \"discard_pile\": [\"Ac\", \"4s\"], \"hands\": {\"0\": [], \"1\": [\"5s\", \"Qs\", \"2c\", \"7c\", \"9c\", \"Kc\", \"Kd\", \"9h\", \"Th\", \"Kh\"]}, \"deadwood\": {\"0\": null, \"1\": 52}, \"repeated_move\": 0}",
+          "currentPlayer": 0,
+          "playerId": 1,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14,0:52,0:49,1:52,1:6,0:52,0:14,1:52,1:32,0:52,0:47,1:52,1:48,0:52,0:13,1:53,-1:19,1:3,0:53,-1:34,0:48,1:52,1:49\nmove_number=43\n__dict__=gASViQEAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRYRwEAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAo1Mgo0OQo1Mgo2CjUyCjE0CjUyCjMyCjUyCjQ3CjUyCjQ4CjUyCjEzCjUzCjE5CjMKNTMKMzQKNDgKNTIKNDkKCpRicy4=\n",
+          "legalActions": [],
+          "legalActionStrings": []
+        },
+        "status": "INACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "submission": 53,
+          "thoughts": "cascade consider spark lambda epsilon spark cascade phi"
+        },
+        "reward": null,
+        "info": {
+          "actionSubmitted": 53,
+          "actionSubmittedToString": "Player: 0 Action: Draw stock",
+          "actionApplied": 53,
+          "timeTaken": 0.0,
+          "agentSelfReportedStatus": null
+        },
+        "observation": {
+          "remainingOverageTime": 12,
+          "step": 22,
+          "observationString": "{\"phase\": \"Discard\", \"current_player\": 0, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"Jh\", \"upcard\": null, \"stock_size\": 28, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\"], \"hands\": {\"0\": [\"6s\", \"7s\", \"8s\", \"6c\", \"Qc\", \"3d\", \"6d\", \"7d\", \"9d\", \"5h\", \"Qh\"], \"1\": []}, \"deadwood\": {\"0\": 46, \"1\": null}, \"repeated_move\": 0}",
+          "currentPlayer": 0,
+          "playerId": 0,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14,0:52,0:49,1:52,1:6,0:52,0:14,1:52,1:32,0:52,0:47,1:52,1:48,0:52,0:13,1:53,-1:19,1:3,0:53,-1:34,0:48,1:52,1:49,0:53,-1:24\nmove_number=45\n__dict__=gASVjwEAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRYTQEAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAo1Mgo0OQo1Mgo2CjUyCjE0CjUyCjMyCjUyCjQ3CjUyCjQ4CjUyCjEzCjUzCjE5CjMKNTMKMzQKNDgKNTIKNDkKNTMKMjQKCpRicy4=\n",
+          "legalActions": [5, 6, 7, 18, 24, 28, 31, 32, 34, 43, 50],
+          "legalActionStrings": [
+            "Player: 0 Action: 6s",
+            "Player: 0 Action: 7s",
+            "Player: 0 Action: 8s",
+            "Player: 0 Action: 6c",
+            "Player: 0 Action: Qc",
+            "Player: 0 Action: 3d",
+            "Player: 0 Action: 6d",
+            "Player: 0 Action: 7d",
+            "Player: 0 Action: 9d",
+            "Player: 0 Action: 5h",
+            "Player: 0 Action: Qh"
+          ]
+        },
+        "status": "ACTIVE"
+      },
+      {
+        "action": {
+          "submission": -1
+        },
+        "reward": null,
+        "info": {},
+        "observation": {
+          "remainingOverageTime": 12,
+          "observationString": "{\"phase\": \"Discard\", \"current_player\": 0, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"Jh\", \"upcard\": null, \"stock_size\": 28, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\"], \"hands\": {\"0\": [], \"1\": [\"5s\", \"Qs\", \"2c\", \"7c\", \"9c\", \"Kc\", \"Kd\", \"9h\", \"Th\", \"Kh\"]}, \"deadwood\": {\"0\": null, \"1\": 52}, \"repeated_move\": 0}",
+          "currentPlayer": 0,
+          "playerId": 1,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14,0:52,0:49,1:52,1:6,0:52,0:14,1:52,1:32,0:52,0:47,1:52,1:48,0:52,0:13,1:53,-1:19,1:3,0:53,-1:34,0:48,1:52,1:49,0:53,-1:24\nmove_number=45\n__dict__=gASVjwEAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRYTQEAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAo1Mgo0OQo1Mgo2CjUyCjE0CjUyCjMyCjUyCjQ3CjUyCjQ4CjUyCjEzCjUzCjE5CjMKNTMKMzQKNDgKNTIKNDkKNTMKMjQKCpRicy4=\n",
+          "legalActions": [],
+          "legalActionStrings": []
+        },
+        "status": "INACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "submission": 6,
+          "thoughts": "echo upsilon iota gamma wonder epsilon ember imagine"
+        },
+        "reward": null,
+        "info": {
+          "actionSubmitted": 6,
+          "actionSubmittedToString": "Player: 0 Action: 7s",
+          "actionApplied": 6,
+          "timeTaken": 0.0,
+          "agentSelfReportedStatus": null
+        },
+        "observation": {
+          "remainingOverageTime": 12,
+          "step": 23,
+          "observationString": "{\"phase\": \"Draw\", \"current_player\": 1, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"Jh\", \"upcard\": \"7s\", \"stock_size\": 28, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\"], \"hands\": {\"0\": [\"6s\", \"8s\", \"6c\", \"Qc\", \"3d\", \"6d\", \"7d\", \"9d\", \"5h\", \"Qh\"], \"1\": []}, \"deadwood\": {\"0\": 52, \"1\": null}, \"repeated_move\": 0}",
+          "currentPlayer": 1,
+          "playerId": 0,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14,0:52,0:49,1:52,1:6,0:52,0:14,1:52,1:32,0:52,0:47,1:52,1:48,0:52,0:13,1:53,-1:19,1:3,0:53,-1:34,0:48,1:52,1:49,0:53,-1:24,0:6\nmove_number=46\n__dict__=gASVkQEAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRYTwEAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAo1Mgo0OQo1Mgo2CjUyCjE0CjUyCjMyCjUyCjQ3CjUyCjQ4CjUyCjEzCjUzCjE5CjMKNTMKMzQKNDgKNTIKNDkKNTMKMjQKNgoKlGJzLg==\n",
+          "legalActions": [],
+          "legalActionStrings": []
+        },
+        "status": "INACTIVE"
+      },
+      {
+        "action": {
+          "submission": -1
+        },
+        "reward": null,
+        "info": {},
+        "observation": {
+          "remainingOverageTime": 12,
+          "observationString": "{\"phase\": \"Draw\", \"current_player\": 1, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"Jh\", \"upcard\": \"7s\", \"stock_size\": 28, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\"], \"hands\": {\"0\": [], \"1\": [\"5s\", \"Qs\", \"2c\", \"7c\", \"9c\", \"Kc\", \"Kd\", \"9h\", \"Th\", \"Kh\"]}, \"deadwood\": {\"0\": null, \"1\": 52}, \"repeated_move\": 0}",
+          "currentPlayer": 1,
+          "playerId": 1,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14,0:52,0:49,1:52,1:6,0:52,0:14,1:52,1:32,0:52,0:47,1:52,1:48,0:52,0:13,1:53,-1:19,1:3,0:53,-1:34,0:48,1:52,1:49,0:53,-1:24,0:6\nmove_number=46\n__dict__=gASVkQEAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRYTwEAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAo1Mgo0OQo1Mgo2CjUyCjE0CjUyCjMyCjUyCjQ3CjUyCjQ4CjUyCjEzCjUzCjE5CjMKNTMKMzQKNDgKNTIKNDkKNTMKMjQKNgoKlGJzLg==\n",
+          "legalActions": [52, 53],
+          "legalActionStrings": [
+            "Player: 1 Action: Draw upcard",
+            "Player: 1 Action: Draw stock"
+          ]
+        },
+        "status": "ACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "submission": -1
+        },
+        "reward": null,
+        "info": {},
+        "observation": {
+          "remainingOverageTime": 12,
+          "step": 24,
+          "observationString": "{\"phase\": \"Discard\", \"current_player\": 1, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"7s\", \"upcard\": null, \"stock_size\": 28, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\"], \"hands\": {\"0\": [\"6s\", \"8s\", \"6c\", \"Qc\", \"3d\", \"6d\", \"7d\", \"9d\", \"5h\", \"Qh\"], \"1\": []}, \"deadwood\": {\"0\": 52, \"1\": null}, \"repeated_move\": 0}",
+          "currentPlayer": 1,
+          "playerId": 0,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14,0:52,0:49,1:52,1:6,0:52,0:14,1:52,1:32,0:52,0:47,1:52,1:48,0:52,0:13,1:53,-1:19,1:3,0:53,-1:34,0:48,1:52,1:49,0:53,-1:24,0:6,1:52\nmove_number=47\n__dict__=gASVlAEAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRYUgEAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAo1Mgo0OQo1Mgo2CjUyCjE0CjUyCjMyCjUyCjQ3CjUyCjQ4CjUyCjEzCjUzCjE5CjMKNTMKMzQKNDgKNTIKNDkKNTMKMjQKNgo1MgoKlGJzLg==\n",
+          "legalActions": [],
+          "legalActionStrings": []
+        },
+        "status": "INACTIVE"
+      },
+      {
+        "action": {
+          "submission": 52,
+          "thoughts": "lantern psi nu iota wonder ponder zeta upsilon"
+        },
+        "reward": null,
+        "info": {
+          "actionSubmitted": 52,
+          "actionSubmittedToString": "Player: 1 Action: Draw upcard",
+          "actionApplied": 52,
+          "timeTaken": 0.0,
+          "agentSelfReportedStatus": null
+        },
+        "observation": {
+          "remainingOverageTime": 12,
+          "observationString": "{\"phase\": \"Discard\", \"current_player\": 1, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"7s\", \"upcard\": null, \"stock_size\": 28, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\"], \"hands\": {\"0\": [], \"1\": [\"5s\", \"7s\", \"Qs\", \"2c\", \"7c\", \"9c\", \"Kc\", \"Kd\", \"9h\", \"Th\", \"Kh\"]}, \"deadwood\": {\"0\": null, \"1\": 49}, \"repeated_move\": 0}",
+          "currentPlayer": 1,
+          "playerId": 1,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14,0:52,0:49,1:52,1:6,0:52,0:14,1:52,1:32,0:52,0:47,1:52,1:48,0:52,0:13,1:53,-1:19,1:3,0:53,-1:34,0:48,1:52,1:49,0:53,-1:24,0:6,1:52\nmove_number=47\n__dict__=gASVlAEAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRYUgEAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAo1Mgo0OQo1Mgo2CjUyCjE0CjUyCjMyCjUyCjQ3CjUyCjQ4CjUyCjEzCjUzCjE5CjMKNTMKMzQKNDgKNTIKNDkKNTMKMjQKNgo1MgoKlGJzLg==\n",
+          "legalActions": [4, 6, 11, 14, 19, 21, 25, 38, 47, 48, 51],
+          "legalActionStrings": [
+            "Player: 1 Action: 5s",
+            "Player: 1 Action: 7s",
+            "Player: 1 Action: Qs",
+            "Player: 1 Action: 2c",
+            "Player: 1 Action: 7c",
+            "Player: 1 Action: 9c",
+            "Player: 1 Action: Kc",
+            "Player: 1 Action: Kd",
+            "Player: 1 Action: 9h",
+            "Player: 1 Action: Th",
+            "Player: 1 Action: Kh"
+          ]
+        },
+        "status": "ACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "submission": -1
+        },
+        "reward": null,
+        "info": {},
+        "observation": {
+          "remainingOverageTime": 12,
+          "step": 25,
+          "observationString": "{\"phase\": \"Draw\", \"current_player\": 0, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"7s\", \"upcard\": \"9h\", \"stock_size\": 28, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\"], \"hands\": {\"0\": [\"6s\", \"8s\", \"6c\", \"Qc\", \"3d\", \"6d\", \"7d\", \"9d\", \"5h\", \"Qh\"], \"1\": []}, \"deadwood\": {\"0\": 52, \"1\": null}, \"repeated_move\": 0}",
+          "currentPlayer": 0,
+          "playerId": 0,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14,0:52,0:49,1:52,1:6,0:52,0:14,1:52,1:32,0:52,0:47,1:52,1:48,0:52,0:13,1:53,-1:19,1:3,0:53,-1:34,0:48,1:52,1:49,0:53,-1:24,0:6,1:52,1:47\nmove_number=48\n__dict__=gASVlwEAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRYVQEAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAo1Mgo0OQo1Mgo2CjUyCjE0CjUyCjMyCjUyCjQ3CjUyCjQ4CjUyCjEzCjUzCjE5CjMKNTMKMzQKNDgKNTIKNDkKNTMKMjQKNgo1Mgo0NwoKlGJzLg==\n",
+          "legalActions": [52, 53],
+          "legalActionStrings": [
+            "Player: 0 Action: Draw upcard",
+            "Player: 0 Action: Draw stock"
+          ]
+        },
+        "status": "ACTIVE"
+      },
+      {
+        "action": {
+          "submission": 47,
+          "thoughts": "shadow nu theta eta drift xi omega ponder"
+        },
+        "reward": null,
+        "info": {
+          "actionSubmitted": 47,
+          "actionSubmittedToString": "Player: 1 Action: 9h",
+          "actionApplied": 47,
+          "timeTaken": 0.0,
+          "agentSelfReportedStatus": null
+        },
+        "observation": {
+          "remainingOverageTime": 12,
+          "observationString": "{\"phase\": \"Draw\", \"current_player\": 0, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"7s\", \"upcard\": \"9h\", \"stock_size\": 28, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\"], \"hands\": {\"0\": [], \"1\": [\"5s\", \"7s\", \"Qs\", \"2c\", \"7c\", \"9c\", \"Kc\", \"Kd\", \"Th\", \"Kh\"]}, \"deadwood\": {\"0\": null, \"1\": 50}, \"repeated_move\": 0}",
+          "currentPlayer": 0,
+          "playerId": 1,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14,0:52,0:49,1:52,1:6,0:52,0:14,1:52,1:32,0:52,0:47,1:52,1:48,0:52,0:13,1:53,-1:19,1:3,0:53,-1:34,0:48,1:52,1:49,0:53,-1:24,0:6,1:52,1:47\nmove_number=48\n__dict__=gASVlwEAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRYVQEAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAo1Mgo0OQo1Mgo2CjUyCjE0CjUyCjMyCjUyCjQ3CjUyCjQ4CjUyCjEzCjUzCjE5CjMKNTMKMzQKNDgKNTIKNDkKNTMKMjQKNgo1Mgo0NwoKlGJzLg==\n",
+          "legalActions": [],
+          "legalActionStrings": []
+        },
+        "status": "INACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "submission": 52,
+          "thoughts": "tau omicron cascade shadow echo reflect theta tau"
+        },
+        "reward": null,
+        "info": {
+          "actionSubmitted": 52,
+          "actionSubmittedToString": "Player: 0 Action: Draw upcard",
+          "actionApplied": 52,
+          "timeTaken": 0.0,
+          "agentSelfReportedStatus": null
+        },
+        "observation": {
+          "remainingOverageTime": 12,
+          "step": 26,
+          "observationString": "{\"phase\": \"Discard\", \"current_player\": 0, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"9h\", \"upcard\": null, \"stock_size\": 28, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\"], \"hands\": {\"0\": [\"6s\", \"8s\", \"6c\", \"Qc\", \"3d\", \"6d\", \"7d\", \"9d\", \"5h\", \"9h\", \"Qh\"], \"1\": []}, \"deadwood\": {\"0\": 51, \"1\": null}, \"repeated_move\": 0}",
+          "currentPlayer": 0,
+          "playerId": 0,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14,0:52,0:49,1:52,1:6,0:52,0:14,1:52,1:32,0:52,0:47,1:52,1:48,0:52,0:13,1:53,-1:19,1:3,0:53,-1:34,0:48,1:52,1:49,0:53,-1:24,0:6,1:52,1:47,0:52\nmove_number=49\n__dict__=gASVmgEAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRYWAEAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAo1Mgo0OQo1Mgo2CjUyCjE0CjUyCjMyCjUyCjQ3CjUyCjQ4CjUyCjEzCjUzCjE5CjMKNTMKMzQKNDgKNTIKNDkKNTMKMjQKNgo1Mgo0Nwo1MgoKlGJzLg==\n",
+          "legalActions": [5, 7, 18, 24, 28, 31, 32, 34, 43, 47, 50],
+          "legalActionStrings": [
+            "Player: 0 Action: 6s",
+            "Player: 0 Action: 8s",
+            "Player: 0 Action: 6c",
+            "Player: 0 Action: Qc",
+            "Player: 0 Action: 3d",
+            "Player: 0 Action: 6d",
+            "Player: 0 Action: 7d",
+            "Player: 0 Action: 9d",
+            "Player: 0 Action: 5h",
+            "Player: 0 Action: 9h",
+            "Player: 0 Action: Qh"
+          ]
+        },
+        "status": "ACTIVE"
+      },
+      {
+        "action": {
+          "submission": -1
+        },
+        "reward": null,
+        "info": {},
+        "observation": {
+          "remainingOverageTime": 12,
+          "observationString": "{\"phase\": \"Discard\", \"current_player\": 0, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"9h\", \"upcard\": null, \"stock_size\": 28, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\"], \"hands\": {\"0\": [], \"1\": [\"5s\", \"7s\", \"Qs\", \"2c\", \"7c\", \"9c\", \"Kc\", \"Kd\", \"Th\", \"Kh\"]}, \"deadwood\": {\"0\": null, \"1\": 50}, \"repeated_move\": 0}",
+          "currentPlayer": 0,
+          "playerId": 1,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14,0:52,0:49,1:52,1:6,0:52,0:14,1:52,1:32,0:52,0:47,1:52,1:48,0:52,0:13,1:53,-1:19,1:3,0:53,-1:34,0:48,1:52,1:49,0:53,-1:24,0:6,1:52,1:47,0:52\nmove_number=49\n__dict__=gASVmgEAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRYWAEAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAo1Mgo0OQo1Mgo2CjUyCjE0CjUyCjMyCjUyCjQ3CjUyCjQ4CjUyCjEzCjUzCjE5CjMKNTMKMzQKNDgKNTIKNDkKNTMKMjQKNgo1Mgo0Nwo1MgoKlGJzLg==\n",
+          "legalActions": [],
+          "legalActionStrings": []
+        },
+        "status": "INACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "submission": 43,
+          "thoughts": "delta drift kappa muse ripple nu eta eta"
+        },
+        "reward": null,
+        "info": {
+          "actionSubmitted": 43,
+          "actionSubmittedToString": "Player: 0 Action: 5h",
+          "actionApplied": 43,
+          "timeTaken": 0.0,
+          "agentSelfReportedStatus": null
+        },
+        "observation": {
+          "remainingOverageTime": 12,
+          "step": 27,
+          "observationString": "{\"phase\": \"Draw\", \"current_player\": 1, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"9h\", \"upcard\": \"5h\", \"stock_size\": 28, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\"], \"hands\": {\"0\": [\"6s\", \"8s\", \"6c\", \"Qc\", \"3d\", \"6d\", \"7d\", \"9d\", \"9h\", \"Qh\"], \"1\": []}, \"deadwood\": {\"0\": 56, \"1\": null}, \"repeated_move\": 0}",
+          "currentPlayer": 1,
+          "playerId": 0,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14,0:52,0:49,1:52,1:6,0:52,0:14,1:52,1:32,0:52,0:47,1:52,1:48,0:52,0:13,1:53,-1:19,1:3,0:53,-1:34,0:48,1:52,1:49,0:53,-1:24,0:6,1:52,1:47,0:52,0:43\nmove_number=50\n__dict__=gASVnQEAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRYWwEAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAo1Mgo0OQo1Mgo2CjUyCjE0CjUyCjMyCjUyCjQ3CjUyCjQ4CjUyCjEzCjUzCjE5CjMKNTMKMzQKNDgKNTIKNDkKNTMKMjQKNgo1Mgo0Nwo1Mgo0MwoKlGJzLg==\n",
+          "legalActions": [],
+          "legalActionStrings": []
+        },
+        "status": "INACTIVE"
+      },
+      {
+        "action": {
+          "submission": -1
+        },
+        "reward": null,
+        "info": {},
+        "observation": {
+          "remainingOverageTime": 12,
+          "observationString": "{\"phase\": \"Draw\", \"current_player\": 1, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"9h\", \"upcard\": \"5h\", \"stock_size\": 28, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\"], \"hands\": {\"0\": [], \"1\": [\"5s\", \"7s\", \"Qs\", \"2c\", \"7c\", \"9c\", \"Kc\", \"Kd\", \"Th\", \"Kh\"]}, \"deadwood\": {\"0\": null, \"1\": 50}, \"repeated_move\": 0}",
+          "currentPlayer": 1,
+          "playerId": 1,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14,0:52,0:49,1:52,1:6,0:52,0:14,1:52,1:32,0:52,0:47,1:52,1:48,0:52,0:13,1:53,-1:19,1:3,0:53,-1:34,0:48,1:52,1:49,0:53,-1:24,0:6,1:52,1:47,0:52,0:43\nmove_number=50\n__dict__=gASVnQEAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRYWwEAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAo1Mgo0OQo1Mgo2CjUyCjE0CjUyCjMyCjUyCjQ3CjUyCjQ4CjUyCjEzCjUzCjE5CjMKNTMKMzQKNDgKNTIKNDkKNTMKMjQKNgo1Mgo0Nwo1Mgo0MwoKlGJzLg==\n",
+          "legalActions": [52, 53],
+          "legalActionStrings": [
+            "Player: 1 Action: Draw upcard",
+            "Player: 1 Action: Draw stock"
+          ]
+        },
+        "status": "ACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "submission": -1
+        },
+        "reward": null,
+        "info": {},
+        "observation": {
+          "remainingOverageTime": 12,
+          "step": 28,
+          "observationString": "{\"phase\": \"Discard\", \"current_player\": 1, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"5h\", \"upcard\": null, \"stock_size\": 28, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\"], \"hands\": {\"0\": [\"6s\", \"8s\", \"6c\", \"Qc\", \"3d\", \"6d\", \"7d\", \"9d\", \"9h\", \"Qh\"], \"1\": []}, \"deadwood\": {\"0\": 56, \"1\": null}, \"repeated_move\": 0}",
+          "currentPlayer": 1,
+          "playerId": 0,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14,0:52,0:49,1:52,1:6,0:52,0:14,1:52,1:32,0:52,0:47,1:52,1:48,0:52,0:13,1:53,-1:19,1:3,0:53,-1:34,0:48,1:52,1:49,0:53,-1:24,0:6,1:52,1:47,0:52,0:43,1:52\nmove_number=51\n__dict__=gASVoAEAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRYXgEAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAo1Mgo0OQo1Mgo2CjUyCjE0CjUyCjMyCjUyCjQ3CjUyCjQ4CjUyCjEzCjUzCjE5CjMKNTMKMzQKNDgKNTIKNDkKNTMKMjQKNgo1Mgo0Nwo1Mgo0Mwo1MgoKlGJzLg==\n",
+          "legalActions": [],
+          "legalActionStrings": []
+        },
+        "status": "INACTIVE"
+      },
+      {
+        "action": {
+          "submission": 52,
+          "thoughts": "spark theta pi phi delta zeta epsilon mu"
+        },
+        "reward": null,
+        "info": {
+          "actionSubmitted": 52,
+          "actionSubmittedToString": "Player: 1 Action: Draw upcard",
+          "actionApplied": 52,
+          "timeTaken": 0.0,
+          "agentSelfReportedStatus": null
+        },
+        "observation": {
+          "remainingOverageTime": 12,
+          "observationString": "{\"phase\": \"Discard\", \"current_player\": 1, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"5h\", \"upcard\": null, \"stock_size\": 28, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\"], \"hands\": {\"0\": [], \"1\": [\"5s\", \"7s\", \"Qs\", \"2c\", \"7c\", \"9c\", \"Kc\", \"Kd\", \"5h\", \"Th\", \"Kh\"]}, \"deadwood\": {\"0\": null, \"1\": 45}, \"repeated_move\": 0}",
+          "currentPlayer": 1,
+          "playerId": 1,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14,0:52,0:49,1:52,1:6,0:52,0:14,1:52,1:32,0:52,0:47,1:52,1:48,0:52,0:13,1:53,-1:19,1:3,0:53,-1:34,0:48,1:52,1:49,0:53,-1:24,0:6,1:52,1:47,0:52,0:43,1:52\nmove_number=51\n__dict__=gASVoAEAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRYXgEAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAo1Mgo0OQo1Mgo2CjUyCjE0CjUyCjMyCjUyCjQ3CjUyCjQ4CjUyCjEzCjUzCjE5CjMKNTMKMzQKNDgKNTIKNDkKNTMKMjQKNgo1Mgo0Nwo1Mgo0Mwo1MgoKlGJzLg==\n",
+          "legalActions": [4, 6, 11, 14, 19, 21, 25, 38, 43, 48, 51],
+          "legalActionStrings": [
+            "Player: 1 Action: 5s",
+            "Player: 1 Action: 7s",
+            "Player: 1 Action: Qs",
+            "Player: 1 Action: 2c",
+            "Player: 1 Action: 7c",
+            "Player: 1 Action: 9c",
+            "Player: 1 Action: Kc",
+            "Player: 1 Action: Kd",
+            "Player: 1 Action: 5h",
+            "Player: 1 Action: Th",
+            "Player: 1 Action: Kh"
+          ]
+        },
+        "status": "ACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "submission": -1
+        },
+        "reward": null,
+        "info": {},
+        "observation": {
+          "remainingOverageTime": 12,
+          "step": 29,
+          "observationString": "{\"phase\": \"Draw\", \"current_player\": 0, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"5h\", \"upcard\": \"5h\", \"stock_size\": 28, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\"], \"hands\": {\"0\": [\"6s\", \"8s\", \"6c\", \"Qc\", \"3d\", \"6d\", \"7d\", \"9d\", \"9h\", \"Qh\"], \"1\": []}, \"deadwood\": {\"0\": 56, \"1\": null}, \"repeated_move\": 1}",
+          "currentPlayer": 0,
+          "playerId": 0,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14,0:52,0:49,1:52,1:6,0:52,0:14,1:52,1:32,0:52,0:47,1:52,1:48,0:52,0:13,1:53,-1:19,1:3,0:53,-1:34,0:48,1:52,1:49,0:53,-1:24,0:6,1:52,1:47,0:52,0:43,1:52,1:43\nmove_number=52\n__dict__=gASVowEAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRYYQEAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAo1Mgo0OQo1Mgo2CjUyCjE0CjUyCjMyCjUyCjQ3CjUyCjQ4CjUyCjEzCjUzCjE5CjMKNTMKMzQKNDgKNTIKNDkKNTMKMjQKNgo1Mgo0Nwo1Mgo0Mwo1Mgo0MwoKlGJzLg==\n",
+          "legalActions": [52, 53],
+          "legalActionStrings": [
+            "Player: 0 Action: Draw upcard",
+            "Player: 0 Action: Draw stock"
+          ]
+        },
+        "status": "ACTIVE"
+      },
+      {
+        "action": {
+          "submission": 43,
+          "thoughts": "cascade xi alpha iota beta echo lantern beta"
+        },
+        "reward": null,
+        "info": {
+          "actionSubmitted": 43,
+          "actionSubmittedToString": "Player: 1 Action: 5h",
+          "actionApplied": 43,
+          "timeTaken": 0.0,
+          "agentSelfReportedStatus": null
+        },
+        "observation": {
+          "remainingOverageTime": 12,
+          "observationString": "{\"phase\": \"Draw\", \"current_player\": 0, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"5h\", \"upcard\": \"5h\", \"stock_size\": 28, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\"], \"hands\": {\"0\": [], \"1\": [\"5s\", \"7s\", \"Qs\", \"2c\", \"7c\", \"9c\", \"Kc\", \"Kd\", \"Th\", \"Kh\"]}, \"deadwood\": {\"0\": null, \"1\": 50}, \"repeated_move\": 1}",
+          "currentPlayer": 0,
+          "playerId": 1,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14,0:52,0:49,1:52,1:6,0:52,0:14,1:52,1:32,0:52,0:47,1:52,1:48,0:52,0:13,1:53,-1:19,1:3,0:53,-1:34,0:48,1:52,1:49,0:53,-1:24,0:6,1:52,1:47,0:52,0:43,1:52,1:43\nmove_number=52\n__dict__=gASVowEAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRYYQEAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAo1Mgo0OQo1Mgo2CjUyCjE0CjUyCjMyCjUyCjQ3CjUyCjQ4CjUyCjEzCjUzCjE5CjMKNTMKMzQKNDgKNTIKNDkKNTMKMjQKNgo1Mgo0Nwo1Mgo0Mwo1Mgo0MwoKlGJzLg==\n",
+          "legalActions": [],
+          "legalActionStrings": []
+        },
+        "status": "INACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "submission": 53,
+          "thoughts": "ripple lantern psi echo nu upsilon consider omicron"
+        },
+        "reward": null,
+        "info": {
+          "actionSubmitted": 53,
+          "actionSubmittedToString": "Player: 0 Action: Draw stock",
+          "actionApplied": 53,
+          "timeTaken": 0.0,
+          "agentSelfReportedStatus": null
+        },
+        "observation": {
+          "remainingOverageTime": 12,
+          "step": 30,
+          "observationString": "{\"phase\": \"Discard\", \"current_player\": 0, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"5h\", \"upcard\": null, \"stock_size\": 27, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\"], \"hands\": {\"0\": [\"6s\", \"8s\", \"6c\", \"Qc\", \"3d\", \"6d\", \"7d\", \"8d\", \"9d\", \"9h\", \"Qh\"], \"1\": []}, \"deadwood\": {\"0\": 30, \"1\": null}, \"repeated_move\": 1}",
+          "currentPlayer": 0,
+          "playerId": 0,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14,0:52,0:49,1:52,1:6,0:52,0:14,1:52,1:32,0:52,0:47,1:52,1:48,0:52,0:13,1:53,-1:19,1:3,0:53,-1:34,0:48,1:52,1:49,0:53,-1:24,0:6,1:52,1:47,0:52,0:43,1:52,1:43,0:53,-1:33\nmove_number=54\n__dict__=gASVqQEAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRYZwEAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAo1Mgo0OQo1Mgo2CjUyCjE0CjUyCjMyCjUyCjQ3CjUyCjQ4CjUyCjEzCjUzCjE5CjMKNTMKMzQKNDgKNTIKNDkKNTMKMjQKNgo1Mgo0Nwo1Mgo0Mwo1Mgo0Mwo1MwozMwoKlGJzLg==\n",
+          "legalActions": [5, 7, 18, 24, 28, 31, 32, 33, 34, 47, 50],
+          "legalActionStrings": [
+            "Player: 0 Action: 6s",
+            "Player: 0 Action: 8s",
+            "Player: 0 Action: 6c",
+            "Player: 0 Action: Qc",
+            "Player: 0 Action: 3d",
+            "Player: 0 Action: 6d",
+            "Player: 0 Action: 7d",
+            "Player: 0 Action: 8d",
+            "Player: 0 Action: 9d",
+            "Player: 0 Action: 9h",
+            "Player: 0 Action: Qh"
+          ]
+        },
+        "status": "ACTIVE"
+      },
+      {
+        "action": {
+          "submission": -1
+        },
+        "reward": null,
+        "info": {},
+        "observation": {
+          "remainingOverageTime": 12,
+          "observationString": "{\"phase\": \"Discard\", \"current_player\": 0, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"5h\", \"upcard\": null, \"stock_size\": 27, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\"], \"hands\": {\"0\": [], \"1\": [\"5s\", \"7s\", \"Qs\", \"2c\", \"7c\", \"9c\", \"Kc\", \"Kd\", \"Th\", \"Kh\"]}, \"deadwood\": {\"0\": null, \"1\": 50}, \"repeated_move\": 1}",
+          "currentPlayer": 0,
+          "playerId": 1,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14,0:52,0:49,1:52,1:6,0:52,0:14,1:52,1:32,0:52,0:47,1:52,1:48,0:52,0:13,1:53,-1:19,1:3,0:53,-1:34,0:48,1:52,1:49,0:53,-1:24,0:6,1:52,1:47,0:52,0:43,1:52,1:43,0:53,-1:33\nmove_number=54\n__dict__=gASVqQEAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRYZwEAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAo1Mgo0OQo1Mgo2CjUyCjE0CjUyCjMyCjUyCjQ3CjUyCjQ4CjUyCjEzCjUzCjE5CjMKNTMKMzQKNDgKNTIKNDkKNTMKMjQKNgo1Mgo0Nwo1Mgo0Mwo1Mgo0Mwo1MwozMwoKlGJzLg==\n",
+          "legalActions": [],
+          "legalActionStrings": []
+        },
+        "status": "INACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "submission": 31,
+          "thoughts": "xi gamma reflect upsilon lantern horizon phi lambda"
+        },
+        "reward": null,
+        "info": {
+          "actionSubmitted": 31,
+          "actionSubmittedToString": "Player: 0 Action: 6d",
+          "actionApplied": 31,
+          "timeTaken": 0.0,
+          "agentSelfReportedStatus": null
+        },
+        "observation": {
+          "remainingOverageTime": 12,
+          "step": 31,
+          "observationString": "{\"phase\": \"Draw\", \"current_player\": 1, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"5h\", \"upcard\": \"6d\", \"stock_size\": 27, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\"], \"hands\": {\"0\": [\"6s\", \"8s\", \"6c\", \"Qc\", \"3d\", \"7d\", \"8d\", \"9d\", \"9h\", \"Qh\"], \"1\": []}, \"deadwood\": {\"0\": 52, \"1\": null}, \"repeated_move\": 0}",
+          "currentPlayer": 1,
+          "playerId": 0,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14,0:52,0:49,1:52,1:6,0:52,0:14,1:52,1:32,0:52,0:47,1:52,1:48,0:52,0:13,1:53,-1:19,1:3,0:53,-1:34,0:48,1:52,1:49,0:53,-1:24,0:6,1:52,1:47,0:52,0:43,1:52,1:43,0:53,-1:33,0:31\nmove_number=55\n__dict__=gASVrAEAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRYagEAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAo1Mgo0OQo1Mgo2CjUyCjE0CjUyCjMyCjUyCjQ3CjUyCjQ4CjUyCjEzCjUzCjE5CjMKNTMKMzQKNDgKNTIKNDkKNTMKMjQKNgo1Mgo0Nwo1Mgo0Mwo1Mgo0Mwo1MwozMwozMQoKlGJzLg==\n",
+          "legalActions": [],
+          "legalActionStrings": []
+        },
+        "status": "INACTIVE"
+      },
+      {
+        "action": {
+          "submission": -1
+        },
+        "reward": null,
+        "info": {},
+        "observation": {
+          "remainingOverageTime": 12,
+          "observationString": "{\"phase\": \"Draw\", \"current_player\": 1, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"5h\", \"upcard\": \"6d\", \"stock_size\": 27, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\"], \"hands\": {\"0\": [], \"1\": [\"5s\", \"7s\", \"Qs\", \"2c\", \"7c\", \"9c\", \"Kc\", \"Kd\", \"Th\", \"Kh\"]}, \"deadwood\": {\"0\": null, \"1\": 50}, \"repeated_move\": 0}",
+          "currentPlayer": 1,
+          "playerId": 1,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14,0:52,0:49,1:52,1:6,0:52,0:14,1:52,1:32,0:52,0:47,1:52,1:48,0:52,0:13,1:53,-1:19,1:3,0:53,-1:34,0:48,1:52,1:49,0:53,-1:24,0:6,1:52,1:47,0:52,0:43,1:52,1:43,0:53,-1:33,0:31\nmove_number=55\n__dict__=gASVrAEAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRYagEAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAo1Mgo0OQo1Mgo2CjUyCjE0CjUyCjMyCjUyCjQ3CjUyCjQ4CjUyCjEzCjUzCjE5CjMKNTMKMzQKNDgKNTIKNDkKNTMKMjQKNgo1Mgo0Nwo1Mgo0Mwo1Mgo0Mwo1MwozMwozMQoKlGJzLg==\n",
+          "legalActions": [52, 53],
+          "legalActionStrings": [
+            "Player: 1 Action: Draw upcard",
+            "Player: 1 Action: Draw stock"
+          ]
+        },
+        "status": "ACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "submission": -1
+        },
+        "reward": null,
+        "info": {},
+        "observation": {
+          "remainingOverageTime": 12,
+          "step": 32,
+          "observationString": "{\"phase\": \"Discard\", \"current_player\": 1, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"6d\", \"upcard\": null, \"stock_size\": 26, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\"], \"hands\": {\"0\": [\"6s\", \"8s\", \"6c\", \"Qc\", \"3d\", \"7d\", \"8d\", \"9d\", \"9h\", \"Qh\"], \"1\": []}, \"deadwood\": {\"0\": 52, \"1\": null}, \"repeated_move\": 0}",
+          "currentPlayer": 1,
+          "playerId": 0,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14,0:52,0:49,1:52,1:6,0:52,0:14,1:52,1:32,0:52,0:47,1:52,1:48,0:52,0:13,1:53,-1:19,1:3,0:53,-1:34,0:48,1:52,1:49,0:53,-1:24,0:6,1:52,1:47,0:52,0:43,1:52,1:43,0:53,-1:33,0:31,1:53,-1:37\nmove_number=57\n__dict__=gASVsgEAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRYcAEAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAo1Mgo0OQo1Mgo2CjUyCjE0CjUyCjMyCjUyCjQ3CjUyCjQ4CjUyCjEzCjUzCjE5CjMKNTMKMzQKNDgKNTIKNDkKNTMKMjQKNgo1Mgo0Nwo1Mgo0Mwo1Mgo0Mwo1MwozMwozMQo1MwozNwoKlGJzLg==\n",
+          "legalActions": [],
+          "legalActionStrings": []
+        },
+        "status": "INACTIVE"
+      },
+      {
+        "action": {
+          "submission": 53,
+          "thoughts": "lantern drift kappa consider wonder spark nu pi"
+        },
+        "reward": null,
+        "info": {
+          "actionSubmitted": 53,
+          "actionSubmittedToString": "Player: 1 Action: Draw stock",
+          "actionApplied": 53,
+          "timeTaken": 0.0,
+          "agentSelfReportedStatus": null
+        },
+        "observation": {
+          "remainingOverageTime": 12,
+          "observationString": "{\"phase\": \"Discard\", \"current_player\": 1, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"6d\", \"upcard\": null, \"stock_size\": 26, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\"], \"hands\": {\"0\": [], \"1\": [\"5s\", \"7s\", \"Qs\", \"2c\", \"7c\", \"9c\", \"Kc\", \"Qd\", \"Kd\", \"Th\", \"Kh\"]}, \"deadwood\": {\"0\": null, \"1\": 50}, \"repeated_move\": 0}",
+          "currentPlayer": 1,
+          "playerId": 1,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14,0:52,0:49,1:52,1:6,0:52,0:14,1:52,1:32,0:52,0:47,1:52,1:48,0:52,0:13,1:53,-1:19,1:3,0:53,-1:34,0:48,1:52,1:49,0:53,-1:24,0:6,1:52,1:47,0:52,0:43,1:52,1:43,0:53,-1:33,0:31,1:53,-1:37\nmove_number=57\n__dict__=gASVsgEAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRYcAEAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAo1Mgo0OQo1Mgo2CjUyCjE0CjUyCjMyCjUyCjQ3CjUyCjQ4CjUyCjEzCjUzCjE5CjMKNTMKMzQKNDgKNTIKNDkKNTMKMjQKNgo1Mgo0Nwo1Mgo0Mwo1Mgo0Mwo1MwozMwozMQo1MwozNwoKlGJzLg==\n",
+          "legalActions": [4, 6, 11, 14, 19, 21, 25, 37, 38, 48, 51],
+          "legalActionStrings": [
+            "Player: 1 Action: 5s",
+            "Player: 1 Action: 7s",
+            "Player: 1 Action: Qs",
+            "Player: 1 Action: 2c",
+            "Player: 1 Action: 7c",
+            "Player: 1 Action: 9c",
+            "Player: 1 Action: Kc",
+            "Player: 1 Action: Qd",
+            "Player: 1 Action: Kd",
+            "Player: 1 Action: Th",
+            "Player: 1 Action: Kh"
+          ]
+        },
+        "status": "ACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "submission": -1
+        },
+        "reward": null,
+        "info": {},
+        "observation": {
+          "remainingOverageTime": 12,
+          "step": 33,
+          "observationString": "{\"phase\": \"Draw\", \"current_player\": 0, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"6d\", \"upcard\": \"Qd\", \"stock_size\": 26, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\"], \"hands\": {\"0\": [\"6s\", \"8s\", \"6c\", \"Qc\", \"3d\", \"7d\", \"8d\", \"9d\", \"9h\", \"Qh\"], \"1\": []}, \"deadwood\": {\"0\": 52, \"1\": null}, \"repeated_move\": 0}",
+          "currentPlayer": 0,
+          "playerId": 0,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14,0:52,0:49,1:52,1:6,0:52,0:14,1:52,1:32,0:52,0:47,1:52,1:48,0:52,0:13,1:53,-1:19,1:3,0:53,-1:34,0:48,1:52,1:49,0:53,-1:24,0:6,1:52,1:47,0:52,0:43,1:52,1:43,0:53,-1:33,0:31,1:53,-1:37,1:37\nmove_number=58\n__dict__=gASVtQEAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRYcwEAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAo1Mgo0OQo1Mgo2CjUyCjE0CjUyCjMyCjUyCjQ3CjUyCjQ4CjUyCjEzCjUzCjE5CjMKNTMKMzQKNDgKNTIKNDkKNTMKMjQKNgo1Mgo0Nwo1Mgo0Mwo1Mgo0Mwo1MwozMwozMQo1MwozNwozNwoKlGJzLg==\n",
+          "legalActions": [52, 53],
+          "legalActionStrings": [
+            "Player: 0 Action: Draw upcard",
+            "Player: 0 Action: Draw stock"
+          ]
+        },
+        "status": "ACTIVE"
+      },
+      {
+        "action": {
+          "submission": 37,
+          "thoughts": "ripple drift epsilon muse echo delta explore beta"
+        },
+        "reward": null,
+        "info": {
+          "actionSubmitted": 37,
+          "actionSubmittedToString": "Player: 1 Action: Qd",
+          "actionApplied": 37,
+          "timeTaken": 0.0,
+          "agentSelfReportedStatus": null
+        },
+        "observation": {
+          "remainingOverageTime": 12,
+          "observationString": "{\"phase\": \"Draw\", \"current_player\": 0, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"6d\", \"upcard\": \"Qd\", \"stock_size\": 26, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\"], \"hands\": {\"0\": [], \"1\": [\"5s\", \"7s\", \"Qs\", \"2c\", \"7c\", \"9c\", \"Kc\", \"Kd\", \"Th\", \"Kh\"]}, \"deadwood\": {\"0\": null, \"1\": 50}, \"repeated_move\": 0}",
+          "currentPlayer": 0,
+          "playerId": 1,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14,0:52,0:49,1:52,1:6,0:52,0:14,1:52,1:32,0:52,0:47,1:52,1:48,0:52,0:13,1:53,-1:19,1:3,0:53,-1:34,0:48,1:52,1:49,0:53,-1:24,0:6,1:52,1:47,0:52,0:43,1:52,1:43,0:53,-1:33,0:31,1:53,-1:37,1:37\nmove_number=58\n__dict__=gASVtQEAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRYcwEAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAo1Mgo0OQo1Mgo2CjUyCjE0CjUyCjMyCjUyCjQ3CjUyCjQ4CjUyCjEzCjUzCjE5CjMKNTMKMzQKNDgKNTIKNDkKNTMKMjQKNgo1Mgo0Nwo1Mgo0Mwo1Mgo0Mwo1MwozMwozMQo1MwozNwozNwoKlGJzLg==\n",
+          "legalActions": [],
+          "legalActionStrings": []
+        },
+        "status": "INACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "submission": 52,
+          "thoughts": "lambda wonder shadow eta phi drift shadow rho"
+        },
+        "reward": null,
+        "info": {
+          "actionSubmitted": 52,
+          "actionSubmittedToString": "Player: 0 Action: Draw upcard",
+          "actionApplied": 52,
+          "timeTaken": 0.0,
+          "agentSelfReportedStatus": null
+        },
+        "observation": {
+          "remainingOverageTime": 12,
+          "step": 34,
+          "observationString": "{\"phase\": \"Discard\", \"current_player\": 0, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"Qd\", \"upcard\": null, \"stock_size\": 26, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\"], \"hands\": {\"0\": [\"6s\", \"8s\", \"6c\", \"Qc\", \"3d\", \"7d\", \"8d\", \"9d\", \"Qd\", \"9h\", \"Qh\"], \"1\": []}, \"deadwood\": {\"0\": 23, \"1\": null}, \"repeated_move\": 0}",
+          "currentPlayer": 0,
+          "playerId": 0,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14,0:52,0:49,1:52,1:6,0:52,0:14,1:52,1:32,0:52,0:47,1:52,1:48,0:52,0:13,1:53,-1:19,1:3,0:53,-1:34,0:48,1:52,1:49,0:53,-1:24,0:6,1:52,1:47,0:52,0:43,1:52,1:43,0:53,-1:33,0:31,1:53,-1:37,1:37,0:52\nmove_number=59\n__dict__=gASVuAEAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRYdgEAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAo1Mgo0OQo1Mgo2CjUyCjE0CjUyCjMyCjUyCjQ3CjUyCjQ4CjUyCjEzCjUzCjE5CjMKNTMKMzQKNDgKNTIKNDkKNTMKMjQKNgo1Mgo0Nwo1Mgo0Mwo1Mgo0Mwo1MwozMwozMQo1MwozNwozNwo1MgoKlGJzLg==\n",
+          "legalActions": [5, 7, 18, 24, 28, 32, 33, 34, 37, 47, 50],
+          "legalActionStrings": [
+            "Player: 0 Action: 6s",
+            "Player: 0 Action: 8s",
+            "Player: 0 Action: 6c",
+            "Player: 0 Action: Qc",
+            "Player: 0 Action: 3d",
+            "Player: 0 Action: 7d",
+            "Player: 0 Action: 8d",
+            "Player: 0 Action: 9d",
+            "Player: 0 Action: Qd",
+            "Player: 0 Action: 9h",
+            "Player: 0 Action: Qh"
+          ]
+        },
+        "status": "ACTIVE"
+      },
+      {
+        "action": {
+          "submission": -1
+        },
+        "reward": null,
+        "info": {},
+        "observation": {
+          "remainingOverageTime": 12,
+          "observationString": "{\"phase\": \"Discard\", \"current_player\": 0, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"Qd\", \"upcard\": null, \"stock_size\": 26, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\"], \"hands\": {\"0\": [], \"1\": [\"5s\", \"7s\", \"Qs\", \"2c\", \"7c\", \"9c\", \"Kc\", \"Kd\", \"Th\", \"Kh\"]}, \"deadwood\": {\"0\": null, \"1\": 50}, \"repeated_move\": 0}",
+          "currentPlayer": 0,
+          "playerId": 1,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14,0:52,0:49,1:52,1:6,0:52,0:14,1:52,1:32,0:52,0:47,1:52,1:48,0:52,0:13,1:53,-1:19,1:3,0:53,-1:34,0:48,1:52,1:49,0:53,-1:24,0:6,1:52,1:47,0:52,0:43,1:52,1:43,0:53,-1:33,0:31,1:53,-1:37,1:37,0:52\nmove_number=59\n__dict__=gASVuAEAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRYdgEAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAo1Mgo0OQo1Mgo2CjUyCjE0CjUyCjMyCjUyCjQ3CjUyCjQ4CjUyCjEzCjUzCjE5CjMKNTMKMzQKNDgKNTIKNDkKNTMKMjQKNgo1Mgo0Nwo1Mgo0Mwo1Mgo0Mwo1MwozMwozMQo1MwozNwozNwo1MgoKlGJzLg==\n",
+          "legalActions": [],
+          "legalActionStrings": []
+        },
+        "status": "INACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "submission": 18,
+          "thoughts": "drift cascade zeta eta theta tau wonder zeta"
+        },
+        "reward": null,
+        "info": {
+          "actionSubmitted": 18,
+          "actionSubmittedToString": "Player: 0 Action: 6c",
+          "actionApplied": 18,
+          "timeTaken": 0.0,
+          "agentSelfReportedStatus": null
+        },
+        "observation": {
+          "remainingOverageTime": 12,
+          "step": 35,
+          "observationString": "{\"phase\": \"Draw\", \"current_player\": 1, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"Qd\", \"upcard\": \"6c\", \"stock_size\": 26, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\"], \"hands\": {\"0\": [\"6s\", \"8s\", \"Qc\", \"3d\", \"7d\", \"8d\", \"9d\", \"Qd\", \"9h\", \"Qh\"], \"1\": []}, \"deadwood\": {\"0\": 26, \"1\": null}, \"repeated_move\": 0}",
+          "currentPlayer": 1,
+          "playerId": 0,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14,0:52,0:49,1:52,1:6,0:52,0:14,1:52,1:32,0:52,0:47,1:52,1:48,0:52,0:13,1:53,-1:19,1:3,0:53,-1:34,0:48,1:52,1:49,0:53,-1:24,0:6,1:52,1:47,0:52,0:43,1:52,1:43,0:53,-1:33,0:31,1:53,-1:37,1:37,0:52,0:18\nmove_number=60\n__dict__=gASVuwEAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRYeQEAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAo1Mgo0OQo1Mgo2CjUyCjE0CjUyCjMyCjUyCjQ3CjUyCjQ4CjUyCjEzCjUzCjE5CjMKNTMKMzQKNDgKNTIKNDkKNTMKMjQKNgo1Mgo0Nwo1Mgo0Mwo1Mgo0Mwo1MwozMwozMQo1MwozNwozNwo1MgoxOAoKlGJzLg==\n",
+          "legalActions": [],
+          "legalActionStrings": []
+        },
+        "status": "INACTIVE"
+      },
+      {
+        "action": {
+          "submission": -1
+        },
+        "reward": null,
+        "info": {},
+        "observation": {
+          "remainingOverageTime": 12,
+          "observationString": "{\"phase\": \"Draw\", \"current_player\": 1, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"Qd\", \"upcard\": \"6c\", \"stock_size\": 26, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\"], \"hands\": {\"0\": [], \"1\": [\"5s\", \"7s\", \"Qs\", \"2c\", \"7c\", \"9c\", \"Kc\", \"Kd\", \"Th\", \"Kh\"]}, \"deadwood\": {\"0\": null, \"1\": 50}, \"repeated_move\": 0}",
+          "currentPlayer": 1,
+          "playerId": 1,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14,0:52,0:49,1:52,1:6,0:52,0:14,1:52,1:32,0:52,0:47,1:52,1:48,0:52,0:13,1:53,-1:19,1:3,0:53,-1:34,0:48,1:52,1:49,0:53,-1:24,0:6,1:52,1:47,0:52,0:43,1:52,1:43,0:53,-1:33,0:31,1:53,-1:37,1:37,0:52,0:18\nmove_number=60\n__dict__=gASVuwEAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRYeQEAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAo1Mgo0OQo1Mgo2CjUyCjE0CjUyCjMyCjUyCjQ3CjUyCjQ4CjUyCjEzCjUzCjE5CjMKNTMKMzQKNDgKNTIKNDkKNTMKMjQKNgo1Mgo0Nwo1Mgo0Mwo1Mgo0Mwo1MwozMwozMQo1MwozNwozNwo1MgoxOAoKlGJzLg==\n",
+          "legalActions": [52, 53],
+          "legalActionStrings": [
+            "Player: 1 Action: Draw upcard",
+            "Player: 1 Action: Draw stock"
+          ]
+        },
+        "status": "ACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "submission": -1
+        },
+        "reward": null,
+        "info": {},
+        "observation": {
+          "remainingOverageTime": 12,
+          "step": 36,
+          "observationString": "{\"phase\": \"Discard\", \"current_player\": 1, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"6c\", \"upcard\": null, \"stock_size\": 26, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\"], \"hands\": {\"0\": [\"6s\", \"8s\", \"Qc\", \"3d\", \"7d\", \"8d\", \"9d\", \"Qd\", \"9h\", \"Qh\"], \"1\": []}, \"deadwood\": {\"0\": 26, \"1\": null}, \"repeated_move\": 0}",
+          "currentPlayer": 1,
+          "playerId": 0,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14,0:52,0:49,1:52,1:6,0:52,0:14,1:52,1:32,0:52,0:47,1:52,1:48,0:52,0:13,1:53,-1:19,1:3,0:53,-1:34,0:48,1:52,1:49,0:53,-1:24,0:6,1:52,1:47,0:52,0:43,1:52,1:43,0:53,-1:33,0:31,1:53,-1:37,1:37,0:52,0:18,1:52\nmove_number=61\n__dict__=gASVvgEAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRYfAEAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAo1Mgo0OQo1Mgo2CjUyCjE0CjUyCjMyCjUyCjQ3CjUyCjQ4CjUyCjEzCjUzCjE5CjMKNTMKMzQKNDgKNTIKNDkKNTMKMjQKNgo1Mgo0Nwo1Mgo0Mwo1Mgo0Mwo1MwozMwozMQo1MwozNwozNwo1MgoxOAo1MgoKlGJzLg==\n",
+          "legalActions": [],
+          "legalActionStrings": []
+        },
+        "status": "INACTIVE"
+      },
+      {
+        "action": {
+          "submission": 52,
+          "thoughts": "drift delta iota omega omega ember reflect gamma"
+        },
+        "reward": null,
+        "info": {
+          "actionSubmitted": 52,
+          "actionSubmittedToString": "Player: 1 Action: Draw upcard",
+          "actionApplied": 52,
+          "timeTaken": 0.0,
+          "agentSelfReportedStatus": null
+        },
+        "observation": {
+          "remainingOverageTime": 12,
+          "observationString": "{\"phase\": \"Discard\", \"current_player\": 1, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"6c\", \"upcard\": null, \"stock_size\": 26, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\"], \"hands\": {\"0\": [], \"1\": [\"5s\", \"7s\", \"Qs\", \"2c\", \"6c\", \"7c\", \"9c\", \"Kc\", \"Kd\", \"Th\", \"Kh\"]}, \"deadwood\": {\"0\": null, \"1\": 46}, \"repeated_move\": 0}",
+          "currentPlayer": 1,
+          "playerId": 1,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14,0:52,0:49,1:52,1:6,0:52,0:14,1:52,1:32,0:52,0:47,1:52,1:48,0:52,0:13,1:53,-1:19,1:3,0:53,-1:34,0:48,1:52,1:49,0:53,-1:24,0:6,1:52,1:47,0:52,0:43,1:52,1:43,0:53,-1:33,0:31,1:53,-1:37,1:37,0:52,0:18,1:52\nmove_number=61\n__dict__=gASVvgEAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRYfAEAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAo1Mgo0OQo1Mgo2CjUyCjE0CjUyCjMyCjUyCjQ3CjUyCjQ4CjUyCjEzCjUzCjE5CjMKNTMKMzQKNDgKNTIKNDkKNTMKMjQKNgo1Mgo0Nwo1Mgo0Mwo1Mgo0Mwo1MwozMwozMQo1MwozNwozNwo1MgoxOAo1MgoKlGJzLg==\n",
+          "legalActions": [4, 6, 11, 14, 18, 19, 21, 25, 38, 48, 51],
+          "legalActionStrings": [
+            "Player: 1 Action: 5s",
+            "Player: 1 Action: 7s",
+            "Player: 1 Action: Qs",
+            "Player: 1 Action: 2c",
+            "Player: 1 Action: 6c",
+            "Player: 1 Action: 7c",
+            "Player: 1 Action: 9c",
+            "Player: 1 Action: Kc",
+            "Player: 1 Action: Kd",
+            "Player: 1 Action: Th",
+            "Player: 1 Action: Kh"
+          ]
+        },
+        "status": "ACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "submission": -1
+        },
+        "reward": null,
+        "info": {},
+        "observation": {
+          "remainingOverageTime": 12,
+          "step": 37,
+          "observationString": "{\"phase\": \"Draw\", \"current_player\": 0, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"6c\", \"upcard\": \"6c\", \"stock_size\": 26, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\"], \"hands\": {\"0\": [\"6s\", \"8s\", \"Qc\", \"3d\", \"7d\", \"8d\", \"9d\", \"Qd\", \"9h\", \"Qh\"], \"1\": []}, \"deadwood\": {\"0\": 26, \"1\": null}, \"repeated_move\": 1}",
+          "currentPlayer": 0,
+          "playerId": 0,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14,0:52,0:49,1:52,1:6,0:52,0:14,1:52,1:32,0:52,0:47,1:52,1:48,0:52,0:13,1:53,-1:19,1:3,0:53,-1:34,0:48,1:52,1:49,0:53,-1:24,0:6,1:52,1:47,0:52,0:43,1:52,1:43,0:53,-1:33,0:31,1:53,-1:37,1:37,0:52,0:18,1:52,1:18\nmove_number=62\n__dict__=gASVwQEAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRYfwEAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAo1Mgo0OQo1Mgo2CjUyCjE0CjUyCjMyCjUyCjQ3CjUyCjQ4CjUyCjEzCjUzCjE5CjMKNTMKMzQKNDgKNTIKNDkKNTMKMjQKNgo1Mgo0Nwo1Mgo0Mwo1Mgo0Mwo1MwozMwozMQo1MwozNwozNwo1MgoxOAo1MgoxOAoKlGJzLg==\n",
+          "legalActions": [52, 53],
+          "legalActionStrings": [
+            "Player: 0 Action: Draw upcard",
+            "Player: 0 Action: Draw stock"
+          ]
+        },
+        "status": "ACTIVE"
+      },
+      {
+        "action": {
+          "submission": 18,
+          "thoughts": "omega ember nu beta iota chi beta eta"
+        },
+        "reward": null,
+        "info": {
+          "actionSubmitted": 18,
+          "actionSubmittedToString": "Player: 1 Action: 6c",
+          "actionApplied": 18,
+          "timeTaken": 0.0,
+          "agentSelfReportedStatus": null
+        },
+        "observation": {
+          "remainingOverageTime": 12,
+          "observationString": "{\"phase\": \"Draw\", \"current_player\": 0, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"6c\", \"upcard\": \"6c\", \"stock_size\": 26, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\"], \"hands\": {\"0\": [], \"1\": [\"5s\", \"7s\", \"Qs\", \"2c\", \"7c\", \"9c\", \"Kc\", \"Kd\", \"Th\", \"Kh\"]}, \"deadwood\": {\"0\": null, \"1\": 50}, \"repeated_move\": 1}",
+          "currentPlayer": 0,
+          "playerId": 1,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14,0:52,0:49,1:52,1:6,0:52,0:14,1:52,1:32,0:52,0:47,1:52,1:48,0:52,0:13,1:53,-1:19,1:3,0:53,-1:34,0:48,1:52,1:49,0:53,-1:24,0:6,1:52,1:47,0:52,0:43,1:52,1:43,0:53,-1:33,0:31,1:53,-1:37,1:37,0:52,0:18,1:52,1:18\nmove_number=62\n__dict__=gASVwQEAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRYfwEAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAo1Mgo0OQo1Mgo2CjUyCjE0CjUyCjMyCjUyCjQ3CjUyCjQ4CjUyCjEzCjUzCjE5CjMKNTMKMzQKNDgKNTIKNDkKNTMKMjQKNgo1Mgo0Nwo1Mgo0Mwo1Mgo0Mwo1MwozMwozMQo1MwozNwozNwo1MgoxOAo1MgoxOAoKlGJzLg==\n",
+          "legalActions": [],
+          "legalActionStrings": []
+        },
+        "status": "INACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "submission": 53,
+          "thoughts": "kappa lantern nu alpha upsilon horizon delta horizon"
+        },
+        "reward": null,
+        "info": {
+          "actionSubmitted": 53,
+          "actionSubmittedToString": "Player: 0 Action: Draw stock",
+          "actionApplied": 53,
+          "timeTaken": 0.0,
+          "agentSelfReportedStatus": null
+        },
+        "observation": {
+          "remainingOverageTime": 12,
+          "step": 38,
+          "observationString": "{\"phase\": \"Discard\", \"current_player\": 0, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"6c\", \"upcard\": null, \"stock_size\": 25, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\"], \"hands\": {\"0\": [\"6s\", \"8s\", \"Qc\", \"3d\", \"5d\", \"7d\", \"8d\", \"9d\", \"Qd\", \"9h\", \"Qh\"], \"1\": []}, \"deadwood\": {\"0\": 22, \"1\": null}, \"repeated_move\": 1}",
+          "currentPlayer": 0,
+          "playerId": 0,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14,0:52,0:49,1:52,1:6,0:52,0:14,1:52,1:32,0:52,0:47,1:52,1:48,0:52,0:13,1:53,-1:19,1:3,0:53,-1:34,0:48,1:52,1:49,0:53,-1:24,0:6,1:52,1:47,0:52,0:43,1:52,1:43,0:53,-1:33,0:31,1:53,-1:37,1:37,0:52,0:18,1:52,1:18,0:53,-1:30\nmove_number=64\n__dict__=gASVxwEAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRYhQEAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAo1Mgo0OQo1Mgo2CjUyCjE0CjUyCjMyCjUyCjQ3CjUyCjQ4CjUyCjEzCjUzCjE5CjMKNTMKMzQKNDgKNTIKNDkKNTMKMjQKNgo1Mgo0Nwo1Mgo0Mwo1Mgo0Mwo1MwozMwozMQo1MwozNwozNwo1MgoxOAo1MgoxOAo1MwozMAoKlGJzLg==\n",
+          "legalActions": [5, 7, 24, 28, 30, 32, 33, 34, 37, 47, 50],
+          "legalActionStrings": [
+            "Player: 0 Action: 6s",
+            "Player: 0 Action: 8s",
+            "Player: 0 Action: Qc",
+            "Player: 0 Action: 3d",
+            "Player: 0 Action: 5d",
+            "Player: 0 Action: 7d",
+            "Player: 0 Action: 8d",
+            "Player: 0 Action: 9d",
+            "Player: 0 Action: Qd",
+            "Player: 0 Action: 9h",
+            "Player: 0 Action: Qh"
+          ]
+        },
+        "status": "ACTIVE"
+      },
+      {
+        "action": {
+          "submission": -1
+        },
+        "reward": null,
+        "info": {},
+        "observation": {
+          "remainingOverageTime": 12,
+          "observationString": "{\"phase\": \"Discard\", \"current_player\": 0, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"6c\", \"upcard\": null, \"stock_size\": 25, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\"], \"hands\": {\"0\": [], \"1\": [\"5s\", \"7s\", \"Qs\", \"2c\", \"7c\", \"9c\", \"Kc\", \"Kd\", \"Th\", \"Kh\"]}, \"deadwood\": {\"0\": null, \"1\": 50}, \"repeated_move\": 1}",
+          "currentPlayer": 0,
+          "playerId": 1,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14,0:52,0:49,1:52,1:6,0:52,0:14,1:52,1:32,0:52,0:47,1:52,1:48,0:52,0:13,1:53,-1:19,1:3,0:53,-1:34,0:48,1:52,1:49,0:53,-1:24,0:6,1:52,1:47,0:52,0:43,1:52,1:43,0:53,-1:33,0:31,1:53,-1:37,1:37,0:52,0:18,1:52,1:18,0:53,-1:30\nmove_number=64\n__dict__=gASVxwEAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRYhQEAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAo1Mgo0OQo1Mgo2CjUyCjE0CjUyCjMyCjUyCjQ3CjUyCjQ4CjUyCjEzCjUzCjE5CjMKNTMKMzQKNDgKNTIKNDkKNTMKMjQKNgo1Mgo0Nwo1Mgo0Mwo1Mgo0Mwo1MwozMwozMQo1MwozNwozNwo1MgoxOAo1MgoxOAo1MwozMAoKlGJzLg==\n",
+          "legalActions": [],
+          "legalActionStrings": []
+        },
+        "status": "INACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "submission": 7,
+          "thoughts": "consider eta tau zeta rho psi pi lambda"
+        },
+        "reward": null,
+        "info": {
+          "actionSubmitted": 7,
+          "actionSubmittedToString": "Player: 0 Action: 8s",
+          "actionApplied": 7,
+          "timeTaken": 0.0,
+          "agentSelfReportedStatus": null
+        },
+        "observation": {
+          "remainingOverageTime": 12,
+          "step": 39,
+          "observationString": "{\"phase\": \"Draw\", \"current_player\": 1, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"6c\", \"upcard\": \"8s\", \"stock_size\": 25, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\"], \"hands\": {\"0\": [\"6s\", \"Qc\", \"3d\", \"5d\", \"7d\", \"8d\", \"9d\", \"Qd\", \"9h\", \"Qh\"], \"1\": []}, \"deadwood\": {\"0\": 23, \"1\": null}, \"repeated_move\": 0}",
+          "currentPlayer": 1,
+          "playerId": 0,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14,0:52,0:49,1:52,1:6,0:52,0:14,1:52,1:32,0:52,0:47,1:52,1:48,0:52,0:13,1:53,-1:19,1:3,0:53,-1:34,0:48,1:52,1:49,0:53,-1:24,0:6,1:52,1:47,0:52,0:43,1:52,1:43,0:53,-1:33,0:31,1:53,-1:37,1:37,0:52,0:18,1:52,1:18,0:53,-1:30,0:7\nmove_number=65\n__dict__=gASVyQEAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRYhwEAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAo1Mgo0OQo1Mgo2CjUyCjE0CjUyCjMyCjUyCjQ3CjUyCjQ4CjUyCjEzCjUzCjE5CjMKNTMKMzQKNDgKNTIKNDkKNTMKMjQKNgo1Mgo0Nwo1Mgo0Mwo1Mgo0Mwo1MwozMwozMQo1MwozNwozNwo1MgoxOAo1MgoxOAo1MwozMAo3CgqUYnMu\n",
+          "legalActions": [],
+          "legalActionStrings": []
+        },
+        "status": "INACTIVE"
+      },
+      {
+        "action": {
+          "submission": -1
+        },
+        "reward": null,
+        "info": {},
+        "observation": {
+          "remainingOverageTime": 12,
+          "observationString": "{\"phase\": \"Draw\", \"current_player\": 1, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"6c\", \"upcard\": \"8s\", \"stock_size\": 25, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\"], \"hands\": {\"0\": [], \"1\": [\"5s\", \"7s\", \"Qs\", \"2c\", \"7c\", \"9c\", \"Kc\", \"Kd\", \"Th\", \"Kh\"]}, \"deadwood\": {\"0\": null, \"1\": 50}, \"repeated_move\": 0}",
+          "currentPlayer": 1,
+          "playerId": 1,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14,0:52,0:49,1:52,1:6,0:52,0:14,1:52,1:32,0:52,0:47,1:52,1:48,0:52,0:13,1:53,-1:19,1:3,0:53,-1:34,0:48,1:52,1:49,0:53,-1:24,0:6,1:52,1:47,0:52,0:43,1:52,1:43,0:53,-1:33,0:31,1:53,-1:37,1:37,0:52,0:18,1:52,1:18,0:53,-1:30,0:7\nmove_number=65\n__dict__=gASVyQEAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRYhwEAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAo1Mgo0OQo1Mgo2CjUyCjE0CjUyCjMyCjUyCjQ3CjUyCjQ4CjUyCjEzCjUzCjE5CjMKNTMKMzQKNDgKNTIKNDkKNTMKMjQKNgo1Mgo0Nwo1Mgo0Mwo1Mgo0Mwo1MwozMwozMQo1MwozNwozNwo1MgoxOAo1MgoxOAo1MwozMAo3CgqUYnMu\n",
+          "legalActions": [52, 53],
+          "legalActionStrings": [
+            "Player: 1 Action: Draw upcard",
+            "Player: 1 Action: Draw stock"
+          ]
+        },
+        "status": "ACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "submission": -1
+        },
+        "reward": null,
+        "info": {},
+        "observation": {
+          "remainingOverageTime": 12,
+          "step": 40,
+          "observationString": "{\"phase\": \"Discard\", \"current_player\": 1, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"8s\", \"upcard\": null, \"stock_size\": 24, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\"], \"hands\": {\"0\": [\"6s\", \"Qc\", \"3d\", \"5d\", \"7d\", \"8d\", \"9d\", \"Qd\", \"9h\", \"Qh\"], \"1\": []}, \"deadwood\": {\"0\": 23, \"1\": null}, \"repeated_move\": 0}",
+          "currentPlayer": 1,
+          "playerId": 0,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14,0:52,0:49,1:52,1:6,0:52,0:14,1:52,1:32,0:52,0:47,1:52,1:48,0:52,0:13,1:53,-1:19,1:3,0:53,-1:34,0:48,1:52,1:49,0:53,-1:24,0:6,1:52,1:47,0:52,0:43,1:52,1:43,0:53,-1:33,0:31,1:53,-1:37,1:37,0:52,0:18,1:52,1:18,0:53,-1:30,0:7,1:53,-1:15\nmove_number=67\n__dict__=gASVzwEAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRYjQEAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAo1Mgo0OQo1Mgo2CjUyCjE0CjUyCjMyCjUyCjQ3CjUyCjQ4CjUyCjEzCjUzCjE5CjMKNTMKMzQKNDgKNTIKNDkKNTMKMjQKNgo1Mgo0Nwo1Mgo0Mwo1Mgo0Mwo1MwozMwozMQo1MwozNwozNwo1MgoxOAo1MgoxOAo1MwozMAo3CjUzCjE1CgqUYnMu\n",
+          "legalActions": [],
+          "legalActionStrings": []
+        },
+        "status": "INACTIVE"
+      },
+      {
+        "action": {
+          "submission": 53,
+          "thoughts": "wonder tau alpha cascade ripple drift muse pi"
+        },
+        "reward": null,
+        "info": {
+          "actionSubmitted": 53,
+          "actionSubmittedToString": "Player: 1 Action: Draw stock",
+          "actionApplied": 53,
+          "timeTaken": 0.0,
+          "agentSelfReportedStatus": null
+        },
+        "observation": {
+          "remainingOverageTime": 12,
+          "observationString": "{\"phase\": \"Discard\", \"current_player\": 1, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"8s\", \"upcard\": null, \"stock_size\": 24, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\"], \"hands\": {\"0\": [], \"1\": [\"5s\", \"7s\", \"Qs\", \"2c\", \"3c\", \"7c\", \"9c\", \"Kc\", \"Kd\", \"Th\", \"Kh\"]}, \"deadwood\": {\"0\": null, \"1\": 43}, \"repeated_move\": 0}",
+          "currentPlayer": 1,
+          "playerId": 1,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14,0:52,0:49,1:52,1:6,0:52,0:14,1:52,1:32,0:52,0:47,1:52,1:48,0:52,0:13,1:53,-1:19,1:3,0:53,-1:34,0:48,1:52,1:49,0:53,-1:24,0:6,1:52,1:47,0:52,0:43,1:52,1:43,0:53,-1:33,0:31,1:53,-1:37,1:37,0:52,0:18,1:52,1:18,0:53,-1:30,0:7,1:53,-1:15\nmove_number=67\n__dict__=gASVzwEAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRYjQEAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAo1Mgo0OQo1Mgo2CjUyCjE0CjUyCjMyCjUyCjQ3CjUyCjQ4CjUyCjEzCjUzCjE5CjMKNTMKMzQKNDgKNTIKNDkKNTMKMjQKNgo1Mgo0Nwo1Mgo0Mwo1Mgo0Mwo1MwozMwozMQo1MwozNwozNwo1MgoxOAo1MgoxOAo1MwozMAo3CjUzCjE1CgqUYnMu\n",
+          "legalActions": [4, 6, 11, 14, 15, 19, 21, 25, 38, 48, 51],
+          "legalActionStrings": [
+            "Player: 1 Action: 5s",
+            "Player: 1 Action: 7s",
+            "Player: 1 Action: Qs",
+            "Player: 1 Action: 2c",
+            "Player: 1 Action: 3c",
+            "Player: 1 Action: 7c",
+            "Player: 1 Action: 9c",
+            "Player: 1 Action: Kc",
+            "Player: 1 Action: Kd",
+            "Player: 1 Action: Th",
+            "Player: 1 Action: Kh"
+          ]
+        },
+        "status": "ACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "submission": -1
+        },
+        "reward": null,
+        "info": {},
+        "observation": {
+          "remainingOverageTime": 12,
+          "step": 41,
+          "observationString": "{\"phase\": \"Draw\", \"current_player\": 0, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"8s\", \"upcard\": \"3c\", \"stock_size\": 24, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\"], \"hands\": {\"0\": [\"6s\", \"Qc\", \"3d\", \"5d\", \"7d\", \"8d\", \"9d\", \"Qd\", \"9h\", \"Qh\"], \"1\": []}, \"deadwood\": {\"0\": 23, \"1\": null}, \"repeated_move\": 0}",
+          "currentPlayer": 0,
+          "playerId": 0,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14,0:52,0:49,1:52,1:6,0:52,0:14,1:52,1:32,0:52,0:47,1:52,1:48,0:52,0:13,1:53,-1:19,1:3,0:53,-1:34,0:48,1:52,1:49,0:53,-1:24,0:6,1:52,1:47,0:52,0:43,1:52,1:43,0:53,-1:33,0:31,1:53,-1:37,1:37,0:52,0:18,1:52,1:18,0:53,-1:30,0:7,1:53,-1:15,1:15\nmove_number=68\n__dict__=gASV0gEAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRYkAEAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAo1Mgo0OQo1Mgo2CjUyCjE0CjUyCjMyCjUyCjQ3CjUyCjQ4CjUyCjEzCjUzCjE5CjMKNTMKMzQKNDgKNTIKNDkKNTMKMjQKNgo1Mgo0Nwo1Mgo0Mwo1Mgo0Mwo1MwozMwozMQo1MwozNwozNwo1MgoxOAo1MgoxOAo1MwozMAo3CjUzCjE1CjE1CgqUYnMu\n",
+          "legalActions": [52, 53],
+          "legalActionStrings": [
+            "Player: 0 Action: Draw upcard",
+            "Player: 0 Action: Draw stock"
+          ]
+        },
+        "status": "ACTIVE"
+      },
+      {
+        "action": {
+          "submission": 15,
+          "thoughts": "imagine explore ripple cascade ember zeta psi chi"
+        },
+        "reward": null,
+        "info": {
+          "actionSubmitted": 15,
+          "actionSubmittedToString": "Player: 1 Action: 3c",
+          "actionApplied": 15,
+          "timeTaken": 0.0,
+          "agentSelfReportedStatus": null
+        },
+        "observation": {
+          "remainingOverageTime": 12,
+          "observationString": "{\"phase\": \"Draw\", \"current_player\": 0, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"8s\", \"upcard\": \"3c\", \"stock_size\": 24, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\"], \"hands\": {\"0\": [], \"1\": [\"5s\", \"7s\", \"Qs\", \"2c\", \"7c\", \"9c\", \"Kc\", \"Kd\", \"Th\", \"Kh\"]}, \"deadwood\": {\"0\": null, \"1\": 50}, \"repeated_move\": 0}",
+          "currentPlayer": 0,
+          "playerId": 1,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14,0:52,0:49,1:52,1:6,0:52,0:14,1:52,1:32,0:52,0:47,1:52,1:48,0:52,0:13,1:53,-1:19,1:3,0:53,-1:34,0:48,1:52,1:49,0:53,-1:24,0:6,1:52,1:47,0:52,0:43,1:52,1:43,0:53,-1:33,0:31,1:53,-1:37,1:37,0:52,0:18,1:52,1:18,0:53,-1:30,0:7,1:53,-1:15,1:15\nmove_number=68\n__dict__=gASV0gEAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRYkAEAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAo1Mgo0OQo1Mgo2CjUyCjE0CjUyCjMyCjUyCjQ3CjUyCjQ4CjUyCjEzCjUzCjE5CjMKNTMKMzQKNDgKNTIKNDkKNTMKMjQKNgo1Mgo0Nwo1Mgo0Mwo1Mgo0Mwo1MwozMwozMQo1MwozNwozNwo1MgoxOAo1MgoxOAo1MwozMAo3CjUzCjE1CjE1CgqUYnMu\n",
+          "legalActions": [],
+          "legalActionStrings": []
+        },
+        "status": "INACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "submission": 53,
+          "thoughts": "gamma nu wonder mu delta muse pi wonder"
+        },
+        "reward": null,
+        "info": {
+          "actionSubmitted": 53,
+          "actionSubmittedToString": "Player: 0 Action: Draw stock",
+          "actionApplied": 53,
+          "timeTaken": 0.0,
+          "agentSelfReportedStatus": null
+        },
+        "observation": {
+          "remainingOverageTime": 12,
+          "step": 42,
+          "observationString": "{\"phase\": \"Discard\", \"current_player\": 0, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"3c\", \"upcard\": null, \"stock_size\": 23, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\"], \"hands\": {\"0\": [\"6s\", \"5c\", \"Qc\", \"3d\", \"5d\", \"7d\", \"8d\", \"9d\", \"Qd\", \"9h\", \"Qh\"], \"1\": []}, \"deadwood\": {\"0\": 19, \"1\": null}, \"repeated_move\": 0}",
+          "currentPlayer": 0,
+          "playerId": 0,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14,0:52,0:49,1:52,1:6,0:52,0:14,1:52,1:32,0:52,0:47,1:52,1:48,0:52,0:13,1:53,-1:19,1:3,0:53,-1:34,0:48,1:52,1:49,0:53,-1:24,0:6,1:52,1:47,0:52,0:43,1:52,1:43,0:53,-1:33,0:31,1:53,-1:37,1:37,0:52,0:18,1:52,1:18,0:53,-1:30,0:7,1:53,-1:15,1:15,0:53,-1:17\nmove_number=70\n__dict__=gASV2AEAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRYlgEAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAo1Mgo0OQo1Mgo2CjUyCjE0CjUyCjMyCjUyCjQ3CjUyCjQ4CjUyCjEzCjUzCjE5CjMKNTMKMzQKNDgKNTIKNDkKNTMKMjQKNgo1Mgo0Nwo1Mgo0Mwo1Mgo0Mwo1MwozMwozMQo1MwozNwozNwo1MgoxOAo1MgoxOAo1MwozMAo3CjUzCjE1CjE1CjUzCjE3CgqUYnMu\n",
+          "legalActions": [5, 17, 24, 28, 30, 32, 33, 34, 37, 47, 50],
+          "legalActionStrings": [
+            "Player: 0 Action: 6s",
+            "Player: 0 Action: 5c",
+            "Player: 0 Action: Qc",
+            "Player: 0 Action: 3d",
+            "Player: 0 Action: 5d",
+            "Player: 0 Action: 7d",
+            "Player: 0 Action: 8d",
+            "Player: 0 Action: 9d",
+            "Player: 0 Action: Qd",
+            "Player: 0 Action: 9h",
+            "Player: 0 Action: Qh"
+          ]
+        },
+        "status": "ACTIVE"
+      },
+      {
+        "action": {
+          "submission": -1
+        },
+        "reward": null,
+        "info": {},
+        "observation": {
+          "remainingOverageTime": 12,
+          "observationString": "{\"phase\": \"Discard\", \"current_player\": 0, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"3c\", \"upcard\": null, \"stock_size\": 23, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\"], \"hands\": {\"0\": [], \"1\": [\"5s\", \"7s\", \"Qs\", \"2c\", \"7c\", \"9c\", \"Kc\", \"Kd\", \"Th\", \"Kh\"]}, \"deadwood\": {\"0\": null, \"1\": 50}, \"repeated_move\": 0}",
+          "currentPlayer": 0,
+          "playerId": 1,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14,0:52,0:49,1:52,1:6,0:52,0:14,1:52,1:32,0:52,0:47,1:52,1:48,0:52,0:13,1:53,-1:19,1:3,0:53,-1:34,0:48,1:52,1:49,0:53,-1:24,0:6,1:52,1:47,0:52,0:43,1:52,1:43,0:53,-1:33,0:31,1:53,-1:37,1:37,0:52,0:18,1:52,1:18,0:53,-1:30,0:7,1:53,-1:15,1:15,0:53,-1:17\nmove_number=70\n__dict__=gASV2AEAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRYlgEAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAo1Mgo0OQo1Mgo2CjUyCjE0CjUyCjMyCjUyCjQ3CjUyCjQ4CjUyCjEzCjUzCjE5CjMKNTMKMzQKNDgKNTIKNDkKNTMKMjQKNgo1Mgo0Nwo1Mgo0Mwo1Mgo0Mwo1MwozMwozMQo1MwozNwozNwo1MgoxOAo1MgoxOAo1MwozMAo3CjUzCjE1CjE1CjUzCjE3CgqUYnMu\n",
+          "legalActions": [],
+          "legalActionStrings": []
+        },
+        "status": "INACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "submission": 37,
+          "thoughts": "chi echo wonder echo reflect ripple drift cascade"
+        },
+        "reward": null,
+        "info": {
+          "actionSubmitted": 37,
+          "actionSubmittedToString": "Player: 0 Action: Qd",
+          "actionApplied": 37,
+          "timeTaken": 0.0,
+          "agentSelfReportedStatus": null
+        },
+        "observation": {
+          "remainingOverageTime": 12,
+          "step": 43,
+          "observationString": "{\"phase\": \"Draw\", \"current_player\": 1, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"3c\", \"upcard\": \"Qd\", \"stock_size\": 23, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\"], \"hands\": {\"0\": [\"6s\", \"5c\", \"Qc\", \"3d\", \"5d\", \"7d\", \"8d\", \"9d\", \"9h\", \"Qh\"], \"1\": []}, \"deadwood\": {\"0\": 48, \"1\": null}, \"repeated_move\": 0}",
+          "currentPlayer": 1,
+          "playerId": 0,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14,0:52,0:49,1:52,1:6,0:52,0:14,1:52,1:32,0:52,0:47,1:52,1:48,0:52,0:13,1:53,-1:19,1:3,0:53,-1:34,0:48,1:52,1:49,0:53,-1:24,0:6,1:52,1:47,0:52,0:43,1:52,1:43,0:53,-1:33,0:31,1:53,-1:37,1:37,0:52,0:18,1:52,1:18,0:53,-1:30,0:7,1:53,-1:15,1:15,0:53,-1:17,0:37\nmove_number=71\n__dict__=gASV2wEAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRYmQEAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAo1Mgo0OQo1Mgo2CjUyCjE0CjUyCjMyCjUyCjQ3CjUyCjQ4CjUyCjEzCjUzCjE5CjMKNTMKMzQKNDgKNTIKNDkKNTMKMjQKNgo1Mgo0Nwo1Mgo0Mwo1Mgo0Mwo1MwozMwozMQo1MwozNwozNwo1MgoxOAo1MgoxOAo1MwozMAo3CjUzCjE1CjE1CjUzCjE3CjM3CgqUYnMu\n",
+          "legalActions": [],
+          "legalActionStrings": []
+        },
+        "status": "INACTIVE"
+      },
+      {
+        "action": {
+          "submission": -1
+        },
+        "reward": null,
+        "info": {},
+        "observation": {
+          "remainingOverageTime": 12,
+          "observationString": "{\"phase\": \"Draw\", \"current_player\": 1, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"3c\", \"upcard\": \"Qd\", \"stock_size\": 23, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\"], \"hands\": {\"0\": [], \"1\": [\"5s\", \"7s\", \"Qs\", \"2c\", \"7c\", \"9c\", \"Kc\", \"Kd\", \"Th\", \"Kh\"]}, \"deadwood\": {\"0\": null, \"1\": 50}, \"repeated_move\": 0}",
+          "currentPlayer": 1,
+          "playerId": 1,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14,0:52,0:49,1:52,1:6,0:52,0:14,1:52,1:32,0:52,0:47,1:52,1:48,0:52,0:13,1:53,-1:19,1:3,0:53,-1:34,0:48,1:52,1:49,0:53,-1:24,0:6,1:52,1:47,0:52,0:43,1:52,1:43,0:53,-1:33,0:31,1:53,-1:37,1:37,0:52,0:18,1:52,1:18,0:53,-1:30,0:7,1:53,-1:15,1:15,0:53,-1:17,0:37\nmove_number=71\n__dict__=gASV2wEAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRYmQEAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAo1Mgo0OQo1Mgo2CjUyCjE0CjUyCjMyCjUyCjQ3CjUyCjQ4CjUyCjEzCjUzCjE5CjMKNTMKMzQKNDgKNTIKNDkKNTMKMjQKNgo1Mgo0Nwo1Mgo0Mwo1Mgo0Mwo1MwozMwozMQo1MwozNwozNwo1MgoxOAo1MgoxOAo1MwozMAo3CjUzCjE1CjE1CjUzCjE3CjM3CgqUYnMu\n",
+          "legalActions": [52, 53],
+          "legalActionStrings": [
+            "Player: 1 Action: Draw upcard",
+            "Player: 1 Action: Draw stock"
+          ]
+        },
+        "status": "ACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "submission": -1
+        },
+        "reward": null,
+        "info": {},
+        "observation": {
+          "remainingOverageTime": 12,
+          "step": 44,
+          "observationString": "{\"phase\": \"Discard\", \"current_player\": 1, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"Qd\", \"upcard\": null, \"stock_size\": 23, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\"], \"hands\": {\"0\": [\"6s\", \"5c\", \"Qc\", \"3d\", \"5d\", \"7d\", \"8d\", \"9d\", \"9h\", \"Qh\"], \"1\": []}, \"deadwood\": {\"0\": 48, \"1\": null}, \"repeated_move\": 0}",
+          "currentPlayer": 1,
+          "playerId": 0,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14,0:52,0:49,1:52,1:6,0:52,0:14,1:52,1:32,0:52,0:47,1:52,1:48,0:52,0:13,1:53,-1:19,1:3,0:53,-1:34,0:48,1:52,1:49,0:53,-1:24,0:6,1:52,1:47,0:52,0:43,1:52,1:43,0:53,-1:33,0:31,1:53,-1:37,1:37,0:52,0:18,1:52,1:18,0:53,-1:30,0:7,1:53,-1:15,1:15,0:53,-1:17,0:37,1:52\nmove_number=72\n__dict__=gASV3gEAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRYnAEAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAo1Mgo0OQo1Mgo2CjUyCjE0CjUyCjMyCjUyCjQ3CjUyCjQ4CjUyCjEzCjUzCjE5CjMKNTMKMzQKNDgKNTIKNDkKNTMKMjQKNgo1Mgo0Nwo1Mgo0Mwo1Mgo0Mwo1MwozMwozMQo1MwozNwozNwo1MgoxOAo1MgoxOAo1MwozMAo3CjUzCjE1CjE1CjUzCjE3CjM3CjUyCgqUYnMu\n",
+          "legalActions": [],
+          "legalActionStrings": []
+        },
+        "status": "INACTIVE"
+      },
+      {
+        "action": {
+          "submission": 52,
+          "thoughts": "tau omega eta kappa reflect omicron theta psi"
+        },
+        "reward": null,
+        "info": {
+          "actionSubmitted": 52,
+          "actionSubmittedToString": "Player: 1 Action: Draw upcard",
+          "actionApplied": 52,
+          "timeTaken": 0.0,
+          "agentSelfReportedStatus": null
+        },
+        "observation": {
+          "remainingOverageTime": 12,
+          "observationString": "{\"phase\": \"Discard\", \"current_player\": 1, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"Qd\", \"upcard\": null, \"stock_size\": 23, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\"], \"hands\": {\"0\": [], \"1\": [\"5s\", \"7s\", \"Qs\", \"2c\", \"7c\", \"9c\", \"Kc\", \"Qd\", \"Kd\", \"Th\", \"Kh\"]}, \"deadwood\": {\"0\": null, \"1\": 50}, \"repeated_move\": 0}",
+          "currentPlayer": 1,
+          "playerId": 1,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14,0:52,0:49,1:52,1:6,0:52,0:14,1:52,1:32,0:52,0:47,1:52,1:48,0:52,0:13,1:53,-1:19,1:3,0:53,-1:34,0:48,1:52,1:49,0:53,-1:24,0:6,1:52,1:47,0:52,0:43,1:52,1:43,0:53,-1:33,0:31,1:53,-1:37,1:37,0:52,0:18,1:52,1:18,0:53,-1:30,0:7,1:53,-1:15,1:15,0:53,-1:17,0:37,1:52\nmove_number=72\n__dict__=gASV3gEAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRYnAEAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAo1Mgo0OQo1Mgo2CjUyCjE0CjUyCjMyCjUyCjQ3CjUyCjQ4CjUyCjEzCjUzCjE5CjMKNTMKMzQKNDgKNTIKNDkKNTMKMjQKNgo1Mgo0Nwo1Mgo0Mwo1Mgo0Mwo1MwozMwozMQo1MwozNwozNwo1MgoxOAo1MgoxOAo1MwozMAo3CjUzCjE1CjE1CjUzCjE3CjM3CjUyCgqUYnMu\n",
+          "legalActions": [4, 6, 11, 14, 19, 21, 25, 37, 38, 48, 51],
+          "legalActionStrings": [
+            "Player: 1 Action: 5s",
+            "Player: 1 Action: 7s",
+            "Player: 1 Action: Qs",
+            "Player: 1 Action: 2c",
+            "Player: 1 Action: 7c",
+            "Player: 1 Action: 9c",
+            "Player: 1 Action: Kc",
+            "Player: 1 Action: Qd",
+            "Player: 1 Action: Kd",
+            "Player: 1 Action: Th",
+            "Player: 1 Action: Kh"
+          ]
+        },
+        "status": "ACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "submission": -1
+        },
+        "reward": null,
+        "info": {},
+        "observation": {
+          "remainingOverageTime": 12,
+          "step": 45,
+          "observationString": "{\"phase\": \"Draw\", \"current_player\": 0, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"Qd\", \"upcard\": \"9c\", \"stock_size\": 23, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\"], \"hands\": {\"0\": [\"6s\", \"5c\", \"Qc\", \"3d\", \"5d\", \"7d\", \"8d\", \"9d\", \"9h\", \"Qh\"], \"1\": []}, \"deadwood\": {\"0\": 48, \"1\": null}, \"repeated_move\": 0}",
+          "currentPlayer": 0,
+          "playerId": 0,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14,0:52,0:49,1:52,1:6,0:52,0:14,1:52,1:32,0:52,0:47,1:52,1:48,0:52,0:13,1:53,-1:19,1:3,0:53,-1:34,0:48,1:52,1:49,0:53,-1:24,0:6,1:52,1:47,0:52,0:43,1:52,1:43,0:53,-1:33,0:31,1:53,-1:37,1:37,0:52,0:18,1:52,1:18,0:53,-1:30,0:7,1:53,-1:15,1:15,0:53,-1:17,0:37,1:52,1:21\nmove_number=73\n__dict__=gASV4QEAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRYnwEAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAo1Mgo0OQo1Mgo2CjUyCjE0CjUyCjMyCjUyCjQ3CjUyCjQ4CjUyCjEzCjUzCjE5CjMKNTMKMzQKNDgKNTIKNDkKNTMKMjQKNgo1Mgo0Nwo1Mgo0Mwo1Mgo0Mwo1MwozMwozMQo1MwozNwozNwo1MgoxOAo1MgoxOAo1MwozMAo3CjUzCjE1CjE1CjUzCjE3CjM3CjUyCjIxCgqUYnMu\n",
+          "legalActions": [52, 53],
+          "legalActionStrings": [
+            "Player: 0 Action: Draw upcard",
+            "Player: 0 Action: Draw stock"
+          ]
+        },
+        "status": "ACTIVE"
+      },
+      {
+        "action": {
+          "submission": 21,
+          "thoughts": "delta reflect explore reflect nu drift omicron zeta"
+        },
+        "reward": null,
+        "info": {
+          "actionSubmitted": 21,
+          "actionSubmittedToString": "Player: 1 Action: 9c",
+          "actionApplied": 21,
+          "timeTaken": 0.0,
+          "agentSelfReportedStatus": null
+        },
+        "observation": {
+          "remainingOverageTime": 12,
+          "observationString": "{\"phase\": \"Draw\", \"current_player\": 0, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"Qd\", \"upcard\": \"9c\", \"stock_size\": 23, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\"], \"hands\": {\"0\": [], \"1\": [\"5s\", \"7s\", \"Qs\", \"2c\", \"7c\", \"Kc\", \"Qd\", \"Kd\", \"Th\", \"Kh\"]}, \"deadwood\": {\"0\": null, \"1\": 51}, \"repeated_move\": 0}",
+          "currentPlayer": 0,
+          "playerId": 1,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14,0:52,0:49,1:52,1:6,0:52,0:14,1:52,1:32,0:52,0:47,1:52,1:48,0:52,0:13,1:53,-1:19,1:3,0:53,-1:34,0:48,1:52,1:49,0:53,-1:24,0:6,1:52,1:47,0:52,0:43,1:52,1:43,0:53,-1:33,0:31,1:53,-1:37,1:37,0:52,0:18,1:52,1:18,0:53,-1:30,0:7,1:53,-1:15,1:15,0:53,-1:17,0:37,1:52,1:21\nmove_number=73\n__dict__=gASV4QEAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRYnwEAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAo1Mgo0OQo1Mgo2CjUyCjE0CjUyCjMyCjUyCjQ3CjUyCjQ4CjUyCjEzCjUzCjE5CjMKNTMKMzQKNDgKNTIKNDkKNTMKMjQKNgo1Mgo0Nwo1Mgo0Mwo1Mgo0Mwo1MwozMwozMQo1MwozNwozNwo1MgoxOAo1MgoxOAo1MwozMAo3CjUzCjE1CjE1CjUzCjE3CjM3CjUyCjIxCgqUYnMu\n",
+          "legalActions": [],
+          "legalActionStrings": []
+        },
+        "status": "INACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "submission": 53,
+          "thoughts": "echo nu gamma psi sigma pi chi theta"
+        },
+        "reward": null,
+        "info": {
+          "actionSubmitted": 53,
+          "actionSubmittedToString": "Player: 0 Action: Draw stock",
+          "actionApplied": 53,
+          "timeTaken": 0.0,
+          "agentSelfReportedStatus": null
+        },
+        "observation": {
+          "remainingOverageTime": 12,
+          "step": 46,
+          "observationString": "{\"phase\": \"Discard\", \"current_player\": 0, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"9c\", \"upcard\": null, \"stock_size\": 22, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\"], \"hands\": {\"0\": [\"6s\", \"5c\", \"Qc\", \"3d\", \"5d\", \"7d\", \"8d\", \"9d\", \"2h\", \"9h\", \"Qh\"], \"1\": []}, \"deadwood\": {\"0\": 40, \"1\": null}, \"repeated_move\": 0}",
+          "currentPlayer": 0,
+          "playerId": 0,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14,0:52,0:49,1:52,1:6,0:52,0:14,1:52,1:32,0:52,0:47,1:52,1:48,0:52,0:13,1:53,-1:19,1:3,0:53,-1:34,0:48,1:52,1:49,0:53,-1:24,0:6,1:52,1:47,0:52,0:43,1:52,1:43,0:53,-1:33,0:31,1:53,-1:37,1:37,0:52,0:18,1:52,1:18,0:53,-1:30,0:7,1:53,-1:15,1:15,0:53,-1:17,0:37,1:52,1:21,0:53,-1:40\nmove_number=75\n__dict__=gASV5wEAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRYpQEAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAo1Mgo0OQo1Mgo2CjUyCjE0CjUyCjMyCjUyCjQ3CjUyCjQ4CjUyCjEzCjUzCjE5CjMKNTMKMzQKNDgKNTIKNDkKNTMKMjQKNgo1Mgo0Nwo1Mgo0Mwo1Mgo0Mwo1MwozMwozMQo1MwozNwozNwo1MgoxOAo1MgoxOAo1MwozMAo3CjUzCjE1CjE1CjUzCjE3CjM3CjUyCjIxCjUzCjQwCgqUYnMu\n",
+          "legalActions": [5, 17, 24, 28, 30, 32, 33, 34, 40, 47, 50],
+          "legalActionStrings": [
+            "Player: 0 Action: 6s",
+            "Player: 0 Action: 5c",
+            "Player: 0 Action: Qc",
+            "Player: 0 Action: 3d",
+            "Player: 0 Action: 5d",
+            "Player: 0 Action: 7d",
+            "Player: 0 Action: 8d",
+            "Player: 0 Action: 9d",
+            "Player: 0 Action: 2h",
+            "Player: 0 Action: 9h",
+            "Player: 0 Action: Qh"
+          ]
+        },
+        "status": "ACTIVE"
+      },
+      {
+        "action": {
+          "submission": -1
+        },
+        "reward": null,
+        "info": {},
+        "observation": {
+          "remainingOverageTime": 12,
+          "observationString": "{\"phase\": \"Discard\", \"current_player\": 0, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"9c\", \"upcard\": null, \"stock_size\": 22, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\"], \"hands\": {\"0\": [], \"1\": [\"5s\", \"7s\", \"Qs\", \"2c\", \"7c\", \"Kc\", \"Qd\", \"Kd\", \"Th\", \"Kh\"]}, \"deadwood\": {\"0\": null, \"1\": 51}, \"repeated_move\": 0}",
+          "currentPlayer": 0,
+          "playerId": 1,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14,0:52,0:49,1:52,1:6,0:52,0:14,1:52,1:32,0:52,0:47,1:52,1:48,0:52,0:13,1:53,-1:19,1:3,0:53,-1:34,0:48,1:52,1:49,0:53,-1:24,0:6,1:52,1:47,0:52,0:43,1:52,1:43,0:53,-1:33,0:31,1:53,-1:37,1:37,0:52,0:18,1:52,1:18,0:53,-1:30,0:7,1:53,-1:15,1:15,0:53,-1:17,0:37,1:52,1:21,0:53,-1:40\nmove_number=75\n__dict__=gASV5wEAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRYpQEAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAo1Mgo0OQo1Mgo2CjUyCjE0CjUyCjMyCjUyCjQ3CjUyCjQ4CjUyCjEzCjUzCjE5CjMKNTMKMzQKNDgKNTIKNDkKNTMKMjQKNgo1Mgo0Nwo1Mgo0Mwo1Mgo0Mwo1MwozMwozMQo1MwozNwozNwo1MgoxOAo1MgoxOAo1MwozMAo3CjUzCjE1CjE1CjUzCjE3CjM3CjUyCjIxCjUzCjQwCgqUYnMu\n",
+          "legalActions": [],
+          "legalActionStrings": []
+        },
+        "status": "INACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "submission": 30,
+          "thoughts": "lantern echo alpha chi shadow reflect shadow chi"
+        },
+        "reward": null,
+        "info": {
+          "actionSubmitted": 30,
+          "actionSubmittedToString": "Player: 0 Action: 5d",
+          "actionApplied": 30,
+          "timeTaken": 0.0,
+          "agentSelfReportedStatus": null
+        },
+        "observation": {
+          "remainingOverageTime": 12,
+          "step": 47,
+          "observationString": "{\"phase\": \"Draw\", \"current_player\": 1, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"9c\", \"upcard\": \"5d\", \"stock_size\": 22, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\"], \"hands\": {\"0\": [\"6s\", \"5c\", \"Qc\", \"3d\", \"7d\", \"8d\", \"9d\", \"2h\", \"9h\", \"Qh\"], \"1\": []}, \"deadwood\": {\"0\": 45, \"1\": null}, \"repeated_move\": 0}",
+          "currentPlayer": 1,
+          "playerId": 0,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14,0:52,0:49,1:52,1:6,0:52,0:14,1:52,1:32,0:52,0:47,1:52,1:48,0:52,0:13,1:53,-1:19,1:3,0:53,-1:34,0:48,1:52,1:49,0:53,-1:24,0:6,1:52,1:47,0:52,0:43,1:52,1:43,0:53,-1:33,0:31,1:53,-1:37,1:37,0:52,0:18,1:52,1:18,0:53,-1:30,0:7,1:53,-1:15,1:15,0:53,-1:17,0:37,1:52,1:21,0:53,-1:40,0:30\nmove_number=76\n__dict__=gASV6gEAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRYqAEAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAo1Mgo0OQo1Mgo2CjUyCjE0CjUyCjMyCjUyCjQ3CjUyCjQ4CjUyCjEzCjUzCjE5CjMKNTMKMzQKNDgKNTIKNDkKNTMKMjQKNgo1Mgo0Nwo1Mgo0Mwo1Mgo0Mwo1MwozMwozMQo1MwozNwozNwo1MgoxOAo1MgoxOAo1MwozMAo3CjUzCjE1CjE1CjUzCjE3CjM3CjUyCjIxCjUzCjQwCjMwCgqUYnMu\n",
+          "legalActions": [],
+          "legalActionStrings": []
+        },
+        "status": "INACTIVE"
+      },
+      {
+        "action": {
+          "submission": -1
+        },
+        "reward": null,
+        "info": {},
+        "observation": {
+          "remainingOverageTime": 12,
+          "observationString": "{\"phase\": \"Draw\", \"current_player\": 1, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"9c\", \"upcard\": \"5d\", \"stock_size\": 22, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\"], \"hands\": {\"0\": [], \"1\": [\"5s\", \"7s\", \"Qs\", \"2c\", \"7c\", \"Kc\", \"Qd\", \"Kd\", \"Th\", \"Kh\"]}, \"deadwood\": {\"0\": null, \"1\": 51}, \"repeated_move\": 0}",
+          "currentPlayer": 1,
+          "playerId": 1,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14,0:52,0:49,1:52,1:6,0:52,0:14,1:52,1:32,0:52,0:47,1:52,1:48,0:52,0:13,1:53,-1:19,1:3,0:53,-1:34,0:48,1:52,1:49,0:53,-1:24,0:6,1:52,1:47,0:52,0:43,1:52,1:43,0:53,-1:33,0:31,1:53,-1:37,1:37,0:52,0:18,1:52,1:18,0:53,-1:30,0:7,1:53,-1:15,1:15,0:53,-1:17,0:37,1:52,1:21,0:53,-1:40,0:30\nmove_number=76\n__dict__=gASV6gEAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRYqAEAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAo1Mgo0OQo1Mgo2CjUyCjE0CjUyCjMyCjUyCjQ3CjUyCjQ4CjUyCjEzCjUzCjE5CjMKNTMKMzQKNDgKNTIKNDkKNTMKMjQKNgo1Mgo0Nwo1Mgo0Mwo1Mgo0Mwo1MwozMwozMQo1MwozNwozNwo1MgoxOAo1MgoxOAo1MwozMAo3CjUzCjE1CjE1CjUzCjE3CjM3CjUyCjIxCjUzCjQwCjMwCgqUYnMu\n",
+          "legalActions": [52, 53],
+          "legalActionStrings": [
+            "Player: 1 Action: Draw upcard",
+            "Player: 1 Action: Draw stock"
+          ]
+        },
+        "status": "ACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "submission": -1
+        },
+        "reward": null,
+        "info": {},
+        "observation": {
+          "remainingOverageTime": 12,
+          "step": 48,
+          "observationString": "{\"phase\": \"Discard\", \"current_player\": 1, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"5d\", \"upcard\": null, \"stock_size\": 21, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\"], \"hands\": {\"0\": [\"6s\", \"5c\", \"Qc\", \"3d\", \"7d\", \"8d\", \"9d\", \"2h\", \"9h\", \"Qh\"], \"1\": []}, \"deadwood\": {\"0\": 45, \"1\": null}, \"repeated_move\": 0}",
+          "currentPlayer": 1,
+          "playerId": 0,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14,0:52,0:49,1:52,1:6,0:52,0:14,1:52,1:32,0:52,0:47,1:52,1:48,0:52,0:13,1:53,-1:19,1:3,0:53,-1:34,0:48,1:52,1:49,0:53,-1:24,0:6,1:52,1:47,0:52,0:43,1:52,1:43,0:53,-1:33,0:31,1:53,-1:37,1:37,0:52,0:18,1:52,1:18,0:53,-1:30,0:7,1:53,-1:15,1:15,0:53,-1:17,0:37,1:52,1:21,0:53,-1:40,0:30,1:53,-1:9\nmove_number=78\n__dict__=gASV7wEAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRYrQEAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAo1Mgo0OQo1Mgo2CjUyCjE0CjUyCjMyCjUyCjQ3CjUyCjQ4CjUyCjEzCjUzCjE5CjMKNTMKMzQKNDgKNTIKNDkKNTMKMjQKNgo1Mgo0Nwo1Mgo0Mwo1Mgo0Mwo1MwozMwozMQo1MwozNwozNwo1MgoxOAo1MgoxOAo1MwozMAo3CjUzCjE1CjE1CjUzCjE3CjM3CjUyCjIxCjUzCjQwCjMwCjUzCjkKCpRicy4=\n",
+          "legalActions": [],
+          "legalActionStrings": []
+        },
+        "status": "INACTIVE"
+      },
+      {
+        "action": {
+          "submission": 53,
+          "thoughts": "alpha omega omicron shadow zeta lantern explore phi"
+        },
+        "reward": null,
+        "info": {
+          "actionSubmitted": 53,
+          "actionSubmittedToString": "Player: 1 Action: Draw stock",
+          "actionApplied": 53,
+          "timeTaken": 0.0,
+          "agentSelfReportedStatus": null
+        },
+        "observation": {
+          "remainingOverageTime": 12,
+          "observationString": "{\"phase\": \"Discard\", \"current_player\": 1, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"5d\", \"upcard\": null, \"stock_size\": 21, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\"], \"hands\": {\"0\": [], \"1\": [\"5s\", \"7s\", \"Ts\", \"Qs\", \"2c\", \"7c\", \"Kc\", \"Qd\", \"Kd\", \"Th\", \"Kh\"]}, \"deadwood\": {\"0\": null, \"1\": 51}, \"repeated_move\": 0}",
+          "currentPlayer": 1,
+          "playerId": 1,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14,0:52,0:49,1:52,1:6,0:52,0:14,1:52,1:32,0:52,0:47,1:52,1:48,0:52,0:13,1:53,-1:19,1:3,0:53,-1:34,0:48,1:52,1:49,0:53,-1:24,0:6,1:52,1:47,0:52,0:43,1:52,1:43,0:53,-1:33,0:31,1:53,-1:37,1:37,0:52,0:18,1:52,1:18,0:53,-1:30,0:7,1:53,-1:15,1:15,0:53,-1:17,0:37,1:52,1:21,0:53,-1:40,0:30,1:53,-1:9\nmove_number=78\n__dict__=gASV7wEAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRYrQEAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAo1Mgo0OQo1Mgo2CjUyCjE0CjUyCjMyCjUyCjQ3CjUyCjQ4CjUyCjEzCjUzCjE5CjMKNTMKMzQKNDgKNTIKNDkKNTMKMjQKNgo1Mgo0Nwo1Mgo0Mwo1Mgo0Mwo1MwozMwozMQo1MwozNwozNwo1MgoxOAo1MgoxOAo1MwozMAo3CjUzCjE1CjE1CjUzCjE3CjM3CjUyCjIxCjUzCjQwCjMwCjUzCjkKCpRicy4=\n",
+          "legalActions": [4, 6, 9, 11, 14, 19, 25, 37, 38, 48, 51],
+          "legalActionStrings": [
+            "Player: 1 Action: 5s",
+            "Player: 1 Action: 7s",
+            "Player: 1 Action: Ts",
+            "Player: 1 Action: Qs",
+            "Player: 1 Action: 2c",
+            "Player: 1 Action: 7c",
+            "Player: 1 Action: Kc",
+            "Player: 1 Action: Qd",
+            "Player: 1 Action: Kd",
+            "Player: 1 Action: Th",
+            "Player: 1 Action: Kh"
+          ]
+        },
+        "status": "ACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "submission": -1
+        },
+        "reward": null,
+        "info": {},
+        "observation": {
+          "remainingOverageTime": 12,
+          "step": 49,
+          "observationString": "{\"phase\": \"Draw\", \"current_player\": 0, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"5d\", \"upcard\": \"7c\", \"stock_size\": 21, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\"], \"hands\": {\"0\": [\"6s\", \"5c\", \"Qc\", \"3d\", \"7d\", \"8d\", \"9d\", \"2h\", \"9h\", \"Qh\"], \"1\": []}, \"deadwood\": {\"0\": 45, \"1\": null}, \"repeated_move\": 0}",
+          "currentPlayer": 0,
+          "playerId": 0,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14,0:52,0:49,1:52,1:6,0:52,0:14,1:52,1:32,0:52,0:47,1:52,1:48,0:52,0:13,1:53,-1:19,1:3,0:53,-1:34,0:48,1:52,1:49,0:53,-1:24,0:6,1:52,1:47,0:52,0:43,1:52,1:43,0:53,-1:33,0:31,1:53,-1:37,1:37,0:52,0:18,1:52,1:18,0:53,-1:30,0:7,1:53,-1:15,1:15,0:53,-1:17,0:37,1:52,1:21,0:53,-1:40,0:30,1:53,-1:9,1:19\nmove_number=79\n__dict__=gASV8gEAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRYsAEAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAo1Mgo0OQo1Mgo2CjUyCjE0CjUyCjMyCjUyCjQ3CjUyCjQ4CjUyCjEzCjUzCjE5CjMKNTMKMzQKNDgKNTIKNDkKNTMKMjQKNgo1Mgo0Nwo1Mgo0Mwo1Mgo0Mwo1MwozMwozMQo1MwozNwozNwo1MgoxOAo1MgoxOAo1MwozMAo3CjUzCjE1CjE1CjUzCjE3CjM3CjUyCjIxCjUzCjQwCjMwCjUzCjkKMTkKCpRicy4=\n",
+          "legalActions": [52, 53],
+          "legalActionStrings": [
+            "Player: 0 Action: Draw upcard",
+            "Player: 0 Action: Draw stock"
+          ]
+        },
+        "status": "ACTIVE"
+      },
+      {
+        "action": {
+          "submission": 19,
+          "thoughts": "shadow gamma delta kappa gamma reflect iota delta"
+        },
+        "reward": null,
+        "info": {
+          "actionSubmitted": 19,
+          "actionSubmittedToString": "Player: 1 Action: 7c",
+          "actionApplied": 19,
+          "timeTaken": 0.0,
+          "agentSelfReportedStatus": null
+        },
+        "observation": {
+          "remainingOverageTime": 12,
+          "observationString": "{\"phase\": \"Draw\", \"current_player\": 0, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"5d\", \"upcard\": \"7c\", \"stock_size\": 21, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\"], \"hands\": {\"0\": [], \"1\": [\"5s\", \"7s\", \"Ts\", \"Qs\", \"2c\", \"Kc\", \"Qd\", \"Kd\", \"Th\", \"Kh\"]}, \"deadwood\": {\"0\": null, \"1\": 54}, \"repeated_move\": 0}",
+          "currentPlayer": 0,
+          "playerId": 1,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14,0:52,0:49,1:52,1:6,0:52,0:14,1:52,1:32,0:52,0:47,1:52,1:48,0:52,0:13,1:53,-1:19,1:3,0:53,-1:34,0:48,1:52,1:49,0:53,-1:24,0:6,1:52,1:47,0:52,0:43,1:52,1:43,0:53,-1:33,0:31,1:53,-1:37,1:37,0:52,0:18,1:52,1:18,0:53,-1:30,0:7,1:53,-1:15,1:15,0:53,-1:17,0:37,1:52,1:21,0:53,-1:40,0:30,1:53,-1:9,1:19\nmove_number=79\n__dict__=gASV8gEAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRYsAEAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAo1Mgo0OQo1Mgo2CjUyCjE0CjUyCjMyCjUyCjQ3CjUyCjQ4CjUyCjEzCjUzCjE5CjMKNTMKMzQKNDgKNTIKNDkKNTMKMjQKNgo1Mgo0Nwo1Mgo0Mwo1Mgo0Mwo1MwozMwozMQo1MwozNwozNwo1MgoxOAo1MgoxOAo1MwozMAo3CjUzCjE1CjE1CjUzCjE3CjM3CjUyCjIxCjUzCjQwCjMwCjUzCjkKMTkKCpRicy4=\n",
+          "legalActions": [],
+          "legalActionStrings": []
+        },
+        "status": "INACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "submission": 52,
+          "thoughts": "muse nu gamma eta pi spark imagine echo"
+        },
+        "reward": null,
+        "info": {
+          "actionSubmitted": 52,
+          "actionSubmittedToString": "Player: 0 Action: Draw upcard",
+          "actionApplied": 52,
+          "timeTaken": 0.0,
+          "agentSelfReportedStatus": null
+        },
+        "observation": {
+          "remainingOverageTime": 12,
+          "step": 50,
+          "observationString": "{\"phase\": \"Discard\", \"current_player\": 0, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"7c\", \"upcard\": null, \"stock_size\": 21, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\"], \"hands\": {\"0\": [\"6s\", \"5c\", \"7c\", \"Qc\", \"3d\", \"7d\", \"8d\", \"9d\", \"2h\", \"9h\", \"Qh\"], \"1\": []}, \"deadwood\": {\"0\": 42, \"1\": null}, \"repeated_move\": 0}",
+          "currentPlayer": 0,
+          "playerId": 0,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14,0:52,0:49,1:52,1:6,0:52,0:14,1:52,1:32,0:52,0:47,1:52,1:48,0:52,0:13,1:53,-1:19,1:3,0:53,-1:34,0:48,1:52,1:49,0:53,-1:24,0:6,1:52,1:47,0:52,0:43,1:52,1:43,0:53,-1:33,0:31,1:53,-1:37,1:37,0:52,0:18,1:52,1:18,0:53,-1:30,0:7,1:53,-1:15,1:15,0:53,-1:17,0:37,1:52,1:21,0:53,-1:40,0:30,1:53,-1:9,1:19,0:52\nmove_number=80\n__dict__=gASV9QEAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRYswEAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAo1Mgo0OQo1Mgo2CjUyCjE0CjUyCjMyCjUyCjQ3CjUyCjQ4CjUyCjEzCjUzCjE5CjMKNTMKMzQKNDgKNTIKNDkKNTMKMjQKNgo1Mgo0Nwo1Mgo0Mwo1Mgo0Mwo1MwozMwozMQo1MwozNwozNwo1MgoxOAo1MgoxOAo1MwozMAo3CjUzCjE1CjE1CjUzCjE3CjM3CjUyCjIxCjUzCjQwCjMwCjUzCjkKMTkKNTIKCpRicy4=\n",
+          "legalActions": [5, 17, 19, 24, 28, 32, 33, 34, 40, 47, 50],
+          "legalActionStrings": [
+            "Player: 0 Action: 6s",
+            "Player: 0 Action: 5c",
+            "Player: 0 Action: 7c",
+            "Player: 0 Action: Qc",
+            "Player: 0 Action: 3d",
+            "Player: 0 Action: 7d",
+            "Player: 0 Action: 8d",
+            "Player: 0 Action: 9d",
+            "Player: 0 Action: 2h",
+            "Player: 0 Action: 9h",
+            "Player: 0 Action: Qh"
+          ]
+        },
+        "status": "ACTIVE"
+      },
+      {
+        "action": {
+          "submission": -1
+        },
+        "reward": null,
+        "info": {},
+        "observation": {
+          "remainingOverageTime": 12,
+          "observationString": "{\"phase\": \"Discard\", \"current_player\": 0, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"7c\", \"upcard\": null, \"stock_size\": 21, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\"], \"hands\": {\"0\": [], \"1\": [\"5s\", \"7s\", \"Ts\", \"Qs\", \"2c\", \"Kc\", \"Qd\", \"Kd\", \"Th\", \"Kh\"]}, \"deadwood\": {\"0\": null, \"1\": 54}, \"repeated_move\": 0}",
+          "currentPlayer": 0,
+          "playerId": 1,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14,0:52,0:49,1:52,1:6,0:52,0:14,1:52,1:32,0:52,0:47,1:52,1:48,0:52,0:13,1:53,-1:19,1:3,0:53,-1:34,0:48,1:52,1:49,0:53,-1:24,0:6,1:52,1:47,0:52,0:43,1:52,1:43,0:53,-1:33,0:31,1:53,-1:37,1:37,0:52,0:18,1:52,1:18,0:53,-1:30,0:7,1:53,-1:15,1:15,0:53,-1:17,0:37,1:52,1:21,0:53,-1:40,0:30,1:53,-1:9,1:19,0:52\nmove_number=80\n__dict__=gASV9QEAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRYswEAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAo1Mgo0OQo1Mgo2CjUyCjE0CjUyCjMyCjUyCjQ3CjUyCjQ4CjUyCjEzCjUzCjE5CjMKNTMKMzQKNDgKNTIKNDkKNTMKMjQKNgo1Mgo0Nwo1Mgo0Mwo1Mgo0Mwo1MwozMwozMQo1MwozNwozNwo1MgoxOAo1MgoxOAo1MwozMAo3CjUzCjE1CjE1CjUzCjE3CjM3CjUyCjIxCjUzCjQwCjMwCjUzCjkKMTkKNTIKCpRicy4=\n",
+          "legalActions": [],
+          "legalActionStrings": []
+        },
+        "status": "INACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "submission": 40,
+          "thoughts": "zeta explore zeta beta eta alpha kappa reflect"
+        },
+        "reward": null,
+        "info": {
+          "actionSubmitted": 40,
+          "actionSubmittedToString": "Player: 0 Action: 2h",
+          "actionApplied": 40,
+          "timeTaken": 0.0,
+          "agentSelfReportedStatus": null
+        },
+        "observation": {
+          "remainingOverageTime": 12,
+          "step": 51,
+          "observationString": "{\"phase\": \"Draw\", \"current_player\": 1, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"7c\", \"upcard\": \"2h\", \"stock_size\": 21, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\"], \"hands\": {\"0\": [\"6s\", \"5c\", \"7c\", \"Qc\", \"3d\", \"7d\", \"8d\", \"9d\", \"9h\", \"Qh\"], \"1\": []}, \"deadwood\": {\"0\": 50, \"1\": null}, \"repeated_move\": 0}",
+          "currentPlayer": 1,
+          "playerId": 0,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14,0:52,0:49,1:52,1:6,0:52,0:14,1:52,1:32,0:52,0:47,1:52,1:48,0:52,0:13,1:53,-1:19,1:3,0:53,-1:34,0:48,1:52,1:49,0:53,-1:24,0:6,1:52,1:47,0:52,0:43,1:52,1:43,0:53,-1:33,0:31,1:53,-1:37,1:37,0:52,0:18,1:52,1:18,0:53,-1:30,0:7,1:53,-1:15,1:15,0:53,-1:17,0:37,1:52,1:21,0:53,-1:40,0:30,1:53,-1:9,1:19,0:52,0:40\nmove_number=81\n__dict__=gASV+AEAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRYtgEAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAo1Mgo0OQo1Mgo2CjUyCjE0CjUyCjMyCjUyCjQ3CjUyCjQ4CjUyCjEzCjUzCjE5CjMKNTMKMzQKNDgKNTIKNDkKNTMKMjQKNgo1Mgo0Nwo1Mgo0Mwo1Mgo0Mwo1MwozMwozMQo1MwozNwozNwo1MgoxOAo1MgoxOAo1MwozMAo3CjUzCjE1CjE1CjUzCjE3CjM3CjUyCjIxCjUzCjQwCjMwCjUzCjkKMTkKNTIKNDAKCpRicy4=\n",
+          "legalActions": [],
+          "legalActionStrings": []
+        },
+        "status": "INACTIVE"
+      },
+      {
+        "action": {
+          "submission": -1
+        },
+        "reward": null,
+        "info": {},
+        "observation": {
+          "remainingOverageTime": 12,
+          "observationString": "{\"phase\": \"Draw\", \"current_player\": 1, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"7c\", \"upcard\": \"2h\", \"stock_size\": 21, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\"], \"hands\": {\"0\": [], \"1\": [\"5s\", \"7s\", \"Ts\", \"Qs\", \"2c\", \"Kc\", \"Qd\", \"Kd\", \"Th\", \"Kh\"]}, \"deadwood\": {\"0\": null, \"1\": 54}, \"repeated_move\": 0}",
+          "currentPlayer": 1,
+          "playerId": 1,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14,0:52,0:49,1:52,1:6,0:52,0:14,1:52,1:32,0:52,0:47,1:52,1:48,0:52,0:13,1:53,-1:19,1:3,0:53,-1:34,0:48,1:52,1:49,0:53,-1:24,0:6,1:52,1:47,0:52,0:43,1:52,1:43,0:53,-1:33,0:31,1:53,-1:37,1:37,0:52,0:18,1:52,1:18,0:53,-1:30,0:7,1:53,-1:15,1:15,0:53,-1:17,0:37,1:52,1:21,0:53,-1:40,0:30,1:53,-1:9,1:19,0:52,0:40\nmove_number=81\n__dict__=gASV+AEAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRYtgEAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAo1Mgo0OQo1Mgo2CjUyCjE0CjUyCjMyCjUyCjQ3CjUyCjQ4CjUyCjEzCjUzCjE5CjMKNTMKMzQKNDgKNTIKNDkKNTMKMjQKNgo1Mgo0Nwo1Mgo0Mwo1Mgo0Mwo1MwozMwozMQo1MwozNwozNwo1MgoxOAo1MgoxOAo1MwozMAo3CjUzCjE1CjE1CjUzCjE3CjM3CjUyCjIxCjUzCjQwCjMwCjUzCjkKMTkKNTIKNDAKCpRicy4=\n",
+          "legalActions": [52, 53],
+          "legalActionStrings": [
+            "Player: 1 Action: Draw upcard",
+            "Player: 1 Action: Draw stock"
+          ]
+        },
+        "status": "ACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "submission": -1
+        },
+        "reward": null,
+        "info": {},
+        "observation": {
+          "remainingOverageTime": 12,
+          "step": 52,
+          "observationString": "{\"phase\": \"Discard\", \"current_player\": 1, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"2h\", \"upcard\": null, \"stock_size\": 20, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\", \"2h\"], \"hands\": {\"0\": [\"6s\", \"5c\", \"7c\", \"Qc\", \"3d\", \"7d\", \"8d\", \"9d\", \"9h\", \"Qh\"], \"1\": []}, \"deadwood\": {\"0\": 50, \"1\": null}, \"repeated_move\": 0}",
+          "currentPlayer": 1,
+          "playerId": 0,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14,0:52,0:49,1:52,1:6,0:52,0:14,1:52,1:32,0:52,0:47,1:52,1:48,0:52,0:13,1:53,-1:19,1:3,0:53,-1:34,0:48,1:52,1:49,0:53,-1:24,0:6,1:52,1:47,0:52,0:43,1:52,1:43,0:53,-1:33,0:31,1:53,-1:37,1:37,0:52,0:18,1:52,1:18,0:53,-1:30,0:7,1:53,-1:15,1:15,0:53,-1:17,0:37,1:52,1:21,0:53,-1:40,0:30,1:53,-1:9,1:19,0:52,0:40,1:53,-1:29\nmove_number=83\n__dict__=gASV/gEAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRYvAEAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAo1Mgo0OQo1Mgo2CjUyCjE0CjUyCjMyCjUyCjQ3CjUyCjQ4CjUyCjEzCjUzCjE5CjMKNTMKMzQKNDgKNTIKNDkKNTMKMjQKNgo1Mgo0Nwo1Mgo0Mwo1Mgo0Mwo1MwozMwozMQo1MwozNwozNwo1MgoxOAo1MgoxOAo1MwozMAo3CjUzCjE1CjE1CjUzCjE3CjM3CjUyCjIxCjUzCjQwCjMwCjUzCjkKMTkKNTIKNDAKNTMKMjkKCpRicy4=\n",
+          "legalActions": [],
+          "legalActionStrings": []
+        },
+        "status": "INACTIVE"
+      },
+      {
+        "action": {
+          "submission": 53,
+          "thoughts": "alpha phi shadow ponder explore phi explore tau"
+        },
+        "reward": null,
+        "info": {
+          "actionSubmitted": 53,
+          "actionSubmittedToString": "Player: 1 Action: Draw stock",
+          "actionApplied": 53,
+          "timeTaken": 0.0,
+          "agentSelfReportedStatus": null
+        },
+        "observation": {
+          "remainingOverageTime": 12,
+          "observationString": "{\"phase\": \"Discard\", \"current_player\": 1, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"2h\", \"upcard\": null, \"stock_size\": 20, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\", \"2h\"], \"hands\": {\"0\": [], \"1\": [\"5s\", \"7s\", \"Ts\", \"Qs\", \"2c\", \"Kc\", \"4d\", \"Qd\", \"Kd\", \"Th\", \"Kh\"]}, \"deadwood\": {\"0\": null, \"1\": 48}, \"repeated_move\": 0}",
+          "currentPlayer": 1,
+          "playerId": 1,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14,0:52,0:49,1:52,1:6,0:52,0:14,1:52,1:32,0:52,0:47,1:52,1:48,0:52,0:13,1:53,-1:19,1:3,0:53,-1:34,0:48,1:52,1:49,0:53,-1:24,0:6,1:52,1:47,0:52,0:43,1:52,1:43,0:53,-1:33,0:31,1:53,-1:37,1:37,0:52,0:18,1:52,1:18,0:53,-1:30,0:7,1:53,-1:15,1:15,0:53,-1:17,0:37,1:52,1:21,0:53,-1:40,0:30,1:53,-1:9,1:19,0:52,0:40,1:53,-1:29\nmove_number=83\n__dict__=gASV/gEAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRYvAEAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAo1Mgo0OQo1Mgo2CjUyCjE0CjUyCjMyCjUyCjQ3CjUyCjQ4CjUyCjEzCjUzCjE5CjMKNTMKMzQKNDgKNTIKNDkKNTMKMjQKNgo1Mgo0Nwo1Mgo0Mwo1Mgo0Mwo1MwozMwozMQo1MwozNwozNwo1MgoxOAo1MgoxOAo1MwozMAo3CjUzCjE1CjE1CjUzCjE3CjM3CjUyCjIxCjUzCjQwCjMwCjUzCjkKMTkKNTIKNDAKNTMKMjkKCpRicy4=\n",
+          "legalActions": [4, 6, 9, 11, 14, 25, 29, 37, 38, 48, 51],
+          "legalActionStrings": [
+            "Player: 1 Action: 5s",
+            "Player: 1 Action: 7s",
+            "Player: 1 Action: Ts",
+            "Player: 1 Action: Qs",
+            "Player: 1 Action: 2c",
+            "Player: 1 Action: Kc",
+            "Player: 1 Action: 4d",
+            "Player: 1 Action: Qd",
+            "Player: 1 Action: Kd",
+            "Player: 1 Action: Th",
+            "Player: 1 Action: Kh"
+          ]
+        },
+        "status": "ACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "submission": -1
+        },
+        "reward": null,
+        "info": {},
+        "observation": {
+          "remainingOverageTime": 12,
+          "step": 53,
+          "observationString": "{\"phase\": \"Draw\", \"current_player\": 0, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"2h\", \"upcard\": \"Ts\", \"stock_size\": 20, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\", \"2h\"], \"hands\": {\"0\": [\"6s\", \"5c\", \"7c\", \"Qc\", \"3d\", \"7d\", \"8d\", \"9d\", \"9h\", \"Qh\"], \"1\": []}, \"deadwood\": {\"0\": 50, \"1\": null}, \"repeated_move\": 0}",
+          "currentPlayer": 0,
+          "playerId": 0,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14,0:52,0:49,1:52,1:6,0:52,0:14,1:52,1:32,0:52,0:47,1:52,1:48,0:52,0:13,1:53,-1:19,1:3,0:53,-1:34,0:48,1:52,1:49,0:53,-1:24,0:6,1:52,1:47,0:52,0:43,1:52,1:43,0:53,-1:33,0:31,1:53,-1:37,1:37,0:52,0:18,1:52,1:18,0:53,-1:30,0:7,1:53,-1:15,1:15,0:53,-1:17,0:37,1:52,1:21,0:53,-1:40,0:30,1:53,-1:9,1:19,0:52,0:40,1:53,-1:29,1:9\nmove_number=84\n__dict__=gASVAAIAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRYvgEAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAo1Mgo0OQo1Mgo2CjUyCjE0CjUyCjMyCjUyCjQ3CjUyCjQ4CjUyCjEzCjUzCjE5CjMKNTMKMzQKNDgKNTIKNDkKNTMKMjQKNgo1Mgo0Nwo1Mgo0Mwo1Mgo0Mwo1MwozMwozMQo1MwozNwozNwo1MgoxOAo1MgoxOAo1MwozMAo3CjUzCjE1CjE1CjUzCjE3CjM3CjUyCjIxCjUzCjQwCjMwCjUzCjkKMTkKNTIKNDAKNTMKMjkKOQoKlGJzLg==\n",
+          "legalActions": [52, 53],
+          "legalActionStrings": [
+            "Player: 0 Action: Draw upcard",
+            "Player: 0 Action: Draw stock"
+          ]
+        },
+        "status": "ACTIVE"
+      },
+      {
+        "action": {
+          "submission": 9,
+          "thoughts": "lambda theta horizon zeta nu beta eta wonder"
+        },
+        "reward": null,
+        "info": {
+          "actionSubmitted": 9,
+          "actionSubmittedToString": "Player: 1 Action: Ts",
+          "actionApplied": 9,
+          "timeTaken": 0.0,
+          "agentSelfReportedStatus": null
+        },
+        "observation": {
+          "remainingOverageTime": 12,
+          "observationString": "{\"phase\": \"Draw\", \"current_player\": 0, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"2h\", \"upcard\": \"Ts\", \"stock_size\": 20, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\", \"2h\"], \"hands\": {\"0\": [], \"1\": [\"5s\", \"7s\", \"Qs\", \"2c\", \"Kc\", \"4d\", \"Qd\", \"Kd\", \"Th\", \"Kh\"]}, \"deadwood\": {\"0\": null, \"1\": 48}, \"repeated_move\": 0}",
+          "currentPlayer": 0,
+          "playerId": 1,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14,0:52,0:49,1:52,1:6,0:52,0:14,1:52,1:32,0:52,0:47,1:52,1:48,0:52,0:13,1:53,-1:19,1:3,0:53,-1:34,0:48,1:52,1:49,0:53,-1:24,0:6,1:52,1:47,0:52,0:43,1:52,1:43,0:53,-1:33,0:31,1:53,-1:37,1:37,0:52,0:18,1:52,1:18,0:53,-1:30,0:7,1:53,-1:15,1:15,0:53,-1:17,0:37,1:52,1:21,0:53,-1:40,0:30,1:53,-1:9,1:19,0:52,0:40,1:53,-1:29,1:9\nmove_number=84\n__dict__=gASVAAIAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRYvgEAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAo1Mgo0OQo1Mgo2CjUyCjE0CjUyCjMyCjUyCjQ3CjUyCjQ4CjUyCjEzCjUzCjE5CjMKNTMKMzQKNDgKNTIKNDkKNTMKMjQKNgo1Mgo0Nwo1Mgo0Mwo1Mgo0Mwo1MwozMwozMQo1MwozNwozNwo1MgoxOAo1MgoxOAo1MwozMAo3CjUzCjE1CjE1CjUzCjE3CjM3CjUyCjIxCjUzCjQwCjMwCjUzCjkKMTkKNTIKNDAKNTMKMjkKOQoKlGJzLg==\n",
+          "legalActions": [],
+          "legalActionStrings": []
+        },
+        "status": "INACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "submission": 52,
+          "thoughts": "wonder epsilon epsilon chi muse zeta phi phi"
+        },
+        "reward": null,
+        "info": {
+          "actionSubmitted": 52,
+          "actionSubmittedToString": "Player: 0 Action: Draw upcard",
+          "actionApplied": 52,
+          "timeTaken": 0.0,
+          "agentSelfReportedStatus": null
+        },
+        "observation": {
+          "remainingOverageTime": 12,
+          "step": 54,
+          "observationString": "{\"phase\": \"Discard\", \"current_player\": 0, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"Ts\", \"upcard\": null, \"stock_size\": 20, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\", \"2h\"], \"hands\": {\"0\": [\"6s\", \"Ts\", \"5c\", \"7c\", \"Qc\", \"3d\", \"7d\", \"8d\", \"9d\", \"9h\", \"Qh\"], \"1\": []}, \"deadwood\": {\"0\": 50, \"1\": null}, \"repeated_move\": 0}",
+          "currentPlayer": 0,
+          "playerId": 0,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14,0:52,0:49,1:52,1:6,0:52,0:14,1:52,1:32,0:52,0:47,1:52,1:48,0:52,0:13,1:53,-1:19,1:3,0:53,-1:34,0:48,1:52,1:49,0:53,-1:24,0:6,1:52,1:47,0:52,0:43,1:52,1:43,0:53,-1:33,0:31,1:53,-1:37,1:37,0:52,0:18,1:52,1:18,0:53,-1:30,0:7,1:53,-1:15,1:15,0:53,-1:17,0:37,1:52,1:21,0:53,-1:40,0:30,1:53,-1:9,1:19,0:52,0:40,1:53,-1:29,1:9,0:52\nmove_number=85\n__dict__=gASVAwIAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRYwQEAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAo1Mgo0OQo1Mgo2CjUyCjE0CjUyCjMyCjUyCjQ3CjUyCjQ4CjUyCjEzCjUzCjE5CjMKNTMKMzQKNDgKNTIKNDkKNTMKMjQKNgo1Mgo0Nwo1Mgo0Mwo1Mgo0Mwo1MwozMwozMQo1MwozNwozNwo1MgoxOAo1MgoxOAo1MwozMAo3CjUzCjE1CjE1CjUzCjE3CjM3CjUyCjIxCjUzCjQwCjMwCjUzCjkKMTkKNTIKNDAKNTMKMjkKOQo1MgoKlGJzLg==\n",
+          "legalActions": [5, 9, 17, 19, 24, 28, 32, 33, 34, 47, 50],
+          "legalActionStrings": [
+            "Player: 0 Action: 6s",
+            "Player: 0 Action: Ts",
+            "Player: 0 Action: 5c",
+            "Player: 0 Action: 7c",
+            "Player: 0 Action: Qc",
+            "Player: 0 Action: 3d",
+            "Player: 0 Action: 7d",
+            "Player: 0 Action: 8d",
+            "Player: 0 Action: 9d",
+            "Player: 0 Action: 9h",
+            "Player: 0 Action: Qh"
+          ]
+        },
+        "status": "ACTIVE"
+      },
+      {
+        "action": {
+          "submission": -1
+        },
+        "reward": null,
+        "info": {},
+        "observation": {
+          "remainingOverageTime": 12,
+          "observationString": "{\"phase\": \"Discard\", \"current_player\": 0, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"Ts\", \"upcard\": null, \"stock_size\": 20, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\", \"2h\"], \"hands\": {\"0\": [], \"1\": [\"5s\", \"7s\", \"Qs\", \"2c\", \"Kc\", \"4d\", \"Qd\", \"Kd\", \"Th\", \"Kh\"]}, \"deadwood\": {\"0\": null, \"1\": 48}, \"repeated_move\": 0}",
+          "currentPlayer": 0,
+          "playerId": 1,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14,0:52,0:49,1:52,1:6,0:52,0:14,1:52,1:32,0:52,0:47,1:52,1:48,0:52,0:13,1:53,-1:19,1:3,0:53,-1:34,0:48,1:52,1:49,0:53,-1:24,0:6,1:52,1:47,0:52,0:43,1:52,1:43,0:53,-1:33,0:31,1:53,-1:37,1:37,0:52,0:18,1:52,1:18,0:53,-1:30,0:7,1:53,-1:15,1:15,0:53,-1:17,0:37,1:52,1:21,0:53,-1:40,0:30,1:53,-1:9,1:19,0:52,0:40,1:53,-1:29,1:9,0:52\nmove_number=85\n__dict__=gASVAwIAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRYwQEAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAo1Mgo0OQo1Mgo2CjUyCjE0CjUyCjMyCjUyCjQ3CjUyCjQ4CjUyCjEzCjUzCjE5CjMKNTMKMzQKNDgKNTIKNDkKNTMKMjQKNgo1Mgo0Nwo1Mgo0Mwo1Mgo0Mwo1MwozMwozMQo1MwozNwozNwo1MgoxOAo1MgoxOAo1MwozMAo3CjUzCjE1CjE1CjUzCjE3CjM3CjUyCjIxCjUzCjQwCjMwCjUzCjkKMTkKNTIKNDAKNTMKMjkKOQo1MgoKlGJzLg==\n",
+          "legalActions": [],
+          "legalActionStrings": []
+        },
+        "status": "INACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "submission": 47,
+          "thoughts": "pi lantern tau tau rho sigma wonder zeta"
+        },
+        "reward": null,
+        "info": {
+          "actionSubmitted": 47,
+          "actionSubmittedToString": "Player: 0 Action: 9h",
+          "actionApplied": 47,
+          "timeTaken": 0.0,
+          "agentSelfReportedStatus": null
+        },
+        "observation": {
+          "remainingOverageTime": 12,
+          "step": 55,
+          "observationString": "{\"phase\": \"Draw\", \"current_player\": 1, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"Ts\", \"upcard\": \"9h\", \"stock_size\": 20, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\", \"2h\"], \"hands\": {\"0\": [\"6s\", \"Ts\", \"5c\", \"7c\", \"Qc\", \"3d\", \"7d\", \"8d\", \"9d\", \"Qh\"], \"1\": []}, \"deadwood\": {\"0\": 51, \"1\": null}, \"repeated_move\": 0}",
+          "currentPlayer": 1,
+          "playerId": 0,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14,0:52,0:49,1:52,1:6,0:52,0:14,1:52,1:32,0:52,0:47,1:52,1:48,0:52,0:13,1:53,-1:19,1:3,0:53,-1:34,0:48,1:52,1:49,0:53,-1:24,0:6,1:52,1:47,0:52,0:43,1:52,1:43,0:53,-1:33,0:31,1:53,-1:37,1:37,0:52,0:18,1:52,1:18,0:53,-1:30,0:7,1:53,-1:15,1:15,0:53,-1:17,0:37,1:52,1:21,0:53,-1:40,0:30,1:53,-1:9,1:19,0:52,0:40,1:53,-1:29,1:9,0:52,0:47\nmove_number=86\n__dict__=gASVBgIAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRYxAEAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAo1Mgo0OQo1Mgo2CjUyCjE0CjUyCjMyCjUyCjQ3CjUyCjQ4CjUyCjEzCjUzCjE5CjMKNTMKMzQKNDgKNTIKNDkKNTMKMjQKNgo1Mgo0Nwo1Mgo0Mwo1Mgo0Mwo1MwozMwozMQo1MwozNwozNwo1MgoxOAo1MgoxOAo1MwozMAo3CjUzCjE1CjE1CjUzCjE3CjM3CjUyCjIxCjUzCjQwCjMwCjUzCjkKMTkKNTIKNDAKNTMKMjkKOQo1Mgo0NwoKlGJzLg==\n",
+          "legalActions": [],
+          "legalActionStrings": []
+        },
+        "status": "INACTIVE"
+      },
+      {
+        "action": {
+          "submission": -1
+        },
+        "reward": null,
+        "info": {},
+        "observation": {
+          "remainingOverageTime": 12,
+          "observationString": "{\"phase\": \"Draw\", \"current_player\": 1, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"Ts\", \"upcard\": \"9h\", \"stock_size\": 20, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\", \"2h\"], \"hands\": {\"0\": [], \"1\": [\"5s\", \"7s\", \"Qs\", \"2c\", \"Kc\", \"4d\", \"Qd\", \"Kd\", \"Th\", \"Kh\"]}, \"deadwood\": {\"0\": null, \"1\": 48}, \"repeated_move\": 0}",
+          "currentPlayer": 1,
+          "playerId": 1,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14,0:52,0:49,1:52,1:6,0:52,0:14,1:52,1:32,0:52,0:47,1:52,1:48,0:52,0:13,1:53,-1:19,1:3,0:53,-1:34,0:48,1:52,1:49,0:53,-1:24,0:6,1:52,1:47,0:52,0:43,1:52,1:43,0:53,-1:33,0:31,1:53,-1:37,1:37,0:52,0:18,1:52,1:18,0:53,-1:30,0:7,1:53,-1:15,1:15,0:53,-1:17,0:37,1:52,1:21,0:53,-1:40,0:30,1:53,-1:9,1:19,0:52,0:40,1:53,-1:29,1:9,0:52,0:47\nmove_number=86\n__dict__=gASVBgIAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRYxAEAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAo1Mgo0OQo1Mgo2CjUyCjE0CjUyCjMyCjUyCjQ3CjUyCjQ4CjUyCjEzCjUzCjE5CjMKNTMKMzQKNDgKNTIKNDkKNTMKMjQKNgo1Mgo0Nwo1Mgo0Mwo1Mgo0Mwo1MwozMwozMQo1MwozNwozNwo1MgoxOAo1MgoxOAo1MwozMAo3CjUzCjE1CjE1CjUzCjE3CjM3CjUyCjIxCjUzCjQwCjMwCjUzCjkKMTkKNTIKNDAKNTMKMjkKOQo1Mgo0NwoKlGJzLg==\n",
+          "legalActions": [52, 53],
+          "legalActionStrings": [
+            "Player: 1 Action: Draw upcard",
+            "Player: 1 Action: Draw stock"
+          ]
+        },
+        "status": "ACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "submission": -1
+        },
+        "reward": null,
+        "info": {},
+        "observation": {
+          "remainingOverageTime": 12,
+          "step": 56,
+          "observationString": "{\"phase\": \"Discard\", \"current_player\": 1, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"9h\", \"upcard\": null, \"stock_size\": 20, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\", \"2h\"], \"hands\": {\"0\": [\"6s\", \"Ts\", \"5c\", \"7c\", \"Qc\", \"3d\", \"7d\", \"8d\", \"9d\", \"Qh\"], \"1\": []}, \"deadwood\": {\"0\": 51, \"1\": null}, \"repeated_move\": 0}",
+          "currentPlayer": 1,
+          "playerId": 0,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14,0:52,0:49,1:52,1:6,0:52,0:14,1:52,1:32,0:52,0:47,1:52,1:48,0:52,0:13,1:53,-1:19,1:3,0:53,-1:34,0:48,1:52,1:49,0:53,-1:24,0:6,1:52,1:47,0:52,0:43,1:52,1:43,0:53,-1:33,0:31,1:53,-1:37,1:37,0:52,0:18,1:52,1:18,0:53,-1:30,0:7,1:53,-1:15,1:15,0:53,-1:17,0:37,1:52,1:21,0:53,-1:40,0:30,1:53,-1:9,1:19,0:52,0:40,1:53,-1:29,1:9,0:52,0:47,1:52\nmove_number=87\n__dict__=gASVCQIAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRYxwEAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAo1Mgo0OQo1Mgo2CjUyCjE0CjUyCjMyCjUyCjQ3CjUyCjQ4CjUyCjEzCjUzCjE5CjMKNTMKMzQKNDgKNTIKNDkKNTMKMjQKNgo1Mgo0Nwo1Mgo0Mwo1Mgo0Mwo1MwozMwozMQo1MwozNwozNwo1MgoxOAo1MgoxOAo1MwozMAo3CjUzCjE1CjE1CjUzCjE3CjM3CjUyCjIxCjUzCjQwCjMwCjUzCjkKMTkKNTIKNDAKNTMKMjkKOQo1Mgo0Nwo1MgoKlGJzLg==\n",
+          "legalActions": [],
+          "legalActionStrings": []
+        },
+        "status": "INACTIVE"
+      },
+      {
+        "action": {
+          "submission": 52,
+          "thoughts": "ripple mu pi pi nu omicron chi alpha"
+        },
+        "reward": null,
+        "info": {
+          "actionSubmitted": 52,
+          "actionSubmittedToString": "Player: 1 Action: Draw upcard",
+          "actionApplied": 52,
+          "timeTaken": 0.0,
+          "agentSelfReportedStatus": null
+        },
+        "observation": {
+          "remainingOverageTime": 12,
+          "observationString": "{\"phase\": \"Discard\", \"current_player\": 1, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"9h\", \"upcard\": null, \"stock_size\": 20, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\", \"2h\"], \"hands\": {\"0\": [], \"1\": [\"5s\", \"7s\", \"Qs\", \"2c\", \"Kc\", \"4d\", \"Qd\", \"Kd\", \"9h\", \"Th\", \"Kh\"]}, \"deadwood\": {\"0\": null, \"1\": 47}, \"repeated_move\": 0}",
+          "currentPlayer": 1,
+          "playerId": 1,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14,0:52,0:49,1:52,1:6,0:52,0:14,1:52,1:32,0:52,0:47,1:52,1:48,0:52,0:13,1:53,-1:19,1:3,0:53,-1:34,0:48,1:52,1:49,0:53,-1:24,0:6,1:52,1:47,0:52,0:43,1:52,1:43,0:53,-1:33,0:31,1:53,-1:37,1:37,0:52,0:18,1:52,1:18,0:53,-1:30,0:7,1:53,-1:15,1:15,0:53,-1:17,0:37,1:52,1:21,0:53,-1:40,0:30,1:53,-1:9,1:19,0:52,0:40,1:53,-1:29,1:9,0:52,0:47,1:52\nmove_number=87\n__dict__=gASVCQIAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRYxwEAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAo1Mgo0OQo1Mgo2CjUyCjE0CjUyCjMyCjUyCjQ3CjUyCjQ4CjUyCjEzCjUzCjE5CjMKNTMKMzQKNDgKNTIKNDkKNTMKMjQKNgo1Mgo0Nwo1Mgo0Mwo1Mgo0Mwo1MwozMwozMQo1MwozNwozNwo1MgoxOAo1MgoxOAo1MwozMAo3CjUzCjE1CjE1CjUzCjE3CjM3CjUyCjIxCjUzCjQwCjMwCjUzCjkKMTkKNTIKNDAKNTMKMjkKOQo1Mgo0Nwo1MgoKlGJzLg==\n",
+          "legalActions": [4, 6, 11, 14, 25, 29, 37, 38, 47, 48, 51],
+          "legalActionStrings": [
+            "Player: 1 Action: 5s",
+            "Player: 1 Action: 7s",
+            "Player: 1 Action: Qs",
+            "Player: 1 Action: 2c",
+            "Player: 1 Action: Kc",
+            "Player: 1 Action: 4d",
+            "Player: 1 Action: Qd",
+            "Player: 1 Action: Kd",
+            "Player: 1 Action: 9h",
+            "Player: 1 Action: Th",
+            "Player: 1 Action: Kh"
+          ]
+        },
+        "status": "ACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "submission": -1
+        },
+        "reward": null,
+        "info": {},
+        "observation": {
+          "remainingOverageTime": 12,
+          "step": 57,
+          "observationString": "{\"phase\": \"Draw\", \"current_player\": 0, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"9h\", \"upcard\": \"5s\", \"stock_size\": 20, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\", \"2h\"], \"hands\": {\"0\": [\"6s\", \"Ts\", \"5c\", \"7c\", \"Qc\", \"3d\", \"7d\", \"8d\", \"9d\", \"Qh\"], \"1\": []}, \"deadwood\": {\"0\": 51, \"1\": null}, \"repeated_move\": 0}",
+          "currentPlayer": 0,
+          "playerId": 0,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14,0:52,0:49,1:52,1:6,0:52,0:14,1:52,1:32,0:52,0:47,1:52,1:48,0:52,0:13,1:53,-1:19,1:3,0:53,-1:34,0:48,1:52,1:49,0:53,-1:24,0:6,1:52,1:47,0:52,0:43,1:52,1:43,0:53,-1:33,0:31,1:53,-1:37,1:37,0:52,0:18,1:52,1:18,0:53,-1:30,0:7,1:53,-1:15,1:15,0:53,-1:17,0:37,1:52,1:21,0:53,-1:40,0:30,1:53,-1:9,1:19,0:52,0:40,1:53,-1:29,1:9,0:52,0:47,1:52,1:4\nmove_number=88\n__dict__=gASVCwIAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRYyQEAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAo1Mgo0OQo1Mgo2CjUyCjE0CjUyCjMyCjUyCjQ3CjUyCjQ4CjUyCjEzCjUzCjE5CjMKNTMKMzQKNDgKNTIKNDkKNTMKMjQKNgo1Mgo0Nwo1Mgo0Mwo1Mgo0Mwo1MwozMwozMQo1MwozNwozNwo1MgoxOAo1MgoxOAo1MwozMAo3CjUzCjE1CjE1CjUzCjE3CjM3CjUyCjIxCjUzCjQwCjMwCjUzCjkKMTkKNTIKNDAKNTMKMjkKOQo1Mgo0Nwo1Mgo0CgqUYnMu\n",
+          "legalActions": [52, 53],
+          "legalActionStrings": [
+            "Player: 0 Action: Draw upcard",
+            "Player: 0 Action: Draw stock"
+          ]
+        },
+        "status": "ACTIVE"
+      },
+      {
+        "action": {
+          "submission": 4,
+          "thoughts": "lambda ripple eta horizon ripple horizon imagine zeta"
+        },
+        "reward": null,
+        "info": {
+          "actionSubmitted": 4,
+          "actionSubmittedToString": "Player: 1 Action: 5s",
+          "actionApplied": 4,
+          "timeTaken": 0.0,
+          "agentSelfReportedStatus": null
+        },
+        "observation": {
+          "remainingOverageTime": 12,
+          "observationString": "{\"phase\": \"Draw\", \"current_player\": 0, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"9h\", \"upcard\": \"5s\", \"stock_size\": 20, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\", \"2h\"], \"hands\": {\"0\": [], \"1\": [\"7s\", \"Qs\", \"2c\", \"Kc\", \"4d\", \"Qd\", \"Kd\", \"9h\", \"Th\", \"Kh\"]}, \"deadwood\": {\"0\": null, \"1\": 52}, \"repeated_move\": 0}",
+          "currentPlayer": 0,
+          "playerId": 1,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14,0:52,0:49,1:52,1:6,0:52,0:14,1:52,1:32,0:52,0:47,1:52,1:48,0:52,0:13,1:53,-1:19,1:3,0:53,-1:34,0:48,1:52,1:49,0:53,-1:24,0:6,1:52,1:47,0:52,0:43,1:52,1:43,0:53,-1:33,0:31,1:53,-1:37,1:37,0:52,0:18,1:52,1:18,0:53,-1:30,0:7,1:53,-1:15,1:15,0:53,-1:17,0:37,1:52,1:21,0:53,-1:40,0:30,1:53,-1:9,1:19,0:52,0:40,1:53,-1:29,1:9,0:52,0:47,1:52,1:4\nmove_number=88\n__dict__=gASVCwIAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRYyQEAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAo1Mgo0OQo1Mgo2CjUyCjE0CjUyCjMyCjUyCjQ3CjUyCjQ4CjUyCjEzCjUzCjE5CjMKNTMKMzQKNDgKNTIKNDkKNTMKMjQKNgo1Mgo0Nwo1Mgo0Mwo1Mgo0Mwo1MwozMwozMQo1MwozNwozNwo1MgoxOAo1MgoxOAo1MwozMAo3CjUzCjE1CjE1CjUzCjE3CjM3CjUyCjIxCjUzCjQwCjMwCjUzCjkKMTkKNTIKNDAKNTMKMjkKOQo1Mgo0Nwo1Mgo0CgqUYnMu\n",
+          "legalActions": [],
+          "legalActionStrings": []
+        },
+        "status": "INACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "submission": 52,
+          "thoughts": "beta pi reflect imagine reflect zeta zeta lantern"
+        },
+        "reward": null,
+        "info": {
+          "actionSubmitted": 52,
+          "actionSubmittedToString": "Player: 0 Action: Draw upcard",
+          "actionApplied": 52,
+          "timeTaken": 0.0,
+          "agentSelfReportedStatus": null
+        },
+        "observation": {
+          "remainingOverageTime": 12,
+          "step": 58,
+          "observationString": "{\"phase\": \"Discard\", \"current_player\": 0, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"5s\", \"upcard\": null, \"stock_size\": 20, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\", \"2h\"], \"hands\": {\"0\": [\"5s\", \"6s\", \"Ts\", \"5c\", \"7c\", \"Qc\", \"3d\", \"7d\", \"8d\", \"9d\", \"Qh\"], \"1\": []}, \"deadwood\": {\"0\": 46, \"1\": null}, \"repeated_move\": 0}",
+          "currentPlayer": 0,
+          "playerId": 0,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14,0:52,0:49,1:52,1:6,0:52,0:14,1:52,1:32,0:52,0:47,1:52,1:48,0:52,0:13,1:53,-1:19,1:3,0:53,-1:34,0:48,1:52,1:49,0:53,-1:24,0:6,1:52,1:47,0:52,0:43,1:52,1:43,0:53,-1:33,0:31,1:53,-1:37,1:37,0:52,0:18,1:52,1:18,0:53,-1:30,0:7,1:53,-1:15,1:15,0:53,-1:17,0:37,1:52,1:21,0:53,-1:40,0:30,1:53,-1:9,1:19,0:52,0:40,1:53,-1:29,1:9,0:52,0:47,1:52,1:4,0:52\nmove_number=89\n__dict__=gASVDgIAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRYzAEAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAo1Mgo0OQo1Mgo2CjUyCjE0CjUyCjMyCjUyCjQ3CjUyCjQ4CjUyCjEzCjUzCjE5CjMKNTMKMzQKNDgKNTIKNDkKNTMKMjQKNgo1Mgo0Nwo1Mgo0Mwo1Mgo0Mwo1MwozMwozMQo1MwozNwozNwo1MgoxOAo1MgoxOAo1MwozMAo3CjUzCjE1CjE1CjUzCjE3CjM3CjUyCjIxCjUzCjQwCjMwCjUzCjkKMTkKNTIKNDAKNTMKMjkKOQo1Mgo0Nwo1Mgo0CjUyCgqUYnMu\n",
+          "legalActions": [4, 5, 9, 17, 19, 24, 28, 32, 33, 34, 50],
+          "legalActionStrings": [
+            "Player: 0 Action: 5s",
+            "Player: 0 Action: 6s",
+            "Player: 0 Action: Ts",
+            "Player: 0 Action: 5c",
+            "Player: 0 Action: 7c",
+            "Player: 0 Action: Qc",
+            "Player: 0 Action: 3d",
+            "Player: 0 Action: 7d",
+            "Player: 0 Action: 8d",
+            "Player: 0 Action: 9d",
+            "Player: 0 Action: Qh"
+          ]
+        },
+        "status": "ACTIVE"
+      },
+      {
+        "action": {
+          "submission": -1
+        },
+        "reward": null,
+        "info": {},
+        "observation": {
+          "remainingOverageTime": 12,
+          "observationString": "{\"phase\": \"Discard\", \"current_player\": 0, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"5s\", \"upcard\": null, \"stock_size\": 20, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\", \"2h\"], \"hands\": {\"0\": [], \"1\": [\"7s\", \"Qs\", \"2c\", \"Kc\", \"4d\", \"Qd\", \"Kd\", \"9h\", \"Th\", \"Kh\"]}, \"deadwood\": {\"0\": null, \"1\": 52}, \"repeated_move\": 0}",
+          "currentPlayer": 0,
+          "playerId": 1,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14,0:52,0:49,1:52,1:6,0:52,0:14,1:52,1:32,0:52,0:47,1:52,1:48,0:52,0:13,1:53,-1:19,1:3,0:53,-1:34,0:48,1:52,1:49,0:53,-1:24,0:6,1:52,1:47,0:52,0:43,1:52,1:43,0:53,-1:33,0:31,1:53,-1:37,1:37,0:52,0:18,1:52,1:18,0:53,-1:30,0:7,1:53,-1:15,1:15,0:53,-1:17,0:37,1:52,1:21,0:53,-1:40,0:30,1:53,-1:9,1:19,0:52,0:40,1:53,-1:29,1:9,0:52,0:47,1:52,1:4,0:52\nmove_number=89\n__dict__=gASVDgIAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRYzAEAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAo1Mgo0OQo1Mgo2CjUyCjE0CjUyCjMyCjUyCjQ3CjUyCjQ4CjUyCjEzCjUzCjE5CjMKNTMKMzQKNDgKNTIKNDkKNTMKMjQKNgo1Mgo0Nwo1Mgo0Mwo1Mgo0Mwo1MwozMwozMQo1MwozNwozNwo1MgoxOAo1MgoxOAo1MwozMAo3CjUzCjE1CjE1CjUzCjE3CjM3CjUyCjIxCjUzCjQwCjMwCjUzCjkKMTkKNTIKNDAKNTMKMjkKOQo1Mgo0Nwo1Mgo0CjUyCgqUYnMu\n",
+          "legalActions": [],
+          "legalActionStrings": []
+        },
+        "status": "INACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "submission": 4,
+          "thoughts": "xi imagine tau pi omicron gamma psi ember"
+        },
+        "reward": null,
+        "info": {
+          "actionSubmitted": 4,
+          "actionSubmittedToString": "Player: 0 Action: 5s",
+          "actionApplied": 4,
+          "timeTaken": 0.0,
+          "agentSelfReportedStatus": null
+        },
+        "observation": {
+          "remainingOverageTime": 12,
+          "step": 59,
+          "observationString": "{\"phase\": \"Draw\", \"current_player\": 1, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"5s\", \"upcard\": \"5s\", \"stock_size\": 20, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\", \"2h\"], \"hands\": {\"0\": [\"6s\", \"Ts\", \"5c\", \"7c\", \"Qc\", \"3d\", \"7d\", \"8d\", \"9d\", \"Qh\"], \"1\": []}, \"deadwood\": {\"0\": 51, \"1\": null}, \"repeated_move\": 1}",
+          "currentPlayer": 1,
+          "playerId": 0,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14,0:52,0:49,1:52,1:6,0:52,0:14,1:52,1:32,0:52,0:47,1:52,1:48,0:52,0:13,1:53,-1:19,1:3,0:53,-1:34,0:48,1:52,1:49,0:53,-1:24,0:6,1:52,1:47,0:52,0:43,1:52,1:43,0:53,-1:33,0:31,1:53,-1:37,1:37,0:52,0:18,1:52,1:18,0:53,-1:30,0:7,1:53,-1:15,1:15,0:53,-1:17,0:37,1:52,1:21,0:53,-1:40,0:30,1:53,-1:9,1:19,0:52,0:40,1:53,-1:29,1:9,0:52,0:47,1:52,1:4,0:52,0:4\nmove_number=90\n__dict__=gASVEAIAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRYzgEAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAo1Mgo0OQo1Mgo2CjUyCjE0CjUyCjMyCjUyCjQ3CjUyCjQ4CjUyCjEzCjUzCjE5CjMKNTMKMzQKNDgKNTIKNDkKNTMKMjQKNgo1Mgo0Nwo1Mgo0Mwo1Mgo0Mwo1MwozMwozMQo1MwozNwozNwo1MgoxOAo1MgoxOAo1MwozMAo3CjUzCjE1CjE1CjUzCjE3CjM3CjUyCjIxCjUzCjQwCjMwCjUzCjkKMTkKNTIKNDAKNTMKMjkKOQo1Mgo0Nwo1Mgo0CjUyCjQKCpRicy4=\n",
+          "legalActions": [],
+          "legalActionStrings": []
+        },
+        "status": "INACTIVE"
+      },
+      {
+        "action": {
+          "submission": -1
+        },
+        "reward": null,
+        "info": {},
+        "observation": {
+          "remainingOverageTime": 12,
+          "observationString": "{\"phase\": \"Draw\", \"current_player\": 1, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"5s\", \"upcard\": \"5s\", \"stock_size\": 20, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\", \"2h\"], \"hands\": {\"0\": [], \"1\": [\"7s\", \"Qs\", \"2c\", \"Kc\", \"4d\", \"Qd\", \"Kd\", \"9h\", \"Th\", \"Kh\"]}, \"deadwood\": {\"0\": null, \"1\": 52}, \"repeated_move\": 1}",
+          "currentPlayer": 1,
+          "playerId": 1,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14,0:52,0:49,1:52,1:6,0:52,0:14,1:52,1:32,0:52,0:47,1:52,1:48,0:52,0:13,1:53,-1:19,1:3,0:53,-1:34,0:48,1:52,1:49,0:53,-1:24,0:6,1:52,1:47,0:52,0:43,1:52,1:43,0:53,-1:33,0:31,1:53,-1:37,1:37,0:52,0:18,1:52,1:18,0:53,-1:30,0:7,1:53,-1:15,1:15,0:53,-1:17,0:37,1:52,1:21,0:53,-1:40,0:30,1:53,-1:9,1:19,0:52,0:40,1:53,-1:29,1:9,0:52,0:47,1:52,1:4,0:52,0:4\nmove_number=90\n__dict__=gASVEAIAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRYzgEAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAo1Mgo0OQo1Mgo2CjUyCjE0CjUyCjMyCjUyCjQ3CjUyCjQ4CjUyCjEzCjUzCjE5CjMKNTMKMzQKNDgKNTIKNDkKNTMKMjQKNgo1Mgo0Nwo1Mgo0Mwo1Mgo0Mwo1MwozMwozMQo1MwozNwozNwo1MgoxOAo1MgoxOAo1MwozMAo3CjUzCjE1CjE1CjUzCjE3CjM3CjUyCjIxCjUzCjQwCjMwCjUzCjkKMTkKNTIKNDAKNTMKMjkKOQo1Mgo0Nwo1Mgo0CjUyCjQKCpRicy4=\n",
+          "legalActions": [52, 53],
+          "legalActionStrings": [
+            "Player: 1 Action: Draw upcard",
+            "Player: 1 Action: Draw stock"
+          ]
+        },
+        "status": "ACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "submission": -1
+        },
+        "reward": null,
+        "info": {},
+        "observation": {
+          "remainingOverageTime": 12,
+          "step": 60,
+          "observationString": "{\"phase\": \"Discard\", \"current_player\": 1, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"5s\", \"upcard\": null, \"stock_size\": 19, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\", \"2h\", \"5s\"], \"hands\": {\"0\": [\"6s\", \"Ts\", \"5c\", \"7c\", \"Qc\", \"3d\", \"7d\", \"8d\", \"9d\", \"Qh\"], \"1\": []}, \"deadwood\": {\"0\": 51, \"1\": null}, \"repeated_move\": 1}",
+          "currentPlayer": 1,
+          "playerId": 0,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14,0:52,0:49,1:52,1:6,0:52,0:14,1:52,1:32,0:52,0:47,1:52,1:48,0:52,0:13,1:53,-1:19,1:3,0:53,-1:34,0:48,1:52,1:49,0:53,-1:24,0:6,1:52,1:47,0:52,0:43,1:52,1:43,0:53,-1:33,0:31,1:53,-1:37,1:37,0:52,0:18,1:52,1:18,0:53,-1:30,0:7,1:53,-1:15,1:15,0:53,-1:17,0:37,1:52,1:21,0:53,-1:40,0:30,1:53,-1:9,1:19,0:52,0:40,1:53,-1:29,1:9,0:52,0:47,1:52,1:4,0:52,0:4,1:53,-1:35\nmove_number=92\n__dict__=gASVFgIAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRY1AEAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAo1Mgo0OQo1Mgo2CjUyCjE0CjUyCjMyCjUyCjQ3CjUyCjQ4CjUyCjEzCjUzCjE5CjMKNTMKMzQKNDgKNTIKNDkKNTMKMjQKNgo1Mgo0Nwo1Mgo0Mwo1Mgo0Mwo1MwozMwozMQo1MwozNwozNwo1MgoxOAo1MgoxOAo1MwozMAo3CjUzCjE1CjE1CjUzCjE3CjM3CjUyCjIxCjUzCjQwCjMwCjUzCjkKMTkKNTIKNDAKNTMKMjkKOQo1Mgo0Nwo1Mgo0CjUyCjQKNTMKMzUKCpRicy4=\n",
+          "legalActions": [],
+          "legalActionStrings": []
+        },
+        "status": "INACTIVE"
+      },
+      {
+        "action": {
+          "submission": 53,
+          "thoughts": "beta tau theta delta consider imagine psi lambda"
+        },
+        "reward": null,
+        "info": {
+          "actionSubmitted": 53,
+          "actionSubmittedToString": "Player: 1 Action: Draw stock",
+          "actionApplied": 53,
+          "timeTaken": 0.0,
+          "agentSelfReportedStatus": null
+        },
+        "observation": {
+          "remainingOverageTime": 12,
+          "observationString": "{\"phase\": \"Discard\", \"current_player\": 1, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"5s\", \"upcard\": null, \"stock_size\": 19, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\", \"2h\", \"5s\"], \"hands\": {\"0\": [], \"1\": [\"7s\", \"Qs\", \"2c\", \"Kc\", \"4d\", \"Td\", \"Qd\", \"Kd\", \"9h\", \"Th\", \"Kh\"]}, \"deadwood\": {\"0\": null, \"1\": 52}, \"repeated_move\": 1}",
+          "currentPlayer": 1,
+          "playerId": 1,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14,0:52,0:49,1:52,1:6,0:52,0:14,1:52,1:32,0:52,0:47,1:52,1:48,0:52,0:13,1:53,-1:19,1:3,0:53,-1:34,0:48,1:52,1:49,0:53,-1:24,0:6,1:52,1:47,0:52,0:43,1:52,1:43,0:53,-1:33,0:31,1:53,-1:37,1:37,0:52,0:18,1:52,1:18,0:53,-1:30,0:7,1:53,-1:15,1:15,0:53,-1:17,0:37,1:52,1:21,0:53,-1:40,0:30,1:53,-1:9,1:19,0:52,0:40,1:53,-1:29,1:9,0:52,0:47,1:52,1:4,0:52,0:4,1:53,-1:35\nmove_number=92\n__dict__=gASVFgIAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRY1AEAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAo1Mgo0OQo1Mgo2CjUyCjE0CjUyCjMyCjUyCjQ3CjUyCjQ4CjUyCjEzCjUzCjE5CjMKNTMKMzQKNDgKNTIKNDkKNTMKMjQKNgo1Mgo0Nwo1Mgo0Mwo1Mgo0Mwo1MwozMwozMQo1MwozNwozNwo1MgoxOAo1MgoxOAo1MwozMAo3CjUzCjE1CjE1CjUzCjE3CjM3CjUyCjIxCjUzCjQwCjMwCjUzCjkKMTkKNTIKNDAKNTMKMjkKOQo1Mgo0Nwo1Mgo0CjUyCjQKNTMKMzUKCpRicy4=\n",
+          "legalActions": [6, 11, 14, 25, 29, 35, 37, 38, 47, 48, 51],
+          "legalActionStrings": [
+            "Player: 1 Action: 7s",
+            "Player: 1 Action: Qs",
+            "Player: 1 Action: 2c",
+            "Player: 1 Action: Kc",
+            "Player: 1 Action: 4d",
+            "Player: 1 Action: Td",
+            "Player: 1 Action: Qd",
+            "Player: 1 Action: Kd",
+            "Player: 1 Action: 9h",
+            "Player: 1 Action: Th",
+            "Player: 1 Action: Kh"
+          ]
+        },
+        "status": "ACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "submission": -1
+        },
+        "reward": null,
+        "info": {},
+        "observation": {
+          "remainingOverageTime": 12,
+          "step": 61,
+          "observationString": "{\"phase\": \"Draw\", \"current_player\": 0, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"5s\", \"upcard\": \"7s\", \"stock_size\": 19, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\", \"2h\", \"5s\"], \"hands\": {\"0\": [\"6s\", \"Ts\", \"5c\", \"7c\", \"Qc\", \"3d\", \"7d\", \"8d\", \"9d\", \"Qh\"], \"1\": []}, \"deadwood\": {\"0\": 51, \"1\": null}, \"repeated_move\": 0}",
+          "currentPlayer": 0,
+          "playerId": 0,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14,0:52,0:49,1:52,1:6,0:52,0:14,1:52,1:32,0:52,0:47,1:52,1:48,0:52,0:13,1:53,-1:19,1:3,0:53,-1:34,0:48,1:52,1:49,0:53,-1:24,0:6,1:52,1:47,0:52,0:43,1:52,1:43,0:53,-1:33,0:31,1:53,-1:37,1:37,0:52,0:18,1:52,1:18,0:53,-1:30,0:7,1:53,-1:15,1:15,0:53,-1:17,0:37,1:52,1:21,0:53,-1:40,0:30,1:53,-1:9,1:19,0:52,0:40,1:53,-1:29,1:9,0:52,0:47,1:52,1:4,0:52,0:4,1:53,-1:35,1:6\nmove_number=93\n__dict__=gASVGAIAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRY1gEAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAo1Mgo0OQo1Mgo2CjUyCjE0CjUyCjMyCjUyCjQ3CjUyCjQ4CjUyCjEzCjUzCjE5CjMKNTMKMzQKNDgKNTIKNDkKNTMKMjQKNgo1Mgo0Nwo1Mgo0Mwo1Mgo0Mwo1MwozMwozMQo1MwozNwozNwo1MgoxOAo1MgoxOAo1MwozMAo3CjUzCjE1CjE1CjUzCjE3CjM3CjUyCjIxCjUzCjQwCjMwCjUzCjkKMTkKNTIKNDAKNTMKMjkKOQo1Mgo0Nwo1Mgo0CjUyCjQKNTMKMzUKNgoKlGJzLg==\n",
+          "legalActions": [52, 53],
+          "legalActionStrings": [
+            "Player: 0 Action: Draw upcard",
+            "Player: 0 Action: Draw stock"
+          ]
+        },
+        "status": "ACTIVE"
+      },
+      {
+        "action": {
+          "submission": 6,
+          "thoughts": "muse upsilon alpha cascade eta psi explore eta"
+        },
+        "reward": null,
+        "info": {
+          "actionSubmitted": 6,
+          "actionSubmittedToString": "Player: 1 Action: 7s",
+          "actionApplied": 6,
+          "timeTaken": 0.0,
+          "agentSelfReportedStatus": null
+        },
+        "observation": {
+          "remainingOverageTime": 12,
+          "observationString": "{\"phase\": \"Draw\", \"current_player\": 0, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"5s\", \"upcard\": \"7s\", \"stock_size\": 19, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\", \"2h\", \"5s\"], \"hands\": {\"0\": [], \"1\": [\"Qs\", \"2c\", \"Kc\", \"4d\", \"Td\", \"Qd\", \"Kd\", \"9h\", \"Th\", \"Kh\"]}, \"deadwood\": {\"0\": null, \"1\": 55}, \"repeated_move\": 0}",
+          "currentPlayer": 0,
+          "playerId": 1,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14,0:52,0:49,1:52,1:6,0:52,0:14,1:52,1:32,0:52,0:47,1:52,1:48,0:52,0:13,1:53,-1:19,1:3,0:53,-1:34,0:48,1:52,1:49,0:53,-1:24,0:6,1:52,1:47,0:52,0:43,1:52,1:43,0:53,-1:33,0:31,1:53,-1:37,1:37,0:52,0:18,1:52,1:18,0:53,-1:30,0:7,1:53,-1:15,1:15,0:53,-1:17,0:37,1:52,1:21,0:53,-1:40,0:30,1:53,-1:9,1:19,0:52,0:40,1:53,-1:29,1:9,0:52,0:47,1:52,1:4,0:52,0:4,1:53,-1:35,1:6\nmove_number=93\n__dict__=gASVGAIAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRY1gEAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAo1Mgo0OQo1Mgo2CjUyCjE0CjUyCjMyCjUyCjQ3CjUyCjQ4CjUyCjEzCjUzCjE5CjMKNTMKMzQKNDgKNTIKNDkKNTMKMjQKNgo1Mgo0Nwo1Mgo0Mwo1Mgo0Mwo1MwozMwozMQo1MwozNwozNwo1MgoxOAo1MgoxOAo1MwozMAo3CjUzCjE1CjE1CjUzCjE3CjM3CjUyCjIxCjUzCjQwCjMwCjUzCjkKMTkKNTIKNDAKNTMKMjkKOQo1Mgo0Nwo1Mgo0CjUyCjQKNTMKMzUKNgoKlGJzLg==\n",
+          "legalActions": [],
+          "legalActionStrings": []
+        },
+        "status": "INACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "submission": 52,
+          "thoughts": "zeta reflect delta delta upsilon upsilon iota kappa"
+        },
+        "reward": null,
+        "info": {
+          "actionSubmitted": 52,
+          "actionSubmittedToString": "Player: 0 Action: Draw upcard",
+          "actionApplied": 52,
+          "timeTaken": 0.0,
+          "agentSelfReportedStatus": null
+        },
+        "observation": {
+          "remainingOverageTime": 12,
+          "step": 62,
+          "observationString": "{\"phase\": \"Discard\", \"current_player\": 0, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"7s\", \"upcard\": null, \"stock_size\": 19, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\", \"2h\", \"5s\"], \"hands\": {\"0\": [\"6s\", \"7s\", \"Ts\", \"5c\", \"7c\", \"Qc\", \"3d\", \"7d\", \"8d\", \"9d\", \"Qh\"], \"1\": []}, \"deadwood\": {\"0\": 48, \"1\": null}, \"repeated_move\": 0}",
+          "currentPlayer": 0,
+          "playerId": 0,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14,0:52,0:49,1:52,1:6,0:52,0:14,1:52,1:32,0:52,0:47,1:52,1:48,0:52,0:13,1:53,-1:19,1:3,0:53,-1:34,0:48,1:52,1:49,0:53,-1:24,0:6,1:52,1:47,0:52,0:43,1:52,1:43,0:53,-1:33,0:31,1:53,-1:37,1:37,0:52,0:18,1:52,1:18,0:53,-1:30,0:7,1:53,-1:15,1:15,0:53,-1:17,0:37,1:52,1:21,0:53,-1:40,0:30,1:53,-1:9,1:19,0:52,0:40,1:53,-1:29,1:9,0:52,0:47,1:52,1:4,0:52,0:4,1:53,-1:35,1:6,0:52\nmove_number=94\n__dict__=gASVGwIAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRY2QEAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAo1Mgo0OQo1Mgo2CjUyCjE0CjUyCjMyCjUyCjQ3CjUyCjQ4CjUyCjEzCjUzCjE5CjMKNTMKMzQKNDgKNTIKNDkKNTMKMjQKNgo1Mgo0Nwo1Mgo0Mwo1Mgo0Mwo1MwozMwozMQo1MwozNwozNwo1MgoxOAo1MgoxOAo1MwozMAo3CjUzCjE1CjE1CjUzCjE3CjM3CjUyCjIxCjUzCjQwCjMwCjUzCjkKMTkKNTIKNDAKNTMKMjkKOQo1Mgo0Nwo1Mgo0CjUyCjQKNTMKMzUKNgo1MgoKlGJzLg==\n",
+          "legalActions": [5, 6, 9, 17, 19, 24, 28, 32, 33, 34, 50],
+          "legalActionStrings": [
+            "Player: 0 Action: 6s",
+            "Player: 0 Action: 7s",
+            "Player: 0 Action: Ts",
+            "Player: 0 Action: 5c",
+            "Player: 0 Action: 7c",
+            "Player: 0 Action: Qc",
+            "Player: 0 Action: 3d",
+            "Player: 0 Action: 7d",
+            "Player: 0 Action: 8d",
+            "Player: 0 Action: 9d",
+            "Player: 0 Action: Qh"
+          ]
+        },
+        "status": "ACTIVE"
+      },
+      {
+        "action": {
+          "submission": -1
+        },
+        "reward": null,
+        "info": {},
+        "observation": {
+          "remainingOverageTime": 12,
+          "observationString": "{\"phase\": \"Discard\", \"current_player\": 0, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"7s\", \"upcard\": null, \"stock_size\": 19, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\", \"2h\", \"5s\"], \"hands\": {\"0\": [], \"1\": [\"Qs\", \"2c\", \"Kc\", \"4d\", \"Td\", \"Qd\", \"Kd\", \"9h\", \"Th\", \"Kh\"]}, \"deadwood\": {\"0\": null, \"1\": 55}, \"repeated_move\": 0}",
+          "currentPlayer": 0,
+          "playerId": 1,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14,0:52,0:49,1:52,1:6,0:52,0:14,1:52,1:32,0:52,0:47,1:52,1:48,0:52,0:13,1:53,-1:19,1:3,0:53,-1:34,0:48,1:52,1:49,0:53,-1:24,0:6,1:52,1:47,0:52,0:43,1:52,1:43,0:53,-1:33,0:31,1:53,-1:37,1:37,0:52,0:18,1:52,1:18,0:53,-1:30,0:7,1:53,-1:15,1:15,0:53,-1:17,0:37,1:52,1:21,0:53,-1:40,0:30,1:53,-1:9,1:19,0:52,0:40,1:53,-1:29,1:9,0:52,0:47,1:52,1:4,0:52,0:4,1:53,-1:35,1:6,0:52\nmove_number=94\n__dict__=gASVGwIAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRY2QEAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAo1Mgo0OQo1Mgo2CjUyCjE0CjUyCjMyCjUyCjQ3CjUyCjQ4CjUyCjEzCjUzCjE5CjMKNTMKMzQKNDgKNTIKNDkKNTMKMjQKNgo1Mgo0Nwo1Mgo0Mwo1Mgo0Mwo1MwozMwozMQo1MwozNwozNwo1MgoxOAo1MgoxOAo1MwozMAo3CjUzCjE1CjE1CjUzCjE3CjM3CjUyCjIxCjUzCjQwCjMwCjUzCjkKMTkKNTIKNDAKNTMKMjkKOQo1Mgo0Nwo1Mgo0CjUyCjQKNTMKMzUKNgo1MgoKlGJzLg==\n",
+          "legalActions": [],
+          "legalActionStrings": []
+        },
+        "status": "INACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "submission": 19,
+          "thoughts": "theta phi omega pi pi consider sigma sigma"
+        },
+        "reward": null,
+        "info": {
+          "actionSubmitted": 19,
+          "actionSubmittedToString": "Player: 0 Action: 7c",
+          "actionApplied": 19,
+          "timeTaken": 0.0,
+          "agentSelfReportedStatus": null
+        },
+        "observation": {
+          "remainingOverageTime": 12,
+          "step": 63,
+          "observationString": "{\"phase\": \"Draw\", \"current_player\": 1, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"7s\", \"upcard\": \"7c\", \"stock_size\": 19, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\", \"2h\", \"5s\"], \"hands\": {\"0\": [\"6s\", \"7s\", \"Ts\", \"5c\", \"Qc\", \"3d\", \"7d\", \"8d\", \"9d\", \"Qh\"], \"1\": []}, \"deadwood\": {\"0\": 51, \"1\": null}, \"repeated_move\": 0}",
+          "currentPlayer": 1,
+          "playerId": 0,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14,0:52,0:49,1:52,1:6,0:52,0:14,1:52,1:32,0:52,0:47,1:52,1:48,0:52,0:13,1:53,-1:19,1:3,0:53,-1:34,0:48,1:52,1:49,0:53,-1:24,0:6,1:52,1:47,0:52,0:43,1:52,1:43,0:53,-1:33,0:31,1:53,-1:37,1:37,0:52,0:18,1:52,1:18,0:53,-1:30,0:7,1:53,-1:15,1:15,0:53,-1:17,0:37,1:52,1:21,0:53,-1:40,0:30,1:53,-1:9,1:19,0:52,0:40,1:53,-1:29,1:9,0:52,0:47,1:52,1:4,0:52,0:4,1:53,-1:35,1:6,0:52,0:19\nmove_number=95\n__dict__=gASVHgIAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRY3AEAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAo1Mgo0OQo1Mgo2CjUyCjE0CjUyCjMyCjUyCjQ3CjUyCjQ4CjUyCjEzCjUzCjE5CjMKNTMKMzQKNDgKNTIKNDkKNTMKMjQKNgo1Mgo0Nwo1Mgo0Mwo1Mgo0Mwo1MwozMwozMQo1MwozNwozNwo1MgoxOAo1MgoxOAo1MwozMAo3CjUzCjE1CjE1CjUzCjE3CjM3CjUyCjIxCjUzCjQwCjMwCjUzCjkKMTkKNTIKNDAKNTMKMjkKOQo1Mgo0Nwo1Mgo0CjUyCjQKNTMKMzUKNgo1MgoxOQoKlGJzLg==\n",
+          "legalActions": [],
+          "legalActionStrings": []
+        },
+        "status": "INACTIVE"
+      },
+      {
+        "action": {
+          "submission": -1
+        },
+        "reward": null,
+        "info": {},
+        "observation": {
+          "remainingOverageTime": 12,
+          "observationString": "{\"phase\": \"Draw\", \"current_player\": 1, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"7s\", \"upcard\": \"7c\", \"stock_size\": 19, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\", \"2h\", \"5s\"], \"hands\": {\"0\": [], \"1\": [\"Qs\", \"2c\", \"Kc\", \"4d\", \"Td\", \"Qd\", \"Kd\", \"9h\", \"Th\", \"Kh\"]}, \"deadwood\": {\"0\": null, \"1\": 55}, \"repeated_move\": 0}",
+          "currentPlayer": 1,
+          "playerId": 1,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14,0:52,0:49,1:52,1:6,0:52,0:14,1:52,1:32,0:52,0:47,1:52,1:48,0:52,0:13,1:53,-1:19,1:3,0:53,-1:34,0:48,1:52,1:49,0:53,-1:24,0:6,1:52,1:47,0:52,0:43,1:52,1:43,0:53,-1:33,0:31,1:53,-1:37,1:37,0:52,0:18,1:52,1:18,0:53,-1:30,0:7,1:53,-1:15,1:15,0:53,-1:17,0:37,1:52,1:21,0:53,-1:40,0:30,1:53,-1:9,1:19,0:52,0:40,1:53,-1:29,1:9,0:52,0:47,1:52,1:4,0:52,0:4,1:53,-1:35,1:6,0:52,0:19\nmove_number=95\n__dict__=gASVHgIAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRY3AEAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAo1Mgo0OQo1Mgo2CjUyCjE0CjUyCjMyCjUyCjQ3CjUyCjQ4CjUyCjEzCjUzCjE5CjMKNTMKMzQKNDgKNTIKNDkKNTMKMjQKNgo1Mgo0Nwo1Mgo0Mwo1Mgo0Mwo1MwozMwozMQo1MwozNwozNwo1MgoxOAo1MgoxOAo1MwozMAo3CjUzCjE1CjE1CjUzCjE3CjM3CjUyCjIxCjUzCjQwCjMwCjUzCjkKMTkKNTIKNDAKNTMKMjkKOQo1Mgo0Nwo1Mgo0CjUyCjQKNTMKMzUKNgo1MgoxOQoKlGJzLg==\n",
+          "legalActions": [52, 53],
+          "legalActionStrings": [
+            "Player: 1 Action: Draw upcard",
+            "Player: 1 Action: Draw stock"
+          ]
+        },
+        "status": "ACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "submission": -1
+        },
+        "reward": null,
+        "info": {},
+        "observation": {
+          "remainingOverageTime": 12,
+          "step": 64,
+          "observationString": "{\"phase\": \"Discard\", \"current_player\": 1, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"7c\", \"upcard\": null, \"stock_size\": 18, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\", \"2h\", \"5s\", \"7c\"], \"hands\": {\"0\": [\"6s\", \"7s\", \"Ts\", \"5c\", \"Qc\", \"3d\", \"7d\", \"8d\", \"9d\", \"Qh\"], \"1\": []}, \"deadwood\": {\"0\": 51, \"1\": null}, \"repeated_move\": 0}",
+          "currentPlayer": 1,
+          "playerId": 0,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14,0:52,0:49,1:52,1:6,0:52,0:14,1:52,1:32,0:52,0:47,1:52,1:48,0:52,0:13,1:53,-1:19,1:3,0:53,-1:34,0:48,1:52,1:49,0:53,-1:24,0:6,1:52,1:47,0:52,0:43,1:52,1:43,0:53,-1:33,0:31,1:53,-1:37,1:37,0:52,0:18,1:52,1:18,0:53,-1:30,0:7,1:53,-1:15,1:15,0:53,-1:17,0:37,1:52,1:21,0:53,-1:40,0:30,1:53,-1:9,1:19,0:52,0:40,1:53,-1:29,1:9,0:52,0:47,1:52,1:4,0:52,0:4,1:53,-1:35,1:6,0:52,0:19,1:53,-1:8\nmove_number=97\n__dict__=gASVIwIAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRY4QEAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAo1Mgo0OQo1Mgo2CjUyCjE0CjUyCjMyCjUyCjQ3CjUyCjQ4CjUyCjEzCjUzCjE5CjMKNTMKMzQKNDgKNTIKNDkKNTMKMjQKNgo1Mgo0Nwo1Mgo0Mwo1Mgo0Mwo1MwozMwozMQo1MwozNwozNwo1MgoxOAo1MgoxOAo1MwozMAo3CjUzCjE1CjE1CjUzCjE3CjM3CjUyCjIxCjUzCjQwCjMwCjUzCjkKMTkKNTIKNDAKNTMKMjkKOQo1Mgo0Nwo1Mgo0CjUyCjQKNTMKMzUKNgo1MgoxOQo1Mwo4CgqUYnMu\n",
+          "legalActions": [],
+          "legalActionStrings": []
+        },
+        "status": "INACTIVE"
+      },
+      {
+        "action": {
+          "submission": 53,
+          "thoughts": "tau xi phi lantern cascade chi kappa omega"
+        },
+        "reward": null,
+        "info": {
+          "actionSubmitted": 53,
+          "actionSubmittedToString": "Player: 1 Action: Draw stock",
+          "actionApplied": 53,
+          "timeTaken": 0.0,
+          "agentSelfReportedStatus": null
+        },
+        "observation": {
+          "remainingOverageTime": 12,
+          "observationString": "{\"phase\": \"Discard\", \"current_player\": 1, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"7c\", \"upcard\": null, \"stock_size\": 18, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\", \"2h\", \"5s\", \"7c\"], \"hands\": {\"0\": [], \"1\": [\"9s\", \"Qs\", \"2c\", \"Kc\", \"4d\", \"Td\", \"Qd\", \"Kd\", \"9h\", \"Th\", \"Kh\"]}, \"deadwood\": {\"0\": null, \"1\": 54}, \"repeated_move\": 0}",
+          "currentPlayer": 1,
+          "playerId": 1,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14,0:52,0:49,1:52,1:6,0:52,0:14,1:52,1:32,0:52,0:47,1:52,1:48,0:52,0:13,1:53,-1:19,1:3,0:53,-1:34,0:48,1:52,1:49,0:53,-1:24,0:6,1:52,1:47,0:52,0:43,1:52,1:43,0:53,-1:33,0:31,1:53,-1:37,1:37,0:52,0:18,1:52,1:18,0:53,-1:30,0:7,1:53,-1:15,1:15,0:53,-1:17,0:37,1:52,1:21,0:53,-1:40,0:30,1:53,-1:9,1:19,0:52,0:40,1:53,-1:29,1:9,0:52,0:47,1:52,1:4,0:52,0:4,1:53,-1:35,1:6,0:52,0:19,1:53,-1:8\nmove_number=97\n__dict__=gASVIwIAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRY4QEAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAo1Mgo0OQo1Mgo2CjUyCjE0CjUyCjMyCjUyCjQ3CjUyCjQ4CjUyCjEzCjUzCjE5CjMKNTMKMzQKNDgKNTIKNDkKNTMKMjQKNgo1Mgo0Nwo1Mgo0Mwo1Mgo0Mwo1MwozMwozMQo1MwozNwozNwo1MgoxOAo1MgoxOAo1MwozMAo3CjUzCjE1CjE1CjUzCjE3CjM3CjUyCjIxCjUzCjQwCjMwCjUzCjkKMTkKNTIKNDAKNTMKMjkKOQo1Mgo0Nwo1Mgo0CjUyCjQKNTMKMzUKNgo1MgoxOQo1Mwo4CgqUYnMu\n",
+          "legalActions": [8, 11, 14, 25, 29, 35, 37, 38, 47, 48, 51],
+          "legalActionStrings": [
+            "Player: 1 Action: 9s",
+            "Player: 1 Action: Qs",
+            "Player: 1 Action: 2c",
+            "Player: 1 Action: Kc",
+            "Player: 1 Action: 4d",
+            "Player: 1 Action: Td",
+            "Player: 1 Action: Qd",
+            "Player: 1 Action: Kd",
+            "Player: 1 Action: 9h",
+            "Player: 1 Action: Th",
+            "Player: 1 Action: Kh"
+          ]
+        },
+        "status": "ACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "submission": -1
+        },
+        "reward": null,
+        "info": {},
+        "observation": {
+          "remainingOverageTime": 12,
+          "step": 65,
+          "observationString": "{\"phase\": \"Draw\", \"current_player\": 0, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"7c\", \"upcard\": \"Td\", \"stock_size\": 18, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\", \"2h\", \"5s\", \"7c\"], \"hands\": {\"0\": [\"6s\", \"7s\", \"Ts\", \"5c\", \"Qc\", \"3d\", \"7d\", \"8d\", \"9d\", \"Qh\"], \"1\": []}, \"deadwood\": {\"0\": 51, \"1\": null}, \"repeated_move\": 0}",
+          "currentPlayer": 0,
+          "playerId": 0,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14,0:52,0:49,1:52,1:6,0:52,0:14,1:52,1:32,0:52,0:47,1:52,1:48,0:52,0:13,1:53,-1:19,1:3,0:53,-1:34,0:48,1:52,1:49,0:53,-1:24,0:6,1:52,1:47,0:52,0:43,1:52,1:43,0:53,-1:33,0:31,1:53,-1:37,1:37,0:52,0:18,1:52,1:18,0:53,-1:30,0:7,1:53,-1:15,1:15,0:53,-1:17,0:37,1:52,1:21,0:53,-1:40,0:30,1:53,-1:9,1:19,0:52,0:40,1:53,-1:29,1:9,0:52,0:47,1:52,1:4,0:52,0:4,1:53,-1:35,1:6,0:52,0:19,1:53,-1:8,1:35\nmove_number=98\n__dict__=gASVJgIAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRY5AEAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAo1Mgo0OQo1Mgo2CjUyCjE0CjUyCjMyCjUyCjQ3CjUyCjQ4CjUyCjEzCjUzCjE5CjMKNTMKMzQKNDgKNTIKNDkKNTMKMjQKNgo1Mgo0Nwo1Mgo0Mwo1Mgo0Mwo1MwozMwozMQo1MwozNwozNwo1MgoxOAo1MgoxOAo1MwozMAo3CjUzCjE1CjE1CjUzCjE3CjM3CjUyCjIxCjUzCjQwCjMwCjUzCjkKMTkKNTIKNDAKNTMKMjkKOQo1Mgo0Nwo1Mgo0CjUyCjQKNTMKMzUKNgo1MgoxOQo1Mwo4CjM1CgqUYnMu\n",
+          "legalActions": [52, 53],
+          "legalActionStrings": [
+            "Player: 0 Action: Draw upcard",
+            "Player: 0 Action: Draw stock"
+          ]
+        },
+        "status": "ACTIVE"
+      },
+      {
+        "action": {
+          "submission": 35,
+          "thoughts": "epsilon theta rho eta chi muse epsilon alpha"
+        },
+        "reward": null,
+        "info": {
+          "actionSubmitted": 35,
+          "actionSubmittedToString": "Player: 1 Action: Td",
+          "actionApplied": 35,
+          "timeTaken": 0.0,
+          "agentSelfReportedStatus": null
+        },
+        "observation": {
+          "remainingOverageTime": 12,
+          "observationString": "{\"phase\": \"Draw\", \"current_player\": 0, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"7c\", \"upcard\": \"Td\", \"stock_size\": 18, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\", \"2h\", \"5s\", \"7c\"], \"hands\": {\"0\": [], \"1\": [\"9s\", \"Qs\", \"2c\", \"Kc\", \"4d\", \"Qd\", \"Kd\", \"9h\", \"Th\", \"Kh\"]}, \"deadwood\": {\"0\": null, \"1\": 54}, \"repeated_move\": 0}",
+          "currentPlayer": 0,
+          "playerId": 1,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14,0:52,0:49,1:52,1:6,0:52,0:14,1:52,1:32,0:52,0:47,1:52,1:48,0:52,0:13,1:53,-1:19,1:3,0:53,-1:34,0:48,1:52,1:49,0:53,-1:24,0:6,1:52,1:47,0:52,0:43,1:52,1:43,0:53,-1:33,0:31,1:53,-1:37,1:37,0:52,0:18,1:52,1:18,0:53,-1:30,0:7,1:53,-1:15,1:15,0:53,-1:17,0:37,1:52,1:21,0:53,-1:40,0:30,1:53,-1:9,1:19,0:52,0:40,1:53,-1:29,1:9,0:52,0:47,1:52,1:4,0:52,0:4,1:53,-1:35,1:6,0:52,0:19,1:53,-1:8,1:35\nmove_number=98\n__dict__=gASVJgIAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRY5AEAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAo1Mgo0OQo1Mgo2CjUyCjE0CjUyCjMyCjUyCjQ3CjUyCjQ4CjUyCjEzCjUzCjE5CjMKNTMKMzQKNDgKNTIKNDkKNTMKMjQKNgo1Mgo0Nwo1Mgo0Mwo1Mgo0Mwo1MwozMwozMQo1MwozNwozNwo1MgoxOAo1MgoxOAo1MwozMAo3CjUzCjE1CjE1CjUzCjE3CjM3CjUyCjIxCjUzCjQwCjMwCjUzCjkKMTkKNTIKNDAKNTMKMjkKOQo1Mgo0Nwo1Mgo0CjUyCjQKNTMKMzUKNgo1MgoxOQo1Mwo4CjM1CgqUYnMu\n",
+          "legalActions": [],
+          "legalActionStrings": []
+        },
+        "status": "INACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "submission": 53,
+          "thoughts": "horizon pi chi drift zeta alpha beta rho"
+        },
+        "reward": null,
+        "info": {
+          "actionSubmitted": 53,
+          "actionSubmittedToString": "Player: 0 Action: Draw stock",
+          "actionApplied": 53,
+          "timeTaken": 0.0,
+          "agentSelfReportedStatus": null
+        },
+        "observation": {
+          "remainingOverageTime": 12,
+          "step": 66,
+          "observationString": "{\"phase\": \"Discard\", \"current_player\": 0, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"Td\", \"upcard\": null, \"stock_size\": 17, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\", \"2h\", \"5s\", \"7c\", \"Td\"], \"hands\": {\"0\": [\"6s\", \"7s\", \"Ts\", \"5c\", \"Qc\", \"Ad\", \"3d\", \"7d\", \"8d\", \"9d\", \"Qh\"], \"1\": []}, \"deadwood\": {\"0\": 42, \"1\": null}, \"repeated_move\": 0}",
+          "currentPlayer": 0,
+          "playerId": 0,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14,0:52,0:49,1:52,1:6,0:52,0:14,1:52,1:32,0:52,0:47,1:52,1:48,0:52,0:13,1:53,-1:19,1:3,0:53,-1:34,0:48,1:52,1:49,0:53,-1:24,0:6,1:52,1:47,0:52,0:43,1:52,1:43,0:53,-1:33,0:31,1:53,-1:37,1:37,0:52,0:18,1:52,1:18,0:53,-1:30,0:7,1:53,-1:15,1:15,0:53,-1:17,0:37,1:52,1:21,0:53,-1:40,0:30,1:53,-1:9,1:19,0:52,0:40,1:53,-1:29,1:9,0:52,0:47,1:52,1:4,0:52,0:4,1:53,-1:35,1:6,0:52,0:19,1:53,-1:8,1:35,0:53,-1:26\nmove_number=100\n__dict__=gASVLAIAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRY6gEAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAo1Mgo0OQo1Mgo2CjUyCjE0CjUyCjMyCjUyCjQ3CjUyCjQ4CjUyCjEzCjUzCjE5CjMKNTMKMzQKNDgKNTIKNDkKNTMKMjQKNgo1Mgo0Nwo1Mgo0Mwo1Mgo0Mwo1MwozMwozMQo1MwozNwozNwo1MgoxOAo1MgoxOAo1MwozMAo3CjUzCjE1CjE1CjUzCjE3CjM3CjUyCjIxCjUzCjQwCjMwCjUzCjkKMTkKNTIKNDAKNTMKMjkKOQo1Mgo0Nwo1Mgo0CjUyCjQKNTMKMzUKNgo1MgoxOQo1Mwo4CjM1CjUzCjI2CgqUYnMu\n",
+          "legalActions": [5, 6, 9, 17, 24, 26, 28, 32, 33, 34, 50],
+          "legalActionStrings": [
+            "Player: 0 Action: 6s",
+            "Player: 0 Action: 7s",
+            "Player: 0 Action: Ts",
+            "Player: 0 Action: 5c",
+            "Player: 0 Action: Qc",
+            "Player: 0 Action: Ad",
+            "Player: 0 Action: 3d",
+            "Player: 0 Action: 7d",
+            "Player: 0 Action: 8d",
+            "Player: 0 Action: 9d",
+            "Player: 0 Action: Qh"
+          ]
+        },
+        "status": "ACTIVE"
+      },
+      {
+        "action": {
+          "submission": -1
+        },
+        "reward": null,
+        "info": {},
+        "observation": {
+          "remainingOverageTime": 12,
+          "observationString": "{\"phase\": \"Discard\", \"current_player\": 0, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"Td\", \"upcard\": null, \"stock_size\": 17, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\", \"2h\", \"5s\", \"7c\", \"Td\"], \"hands\": {\"0\": [], \"1\": [\"9s\", \"Qs\", \"2c\", \"Kc\", \"4d\", \"Qd\", \"Kd\", \"9h\", \"Th\", \"Kh\"]}, \"deadwood\": {\"0\": null, \"1\": 54}, \"repeated_move\": 0}",
+          "currentPlayer": 0,
+          "playerId": 1,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14,0:52,0:49,1:52,1:6,0:52,0:14,1:52,1:32,0:52,0:47,1:52,1:48,0:52,0:13,1:53,-1:19,1:3,0:53,-1:34,0:48,1:52,1:49,0:53,-1:24,0:6,1:52,1:47,0:52,0:43,1:52,1:43,0:53,-1:33,0:31,1:53,-1:37,1:37,0:52,0:18,1:52,1:18,0:53,-1:30,0:7,1:53,-1:15,1:15,0:53,-1:17,0:37,1:52,1:21,0:53,-1:40,0:30,1:53,-1:9,1:19,0:52,0:40,1:53,-1:29,1:9,0:52,0:47,1:52,1:4,0:52,0:4,1:53,-1:35,1:6,0:52,0:19,1:53,-1:8,1:35,0:53,-1:26\nmove_number=100\n__dict__=gASVLAIAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRY6gEAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAo1Mgo0OQo1Mgo2CjUyCjE0CjUyCjMyCjUyCjQ3CjUyCjQ4CjUyCjEzCjUzCjE5CjMKNTMKMzQKNDgKNTIKNDkKNTMKMjQKNgo1Mgo0Nwo1Mgo0Mwo1Mgo0Mwo1MwozMwozMQo1MwozNwozNwo1MgoxOAo1MgoxOAo1MwozMAo3CjUzCjE1CjE1CjUzCjE3CjM3CjUyCjIxCjUzCjQwCjMwCjUzCjkKMTkKNTIKNDAKNTMKMjkKOQo1Mgo0Nwo1Mgo0CjUyCjQKNTMKMzUKNgo1MgoxOQo1Mwo4CjM1CjUzCjI2CgqUYnMu\n",
+          "legalActions": [],
+          "legalActionStrings": []
+        },
+        "status": "INACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "submission": 33,
+          "thoughts": "shadow lantern epsilon explore delta explore kappa upsilon"
+        },
+        "reward": null,
+        "info": {
+          "actionSubmitted": 33,
+          "actionSubmittedToString": "Player: 0 Action: 8d",
+          "actionApplied": 33,
+          "timeTaken": 0.0,
+          "agentSelfReportedStatus": null
+        },
+        "observation": {
+          "remainingOverageTime": 12,
+          "step": 67,
+          "observationString": "{\"phase\": \"Draw\", \"current_player\": 1, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"Td\", \"upcard\": \"8d\", \"stock_size\": 17, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\", \"2h\", \"5s\", \"7c\", \"Td\"], \"hands\": {\"0\": [\"6s\", \"7s\", \"Ts\", \"5c\", \"Qc\", \"Ad\", \"3d\", \"7d\", \"9d\", \"Qh\"], \"1\": []}, \"deadwood\": {\"0\": 68, \"1\": null}, \"repeated_move\": 0}",
+          "currentPlayer": 1,
+          "playerId": 0,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14,0:52,0:49,1:52,1:6,0:52,0:14,1:52,1:32,0:52,0:47,1:52,1:48,0:52,0:13,1:53,-1:19,1:3,0:53,-1:34,0:48,1:52,1:49,0:53,-1:24,0:6,1:52,1:47,0:52,0:43,1:52,1:43,0:53,-1:33,0:31,1:53,-1:37,1:37,0:52,0:18,1:52,1:18,0:53,-1:30,0:7,1:53,-1:15,1:15,0:53,-1:17,0:37,1:52,1:21,0:53,-1:40,0:30,1:53,-1:9,1:19,0:52,0:40,1:53,-1:29,1:9,0:52,0:47,1:52,1:4,0:52,0:4,1:53,-1:35,1:6,0:52,0:19,1:53,-1:8,1:35,0:53,-1:26,0:33\nmove_number=101\n__dict__=gASVLwIAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRY7QEAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAo1Mgo0OQo1Mgo2CjUyCjE0CjUyCjMyCjUyCjQ3CjUyCjQ4CjUyCjEzCjUzCjE5CjMKNTMKMzQKNDgKNTIKNDkKNTMKMjQKNgo1Mgo0Nwo1Mgo0Mwo1Mgo0Mwo1MwozMwozMQo1MwozNwozNwo1MgoxOAo1MgoxOAo1MwozMAo3CjUzCjE1CjE1CjUzCjE3CjM3CjUyCjIxCjUzCjQwCjMwCjUzCjkKMTkKNTIKNDAKNTMKMjkKOQo1Mgo0Nwo1Mgo0CjUyCjQKNTMKMzUKNgo1MgoxOQo1Mwo4CjM1CjUzCjI2CjMzCgqUYnMu\n",
+          "legalActions": [],
+          "legalActionStrings": []
+        },
+        "status": "INACTIVE"
+      },
+      {
+        "action": {
+          "submission": -1
+        },
+        "reward": null,
+        "info": {},
+        "observation": {
+          "remainingOverageTime": 12,
+          "observationString": "{\"phase\": \"Draw\", \"current_player\": 1, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"Td\", \"upcard\": \"8d\", \"stock_size\": 17, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\", \"2h\", \"5s\", \"7c\", \"Td\"], \"hands\": {\"0\": [], \"1\": [\"9s\", \"Qs\", \"2c\", \"Kc\", \"4d\", \"Qd\", \"Kd\", \"9h\", \"Th\", \"Kh\"]}, \"deadwood\": {\"0\": null, \"1\": 54}, \"repeated_move\": 0}",
+          "currentPlayer": 1,
+          "playerId": 1,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14,0:52,0:49,1:52,1:6,0:52,0:14,1:52,1:32,0:52,0:47,1:52,1:48,0:52,0:13,1:53,-1:19,1:3,0:53,-1:34,0:48,1:52,1:49,0:53,-1:24,0:6,1:52,1:47,0:52,0:43,1:52,1:43,0:53,-1:33,0:31,1:53,-1:37,1:37,0:52,0:18,1:52,1:18,0:53,-1:30,0:7,1:53,-1:15,1:15,0:53,-1:17,0:37,1:52,1:21,0:53,-1:40,0:30,1:53,-1:9,1:19,0:52,0:40,1:53,-1:29,1:9,0:52,0:47,1:52,1:4,0:52,0:4,1:53,-1:35,1:6,0:52,0:19,1:53,-1:8,1:35,0:53,-1:26,0:33\nmove_number=101\n__dict__=gASVLwIAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRY7QEAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAo1Mgo0OQo1Mgo2CjUyCjE0CjUyCjMyCjUyCjQ3CjUyCjQ4CjUyCjEzCjUzCjE5CjMKNTMKMzQKNDgKNTIKNDkKNTMKMjQKNgo1Mgo0Nwo1Mgo0Mwo1Mgo0Mwo1MwozMwozMQo1MwozNwozNwo1MgoxOAo1MgoxOAo1MwozMAo3CjUzCjE1CjE1CjUzCjE3CjM3CjUyCjIxCjUzCjQwCjMwCjUzCjkKMTkKNTIKNDAKNTMKMjkKOQo1Mgo0Nwo1Mgo0CjUyCjQKNTMKMzUKNgo1MgoxOQo1Mwo4CjM1CjUzCjI2CjMzCgqUYnMu\n",
+          "legalActions": [52, 53],
+          "legalActionStrings": [
+            "Player: 1 Action: Draw upcard",
+            "Player: 1 Action: Draw stock"
+          ]
+        },
+        "status": "ACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "submission": -1
+        },
+        "reward": null,
+        "info": {},
+        "observation": {
+          "remainingOverageTime": 12,
+          "step": 68,
+          "observationString": "{\"phase\": \"Discard\", \"current_player\": 1, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"8d\", \"upcard\": null, \"stock_size\": 16, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\", \"2h\", \"5s\", \"7c\", \"Td\", \"8d\"], \"hands\": {\"0\": [\"6s\", \"7s\", \"Ts\", \"5c\", \"Qc\", \"Ad\", \"3d\", \"7d\", \"9d\", \"Qh\"], \"1\": []}, \"deadwood\": {\"0\": 68, \"1\": null}, \"repeated_move\": 0}",
+          "currentPlayer": 1,
+          "playerId": 0,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14,0:52,0:49,1:52,1:6,0:52,0:14,1:52,1:32,0:52,0:47,1:52,1:48,0:52,0:13,1:53,-1:19,1:3,0:53,-1:34,0:48,1:52,1:49,0:53,-1:24,0:6,1:52,1:47,0:52,0:43,1:52,1:43,0:53,-1:33,0:31,1:53,-1:37,1:37,0:52,0:18,1:52,1:18,0:53,-1:30,0:7,1:53,-1:15,1:15,0:53,-1:17,0:37,1:52,1:21,0:53,-1:40,0:30,1:53,-1:9,1:19,0:52,0:40,1:53,-1:29,1:9,0:52,0:47,1:52,1:4,0:52,0:4,1:53,-1:35,1:6,0:52,0:19,1:53,-1:8,1:35,0:53,-1:26,0:33,1:53,-1:22\nmove_number=103\n__dict__=gASVNQIAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRY8wEAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAo1Mgo0OQo1Mgo2CjUyCjE0CjUyCjMyCjUyCjQ3CjUyCjQ4CjUyCjEzCjUzCjE5CjMKNTMKMzQKNDgKNTIKNDkKNTMKMjQKNgo1Mgo0Nwo1Mgo0Mwo1Mgo0Mwo1MwozMwozMQo1MwozNwozNwo1MgoxOAo1MgoxOAo1MwozMAo3CjUzCjE1CjE1CjUzCjE3CjM3CjUyCjIxCjUzCjQwCjMwCjUzCjkKMTkKNTIKNDAKNTMKMjkKOQo1Mgo0Nwo1Mgo0CjUyCjQKNTMKMzUKNgo1MgoxOQo1Mwo4CjM1CjUzCjI2CjMzCjUzCjIyCgqUYnMu\n",
+          "legalActions": [],
+          "legalActionStrings": []
+        },
+        "status": "INACTIVE"
+      },
+      {
+        "action": {
+          "submission": 53,
+          "thoughts": "lantern upsilon lambda upsilon ember psi epsilon omega"
+        },
+        "reward": null,
+        "info": {
+          "actionSubmitted": 53,
+          "actionSubmittedToString": "Player: 1 Action: Draw stock",
+          "actionApplied": 53,
+          "timeTaken": 0.0,
+          "agentSelfReportedStatus": null
+        },
+        "observation": {
+          "remainingOverageTime": 12,
+          "observationString": "{\"phase\": \"Discard\", \"current_player\": 1, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"8d\", \"upcard\": null, \"stock_size\": 16, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\", \"2h\", \"5s\", \"7c\", \"Td\", \"8d\"], \"hands\": {\"0\": [], \"1\": [\"9s\", \"Qs\", \"2c\", \"Tc\", \"Kc\", \"4d\", \"Qd\", \"Kd\", \"9h\", \"Th\", \"Kh\"]}, \"deadwood\": {\"0\": null, \"1\": 54}, \"repeated_move\": 0}",
+          "currentPlayer": 1,
+          "playerId": 1,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14,0:52,0:49,1:52,1:6,0:52,0:14,1:52,1:32,0:52,0:47,1:52,1:48,0:52,0:13,1:53,-1:19,1:3,0:53,-1:34,0:48,1:52,1:49,0:53,-1:24,0:6,1:52,1:47,0:52,0:43,1:52,1:43,0:53,-1:33,0:31,1:53,-1:37,1:37,0:52,0:18,1:52,1:18,0:53,-1:30,0:7,1:53,-1:15,1:15,0:53,-1:17,0:37,1:52,1:21,0:53,-1:40,0:30,1:53,-1:9,1:19,0:52,0:40,1:53,-1:29,1:9,0:52,0:47,1:52,1:4,0:52,0:4,1:53,-1:35,1:6,0:52,0:19,1:53,-1:8,1:35,0:53,-1:26,0:33,1:53,-1:22\nmove_number=103\n__dict__=gASVNQIAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRY8wEAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAo1Mgo0OQo1Mgo2CjUyCjE0CjUyCjMyCjUyCjQ3CjUyCjQ4CjUyCjEzCjUzCjE5CjMKNTMKMzQKNDgKNTIKNDkKNTMKMjQKNgo1Mgo0Nwo1Mgo0Mwo1Mgo0Mwo1MwozMwozMQo1MwozNwozNwo1MgoxOAo1MgoxOAo1MwozMAo3CjUzCjE1CjE1CjUzCjE3CjM3CjUyCjIxCjUzCjQwCjMwCjUzCjkKMTkKNTIKNDAKNTMKMjkKOQo1Mgo0Nwo1Mgo0CjUyCjQKNTMKMzUKNgo1MgoxOQo1Mwo4CjM1CjUzCjI2CjMzCjUzCjIyCgqUYnMu\n",
+          "legalActions": [8, 11, 14, 22, 25, 29, 37, 38, 47, 48, 51],
+          "legalActionStrings": [
+            "Player: 1 Action: 9s",
+            "Player: 1 Action: Qs",
+            "Player: 1 Action: 2c",
+            "Player: 1 Action: Tc",
+            "Player: 1 Action: Kc",
+            "Player: 1 Action: 4d",
+            "Player: 1 Action: Qd",
+            "Player: 1 Action: Kd",
+            "Player: 1 Action: 9h",
+            "Player: 1 Action: Th",
+            "Player: 1 Action: Kh"
+          ]
+        },
+        "status": "ACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "submission": -1
+        },
+        "reward": null,
+        "info": {},
+        "observation": {
+          "remainingOverageTime": 12,
+          "step": 69,
+          "observationString": "{\"phase\": \"Draw\", \"current_player\": 0, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"8d\", \"upcard\": \"9s\", \"stock_size\": 16, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\", \"2h\", \"5s\", \"7c\", \"Td\", \"8d\"], \"hands\": {\"0\": [\"6s\", \"7s\", \"Ts\", \"5c\", \"Qc\", \"Ad\", \"3d\", \"7d\", \"9d\", \"Qh\"], \"1\": []}, \"deadwood\": {\"0\": 68, \"1\": null}, \"repeated_move\": 0}",
+          "currentPlayer": 0,
+          "playerId": 0,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14,0:52,0:49,1:52,1:6,0:52,0:14,1:52,1:32,0:52,0:47,1:52,1:48,0:52,0:13,1:53,-1:19,1:3,0:53,-1:34,0:48,1:52,1:49,0:53,-1:24,0:6,1:52,1:47,0:52,0:43,1:52,1:43,0:53,-1:33,0:31,1:53,-1:37,1:37,0:52,0:18,1:52,1:18,0:53,-1:30,0:7,1:53,-1:15,1:15,0:53,-1:17,0:37,1:52,1:21,0:53,-1:40,0:30,1:53,-1:9,1:19,0:52,0:40,1:53,-1:29,1:9,0:52,0:47,1:52,1:4,0:52,0:4,1:53,-1:35,1:6,0:52,0:19,1:53,-1:8,1:35,0:53,-1:26,0:33,1:53,-1:22,1:8\nmove_number=104\n__dict__=gASVNwIAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRY9QEAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAo1Mgo0OQo1Mgo2CjUyCjE0CjUyCjMyCjUyCjQ3CjUyCjQ4CjUyCjEzCjUzCjE5CjMKNTMKMzQKNDgKNTIKNDkKNTMKMjQKNgo1Mgo0Nwo1Mgo0Mwo1Mgo0Mwo1MwozMwozMQo1MwozNwozNwo1MgoxOAo1MgoxOAo1MwozMAo3CjUzCjE1CjE1CjUzCjE3CjM3CjUyCjIxCjUzCjQwCjMwCjUzCjkKMTkKNTIKNDAKNTMKMjkKOQo1Mgo0Nwo1Mgo0CjUyCjQKNTMKMzUKNgo1MgoxOQo1Mwo4CjM1CjUzCjI2CjMzCjUzCjIyCjgKCpRicy4=\n",
+          "legalActions": [52, 53],
+          "legalActionStrings": [
+            "Player: 0 Action: Draw upcard",
+            "Player: 0 Action: Draw stock"
+          ]
+        },
+        "status": "ACTIVE"
+      },
+      {
+        "action": {
+          "submission": 8,
+          "thoughts": "delta epsilon shadow omicron xi mu rho muse"
+        },
+        "reward": null,
+        "info": {
+          "actionSubmitted": 8,
+          "actionSubmittedToString": "Player: 1 Action: 9s",
+          "actionApplied": 8,
+          "timeTaken": 0.0,
+          "agentSelfReportedStatus": null
+        },
+        "observation": {
+          "remainingOverageTime": 12,
+          "observationString": "{\"phase\": \"Draw\", \"current_player\": 0, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"8d\", \"upcard\": \"9s\", \"stock_size\": 16, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\", \"2h\", \"5s\", \"7c\", \"Td\", \"8d\"], \"hands\": {\"0\": [], \"1\": [\"Qs\", \"2c\", \"Tc\", \"Kc\", \"4d\", \"Qd\", \"Kd\", \"9h\", \"Th\", \"Kh\"]}, \"deadwood\": {\"0\": null, \"1\": 55}, \"repeated_move\": 0}",
+          "currentPlayer": 0,
+          "playerId": 1,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14,0:52,0:49,1:52,1:6,0:52,0:14,1:52,1:32,0:52,0:47,1:52,1:48,0:52,0:13,1:53,-1:19,1:3,0:53,-1:34,0:48,1:52,1:49,0:53,-1:24,0:6,1:52,1:47,0:52,0:43,1:52,1:43,0:53,-1:33,0:31,1:53,-1:37,1:37,0:52,0:18,1:52,1:18,0:53,-1:30,0:7,1:53,-1:15,1:15,0:53,-1:17,0:37,1:52,1:21,0:53,-1:40,0:30,1:53,-1:9,1:19,0:52,0:40,1:53,-1:29,1:9,0:52,0:47,1:52,1:4,0:52,0:4,1:53,-1:35,1:6,0:52,0:19,1:53,-1:8,1:35,0:53,-1:26,0:33,1:53,-1:22,1:8\nmove_number=104\n__dict__=gASVNwIAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRY9QEAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAo1Mgo0OQo1Mgo2CjUyCjE0CjUyCjMyCjUyCjQ3CjUyCjQ4CjUyCjEzCjUzCjE5CjMKNTMKMzQKNDgKNTIKNDkKNTMKMjQKNgo1Mgo0Nwo1Mgo0Mwo1Mgo0Mwo1MwozMwozMQo1MwozNwozNwo1MgoxOAo1MgoxOAo1MwozMAo3CjUzCjE1CjE1CjUzCjE3CjM3CjUyCjIxCjUzCjQwCjMwCjUzCjkKMTkKNTIKNDAKNTMKMjkKOQo1Mgo0Nwo1Mgo0CjUyCjQKNTMKMzUKNgo1MgoxOQo1Mwo4CjM1CjUzCjI2CjMzCjUzCjIyCjgKCpRicy4=\n",
+          "legalActions": [],
+          "legalActionStrings": []
+        },
+        "status": "INACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "submission": 52,
+          "thoughts": "zeta omega xi beta omega sigma kappa epsilon"
+        },
+        "reward": null,
+        "info": {
+          "actionSubmitted": 52,
+          "actionSubmittedToString": "Player: 0 Action: Draw upcard",
+          "actionApplied": 52,
+          "timeTaken": 0.0,
+          "agentSelfReportedStatus": null
+        },
+        "observation": {
+          "remainingOverageTime": 12,
+          "step": 70,
+          "observationString": "{\"phase\": \"Discard\", \"current_player\": 0, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"9s\", \"upcard\": null, \"stock_size\": 16, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\", \"2h\", \"5s\", \"7c\", \"Td\", \"8d\"], \"hands\": {\"0\": [\"6s\", \"7s\", \"9s\", \"Ts\", \"5c\", \"Qc\", \"Ad\", \"3d\", \"7d\", \"9d\", \"Qh\"], \"1\": []}, \"deadwood\": {\"0\": 67, \"1\": null}, \"repeated_move\": 0}",
+          "currentPlayer": 0,
+          "playerId": 0,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14,0:52,0:49,1:52,1:6,0:52,0:14,1:52,1:32,0:52,0:47,1:52,1:48,0:52,0:13,1:53,-1:19,1:3,0:53,-1:34,0:48,1:52,1:49,0:53,-1:24,0:6,1:52,1:47,0:52,0:43,1:52,1:43,0:53,-1:33,0:31,1:53,-1:37,1:37,0:52,0:18,1:52,1:18,0:53,-1:30,0:7,1:53,-1:15,1:15,0:53,-1:17,0:37,1:52,1:21,0:53,-1:40,0:30,1:53,-1:9,1:19,0:52,0:40,1:53,-1:29,1:9,0:52,0:47,1:52,1:4,0:52,0:4,1:53,-1:35,1:6,0:52,0:19,1:53,-1:8,1:35,0:53,-1:26,0:33,1:53,-1:22,1:8,0:52\nmove_number=105\n__dict__=gASVOgIAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRY+AEAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAo1Mgo0OQo1Mgo2CjUyCjE0CjUyCjMyCjUyCjQ3CjUyCjQ4CjUyCjEzCjUzCjE5CjMKNTMKMzQKNDgKNTIKNDkKNTMKMjQKNgo1Mgo0Nwo1Mgo0Mwo1Mgo0Mwo1MwozMwozMQo1MwozNwozNwo1MgoxOAo1MgoxOAo1MwozMAo3CjUzCjE1CjE1CjUzCjE3CjM3CjUyCjIxCjUzCjQwCjMwCjUzCjkKMTkKNTIKNDAKNTMKMjkKOQo1Mgo0Nwo1Mgo0CjUyCjQKNTMKMzUKNgo1MgoxOQo1Mwo4CjM1CjUzCjI2CjMzCjUzCjIyCjgKNTIKCpRicy4=\n",
+          "legalActions": [5, 6, 8, 9, 17, 24, 26, 28, 32, 34, 50],
+          "legalActionStrings": [
+            "Player: 0 Action: 6s",
+            "Player: 0 Action: 7s",
+            "Player: 0 Action: 9s",
+            "Player: 0 Action: Ts",
+            "Player: 0 Action: 5c",
+            "Player: 0 Action: Qc",
+            "Player: 0 Action: Ad",
+            "Player: 0 Action: 3d",
+            "Player: 0 Action: 7d",
+            "Player: 0 Action: 9d",
+            "Player: 0 Action: Qh"
+          ]
+        },
+        "status": "ACTIVE"
+      },
+      {
+        "action": {
+          "submission": -1
+        },
+        "reward": null,
+        "info": {},
+        "observation": {
+          "remainingOverageTime": 12,
+          "observationString": "{\"phase\": \"Discard\", \"current_player\": 0, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"9s\", \"upcard\": null, \"stock_size\": 16, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\", \"2h\", \"5s\", \"7c\", \"Td\", \"8d\"], \"hands\": {\"0\": [], \"1\": [\"Qs\", \"2c\", \"Tc\", \"Kc\", \"4d\", \"Qd\", \"Kd\", \"9h\", \"Th\", \"Kh\"]}, \"deadwood\": {\"0\": null, \"1\": 55}, \"repeated_move\": 0}",
+          "currentPlayer": 0,
+          "playerId": 1,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14,0:52,0:49,1:52,1:6,0:52,0:14,1:52,1:32,0:52,0:47,1:52,1:48,0:52,0:13,1:53,-1:19,1:3,0:53,-1:34,0:48,1:52,1:49,0:53,-1:24,0:6,1:52,1:47,0:52,0:43,1:52,1:43,0:53,-1:33,0:31,1:53,-1:37,1:37,0:52,0:18,1:52,1:18,0:53,-1:30,0:7,1:53,-1:15,1:15,0:53,-1:17,0:37,1:52,1:21,0:53,-1:40,0:30,1:53,-1:9,1:19,0:52,0:40,1:53,-1:29,1:9,0:52,0:47,1:52,1:4,0:52,0:4,1:53,-1:35,1:6,0:52,0:19,1:53,-1:8,1:35,0:53,-1:26,0:33,1:53,-1:22,1:8,0:52\nmove_number=105\n__dict__=gASVOgIAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRY+AEAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAo1Mgo0OQo1Mgo2CjUyCjE0CjUyCjMyCjUyCjQ3CjUyCjQ4CjUyCjEzCjUzCjE5CjMKNTMKMzQKNDgKNTIKNDkKNTMKMjQKNgo1Mgo0Nwo1Mgo0Mwo1Mgo0Mwo1MwozMwozMQo1MwozNwozNwo1MgoxOAo1MgoxOAo1MwozMAo3CjUzCjE1CjE1CjUzCjE3CjM3CjUyCjIxCjUzCjQwCjMwCjUzCjkKMTkKNTIKNDAKNTMKMjkKOQo1Mgo0Nwo1Mgo0CjUyCjQKNTMKMzUKNgo1MgoxOQo1Mwo4CjM1CjUzCjI2CjMzCjUzCjIyCjgKNTIKCpRicy4=\n",
+          "legalActions": [],
+          "legalActionStrings": []
+        },
+        "status": "INACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "submission": 32,
+          "thoughts": "cascade omega pi lantern phi wonder imagine theta"
+        },
+        "reward": null,
+        "info": {
+          "actionSubmitted": 32,
+          "actionSubmittedToString": "Player: 0 Action: 7d",
+          "actionApplied": 32,
+          "timeTaken": 0.0,
+          "agentSelfReportedStatus": null
+        },
+        "observation": {
+          "remainingOverageTime": 12,
+          "step": 71,
+          "observationString": "{\"phase\": \"Draw\", \"current_player\": 1, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"9s\", \"upcard\": \"7d\", \"stock_size\": 16, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\", \"2h\", \"5s\", \"7c\", \"Td\", \"8d\"], \"hands\": {\"0\": [\"6s\", \"7s\", \"9s\", \"Ts\", \"5c\", \"Qc\", \"Ad\", \"3d\", \"9d\", \"Qh\"], \"1\": []}, \"deadwood\": {\"0\": 70, \"1\": null}, \"repeated_move\": 0}",
+          "currentPlayer": 1,
+          "playerId": 0,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14,0:52,0:49,1:52,1:6,0:52,0:14,1:52,1:32,0:52,0:47,1:52,1:48,0:52,0:13,1:53,-1:19,1:3,0:53,-1:34,0:48,1:52,1:49,0:53,-1:24,0:6,1:52,1:47,0:52,0:43,1:52,1:43,0:53,-1:33,0:31,1:53,-1:37,1:37,0:52,0:18,1:52,1:18,0:53,-1:30,0:7,1:53,-1:15,1:15,0:53,-1:17,0:37,1:52,1:21,0:53,-1:40,0:30,1:53,-1:9,1:19,0:52,0:40,1:53,-1:29,1:9,0:52,0:47,1:52,1:4,0:52,0:4,1:53,-1:35,1:6,0:52,0:19,1:53,-1:8,1:35,0:53,-1:26,0:33,1:53,-1:22,1:8,0:52,0:32\nmove_number=106\n__dict__=gASVPQIAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRY+wEAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAo1Mgo0OQo1Mgo2CjUyCjE0CjUyCjMyCjUyCjQ3CjUyCjQ4CjUyCjEzCjUzCjE5CjMKNTMKMzQKNDgKNTIKNDkKNTMKMjQKNgo1Mgo0Nwo1Mgo0Mwo1Mgo0Mwo1MwozMwozMQo1MwozNwozNwo1MgoxOAo1MgoxOAo1MwozMAo3CjUzCjE1CjE1CjUzCjE3CjM3CjUyCjIxCjUzCjQwCjMwCjUzCjkKMTkKNTIKNDAKNTMKMjkKOQo1Mgo0Nwo1Mgo0CjUyCjQKNTMKMzUKNgo1MgoxOQo1Mwo4CjM1CjUzCjI2CjMzCjUzCjIyCjgKNTIKMzIKCpRicy4=\n",
+          "legalActions": [],
+          "legalActionStrings": []
+        },
+        "status": "INACTIVE"
+      },
+      {
+        "action": {
+          "submission": -1
+        },
+        "reward": null,
+        "info": {},
+        "observation": {
+          "remainingOverageTime": 12,
+          "observationString": "{\"phase\": \"Draw\", \"current_player\": 1, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"9s\", \"upcard\": \"7d\", \"stock_size\": 16, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\", \"2h\", \"5s\", \"7c\", \"Td\", \"8d\"], \"hands\": {\"0\": [], \"1\": [\"Qs\", \"2c\", \"Tc\", \"Kc\", \"4d\", \"Qd\", \"Kd\", \"9h\", \"Th\", \"Kh\"]}, \"deadwood\": {\"0\": null, \"1\": 55}, \"repeated_move\": 0}",
+          "currentPlayer": 1,
+          "playerId": 1,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14,0:52,0:49,1:52,1:6,0:52,0:14,1:52,1:32,0:52,0:47,1:52,1:48,0:52,0:13,1:53,-1:19,1:3,0:53,-1:34,0:48,1:52,1:49,0:53,-1:24,0:6,1:52,1:47,0:52,0:43,1:52,1:43,0:53,-1:33,0:31,1:53,-1:37,1:37,0:52,0:18,1:52,1:18,0:53,-1:30,0:7,1:53,-1:15,1:15,0:53,-1:17,0:37,1:52,1:21,0:53,-1:40,0:30,1:53,-1:9,1:19,0:52,0:40,1:53,-1:29,1:9,0:52,0:47,1:52,1:4,0:52,0:4,1:53,-1:35,1:6,0:52,0:19,1:53,-1:8,1:35,0:53,-1:26,0:33,1:53,-1:22,1:8,0:52,0:32\nmove_number=106\n__dict__=gASVPQIAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRY+wEAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAo1Mgo0OQo1Mgo2CjUyCjE0CjUyCjMyCjUyCjQ3CjUyCjQ4CjUyCjEzCjUzCjE5CjMKNTMKMzQKNDgKNTIKNDkKNTMKMjQKNgo1Mgo0Nwo1Mgo0Mwo1Mgo0Mwo1MwozMwozMQo1MwozNwozNwo1MgoxOAo1MgoxOAo1MwozMAo3CjUzCjE1CjE1CjUzCjE3CjM3CjUyCjIxCjUzCjQwCjMwCjUzCjkKMTkKNTIKNDAKNTMKMjkKOQo1Mgo0Nwo1Mgo0CjUyCjQKNTMKMzUKNgo1MgoxOQo1Mwo4CjM1CjUzCjI2CjMzCjUzCjIyCjgKNTIKMzIKCpRicy4=\n",
+          "legalActions": [52, 53],
+          "legalActionStrings": [
+            "Player: 1 Action: Draw upcard",
+            "Player: 1 Action: Draw stock"
+          ]
+        },
+        "status": "ACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "submission": -1
+        },
+        "reward": null,
+        "info": {},
+        "observation": {
+          "remainingOverageTime": 12,
+          "step": 72,
+          "observationString": "{\"phase\": \"Discard\", \"current_player\": 1, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"7d\", \"upcard\": null, \"stock_size\": 16, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\", \"2h\", \"5s\", \"7c\", \"Td\", \"8d\"], \"hands\": {\"0\": [\"6s\", \"7s\", \"9s\", \"Ts\", \"5c\", \"Qc\", \"Ad\", \"3d\", \"9d\", \"Qh\"], \"1\": []}, \"deadwood\": {\"0\": 70, \"1\": null}, \"repeated_move\": 0}",
+          "currentPlayer": 1,
+          "playerId": 0,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14,0:52,0:49,1:52,1:6,0:52,0:14,1:52,1:32,0:52,0:47,1:52,1:48,0:52,0:13,1:53,-1:19,1:3,0:53,-1:34,0:48,1:52,1:49,0:53,-1:24,0:6,1:52,1:47,0:52,0:43,1:52,1:43,0:53,-1:33,0:31,1:53,-1:37,1:37,0:52,0:18,1:52,1:18,0:53,-1:30,0:7,1:53,-1:15,1:15,0:53,-1:17,0:37,1:52,1:21,0:53,-1:40,0:30,1:53,-1:9,1:19,0:52,0:40,1:53,-1:29,1:9,0:52,0:47,1:52,1:4,0:52,0:4,1:53,-1:35,1:6,0:52,0:19,1:53,-1:8,1:35,0:53,-1:26,0:33,1:53,-1:22,1:8,0:52,0:32,1:52\nmove_number=107\n__dict__=gASVQAIAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRY/gEAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAo1Mgo0OQo1Mgo2CjUyCjE0CjUyCjMyCjUyCjQ3CjUyCjQ4CjUyCjEzCjUzCjE5CjMKNTMKMzQKNDgKNTIKNDkKNTMKMjQKNgo1Mgo0Nwo1Mgo0Mwo1Mgo0Mwo1MwozMwozMQo1MwozNwozNwo1MgoxOAo1MgoxOAo1MwozMAo3CjUzCjE1CjE1CjUzCjE3CjM3CjUyCjIxCjUzCjQwCjMwCjUzCjkKMTkKNTIKNDAKNTMKMjkKOQo1Mgo0Nwo1Mgo0CjUyCjQKNTMKMzUKNgo1MgoxOQo1Mwo4CjM1CjUzCjI2CjMzCjUzCjIyCjgKNTIKMzIKNTIKCpRicy4=\n",
+          "legalActions": [],
+          "legalActionStrings": []
+        },
+        "status": "INACTIVE"
+      },
+      {
+        "action": {
+          "submission": 52,
+          "thoughts": "alpha mu consider explore explore phi imagine theta"
+        },
+        "reward": null,
+        "info": {
+          "actionSubmitted": 52,
+          "actionSubmittedToString": "Player: 1 Action: Draw upcard",
+          "actionApplied": 52,
+          "timeTaken": 0.0,
+          "agentSelfReportedStatus": null
+        },
+        "observation": {
+          "remainingOverageTime": 12,
+          "observationString": "{\"phase\": \"Discard\", \"current_player\": 1, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"7d\", \"upcard\": null, \"stock_size\": 16, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\", \"2h\", \"5s\", \"7c\", \"Td\", \"8d\"], \"hands\": {\"0\": [], \"1\": [\"Qs\", \"2c\", \"Tc\", \"Kc\", \"4d\", \"7d\", \"Qd\", \"Kd\", \"9h\", \"Th\", \"Kh\"]}, \"deadwood\": {\"0\": null, \"1\": 52}, \"repeated_move\": 0}",
+          "currentPlayer": 1,
+          "playerId": 1,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14,0:52,0:49,1:52,1:6,0:52,0:14,1:52,1:32,0:52,0:47,1:52,1:48,0:52,0:13,1:53,-1:19,1:3,0:53,-1:34,0:48,1:52,1:49,0:53,-1:24,0:6,1:52,1:47,0:52,0:43,1:52,1:43,0:53,-1:33,0:31,1:53,-1:37,1:37,0:52,0:18,1:52,1:18,0:53,-1:30,0:7,1:53,-1:15,1:15,0:53,-1:17,0:37,1:52,1:21,0:53,-1:40,0:30,1:53,-1:9,1:19,0:52,0:40,1:53,-1:29,1:9,0:52,0:47,1:52,1:4,0:52,0:4,1:53,-1:35,1:6,0:52,0:19,1:53,-1:8,1:35,0:53,-1:26,0:33,1:53,-1:22,1:8,0:52,0:32,1:52\nmove_number=107\n__dict__=gASVQAIAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRY/gEAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAo1Mgo0OQo1Mgo2CjUyCjE0CjUyCjMyCjUyCjQ3CjUyCjQ4CjUyCjEzCjUzCjE5CjMKNTMKMzQKNDgKNTIKNDkKNTMKMjQKNgo1Mgo0Nwo1Mgo0Mwo1Mgo0Mwo1MwozMwozMQo1MwozNwozNwo1MgoxOAo1MgoxOAo1MwozMAo3CjUzCjE1CjE1CjUzCjE3CjM3CjUyCjIxCjUzCjQwCjMwCjUzCjkKMTkKNTIKNDAKNTMKMjkKOQo1Mgo0Nwo1Mgo0CjUyCjQKNTMKMzUKNgo1MgoxOQo1Mwo4CjM1CjUzCjI2CjMzCjUzCjIyCjgKNTIKMzIKNTIKCpRicy4=\n",
+          "legalActions": [11, 14, 22, 25, 29, 32, 37, 38, 47, 48, 51],
+          "legalActionStrings": [
+            "Player: 1 Action: Qs",
+            "Player: 1 Action: 2c",
+            "Player: 1 Action: Tc",
+            "Player: 1 Action: Kc",
+            "Player: 1 Action: 4d",
+            "Player: 1 Action: 7d",
+            "Player: 1 Action: Qd",
+            "Player: 1 Action: Kd",
+            "Player: 1 Action: 9h",
+            "Player: 1 Action: Th",
+            "Player: 1 Action: Kh"
+          ]
+        },
+        "status": "ACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "submission": -1
+        },
+        "reward": null,
+        "info": {},
+        "observation": {
+          "remainingOverageTime": 12,
+          "step": 73,
+          "observationString": "{\"phase\": \"Draw\", \"current_player\": 0, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"7d\", \"upcard\": \"Tc\", \"stock_size\": 16, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\", \"2h\", \"5s\", \"7c\", \"Td\", \"8d\"], \"hands\": {\"0\": [\"6s\", \"7s\", \"9s\", \"Ts\", \"5c\", \"Qc\", \"Ad\", \"3d\", \"9d\", \"Qh\"], \"1\": []}, \"deadwood\": {\"0\": 70, \"1\": null}, \"repeated_move\": 0}",
+          "currentPlayer": 0,
+          "playerId": 0,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14,0:52,0:49,1:52,1:6,0:52,0:14,1:52,1:32,0:52,0:47,1:52,1:48,0:52,0:13,1:53,-1:19,1:3,0:53,-1:34,0:48,1:52,1:49,0:53,-1:24,0:6,1:52,1:47,0:52,0:43,1:52,1:43,0:53,-1:33,0:31,1:53,-1:37,1:37,0:52,0:18,1:52,1:18,0:53,-1:30,0:7,1:53,-1:15,1:15,0:53,-1:17,0:37,1:52,1:21,0:53,-1:40,0:30,1:53,-1:9,1:19,0:52,0:40,1:53,-1:29,1:9,0:52,0:47,1:52,1:4,0:52,0:4,1:53,-1:35,1:6,0:52,0:19,1:53,-1:8,1:35,0:53,-1:26,0:33,1:53,-1:22,1:8,0:52,0:32,1:52,1:22\nmove_number=108\n__dict__=gASVQwIAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRYAQIAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAo1Mgo0OQo1Mgo2CjUyCjE0CjUyCjMyCjUyCjQ3CjUyCjQ4CjUyCjEzCjUzCjE5CjMKNTMKMzQKNDgKNTIKNDkKNTMKMjQKNgo1Mgo0Nwo1Mgo0Mwo1Mgo0Mwo1MwozMwozMQo1MwozNwozNwo1MgoxOAo1MgoxOAo1MwozMAo3CjUzCjE1CjE1CjUzCjE3CjM3CjUyCjIxCjUzCjQwCjMwCjUzCjkKMTkKNTIKNDAKNTMKMjkKOQo1Mgo0Nwo1Mgo0CjUyCjQKNTMKMzUKNgo1MgoxOQo1Mwo4CjM1CjUzCjI2CjMzCjUzCjIyCjgKNTIKMzIKNTIKMjIKCpRicy4=\n",
+          "legalActions": [52, 53],
+          "legalActionStrings": [
+            "Player: 0 Action: Draw upcard",
+            "Player: 0 Action: Draw stock"
+          ]
+        },
+        "status": "ACTIVE"
+      },
+      {
+        "action": {
+          "submission": 22,
+          "thoughts": "cascade delta xi xi horizon reflect chi gamma"
+        },
+        "reward": null,
+        "info": {
+          "actionSubmitted": 22,
+          "actionSubmittedToString": "Player: 1 Action: Tc",
+          "actionApplied": 22,
+          "timeTaken": 0.0,
+          "agentSelfReportedStatus": null
+        },
+        "observation": {
+          "remainingOverageTime": 12,
+          "observationString": "{\"phase\": \"Draw\", \"current_player\": 0, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"7d\", \"upcard\": \"Tc\", \"stock_size\": 16, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\", \"2h\", \"5s\", \"7c\", \"Td\", \"8d\"], \"hands\": {\"0\": [], \"1\": [\"Qs\", \"2c\", \"Kc\", \"4d\", \"7d\", \"Qd\", \"Kd\", \"9h\", \"Th\", \"Kh\"]}, \"deadwood\": {\"0\": null, \"1\": 52}, \"repeated_move\": 0}",
+          "currentPlayer": 0,
+          "playerId": 1,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14,0:52,0:49,1:52,1:6,0:52,0:14,1:52,1:32,0:52,0:47,1:52,1:48,0:52,0:13,1:53,-1:19,1:3,0:53,-1:34,0:48,1:52,1:49,0:53,-1:24,0:6,1:52,1:47,0:52,0:43,1:52,1:43,0:53,-1:33,0:31,1:53,-1:37,1:37,0:52,0:18,1:52,1:18,0:53,-1:30,0:7,1:53,-1:15,1:15,0:53,-1:17,0:37,1:52,1:21,0:53,-1:40,0:30,1:53,-1:9,1:19,0:52,0:40,1:53,-1:29,1:9,0:52,0:47,1:52,1:4,0:52,0:4,1:53,-1:35,1:6,0:52,0:19,1:53,-1:8,1:35,0:53,-1:26,0:33,1:53,-1:22,1:8,0:52,0:32,1:52,1:22\nmove_number=108\n__dict__=gASVQwIAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRYAQIAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAo1Mgo0OQo1Mgo2CjUyCjE0CjUyCjMyCjUyCjQ3CjUyCjQ4CjUyCjEzCjUzCjE5CjMKNTMKMzQKNDgKNTIKNDkKNTMKMjQKNgo1Mgo0Nwo1Mgo0Mwo1Mgo0Mwo1MwozMwozMQo1MwozNwozNwo1MgoxOAo1MgoxOAo1MwozMAo3CjUzCjE1CjE1CjUzCjE3CjM3CjUyCjIxCjUzCjQwCjMwCjUzCjkKMTkKNTIKNDAKNTMKMjkKOQo1Mgo0Nwo1Mgo0CjUyCjQKNTMKMzUKNgo1MgoxOQo1Mwo4CjM1CjUzCjI2CjMzCjUzCjIyCjgKNTIKMzIKNTIKMjIKCpRicy4=\n",
+          "legalActions": [],
+          "legalActionStrings": []
+        },
+        "status": "INACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "submission": 52,
+          "thoughts": "beta rho phi beta delta omicron explore shadow"
+        },
+        "reward": null,
+        "info": {
+          "actionSubmitted": 52,
+          "actionSubmittedToString": "Player: 0 Action: Draw upcard",
+          "actionApplied": 52,
+          "timeTaken": 0.0,
+          "agentSelfReportedStatus": null
+        },
+        "observation": {
+          "remainingOverageTime": 12,
+          "step": 74,
+          "observationString": "{\"phase\": \"Discard\", \"current_player\": 0, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"Tc\", \"upcard\": null, \"stock_size\": 16, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\", \"2h\", \"5s\", \"7c\", \"Td\", \"8d\"], \"hands\": {\"0\": [\"6s\", \"7s\", \"9s\", \"Ts\", \"5c\", \"Tc\", \"Qc\", \"Ad\", \"3d\", \"9d\", \"Qh\"], \"1\": []}, \"deadwood\": {\"0\": 70, \"1\": null}, \"repeated_move\": 0}",
+          "currentPlayer": 0,
+          "playerId": 0,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14,0:52,0:49,1:52,1:6,0:52,0:14,1:52,1:32,0:52,0:47,1:52,1:48,0:52,0:13,1:53,-1:19,1:3,0:53,-1:34,0:48,1:52,1:49,0:53,-1:24,0:6,1:52,1:47,0:52,0:43,1:52,1:43,0:53,-1:33,0:31,1:53,-1:37,1:37,0:52,0:18,1:52,1:18,0:53,-1:30,0:7,1:53,-1:15,1:15,0:53,-1:17,0:37,1:52,1:21,0:53,-1:40,0:30,1:53,-1:9,1:19,0:52,0:40,1:53,-1:29,1:9,0:52,0:47,1:52,1:4,0:52,0:4,1:53,-1:35,1:6,0:52,0:19,1:53,-1:8,1:35,0:53,-1:26,0:33,1:53,-1:22,1:8,0:52,0:32,1:52,1:22,0:52\nmove_number=109\n__dict__=gASVRgIAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRYBAIAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAo1Mgo0OQo1Mgo2CjUyCjE0CjUyCjMyCjUyCjQ3CjUyCjQ4CjUyCjEzCjUzCjE5CjMKNTMKMzQKNDgKNTIKNDkKNTMKMjQKNgo1Mgo0Nwo1Mgo0Mwo1Mgo0Mwo1MwozMwozMQo1MwozNwozNwo1MgoxOAo1MgoxOAo1MwozMAo3CjUzCjE1CjE1CjUzCjE3CjM3CjUyCjIxCjUzCjQwCjMwCjUzCjkKMTkKNTIKNDAKNTMKMjkKOQo1Mgo0Nwo1Mgo0CjUyCjQKNTMKMzUKNgo1MgoxOQo1Mwo4CjM1CjUzCjI2CjMzCjUzCjIyCjgKNTIKMzIKNTIKMjIKNTIKCpRicy4=\n",
+          "legalActions": [5, 6, 8, 9, 17, 22, 24, 26, 28, 34, 50],
+          "legalActionStrings": [
+            "Player: 0 Action: 6s",
+            "Player: 0 Action: 7s",
+            "Player: 0 Action: 9s",
+            "Player: 0 Action: Ts",
+            "Player: 0 Action: 5c",
+            "Player: 0 Action: Tc",
+            "Player: 0 Action: Qc",
+            "Player: 0 Action: Ad",
+            "Player: 0 Action: 3d",
+            "Player: 0 Action: 9d",
+            "Player: 0 Action: Qh"
+          ]
+        },
+        "status": "ACTIVE"
+      },
+      {
+        "action": {
+          "submission": -1
+        },
+        "reward": null,
+        "info": {},
+        "observation": {
+          "remainingOverageTime": 12,
+          "observationString": "{\"phase\": \"Discard\", \"current_player\": 0, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"Tc\", \"upcard\": null, \"stock_size\": 16, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\", \"2h\", \"5s\", \"7c\", \"Td\", \"8d\"], \"hands\": {\"0\": [], \"1\": [\"Qs\", \"2c\", \"Kc\", \"4d\", \"7d\", \"Qd\", \"Kd\", \"9h\", \"Th\", \"Kh\"]}, \"deadwood\": {\"0\": null, \"1\": 52}, \"repeated_move\": 0}",
+          "currentPlayer": 0,
+          "playerId": 1,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14,0:52,0:49,1:52,1:6,0:52,0:14,1:52,1:32,0:52,0:47,1:52,1:48,0:52,0:13,1:53,-1:19,1:3,0:53,-1:34,0:48,1:52,1:49,0:53,-1:24,0:6,1:52,1:47,0:52,0:43,1:52,1:43,0:53,-1:33,0:31,1:53,-1:37,1:37,0:52,0:18,1:52,1:18,0:53,-1:30,0:7,1:53,-1:15,1:15,0:53,-1:17,0:37,1:52,1:21,0:53,-1:40,0:30,1:53,-1:9,1:19,0:52,0:40,1:53,-1:29,1:9,0:52,0:47,1:52,1:4,0:52,0:4,1:53,-1:35,1:6,0:52,0:19,1:53,-1:8,1:35,0:53,-1:26,0:33,1:53,-1:22,1:8,0:52,0:32,1:52,1:22,0:52\nmove_number=109\n__dict__=gASVRgIAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRYBAIAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAo1Mgo0OQo1Mgo2CjUyCjE0CjUyCjMyCjUyCjQ3CjUyCjQ4CjUyCjEzCjUzCjE5CjMKNTMKMzQKNDgKNTIKNDkKNTMKMjQKNgo1Mgo0Nwo1Mgo0Mwo1Mgo0Mwo1MwozMwozMQo1MwozNwozNwo1MgoxOAo1MgoxOAo1MwozMAo3CjUzCjE1CjE1CjUzCjE3CjM3CjUyCjIxCjUzCjQwCjMwCjUzCjkKMTkKNTIKNDAKNTMKMjkKOQo1Mgo0Nwo1Mgo0CjUyCjQKNTMKMzUKNgo1MgoxOQo1Mwo4CjM1CjUzCjI2CjMzCjUzCjIyCjgKNTIKMzIKNTIKMjIKNTIKCpRicy4=\n",
+          "legalActions": [],
+          "legalActionStrings": []
+        },
+        "status": "INACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "submission": 24,
+          "thoughts": "horizon mu alpha reflect pi cascade reflect muse"
+        },
+        "reward": null,
+        "info": {
+          "actionSubmitted": 24,
+          "actionSubmittedToString": "Player: 0 Action: Qc",
+          "actionApplied": 24,
+          "timeTaken": 0.0,
+          "agentSelfReportedStatus": null
+        },
+        "observation": {
+          "remainingOverageTime": 12,
+          "step": 75,
+          "observationString": "{\"phase\": \"Draw\", \"current_player\": 1, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"Tc\", \"upcard\": \"Qc\", \"stock_size\": 16, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\", \"2h\", \"5s\", \"7c\", \"Td\", \"8d\"], \"hands\": {\"0\": [\"6s\", \"7s\", \"9s\", \"Ts\", \"5c\", \"Tc\", \"Ad\", \"3d\", \"9d\", \"Qh\"], \"1\": []}, \"deadwood\": {\"0\": 70, \"1\": null}, \"repeated_move\": 0}",
+          "currentPlayer": 1,
+          "playerId": 0,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14,0:52,0:49,1:52,1:6,0:52,0:14,1:52,1:32,0:52,0:47,1:52,1:48,0:52,0:13,1:53,-1:19,1:3,0:53,-1:34,0:48,1:52,1:49,0:53,-1:24,0:6,1:52,1:47,0:52,0:43,1:52,1:43,0:53,-1:33,0:31,1:53,-1:37,1:37,0:52,0:18,1:52,1:18,0:53,-1:30,0:7,1:53,-1:15,1:15,0:53,-1:17,0:37,1:52,1:21,0:53,-1:40,0:30,1:53,-1:9,1:19,0:52,0:40,1:53,-1:29,1:9,0:52,0:47,1:52,1:4,0:52,0:4,1:53,-1:35,1:6,0:52,0:19,1:53,-1:8,1:35,0:53,-1:26,0:33,1:53,-1:22,1:8,0:52,0:32,1:52,1:22,0:52,0:24\nmove_number=110\n__dict__=gASVSQIAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRYBwIAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAo1Mgo0OQo1Mgo2CjUyCjE0CjUyCjMyCjUyCjQ3CjUyCjQ4CjUyCjEzCjUzCjE5CjMKNTMKMzQKNDgKNTIKNDkKNTMKMjQKNgo1Mgo0Nwo1Mgo0Mwo1Mgo0Mwo1MwozMwozMQo1MwozNwozNwo1MgoxOAo1MgoxOAo1MwozMAo3CjUzCjE1CjE1CjUzCjE3CjM3CjUyCjIxCjUzCjQwCjMwCjUzCjkKMTkKNTIKNDAKNTMKMjkKOQo1Mgo0Nwo1Mgo0CjUyCjQKNTMKMzUKNgo1MgoxOQo1Mwo4CjM1CjUzCjI2CjMzCjUzCjIyCjgKNTIKMzIKNTIKMjIKNTIKMjQKCpRicy4=\n",
+          "legalActions": [],
+          "legalActionStrings": []
+        },
+        "status": "INACTIVE"
+      },
+      {
+        "action": {
+          "submission": -1
+        },
+        "reward": null,
+        "info": {},
+        "observation": {
+          "remainingOverageTime": 12,
+          "observationString": "{\"phase\": \"Draw\", \"current_player\": 1, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"Tc\", \"upcard\": \"Qc\", \"stock_size\": 16, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\", \"2h\", \"5s\", \"7c\", \"Td\", \"8d\"], \"hands\": {\"0\": [], \"1\": [\"Qs\", \"2c\", \"Kc\", \"4d\", \"7d\", \"Qd\", \"Kd\", \"9h\", \"Th\", \"Kh\"]}, \"deadwood\": {\"0\": null, \"1\": 52}, \"repeated_move\": 0}",
+          "currentPlayer": 1,
+          "playerId": 1,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14,0:52,0:49,1:52,1:6,0:52,0:14,1:52,1:32,0:52,0:47,1:52,1:48,0:52,0:13,1:53,-1:19,1:3,0:53,-1:34,0:48,1:52,1:49,0:53,-1:24,0:6,1:52,1:47,0:52,0:43,1:52,1:43,0:53,-1:33,0:31,1:53,-1:37,1:37,0:52,0:18,1:52,1:18,0:53,-1:30,0:7,1:53,-1:15,1:15,0:53,-1:17,0:37,1:52,1:21,0:53,-1:40,0:30,1:53,-1:9,1:19,0:52,0:40,1:53,-1:29,1:9,0:52,0:47,1:52,1:4,0:52,0:4,1:53,-1:35,1:6,0:52,0:19,1:53,-1:8,1:35,0:53,-1:26,0:33,1:53,-1:22,1:8,0:52,0:32,1:52,1:22,0:52,0:24\nmove_number=110\n__dict__=gASVSQIAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRYBwIAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAo1Mgo0OQo1Mgo2CjUyCjE0CjUyCjMyCjUyCjQ3CjUyCjQ4CjUyCjEzCjUzCjE5CjMKNTMKMzQKNDgKNTIKNDkKNTMKMjQKNgo1Mgo0Nwo1Mgo0Mwo1Mgo0Mwo1MwozMwozMQo1MwozNwozNwo1MgoxOAo1MgoxOAo1MwozMAo3CjUzCjE1CjE1CjUzCjE3CjM3CjUyCjIxCjUzCjQwCjMwCjUzCjkKMTkKNTIKNDAKNTMKMjkKOQo1Mgo0Nwo1Mgo0CjUyCjQKNTMKMzUKNgo1MgoxOQo1Mwo4CjM1CjUzCjI2CjMzCjUzCjIyCjgKNTIKMzIKNTIKMjIKNTIKMjQKCpRicy4=\n",
+          "legalActions": [52, 53],
+          "legalActionStrings": [
+            "Player: 1 Action: Draw upcard",
+            "Player: 1 Action: Draw stock"
+          ]
+        },
+        "status": "ACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "submission": -1
+        },
+        "reward": null,
+        "info": {},
+        "observation": {
+          "remainingOverageTime": 12,
+          "step": 76,
+          "observationString": "{\"phase\": \"Discard\", \"current_player\": 1, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"Qc\", \"upcard\": null, \"stock_size\": 15, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\", \"2h\", \"5s\", \"7c\", \"Td\", \"8d\", \"Qc\"], \"hands\": {\"0\": [\"6s\", \"7s\", \"9s\", \"Ts\", \"5c\", \"Tc\", \"Ad\", \"3d\", \"9d\", \"Qh\"], \"1\": []}, \"deadwood\": {\"0\": 70, \"1\": null}, \"repeated_move\": 0}",
+          "currentPlayer": 1,
+          "playerId": 0,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14,0:52,0:49,1:52,1:6,0:52,0:14,1:52,1:32,0:52,0:47,1:52,1:48,0:52,0:13,1:53,-1:19,1:3,0:53,-1:34,0:48,1:52,1:49,0:53,-1:24,0:6,1:52,1:47,0:52,0:43,1:52,1:43,0:53,-1:33,0:31,1:53,-1:37,1:37,0:52,0:18,1:52,1:18,0:53,-1:30,0:7,1:53,-1:15,1:15,0:53,-1:17,0:37,1:52,1:21,0:53,-1:40,0:30,1:53,-1:9,1:19,0:52,0:40,1:53,-1:29,1:9,0:52,0:47,1:52,1:4,0:52,0:4,1:53,-1:35,1:6,0:52,0:19,1:53,-1:8,1:35,0:53,-1:26,0:33,1:53,-1:22,1:8,0:52,0:32,1:52,1:22,0:52,0:24,1:53,-1:1\nmove_number=112\n__dict__=gASVTgIAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRYDAIAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAo1Mgo0OQo1Mgo2CjUyCjE0CjUyCjMyCjUyCjQ3CjUyCjQ4CjUyCjEzCjUzCjE5CjMKNTMKMzQKNDgKNTIKNDkKNTMKMjQKNgo1Mgo0Nwo1Mgo0Mwo1Mgo0Mwo1MwozMwozMQo1MwozNwozNwo1MgoxOAo1MgoxOAo1MwozMAo3CjUzCjE1CjE1CjUzCjE3CjM3CjUyCjIxCjUzCjQwCjMwCjUzCjkKMTkKNTIKNDAKNTMKMjkKOQo1Mgo0Nwo1Mgo0CjUyCjQKNTMKMzUKNgo1MgoxOQo1Mwo4CjM1CjUzCjI2CjMzCjUzCjIyCjgKNTIKMzIKNTIKMjIKNTIKMjQKNTMKMQoKlGJzLg==\n",
+          "legalActions": [],
+          "legalActionStrings": []
+        },
+        "status": "INACTIVE"
+      },
+      {
+        "action": {
+          "submission": 53,
+          "thoughts": "kappa eta xi horizon reflect mu xi mu"
+        },
+        "reward": null,
+        "info": {
+          "actionSubmitted": 53,
+          "actionSubmittedToString": "Player: 1 Action: Draw stock",
+          "actionApplied": 53,
+          "timeTaken": 0.0,
+          "agentSelfReportedStatus": null
+        },
+        "observation": {
+          "remainingOverageTime": 12,
+          "observationString": "{\"phase\": \"Discard\", \"current_player\": 1, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"Qc\", \"upcard\": null, \"stock_size\": 15, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\", \"2h\", \"5s\", \"7c\", \"Td\", \"8d\", \"Qc\"], \"hands\": {\"0\": [], \"1\": [\"2s\", \"Qs\", \"2c\", \"Kc\", \"4d\", \"7d\", \"Qd\", \"Kd\", \"9h\", \"Th\", \"Kh\"]}, \"deadwood\": {\"0\": null, \"1\": 44}, \"repeated_move\": 0}",
+          "currentPlayer": 1,
+          "playerId": 1,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14,0:52,0:49,1:52,1:6,0:52,0:14,1:52,1:32,0:52,0:47,1:52,1:48,0:52,0:13,1:53,-1:19,1:3,0:53,-1:34,0:48,1:52,1:49,0:53,-1:24,0:6,1:52,1:47,0:52,0:43,1:52,1:43,0:53,-1:33,0:31,1:53,-1:37,1:37,0:52,0:18,1:52,1:18,0:53,-1:30,0:7,1:53,-1:15,1:15,0:53,-1:17,0:37,1:52,1:21,0:53,-1:40,0:30,1:53,-1:9,1:19,0:52,0:40,1:53,-1:29,1:9,0:52,0:47,1:52,1:4,0:52,0:4,1:53,-1:35,1:6,0:52,0:19,1:53,-1:8,1:35,0:53,-1:26,0:33,1:53,-1:22,1:8,0:52,0:32,1:52,1:22,0:52,0:24,1:53,-1:1\nmove_number=112\n__dict__=gASVTgIAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRYDAIAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAo1Mgo0OQo1Mgo2CjUyCjE0CjUyCjMyCjUyCjQ3CjUyCjQ4CjUyCjEzCjUzCjE5CjMKNTMKMzQKNDgKNTIKNDkKNTMKMjQKNgo1Mgo0Nwo1Mgo0Mwo1Mgo0Mwo1MwozMwozMQo1MwozNwozNwo1MgoxOAo1MgoxOAo1MwozMAo3CjUzCjE1CjE1CjUzCjE3CjM3CjUyCjIxCjUzCjQwCjMwCjUzCjkKMTkKNTIKNDAKNTMKMjkKOQo1Mgo0Nwo1Mgo0CjUyCjQKNTMKMzUKNgo1MgoxOQo1Mwo4CjM1CjUzCjI2CjMzCjUzCjIyCjgKNTIKMzIKNTIKMjIKNTIKMjQKNTMKMQoKlGJzLg==\n",
+          "legalActions": [1, 11, 14, 25, 29, 32, 37, 38, 47, 48, 51],
+          "legalActionStrings": [
+            "Player: 1 Action: 2s",
+            "Player: 1 Action: Qs",
+            "Player: 1 Action: 2c",
+            "Player: 1 Action: Kc",
+            "Player: 1 Action: 4d",
+            "Player: 1 Action: 7d",
+            "Player: 1 Action: Qd",
+            "Player: 1 Action: Kd",
+            "Player: 1 Action: 9h",
+            "Player: 1 Action: Th",
+            "Player: 1 Action: Kh"
+          ]
+        },
+        "status": "ACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "submission": -1
+        },
+        "reward": null,
+        "info": {},
+        "observation": {
+          "remainingOverageTime": 12,
+          "step": 77,
+          "observationString": "{\"phase\": \"Draw\", \"current_player\": 0, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"Qc\", \"upcard\": \"2s\", \"stock_size\": 15, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\", \"2h\", \"5s\", \"7c\", \"Td\", \"8d\", \"Qc\"], \"hands\": {\"0\": [\"6s\", \"7s\", \"9s\", \"Ts\", \"5c\", \"Tc\", \"Ad\", \"3d\", \"9d\", \"Qh\"], \"1\": []}, \"deadwood\": {\"0\": 70, \"1\": null}, \"repeated_move\": 0}",
+          "currentPlayer": 0,
+          "playerId": 0,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14,0:52,0:49,1:52,1:6,0:52,0:14,1:52,1:32,0:52,0:47,1:52,1:48,0:52,0:13,1:53,-1:19,1:3,0:53,-1:34,0:48,1:52,1:49,0:53,-1:24,0:6,1:52,1:47,0:52,0:43,1:52,1:43,0:53,-1:33,0:31,1:53,-1:37,1:37,0:52,0:18,1:52,1:18,0:53,-1:30,0:7,1:53,-1:15,1:15,0:53,-1:17,0:37,1:52,1:21,0:53,-1:40,0:30,1:53,-1:9,1:19,0:52,0:40,1:53,-1:29,1:9,0:52,0:47,1:52,1:4,0:52,0:4,1:53,-1:35,1:6,0:52,0:19,1:53,-1:8,1:35,0:53,-1:26,0:33,1:53,-1:22,1:8,0:52,0:32,1:52,1:22,0:52,0:24,1:53,-1:1,1:1\nmove_number=113\n__dict__=gASVUAIAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRYDgIAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAo1Mgo0OQo1Mgo2CjUyCjE0CjUyCjMyCjUyCjQ3CjUyCjQ4CjUyCjEzCjUzCjE5CjMKNTMKMzQKNDgKNTIKNDkKNTMKMjQKNgo1Mgo0Nwo1Mgo0Mwo1Mgo0Mwo1MwozMwozMQo1MwozNwozNwo1MgoxOAo1MgoxOAo1MwozMAo3CjUzCjE1CjE1CjUzCjE3CjM3CjUyCjIxCjUzCjQwCjMwCjUzCjkKMTkKNTIKNDAKNTMKMjkKOQo1Mgo0Nwo1Mgo0CjUyCjQKNTMKMzUKNgo1MgoxOQo1Mwo4CjM1CjUzCjI2CjMzCjUzCjIyCjgKNTIKMzIKNTIKMjIKNTIKMjQKNTMKMQoxCgqUYnMu\n",
+          "legalActions": [52, 53],
+          "legalActionStrings": [
+            "Player: 0 Action: Draw upcard",
+            "Player: 0 Action: Draw stock"
+          ]
+        },
+        "status": "ACTIVE"
+      },
+      {
+        "action": {
+          "submission": 1,
+          "thoughts": "lambda pi lambda eta wonder epsilon spark upsilon"
+        },
+        "reward": null,
+        "info": {
+          "actionSubmitted": 1,
+          "actionSubmittedToString": "Player: 1 Action: 2s",
+          "actionApplied": 1,
+          "timeTaken": 0.0,
+          "agentSelfReportedStatus": null
+        },
+        "observation": {
+          "remainingOverageTime": 12,
+          "observationString": "{\"phase\": \"Draw\", \"current_player\": 0, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"Qc\", \"upcard\": \"2s\", \"stock_size\": 15, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\", \"2h\", \"5s\", \"7c\", \"Td\", \"8d\", \"Qc\"], \"hands\": {\"0\": [], \"1\": [\"Qs\", \"2c\", \"Kc\", \"4d\", \"7d\", \"Qd\", \"Kd\", \"9h\", \"Th\", \"Kh\"]}, \"deadwood\": {\"0\": null, \"1\": 52}, \"repeated_move\": 0}",
+          "currentPlayer": 0,
+          "playerId": 1,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14,0:52,0:49,1:52,1:6,0:52,0:14,1:52,1:32,0:52,0:47,1:52,1:48,0:52,0:13,1:53,-1:19,1:3,0:53,-1:34,0:48,1:52,1:49,0:53,-1:24,0:6,1:52,1:47,0:52,0:43,1:52,1:43,0:53,-1:33,0:31,1:53,-1:37,1:37,0:52,0:18,1:52,1:18,0:53,-1:30,0:7,1:53,-1:15,1:15,0:53,-1:17,0:37,1:52,1:21,0:53,-1:40,0:30,1:53,-1:9,1:19,0:52,0:40,1:53,-1:29,1:9,0:52,0:47,1:52,1:4,0:52,0:4,1:53,-1:35,1:6,0:52,0:19,1:53,-1:8,1:35,0:53,-1:26,0:33,1:53,-1:22,1:8,0:52,0:32,1:52,1:22,0:52,0:24,1:53,-1:1,1:1\nmove_number=113\n__dict__=gASVUAIAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRYDgIAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAo1Mgo0OQo1Mgo2CjUyCjE0CjUyCjMyCjUyCjQ3CjUyCjQ4CjUyCjEzCjUzCjE5CjMKNTMKMzQKNDgKNTIKNDkKNTMKMjQKNgo1Mgo0Nwo1Mgo0Mwo1Mgo0Mwo1MwozMwozMQo1MwozNwozNwo1MgoxOAo1MgoxOAo1MwozMAo3CjUzCjE1CjE1CjUzCjE3CjM3CjUyCjIxCjUzCjQwCjMwCjUzCjkKMTkKNTIKNDAKNTMKMjkKOQo1Mgo0Nwo1Mgo0CjUyCjQKNTMKMzUKNgo1MgoxOQo1Mwo4CjM1CjUzCjI2CjMzCjUzCjIyCjgKNTIKMzIKNTIKMjIKNTIKMjQKNTMKMQoxCgqUYnMu\n",
+          "legalActions": [],
+          "legalActionStrings": []
+        },
+        "status": "INACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "submission": 52,
+          "thoughts": "eta drift eta imagine consider ponder gamma chi"
+        },
+        "reward": null,
+        "info": {
+          "actionSubmitted": 52,
+          "actionSubmittedToString": "Player: 0 Action: Draw upcard",
+          "actionApplied": 52,
+          "timeTaken": 0.0,
+          "agentSelfReportedStatus": null
+        },
+        "observation": {
+          "remainingOverageTime": 12,
+          "step": 78,
+          "observationString": "{\"phase\": \"Discard\", \"current_player\": 0, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"2s\", \"upcard\": null, \"stock_size\": 15, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\", \"2h\", \"5s\", \"7c\", \"Td\", \"8d\", \"Qc\"], \"hands\": {\"0\": [\"2s\", \"6s\", \"7s\", \"9s\", \"Ts\", \"5c\", \"Tc\", \"Ad\", \"3d\", \"9d\", \"Qh\"], \"1\": []}, \"deadwood\": {\"0\": 62, \"1\": null}, \"repeated_move\": 0}",
+          "currentPlayer": 0,
+          "playerId": 0,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14,0:52,0:49,1:52,1:6,0:52,0:14,1:52,1:32,0:52,0:47,1:52,1:48,0:52,0:13,1:53,-1:19,1:3,0:53,-1:34,0:48,1:52,1:49,0:53,-1:24,0:6,1:52,1:47,0:52,0:43,1:52,1:43,0:53,-1:33,0:31,1:53,-1:37,1:37,0:52,0:18,1:52,1:18,0:53,-1:30,0:7,1:53,-1:15,1:15,0:53,-1:17,0:37,1:52,1:21,0:53,-1:40,0:30,1:53,-1:9,1:19,0:52,0:40,1:53,-1:29,1:9,0:52,0:47,1:52,1:4,0:52,0:4,1:53,-1:35,1:6,0:52,0:19,1:53,-1:8,1:35,0:53,-1:26,0:33,1:53,-1:22,1:8,0:52,0:32,1:52,1:22,0:52,0:24,1:53,-1:1,1:1,0:52\nmove_number=114\n__dict__=gASVUwIAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRYEQIAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAo1Mgo0OQo1Mgo2CjUyCjE0CjUyCjMyCjUyCjQ3CjUyCjQ4CjUyCjEzCjUzCjE5CjMKNTMKMzQKNDgKNTIKNDkKNTMKMjQKNgo1Mgo0Nwo1Mgo0Mwo1Mgo0Mwo1MwozMwozMQo1MwozNwozNwo1MgoxOAo1MgoxOAo1MwozMAo3CjUzCjE1CjE1CjUzCjE3CjM3CjUyCjIxCjUzCjQwCjMwCjUzCjkKMTkKNTIKNDAKNTMKMjkKOQo1Mgo0Nwo1Mgo0CjUyCjQKNTMKMzUKNgo1MgoxOQo1Mwo4CjM1CjUzCjI2CjMzCjUzCjIyCjgKNTIKMzIKNTIKMjIKNTIKMjQKNTMKMQoxCjUyCgqUYnMu\n",
+          "legalActions": [1, 5, 6, 8, 9, 17, 22, 26, 28, 34, 50],
+          "legalActionStrings": [
+            "Player: 0 Action: 2s",
+            "Player: 0 Action: 6s",
+            "Player: 0 Action: 7s",
+            "Player: 0 Action: 9s",
+            "Player: 0 Action: Ts",
+            "Player: 0 Action: 5c",
+            "Player: 0 Action: Tc",
+            "Player: 0 Action: Ad",
+            "Player: 0 Action: 3d",
+            "Player: 0 Action: 9d",
+            "Player: 0 Action: Qh"
+          ]
+        },
+        "status": "ACTIVE"
+      },
+      {
+        "action": {
+          "submission": -1
+        },
+        "reward": null,
+        "info": {},
+        "observation": {
+          "remainingOverageTime": 12,
+          "observationString": "{\"phase\": \"Discard\", \"current_player\": 0, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"2s\", \"upcard\": null, \"stock_size\": 15, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\", \"2h\", \"5s\", \"7c\", \"Td\", \"8d\", \"Qc\"], \"hands\": {\"0\": [], \"1\": [\"Qs\", \"2c\", \"Kc\", \"4d\", \"7d\", \"Qd\", \"Kd\", \"9h\", \"Th\", \"Kh\"]}, \"deadwood\": {\"0\": null, \"1\": 52}, \"repeated_move\": 0}",
+          "currentPlayer": 0,
+          "playerId": 1,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14,0:52,0:49,1:52,1:6,0:52,0:14,1:52,1:32,0:52,0:47,1:52,1:48,0:52,0:13,1:53,-1:19,1:3,0:53,-1:34,0:48,1:52,1:49,0:53,-1:24,0:6,1:52,1:47,0:52,0:43,1:52,1:43,0:53,-1:33,0:31,1:53,-1:37,1:37,0:52,0:18,1:52,1:18,0:53,-1:30,0:7,1:53,-1:15,1:15,0:53,-1:17,0:37,1:52,1:21,0:53,-1:40,0:30,1:53,-1:9,1:19,0:52,0:40,1:53,-1:29,1:9,0:52,0:47,1:52,1:4,0:52,0:4,1:53,-1:35,1:6,0:52,0:19,1:53,-1:8,1:35,0:53,-1:26,0:33,1:53,-1:22,1:8,0:52,0:32,1:52,1:22,0:52,0:24,1:53,-1:1,1:1,0:52\nmove_number=114\n__dict__=gASVUwIAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRYEQIAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAo1Mgo0OQo1Mgo2CjUyCjE0CjUyCjMyCjUyCjQ3CjUyCjQ4CjUyCjEzCjUzCjE5CjMKNTMKMzQKNDgKNTIKNDkKNTMKMjQKNgo1Mgo0Nwo1Mgo0Mwo1Mgo0Mwo1MwozMwozMQo1MwozNwozNwo1MgoxOAo1MgoxOAo1MwozMAo3CjUzCjE1CjE1CjUzCjE3CjM3CjUyCjIxCjUzCjQwCjMwCjUzCjkKMTkKNTIKNDAKNTMKMjkKOQo1Mgo0Nwo1Mgo0CjUyCjQKNTMKMzUKNgo1MgoxOQo1Mwo4CjM1CjUzCjI2CjMzCjUzCjIyCjgKNTIKMzIKNTIKMjIKNTIKMjQKNTMKMQoxCjUyCgqUYnMu\n",
+          "legalActions": [],
+          "legalActionStrings": []
+        },
+        "status": "INACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "submission": 8,
+          "thoughts": "consider cascade mu ripple explore phi psi sigma"
+        },
+        "reward": null,
+        "info": {
+          "actionSubmitted": 8,
+          "actionSubmittedToString": "Player: 0 Action: 9s",
+          "actionApplied": 8,
+          "timeTaken": 0.0,
+          "agentSelfReportedStatus": null
+        },
+        "observation": {
+          "remainingOverageTime": 12,
+          "step": 79,
+          "observationString": "{\"phase\": \"Draw\", \"current_player\": 1, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"2s\", \"upcard\": \"9s\", \"stock_size\": 15, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\", \"2h\", \"5s\", \"7c\", \"Td\", \"8d\", \"Qc\"], \"hands\": {\"0\": [\"2s\", \"6s\", \"7s\", \"Ts\", \"5c\", \"Tc\", \"Ad\", \"3d\", \"9d\", \"Qh\"], \"1\": []}, \"deadwood\": {\"0\": 63, \"1\": null}, \"repeated_move\": 0}",
+          "currentPlayer": 1,
+          "playerId": 0,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14,0:52,0:49,1:52,1:6,0:52,0:14,1:52,1:32,0:52,0:47,1:52,1:48,0:52,0:13,1:53,-1:19,1:3,0:53,-1:34,0:48,1:52,1:49,0:53,-1:24,0:6,1:52,1:47,0:52,0:43,1:52,1:43,0:53,-1:33,0:31,1:53,-1:37,1:37,0:52,0:18,1:52,1:18,0:53,-1:30,0:7,1:53,-1:15,1:15,0:53,-1:17,0:37,1:52,1:21,0:53,-1:40,0:30,1:53,-1:9,1:19,0:52,0:40,1:53,-1:29,1:9,0:52,0:47,1:52,1:4,0:52,0:4,1:53,-1:35,1:6,0:52,0:19,1:53,-1:8,1:35,0:53,-1:26,0:33,1:53,-1:22,1:8,0:52,0:32,1:52,1:22,0:52,0:24,1:53,-1:1,1:1,0:52,0:8\nmove_number=115\n__dict__=gASVVQIAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRYEwIAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAo1Mgo0OQo1Mgo2CjUyCjE0CjUyCjMyCjUyCjQ3CjUyCjQ4CjUyCjEzCjUzCjE5CjMKNTMKMzQKNDgKNTIKNDkKNTMKMjQKNgo1Mgo0Nwo1Mgo0Mwo1Mgo0Mwo1MwozMwozMQo1MwozNwozNwo1MgoxOAo1MgoxOAo1MwozMAo3CjUzCjE1CjE1CjUzCjE3CjM3CjUyCjIxCjUzCjQwCjMwCjUzCjkKMTkKNTIKNDAKNTMKMjkKOQo1Mgo0Nwo1Mgo0CjUyCjQKNTMKMzUKNgo1MgoxOQo1Mwo4CjM1CjUzCjI2CjMzCjUzCjIyCjgKNTIKMzIKNTIKMjIKNTIKMjQKNTMKMQoxCjUyCjgKCpRicy4=\n",
+          "legalActions": [],
+          "legalActionStrings": []
+        },
+        "status": "INACTIVE"
+      },
+      {
+        "action": {
+          "submission": -1
+        },
+        "reward": null,
+        "info": {},
+        "observation": {
+          "remainingOverageTime": 12,
+          "observationString": "{\"phase\": \"Draw\", \"current_player\": 1, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"2s\", \"upcard\": \"9s\", \"stock_size\": 15, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\", \"2h\", \"5s\", \"7c\", \"Td\", \"8d\", \"Qc\"], \"hands\": {\"0\": [], \"1\": [\"Qs\", \"2c\", \"Kc\", \"4d\", \"7d\", \"Qd\", \"Kd\", \"9h\", \"Th\", \"Kh\"]}, \"deadwood\": {\"0\": null, \"1\": 52}, \"repeated_move\": 0}",
+          "currentPlayer": 1,
+          "playerId": 1,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14,0:52,0:49,1:52,1:6,0:52,0:14,1:52,1:32,0:52,0:47,1:52,1:48,0:52,0:13,1:53,-1:19,1:3,0:53,-1:34,0:48,1:52,1:49,0:53,-1:24,0:6,1:52,1:47,0:52,0:43,1:52,1:43,0:53,-1:33,0:31,1:53,-1:37,1:37,0:52,0:18,1:52,1:18,0:53,-1:30,0:7,1:53,-1:15,1:15,0:53,-1:17,0:37,1:52,1:21,0:53,-1:40,0:30,1:53,-1:9,1:19,0:52,0:40,1:53,-1:29,1:9,0:52,0:47,1:52,1:4,0:52,0:4,1:53,-1:35,1:6,0:52,0:19,1:53,-1:8,1:35,0:53,-1:26,0:33,1:53,-1:22,1:8,0:52,0:32,1:52,1:22,0:52,0:24,1:53,-1:1,1:1,0:52,0:8\nmove_number=115\n__dict__=gASVVQIAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRYEwIAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAo1Mgo0OQo1Mgo2CjUyCjE0CjUyCjMyCjUyCjQ3CjUyCjQ4CjUyCjEzCjUzCjE5CjMKNTMKMzQKNDgKNTIKNDkKNTMKMjQKNgo1Mgo0Nwo1Mgo0Mwo1Mgo0Mwo1MwozMwozMQo1MwozNwozNwo1MgoxOAo1MgoxOAo1MwozMAo3CjUzCjE1CjE1CjUzCjE3CjM3CjUyCjIxCjUzCjQwCjMwCjUzCjkKMTkKNTIKNDAKNTMKMjkKOQo1Mgo0Nwo1Mgo0CjUyCjQKNTMKMzUKNgo1MgoxOQo1Mwo4CjM1CjUzCjI2CjMzCjUzCjIyCjgKNTIKMzIKNTIKMjIKNTIKMjQKNTMKMQoxCjUyCjgKCpRicy4=\n",
+          "legalActions": [52, 53],
+          "legalActionStrings": [
+            "Player: 1 Action: Draw upcard",
+            "Player: 1 Action: Draw stock"
+          ]
+        },
+        "status": "ACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "submission": -1
+        },
+        "reward": null,
+        "info": {},
+        "observation": {
+          "remainingOverageTime": 12,
+          "step": 80,
+          "observationString": "{\"phase\": \"Discard\", \"current_player\": 1, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"9s\", \"upcard\": null, \"stock_size\": 14, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\", \"2h\", \"5s\", \"7c\", \"Td\", \"8d\", \"Qc\", \"9s\"], \"hands\": {\"0\": [\"2s\", \"6s\", \"7s\", \"Ts\", \"5c\", \"Tc\", \"Ad\", \"3d\", \"9d\", \"Qh\"], \"1\": []}, \"deadwood\": {\"0\": 63, \"1\": null}, \"repeated_move\": 0}",
+          "currentPlayer": 1,
+          "playerId": 0,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14,0:52,0:49,1:52,1:6,0:52,0:14,1:52,1:32,0:52,0:47,1:52,1:48,0:52,0:13,1:53,-1:19,1:3,0:53,-1:34,0:48,1:52,1:49,0:53,-1:24,0:6,1:52,1:47,0:52,0:43,1:52,1:43,0:53,-1:33,0:31,1:53,-1:37,1:37,0:52,0:18,1:52,1:18,0:53,-1:30,0:7,1:53,-1:15,1:15,0:53,-1:17,0:37,1:52,1:21,0:53,-1:40,0:30,1:53,-1:9,1:19,0:52,0:40,1:53,-1:29,1:9,0:52,0:47,1:52,1:4,0:52,0:4,1:53,-1:35,1:6,0:52,0:19,1:53,-1:8,1:35,0:53,-1:26,0:33,1:53,-1:22,1:8,0:52,0:32,1:52,1:22,0:52,0:24,1:53,-1:1,1:1,0:52,0:8,1:53,-1:46\nmove_number=117\n__dict__=gASVWwIAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRYGQIAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAo1Mgo0OQo1Mgo2CjUyCjE0CjUyCjMyCjUyCjQ3CjUyCjQ4CjUyCjEzCjUzCjE5CjMKNTMKMzQKNDgKNTIKNDkKNTMKMjQKNgo1Mgo0Nwo1Mgo0Mwo1Mgo0Mwo1MwozMwozMQo1MwozNwozNwo1MgoxOAo1MgoxOAo1MwozMAo3CjUzCjE1CjE1CjUzCjE3CjM3CjUyCjIxCjUzCjQwCjMwCjUzCjkKMTkKNTIKNDAKNTMKMjkKOQo1Mgo0Nwo1Mgo0CjUyCjQKNTMKMzUKNgo1MgoxOQo1Mwo4CjM1CjUzCjI2CjMzCjUzCjIyCjgKNTIKMzIKNTIKMjIKNTIKMjQKNTMKMQoxCjUyCjgKNTMKNDYKCpRicy4=\n",
+          "legalActions": [],
+          "legalActionStrings": []
+        },
+        "status": "INACTIVE"
+      },
+      {
+        "action": {
+          "submission": 53,
+          "thoughts": "theta echo reflect echo pi consider ember spark"
+        },
+        "reward": null,
+        "info": {
+          "actionSubmitted": 53,
+          "actionSubmittedToString": "Player: 1 Action: Draw stock",
+          "actionApplied": 53,
+          "timeTaken": 0.0,
+          "agentSelfReportedStatus": null
+        },
+        "observation": {
+          "remainingOverageTime": 12,
+          "observationString": "{\"phase\": \"Discard\", \"current_player\": 1, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"9s\", \"upcard\": null, \"stock_size\": 14, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\", \"2h\", \"5s\", \"7c\", \"Td\", \"8d\", \"Qc\", \"9s\"], \"hands\": {\"0\": [], \"1\": [\"Qs\", \"2c\", \"Kc\", \"4d\", \"7d\", \"Qd\", \"Kd\", \"8h\", \"9h\", \"Th\", \"Kh\"]}, \"deadwood\": {\"0\": null, \"1\": 23}, \"repeated_move\": 0}",
+          "currentPlayer": 1,
+          "playerId": 1,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14,0:52,0:49,1:52,1:6,0:52,0:14,1:52,1:32,0:52,0:47,1:52,1:48,0:52,0:13,1:53,-1:19,1:3,0:53,-1:34,0:48,1:52,1:49,0:53,-1:24,0:6,1:52,1:47,0:52,0:43,1:52,1:43,0:53,-1:33,0:31,1:53,-1:37,1:37,0:52,0:18,1:52,1:18,0:53,-1:30,0:7,1:53,-1:15,1:15,0:53,-1:17,0:37,1:52,1:21,0:53,-1:40,0:30,1:53,-1:9,1:19,0:52,0:40,1:53,-1:29,1:9,0:52,0:47,1:52,1:4,0:52,0:4,1:53,-1:35,1:6,0:52,0:19,1:53,-1:8,1:35,0:53,-1:26,0:33,1:53,-1:22,1:8,0:52,0:32,1:52,1:22,0:52,0:24,1:53,-1:1,1:1,0:52,0:8,1:53,-1:46\nmove_number=117\n__dict__=gASVWwIAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRYGQIAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAo1Mgo0OQo1Mgo2CjUyCjE0CjUyCjMyCjUyCjQ3CjUyCjQ4CjUyCjEzCjUzCjE5CjMKNTMKMzQKNDgKNTIKNDkKNTMKMjQKNgo1Mgo0Nwo1Mgo0Mwo1Mgo0Mwo1MwozMwozMQo1MwozNwozNwo1MgoxOAo1MgoxOAo1MwozMAo3CjUzCjE1CjE1CjUzCjE3CjM3CjUyCjIxCjUzCjQwCjMwCjUzCjkKMTkKNTIKNDAKNTMKMjkKOQo1Mgo0Nwo1Mgo0CjUyCjQKNTMKMzUKNgo1MgoxOQo1Mwo4CjM1CjUzCjI2CjMzCjUzCjIyCjgKNTIKMzIKNTIKMjIKNTIKMjQKNTMKMQoxCjUyCjgKNTMKNDYKCpRicy4=\n",
+          "legalActions": [11, 14, 25, 29, 32, 37, 38, 46, 47, 48, 51],
+          "legalActionStrings": [
+            "Player: 1 Action: Qs",
+            "Player: 1 Action: 2c",
+            "Player: 1 Action: Kc",
+            "Player: 1 Action: 4d",
+            "Player: 1 Action: 7d",
+            "Player: 1 Action: Qd",
+            "Player: 1 Action: Kd",
+            "Player: 1 Action: 8h",
+            "Player: 1 Action: 9h",
+            "Player: 1 Action: Th",
+            "Player: 1 Action: Kh"
+          ]
+        },
+        "status": "ACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "submission": -1
+        },
+        "reward": null,
+        "info": {},
+        "observation": {
+          "remainingOverageTime": 12,
+          "step": 81,
+          "observationString": "{\"phase\": \"Draw\", \"current_player\": 0, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"9s\", \"upcard\": \"Kd\", \"stock_size\": 14, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\", \"2h\", \"5s\", \"7c\", \"Td\", \"8d\", \"Qc\", \"9s\"], \"hands\": {\"0\": [\"2s\", \"6s\", \"7s\", \"Ts\", \"5c\", \"Tc\", \"Ad\", \"3d\", \"9d\", \"Qh\"], \"1\": []}, \"deadwood\": {\"0\": 63, \"1\": null}, \"repeated_move\": 0}",
+          "currentPlayer": 0,
+          "playerId": 0,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14,0:52,0:49,1:52,1:6,0:52,0:14,1:52,1:32,0:52,0:47,1:52,1:48,0:52,0:13,1:53,-1:19,1:3,0:53,-1:34,0:48,1:52,1:49,0:53,-1:24,0:6,1:52,1:47,0:52,0:43,1:52,1:43,0:53,-1:33,0:31,1:53,-1:37,1:37,0:52,0:18,1:52,1:18,0:53,-1:30,0:7,1:53,-1:15,1:15,0:53,-1:17,0:37,1:52,1:21,0:53,-1:40,0:30,1:53,-1:9,1:19,0:52,0:40,1:53,-1:29,1:9,0:52,0:47,1:52,1:4,0:52,0:4,1:53,-1:35,1:6,0:52,0:19,1:53,-1:8,1:35,0:53,-1:26,0:33,1:53,-1:22,1:8,0:52,0:32,1:52,1:22,0:52,0:24,1:53,-1:1,1:1,0:52,0:8,1:53,-1:46,1:38\nmove_number=118\n__dict__=gASVXgIAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRYHAIAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAo1Mgo0OQo1Mgo2CjUyCjE0CjUyCjMyCjUyCjQ3CjUyCjQ4CjUyCjEzCjUzCjE5CjMKNTMKMzQKNDgKNTIKNDkKNTMKMjQKNgo1Mgo0Nwo1Mgo0Mwo1Mgo0Mwo1MwozMwozMQo1MwozNwozNwo1MgoxOAo1MgoxOAo1MwozMAo3CjUzCjE1CjE1CjUzCjE3CjM3CjUyCjIxCjUzCjQwCjMwCjUzCjkKMTkKNTIKNDAKNTMKMjkKOQo1Mgo0Nwo1Mgo0CjUyCjQKNTMKMzUKNgo1MgoxOQo1Mwo4CjM1CjUzCjI2CjMzCjUzCjIyCjgKNTIKMzIKNTIKMjIKNTIKMjQKNTMKMQoxCjUyCjgKNTMKNDYKMzgKCpRicy4=\n",
+          "legalActions": [52, 53],
+          "legalActionStrings": [
+            "Player: 0 Action: Draw upcard",
+            "Player: 0 Action: Draw stock"
+          ]
+        },
+        "status": "ACTIVE"
+      },
+      {
+        "action": {
+          "submission": 38,
+          "thoughts": "horizon consider horizon spark muse lantern sigma eta"
+        },
+        "reward": null,
+        "info": {
+          "actionSubmitted": 38,
+          "actionSubmittedToString": "Player: 1 Action: Kd",
+          "actionApplied": 38,
+          "timeTaken": 0.0,
+          "agentSelfReportedStatus": null
+        },
+        "observation": {
+          "remainingOverageTime": 12,
+          "observationString": "{\"phase\": \"Draw\", \"current_player\": 0, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"9s\", \"upcard\": \"Kd\", \"stock_size\": 14, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\", \"2h\", \"5s\", \"7c\", \"Td\", \"8d\", \"Qc\", \"9s\"], \"hands\": {\"0\": [], \"1\": [\"Qs\", \"2c\", \"Kc\", \"4d\", \"7d\", \"Qd\", \"8h\", \"9h\", \"Th\", \"Kh\"]}, \"deadwood\": {\"0\": null, \"1\": 53}, \"repeated_move\": 0}",
+          "currentPlayer": 0,
+          "playerId": 1,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14,0:52,0:49,1:52,1:6,0:52,0:14,1:52,1:32,0:52,0:47,1:52,1:48,0:52,0:13,1:53,-1:19,1:3,0:53,-1:34,0:48,1:52,1:49,0:53,-1:24,0:6,1:52,1:47,0:52,0:43,1:52,1:43,0:53,-1:33,0:31,1:53,-1:37,1:37,0:52,0:18,1:52,1:18,0:53,-1:30,0:7,1:53,-1:15,1:15,0:53,-1:17,0:37,1:52,1:21,0:53,-1:40,0:30,1:53,-1:9,1:19,0:52,0:40,1:53,-1:29,1:9,0:52,0:47,1:52,1:4,0:52,0:4,1:53,-1:35,1:6,0:52,0:19,1:53,-1:8,1:35,0:53,-1:26,0:33,1:53,-1:22,1:8,0:52,0:32,1:52,1:22,0:52,0:24,1:53,-1:1,1:1,0:52,0:8,1:53,-1:46,1:38\nmove_number=118\n__dict__=gASVXgIAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRYHAIAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAo1Mgo0OQo1Mgo2CjUyCjE0CjUyCjMyCjUyCjQ3CjUyCjQ4CjUyCjEzCjUzCjE5CjMKNTMKMzQKNDgKNTIKNDkKNTMKMjQKNgo1Mgo0Nwo1Mgo0Mwo1Mgo0Mwo1MwozMwozMQo1MwozNwozNwo1MgoxOAo1MgoxOAo1MwozMAo3CjUzCjE1CjE1CjUzCjE3CjM3CjUyCjIxCjUzCjQwCjMwCjUzCjkKMTkKNTIKNDAKNTMKMjkKOQo1Mgo0Nwo1Mgo0CjUyCjQKNTMKMzUKNgo1MgoxOQo1Mwo4CjM1CjUzCjI2CjMzCjUzCjIyCjgKNTIKMzIKNTIKMjIKNTIKMjQKNTMKMQoxCjUyCjgKNTMKNDYKMzgKCpRicy4=\n",
+          "legalActions": [],
+          "legalActionStrings": []
+        },
+        "status": "INACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "submission": 53,
+          "thoughts": "kappa upsilon lambda ponder nu iota kappa alpha"
+        },
+        "reward": null,
+        "info": {
+          "actionSubmitted": 53,
+          "actionSubmittedToString": "Player: 0 Action: Draw stock",
+          "actionApplied": 53,
+          "timeTaken": 0.0,
+          "agentSelfReportedStatus": null
+        },
+        "observation": {
+          "remainingOverageTime": 12,
+          "step": 82,
+          "observationString": "{\"phase\": \"Discard\", \"current_player\": 0, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"Kd\", \"upcard\": null, \"stock_size\": 13, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\", \"2h\", \"5s\", \"7c\", \"Td\", \"8d\", \"Qc\", \"9s\", \"Kd\"], \"hands\": {\"0\": [\"2s\", \"6s\", \"7s\", \"Ts\", \"5c\", \"Tc\", \"Jc\", \"Ad\", \"3d\", \"9d\", \"Qh\"], \"1\": []}, \"deadwood\": {\"0\": 63, \"1\": null}, \"repeated_move\": 0}",
+          "currentPlayer": 0,
+          "playerId": 0,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14,0:52,0:49,1:52,1:6,0:52,0:14,1:52,1:32,0:52,0:47,1:52,1:48,0:52,0:13,1:53,-1:19,1:3,0:53,-1:34,0:48,1:52,1:49,0:53,-1:24,0:6,1:52,1:47,0:52,0:43,1:52,1:43,0:53,-1:33,0:31,1:53,-1:37,1:37,0:52,0:18,1:52,1:18,0:53,-1:30,0:7,1:53,-1:15,1:15,0:53,-1:17,0:37,1:52,1:21,0:53,-1:40,0:30,1:53,-1:9,1:19,0:52,0:40,1:53,-1:29,1:9,0:52,0:47,1:52,1:4,0:52,0:4,1:53,-1:35,1:6,0:52,0:19,1:53,-1:8,1:35,0:53,-1:26,0:33,1:53,-1:22,1:8,0:52,0:32,1:52,1:22,0:52,0:24,1:53,-1:1,1:1,0:52,0:8,1:53,-1:46,1:38,0:53,-1:23\nmove_number=120\n__dict__=gASVZAIAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRYIgIAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAo1Mgo0OQo1Mgo2CjUyCjE0CjUyCjMyCjUyCjQ3CjUyCjQ4CjUyCjEzCjUzCjE5CjMKNTMKMzQKNDgKNTIKNDkKNTMKMjQKNgo1Mgo0Nwo1Mgo0Mwo1Mgo0Mwo1MwozMwozMQo1MwozNwozNwo1MgoxOAo1MgoxOAo1MwozMAo3CjUzCjE1CjE1CjUzCjE3CjM3CjUyCjIxCjUzCjQwCjMwCjUzCjkKMTkKNTIKNDAKNTMKMjkKOQo1Mgo0Nwo1Mgo0CjUyCjQKNTMKMzUKNgo1MgoxOQo1Mwo4CjM1CjUzCjI2CjMzCjUzCjIyCjgKNTIKMzIKNTIKMjIKNTIKMjQKNTMKMQoxCjUyCjgKNTMKNDYKMzgKNTMKMjMKCpRicy4=\n",
+          "legalActions": [1, 5, 6, 9, 17, 22, 23, 26, 28, 34, 50],
+          "legalActionStrings": [
+            "Player: 0 Action: 2s",
+            "Player: 0 Action: 6s",
+            "Player: 0 Action: 7s",
+            "Player: 0 Action: Ts",
+            "Player: 0 Action: 5c",
+            "Player: 0 Action: Tc",
+            "Player: 0 Action: Jc",
+            "Player: 0 Action: Ad",
+            "Player: 0 Action: 3d",
+            "Player: 0 Action: 9d",
+            "Player: 0 Action: Qh"
+          ]
+        },
+        "status": "ACTIVE"
+      },
+      {
+        "action": {
+          "submission": -1
+        },
+        "reward": null,
+        "info": {},
+        "observation": {
+          "remainingOverageTime": 12,
+          "observationString": "{\"phase\": \"Discard\", \"current_player\": 0, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"Kd\", \"upcard\": null, \"stock_size\": 13, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\", \"2h\", \"5s\", \"7c\", \"Td\", \"8d\", \"Qc\", \"9s\", \"Kd\"], \"hands\": {\"0\": [], \"1\": [\"Qs\", \"2c\", \"Kc\", \"4d\", \"7d\", \"Qd\", \"8h\", \"9h\", \"Th\", \"Kh\"]}, \"deadwood\": {\"0\": null, \"1\": 53}, \"repeated_move\": 0}",
+          "currentPlayer": 0,
+          "playerId": 1,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14,0:52,0:49,1:52,1:6,0:52,0:14,1:52,1:32,0:52,0:47,1:52,1:48,0:52,0:13,1:53,-1:19,1:3,0:53,-1:34,0:48,1:52,1:49,0:53,-1:24,0:6,1:52,1:47,0:52,0:43,1:52,1:43,0:53,-1:33,0:31,1:53,-1:37,1:37,0:52,0:18,1:52,1:18,0:53,-1:30,0:7,1:53,-1:15,1:15,0:53,-1:17,0:37,1:52,1:21,0:53,-1:40,0:30,1:53,-1:9,1:19,0:52,0:40,1:53,-1:29,1:9,0:52,0:47,1:52,1:4,0:52,0:4,1:53,-1:35,1:6,0:52,0:19,1:53,-1:8,1:35,0:53,-1:26,0:33,1:53,-1:22,1:8,0:52,0:32,1:52,1:22,0:52,0:24,1:53,-1:1,1:1,0:52,0:8,1:53,-1:46,1:38,0:53,-1:23\nmove_number=120\n__dict__=gASVZAIAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRYIgIAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAo1Mgo0OQo1Mgo2CjUyCjE0CjUyCjMyCjUyCjQ3CjUyCjQ4CjUyCjEzCjUzCjE5CjMKNTMKMzQKNDgKNTIKNDkKNTMKMjQKNgo1Mgo0Nwo1Mgo0Mwo1Mgo0Mwo1MwozMwozMQo1MwozNwozNwo1MgoxOAo1MgoxOAo1MwozMAo3CjUzCjE1CjE1CjUzCjE3CjM3CjUyCjIxCjUzCjQwCjMwCjUzCjkKMTkKNTIKNDAKNTMKMjkKOQo1Mgo0Nwo1Mgo0CjUyCjQKNTMKMzUKNgo1MgoxOQo1Mwo4CjM1CjUzCjI2CjMzCjUzCjIyCjgKNTIKMzIKNTIKMjIKNTIKMjQKNTMKMQoxCjUyCjgKNTMKNDYKMzgKNTMKMjMKCpRicy4=\n",
+          "legalActions": [],
+          "legalActionStrings": []
+        },
+        "status": "INACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "submission": 5,
+          "thoughts": "nu muse lantern sigma cascade ripple psi alpha"
+        },
+        "reward": null,
+        "info": {
+          "actionSubmitted": 5,
+          "actionSubmittedToString": "Player: 0 Action: 6s",
+          "actionApplied": 5,
+          "timeTaken": 0.0,
+          "agentSelfReportedStatus": null
+        },
+        "observation": {
+          "remainingOverageTime": 12,
+          "step": 83,
+          "observationString": "{\"phase\": \"Draw\", \"current_player\": 1, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"Kd\", \"upcard\": \"6s\", \"stock_size\": 13, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\", \"2h\", \"5s\", \"7c\", \"Td\", \"8d\", \"Qc\", \"9s\", \"Kd\"], \"hands\": {\"0\": [\"2s\", \"7s\", \"Ts\", \"5c\", \"Tc\", \"Jc\", \"Ad\", \"3d\", \"9d\", \"Qh\"], \"1\": []}, \"deadwood\": {\"0\": 67, \"1\": null}, \"repeated_move\": 0}",
+          "currentPlayer": 1,
+          "playerId": 0,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14,0:52,0:49,1:52,1:6,0:52,0:14,1:52,1:32,0:52,0:47,1:52,1:48,0:52,0:13,1:53,-1:19,1:3,0:53,-1:34,0:48,1:52,1:49,0:53,-1:24,0:6,1:52,1:47,0:52,0:43,1:52,1:43,0:53,-1:33,0:31,1:53,-1:37,1:37,0:52,0:18,1:52,1:18,0:53,-1:30,0:7,1:53,-1:15,1:15,0:53,-1:17,0:37,1:52,1:21,0:53,-1:40,0:30,1:53,-1:9,1:19,0:52,0:40,1:53,-1:29,1:9,0:52,0:47,1:52,1:4,0:52,0:4,1:53,-1:35,1:6,0:52,0:19,1:53,-1:8,1:35,0:53,-1:26,0:33,1:53,-1:22,1:8,0:52,0:32,1:52,1:22,0:52,0:24,1:53,-1:1,1:1,0:52,0:8,1:53,-1:46,1:38,0:53,-1:23,0:5\nmove_number=121\n__dict__=gASVZgIAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRYJAIAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAo1Mgo0OQo1Mgo2CjUyCjE0CjUyCjMyCjUyCjQ3CjUyCjQ4CjUyCjEzCjUzCjE5CjMKNTMKMzQKNDgKNTIKNDkKNTMKMjQKNgo1Mgo0Nwo1Mgo0Mwo1Mgo0Mwo1MwozMwozMQo1MwozNwozNwo1MgoxOAo1MgoxOAo1MwozMAo3CjUzCjE1CjE1CjUzCjE3CjM3CjUyCjIxCjUzCjQwCjMwCjUzCjkKMTkKNTIKNDAKNTMKMjkKOQo1Mgo0Nwo1Mgo0CjUyCjQKNTMKMzUKNgo1MgoxOQo1Mwo4CjM1CjUzCjI2CjMzCjUzCjIyCjgKNTIKMzIKNTIKMjIKNTIKMjQKNTMKMQoxCjUyCjgKNTMKNDYKMzgKNTMKMjMKNQoKlGJzLg==\n",
+          "legalActions": [],
+          "legalActionStrings": []
+        },
+        "status": "INACTIVE"
+      },
+      {
+        "action": {
+          "submission": -1
+        },
+        "reward": null,
+        "info": {},
+        "observation": {
+          "remainingOverageTime": 12,
+          "observationString": "{\"phase\": \"Draw\", \"current_player\": 1, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"Kd\", \"upcard\": \"6s\", \"stock_size\": 13, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\", \"2h\", \"5s\", \"7c\", \"Td\", \"8d\", \"Qc\", \"9s\", \"Kd\"], \"hands\": {\"0\": [], \"1\": [\"Qs\", \"2c\", \"Kc\", \"4d\", \"7d\", \"Qd\", \"8h\", \"9h\", \"Th\", \"Kh\"]}, \"deadwood\": {\"0\": null, \"1\": 53}, \"repeated_move\": 0}",
+          "currentPlayer": 1,
+          "playerId": 1,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14,0:52,0:49,1:52,1:6,0:52,0:14,1:52,1:32,0:52,0:47,1:52,1:48,0:52,0:13,1:53,-1:19,1:3,0:53,-1:34,0:48,1:52,1:49,0:53,-1:24,0:6,1:52,1:47,0:52,0:43,1:52,1:43,0:53,-1:33,0:31,1:53,-1:37,1:37,0:52,0:18,1:52,1:18,0:53,-1:30,0:7,1:53,-1:15,1:15,0:53,-1:17,0:37,1:52,1:21,0:53,-1:40,0:30,1:53,-1:9,1:19,0:52,0:40,1:53,-1:29,1:9,0:52,0:47,1:52,1:4,0:52,0:4,1:53,-1:35,1:6,0:52,0:19,1:53,-1:8,1:35,0:53,-1:26,0:33,1:53,-1:22,1:8,0:52,0:32,1:52,1:22,0:52,0:24,1:53,-1:1,1:1,0:52,0:8,1:53,-1:46,1:38,0:53,-1:23,0:5\nmove_number=121\n__dict__=gASVZgIAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRYJAIAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAo1Mgo0OQo1Mgo2CjUyCjE0CjUyCjMyCjUyCjQ3CjUyCjQ4CjUyCjEzCjUzCjE5CjMKNTMKMzQKNDgKNTIKNDkKNTMKMjQKNgo1Mgo0Nwo1Mgo0Mwo1Mgo0Mwo1MwozMwozMQo1MwozNwozNwo1MgoxOAo1MgoxOAo1MwozMAo3CjUzCjE1CjE1CjUzCjE3CjM3CjUyCjIxCjUzCjQwCjMwCjUzCjkKMTkKNTIKNDAKNTMKMjkKOQo1Mgo0Nwo1Mgo0CjUyCjQKNTMKMzUKNgo1MgoxOQo1Mwo4CjM1CjUzCjI2CjMzCjUzCjIyCjgKNTIKMzIKNTIKMjIKNTIKMjQKNTMKMQoxCjUyCjgKNTMKNDYKMzgKNTMKMjMKNQoKlGJzLg==\n",
+          "legalActions": [52, 53],
+          "legalActionStrings": [
+            "Player: 1 Action: Draw upcard",
+            "Player: 1 Action: Draw stock"
+          ]
+        },
+        "status": "ACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "submission": -1
+        },
+        "reward": null,
+        "info": {},
+        "observation": {
+          "remainingOverageTime": 12,
+          "step": 84,
+          "observationString": "{\"phase\": \"Discard\", \"current_player\": 1, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"6s\", \"upcard\": null, \"stock_size\": 12, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\", \"2h\", \"5s\", \"7c\", \"Td\", \"8d\", \"Qc\", \"9s\", \"Kd\", \"6s\"], \"hands\": {\"0\": [\"2s\", \"7s\", \"Ts\", \"5c\", \"Tc\", \"Jc\", \"Ad\", \"3d\", \"9d\", \"Qh\"], \"1\": []}, \"deadwood\": {\"0\": 67, \"1\": null}, \"repeated_move\": 0}",
+          "currentPlayer": 1,
+          "playerId": 0,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14,0:52,0:49,1:52,1:6,0:52,0:14,1:52,1:32,0:52,0:47,1:52,1:48,0:52,0:13,1:53,-1:19,1:3,0:53,-1:34,0:48,1:52,1:49,0:53,-1:24,0:6,1:52,1:47,0:52,0:43,1:52,1:43,0:53,-1:33,0:31,1:53,-1:37,1:37,0:52,0:18,1:52,1:18,0:53,-1:30,0:7,1:53,-1:15,1:15,0:53,-1:17,0:37,1:52,1:21,0:53,-1:40,0:30,1:53,-1:9,1:19,0:52,0:40,1:53,-1:29,1:9,0:52,0:47,1:52,1:4,0:52,0:4,1:53,-1:35,1:6,0:52,0:19,1:53,-1:8,1:35,0:53,-1:26,0:33,1:53,-1:22,1:8,0:52,0:32,1:52,1:22,0:52,0:24,1:53,-1:1,1:1,0:52,0:8,1:53,-1:46,1:38,0:53,-1:23,0:5,1:53,-1:42\nmove_number=123\n__dict__=gASVbAIAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRYKgIAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAo1Mgo0OQo1Mgo2CjUyCjE0CjUyCjMyCjUyCjQ3CjUyCjQ4CjUyCjEzCjUzCjE5CjMKNTMKMzQKNDgKNTIKNDkKNTMKMjQKNgo1Mgo0Nwo1Mgo0Mwo1Mgo0Mwo1MwozMwozMQo1MwozNwozNwo1MgoxOAo1MgoxOAo1MwozMAo3CjUzCjE1CjE1CjUzCjE3CjM3CjUyCjIxCjUzCjQwCjMwCjUzCjkKMTkKNTIKNDAKNTMKMjkKOQo1Mgo0Nwo1Mgo0CjUyCjQKNTMKMzUKNgo1MgoxOQo1Mwo4CjM1CjUzCjI2CjMzCjUzCjIyCjgKNTIKMzIKNTIKMjIKNTIKMjQKNTMKMQoxCjUyCjgKNTMKNDYKMzgKNTMKMjMKNQo1Mwo0MgoKlGJzLg==\n",
+          "legalActions": [],
+          "legalActionStrings": []
+        },
+        "status": "INACTIVE"
+      },
+      {
+        "action": {
+          "submission": 53,
+          "thoughts": "mu shadow echo lantern gamma beta chi spark"
+        },
+        "reward": null,
+        "info": {
+          "actionSubmitted": 53,
+          "actionSubmittedToString": "Player: 1 Action: Draw stock",
+          "actionApplied": 53,
+          "timeTaken": 0.0,
+          "agentSelfReportedStatus": null
+        },
+        "observation": {
+          "remainingOverageTime": 12,
+          "observationString": "{\"phase\": \"Discard\", \"current_player\": 1, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"6s\", \"upcard\": null, \"stock_size\": 12, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\", \"2h\", \"5s\", \"7c\", \"Td\", \"8d\", \"Qc\", \"9s\", \"Kd\", \"6s\"], \"hands\": {\"0\": [], \"1\": [\"Qs\", \"2c\", \"Kc\", \"4d\", \"7d\", \"Qd\", \"4h\", \"8h\", \"9h\", \"Th\", \"Kh\"]}, \"deadwood\": {\"0\": null, \"1\": 47}, \"repeated_move\": 0}",
+          "currentPlayer": 1,
+          "playerId": 1,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14,0:52,0:49,1:52,1:6,0:52,0:14,1:52,1:32,0:52,0:47,1:52,1:48,0:52,0:13,1:53,-1:19,1:3,0:53,-1:34,0:48,1:52,1:49,0:53,-1:24,0:6,1:52,1:47,0:52,0:43,1:52,1:43,0:53,-1:33,0:31,1:53,-1:37,1:37,0:52,0:18,1:52,1:18,0:53,-1:30,0:7,1:53,-1:15,1:15,0:53,-1:17,0:37,1:52,1:21,0:53,-1:40,0:30,1:53,-1:9,1:19,0:52,0:40,1:53,-1:29,1:9,0:52,0:47,1:52,1:4,0:52,0:4,1:53,-1:35,1:6,0:52,0:19,1:53,-1:8,1:35,0:53,-1:26,0:33,1:53,-1:22,1:8,0:52,0:32,1:52,1:22,0:52,0:24,1:53,-1:1,1:1,0:52,0:8,1:53,-1:46,1:38,0:53,-1:23,0:5,1:53,-1:42\nmove_number=123\n__dict__=gASVbAIAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRYKgIAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAo1Mgo0OQo1Mgo2CjUyCjE0CjUyCjMyCjUyCjQ3CjUyCjQ4CjUyCjEzCjUzCjE5CjMKNTMKMzQKNDgKNTIKNDkKNTMKMjQKNgo1Mgo0Nwo1Mgo0Mwo1Mgo0Mwo1MwozMwozMQo1MwozNwozNwo1MgoxOAo1MgoxOAo1MwozMAo3CjUzCjE1CjE1CjUzCjE3CjM3CjUyCjIxCjUzCjQwCjMwCjUzCjkKMTkKNTIKNDAKNTMKMjkKOQo1Mgo0Nwo1Mgo0CjUyCjQKNTMKMzUKNgo1MgoxOQo1Mwo4CjM1CjUzCjI2CjMzCjUzCjIyCjgKNTIKMzIKNTIKMjIKNTIKMjQKNTMKMQoxCjUyCjgKNTMKNDYKMzgKNTMKMjMKNQo1Mwo0MgoKlGJzLg==\n",
+          "legalActions": [11, 14, 25, 29, 32, 37, 42, 46, 47, 48, 51],
+          "legalActionStrings": [
+            "Player: 1 Action: Qs",
+            "Player: 1 Action: 2c",
+            "Player: 1 Action: Kc",
+            "Player: 1 Action: 4d",
+            "Player: 1 Action: 7d",
+            "Player: 1 Action: Qd",
+            "Player: 1 Action: 4h",
+            "Player: 1 Action: 8h",
+            "Player: 1 Action: 9h",
+            "Player: 1 Action: Th",
+            "Player: 1 Action: Kh"
+          ]
+        },
+        "status": "ACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "submission": -1
+        },
+        "reward": null,
+        "info": {},
+        "observation": {
+          "remainingOverageTime": 12,
+          "step": 85,
+          "observationString": "{\"phase\": \"Draw\", \"current_player\": 0, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"6s\", \"upcard\": \"4h\", \"stock_size\": 12, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\", \"2h\", \"5s\", \"7c\", \"Td\", \"8d\", \"Qc\", \"9s\", \"Kd\", \"6s\"], \"hands\": {\"0\": [\"2s\", \"7s\", \"Ts\", \"5c\", \"Tc\", \"Jc\", \"Ad\", \"3d\", \"9d\", \"Qh\"], \"1\": []}, \"deadwood\": {\"0\": 67, \"1\": null}, \"repeated_move\": 0}",
+          "currentPlayer": 0,
+          "playerId": 0,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14,0:52,0:49,1:52,1:6,0:52,0:14,1:52,1:32,0:52,0:47,1:52,1:48,0:52,0:13,1:53,-1:19,1:3,0:53,-1:34,0:48,1:52,1:49,0:53,-1:24,0:6,1:52,1:47,0:52,0:43,1:52,1:43,0:53,-1:33,0:31,1:53,-1:37,1:37,0:52,0:18,1:52,1:18,0:53,-1:30,0:7,1:53,-1:15,1:15,0:53,-1:17,0:37,1:52,1:21,0:53,-1:40,0:30,1:53,-1:9,1:19,0:52,0:40,1:53,-1:29,1:9,0:52,0:47,1:52,1:4,0:52,0:4,1:53,-1:35,1:6,0:52,0:19,1:53,-1:8,1:35,0:53,-1:26,0:33,1:53,-1:22,1:8,0:52,0:32,1:52,1:22,0:52,0:24,1:53,-1:1,1:1,0:52,0:8,1:53,-1:46,1:38,0:53,-1:23,0:5,1:53,-1:42,1:42\nmove_number=124\n__dict__=gASVbwIAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRYLQIAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAo1Mgo0OQo1Mgo2CjUyCjE0CjUyCjMyCjUyCjQ3CjUyCjQ4CjUyCjEzCjUzCjE5CjMKNTMKMzQKNDgKNTIKNDkKNTMKMjQKNgo1Mgo0Nwo1Mgo0Mwo1Mgo0Mwo1MwozMwozMQo1MwozNwozNwo1MgoxOAo1MgoxOAo1MwozMAo3CjUzCjE1CjE1CjUzCjE3CjM3CjUyCjIxCjUzCjQwCjMwCjUzCjkKMTkKNTIKNDAKNTMKMjkKOQo1Mgo0Nwo1Mgo0CjUyCjQKNTMKMzUKNgo1MgoxOQo1Mwo4CjM1CjUzCjI2CjMzCjUzCjIyCjgKNTIKMzIKNTIKMjIKNTIKMjQKNTMKMQoxCjUyCjgKNTMKNDYKMzgKNTMKMjMKNQo1Mwo0Mgo0MgoKlGJzLg==\n",
+          "legalActions": [52, 53],
+          "legalActionStrings": [
+            "Player: 0 Action: Draw upcard",
+            "Player: 0 Action: Draw stock"
+          ]
+        },
+        "status": "ACTIVE"
+      },
+      {
+        "action": {
+          "submission": 42,
+          "thoughts": "reflect epsilon explore rho theta horizon alpha nu"
+        },
+        "reward": null,
+        "info": {
+          "actionSubmitted": 42,
+          "actionSubmittedToString": "Player: 1 Action: 4h",
+          "actionApplied": 42,
+          "timeTaken": 0.0,
+          "agentSelfReportedStatus": null
+        },
+        "observation": {
+          "remainingOverageTime": 12,
+          "observationString": "{\"phase\": \"Draw\", \"current_player\": 0, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"6s\", \"upcard\": \"4h\", \"stock_size\": 12, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\", \"2h\", \"5s\", \"7c\", \"Td\", \"8d\", \"Qc\", \"9s\", \"Kd\", \"6s\"], \"hands\": {\"0\": [], \"1\": [\"Qs\", \"2c\", \"Kc\", \"4d\", \"7d\", \"Qd\", \"8h\", \"9h\", \"Th\", \"Kh\"]}, \"deadwood\": {\"0\": null, \"1\": 53}, \"repeated_move\": 0}",
+          "currentPlayer": 0,
+          "playerId": 1,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14,0:52,0:49,1:52,1:6,0:52,0:14,1:52,1:32,0:52,0:47,1:52,1:48,0:52,0:13,1:53,-1:19,1:3,0:53,-1:34,0:48,1:52,1:49,0:53,-1:24,0:6,1:52,1:47,0:52,0:43,1:52,1:43,0:53,-1:33,0:31,1:53,-1:37,1:37,0:52,0:18,1:52,1:18,0:53,-1:30,0:7,1:53,-1:15,1:15,0:53,-1:17,0:37,1:52,1:21,0:53,-1:40,0:30,1:53,-1:9,1:19,0:52,0:40,1:53,-1:29,1:9,0:52,0:47,1:52,1:4,0:52,0:4,1:53,-1:35,1:6,0:52,0:19,1:53,-1:8,1:35,0:53,-1:26,0:33,1:53,-1:22,1:8,0:52,0:32,1:52,1:22,0:52,0:24,1:53,-1:1,1:1,0:52,0:8,1:53,-1:46,1:38,0:53,-1:23,0:5,1:53,-1:42,1:42\nmove_number=124\n__dict__=gASVbwIAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRYLQIAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAo1Mgo0OQo1Mgo2CjUyCjE0CjUyCjMyCjUyCjQ3CjUyCjQ4CjUyCjEzCjUzCjE5CjMKNTMKMzQKNDgKNTIKNDkKNTMKMjQKNgo1Mgo0Nwo1Mgo0Mwo1Mgo0Mwo1MwozMwozMQo1MwozNwozNwo1MgoxOAo1MgoxOAo1MwozMAo3CjUzCjE1CjE1CjUzCjE3CjM3CjUyCjIxCjUzCjQwCjMwCjUzCjkKMTkKNTIKNDAKNTMKMjkKOQo1Mgo0Nwo1Mgo0CjUyCjQKNTMKMzUKNgo1MgoxOQo1Mwo4CjM1CjUzCjI2CjMzCjUzCjIyCjgKNTIKMzIKNTIKMjIKNTIKMjQKNTMKMQoxCjUyCjgKNTMKNDYKMzgKNTMKMjMKNQo1Mwo0Mgo0MgoKlGJzLg==\n",
+          "legalActions": [],
+          "legalActionStrings": []
+        },
+        "status": "INACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "submission": 52,
+          "thoughts": "omega psi rho cascade pi omega upsilon tau"
+        },
+        "reward": null,
+        "info": {
+          "actionSubmitted": 52,
+          "actionSubmittedToString": "Player: 0 Action: Draw upcard",
+          "actionApplied": 52,
+          "timeTaken": 0.0,
+          "agentSelfReportedStatus": null
+        },
+        "observation": {
+          "remainingOverageTime": 12,
+          "step": 86,
+          "observationString": "{\"phase\": \"Discard\", \"current_player\": 0, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"4h\", \"upcard\": null, \"stock_size\": 12, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\", \"2h\", \"5s\", \"7c\", \"Td\", \"8d\", \"Qc\", \"9s\", \"Kd\", \"6s\"], \"hands\": {\"0\": [\"2s\", \"7s\", \"Ts\", \"5c\", \"Tc\", \"Jc\", \"Ad\", \"3d\", \"9d\", \"4h\", \"Qh\"], \"1\": []}, \"deadwood\": {\"0\": 61, \"1\": null}, \"repeated_move\": 0}",
+          "currentPlayer": 0,
+          "playerId": 0,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14,0:52,0:49,1:52,1:6,0:52,0:14,1:52,1:32,0:52,0:47,1:52,1:48,0:52,0:13,1:53,-1:19,1:3,0:53,-1:34,0:48,1:52,1:49,0:53,-1:24,0:6,1:52,1:47,0:52,0:43,1:52,1:43,0:53,-1:33,0:31,1:53,-1:37,1:37,0:52,0:18,1:52,1:18,0:53,-1:30,0:7,1:53,-1:15,1:15,0:53,-1:17,0:37,1:52,1:21,0:53,-1:40,0:30,1:53,-1:9,1:19,0:52,0:40,1:53,-1:29,1:9,0:52,0:47,1:52,1:4,0:52,0:4,1:53,-1:35,1:6,0:52,0:19,1:53,-1:8,1:35,0:53,-1:26,0:33,1:53,-1:22,1:8,0:52,0:32,1:52,1:22,0:52,0:24,1:53,-1:1,1:1,0:52,0:8,1:53,-1:46,1:38,0:53,-1:23,0:5,1:53,-1:42,1:42,0:52\nmove_number=125\n__dict__=gASVcgIAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRYMAIAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAo1Mgo0OQo1Mgo2CjUyCjE0CjUyCjMyCjUyCjQ3CjUyCjQ4CjUyCjEzCjUzCjE5CjMKNTMKMzQKNDgKNTIKNDkKNTMKMjQKNgo1Mgo0Nwo1Mgo0Mwo1Mgo0Mwo1MwozMwozMQo1MwozNwozNwo1MgoxOAo1MgoxOAo1MwozMAo3CjUzCjE1CjE1CjUzCjE3CjM3CjUyCjIxCjUzCjQwCjMwCjUzCjkKMTkKNTIKNDAKNTMKMjkKOQo1Mgo0Nwo1Mgo0CjUyCjQKNTMKMzUKNgo1MgoxOQo1Mwo4CjM1CjUzCjI2CjMzCjUzCjIyCjgKNTIKMzIKNTIKMjIKNTIKMjQKNTMKMQoxCjUyCjgKNTMKNDYKMzgKNTMKMjMKNQo1Mwo0Mgo0Mgo1MgoKlGJzLg==\n",
+          "legalActions": [1, 6, 9, 17, 22, 23, 26, 28, 34, 42, 50],
+          "legalActionStrings": [
+            "Player: 0 Action: 2s",
+            "Player: 0 Action: 7s",
+            "Player: 0 Action: Ts",
+            "Player: 0 Action: 5c",
+            "Player: 0 Action: Tc",
+            "Player: 0 Action: Jc",
+            "Player: 0 Action: Ad",
+            "Player: 0 Action: 3d",
+            "Player: 0 Action: 9d",
+            "Player: 0 Action: 4h",
+            "Player: 0 Action: Qh"
+          ]
+        },
+        "status": "ACTIVE"
+      },
+      {
+        "action": {
+          "submission": -1
+        },
+        "reward": null,
+        "info": {},
+        "observation": {
+          "remainingOverageTime": 12,
+          "observationString": "{\"phase\": \"Discard\", \"current_player\": 0, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"4h\", \"upcard\": null, \"stock_size\": 12, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\", \"2h\", \"5s\", \"7c\", \"Td\", \"8d\", \"Qc\", \"9s\", \"Kd\", \"6s\"], \"hands\": {\"0\": [], \"1\": [\"Qs\", \"2c\", \"Kc\", \"4d\", \"7d\", \"Qd\", \"8h\", \"9h\", \"Th\", \"Kh\"]}, \"deadwood\": {\"0\": null, \"1\": 53}, \"repeated_move\": 0}",
+          "currentPlayer": 0,
+          "playerId": 1,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14,0:52,0:49,1:52,1:6,0:52,0:14,1:52,1:32,0:52,0:47,1:52,1:48,0:52,0:13,1:53,-1:19,1:3,0:53,-1:34,0:48,1:52,1:49,0:53,-1:24,0:6,1:52,1:47,0:52,0:43,1:52,1:43,0:53,-1:33,0:31,1:53,-1:37,1:37,0:52,0:18,1:52,1:18,0:53,-1:30,0:7,1:53,-1:15,1:15,0:53,-1:17,0:37,1:52,1:21,0:53,-1:40,0:30,1:53,-1:9,1:19,0:52,0:40,1:53,-1:29,1:9,0:52,0:47,1:52,1:4,0:52,0:4,1:53,-1:35,1:6,0:52,0:19,1:53,-1:8,1:35,0:53,-1:26,0:33,1:53,-1:22,1:8,0:52,0:32,1:52,1:22,0:52,0:24,1:53,-1:1,1:1,0:52,0:8,1:53,-1:46,1:38,0:53,-1:23,0:5,1:53,-1:42,1:42,0:52\nmove_number=125\n__dict__=gASVcgIAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRYMAIAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAo1Mgo0OQo1Mgo2CjUyCjE0CjUyCjMyCjUyCjQ3CjUyCjQ4CjUyCjEzCjUzCjE5CjMKNTMKMzQKNDgKNTIKNDkKNTMKMjQKNgo1Mgo0Nwo1Mgo0Mwo1Mgo0Mwo1MwozMwozMQo1MwozNwozNwo1MgoxOAo1MgoxOAo1MwozMAo3CjUzCjE1CjE1CjUzCjE3CjM3CjUyCjIxCjUzCjQwCjMwCjUzCjkKMTkKNTIKNDAKNTMKMjkKOQo1Mgo0Nwo1Mgo0CjUyCjQKNTMKMzUKNgo1MgoxOQo1Mwo4CjM1CjUzCjI2CjMzCjUzCjIyCjgKNTIKMzIKNTIKMjIKNTIKMjQKNTMKMQoxCjUyCjgKNTMKNDYKMzgKNTMKMjMKNQo1Mwo0Mgo0Mgo1MgoKlGJzLg==\n",
+          "legalActions": [],
+          "legalActionStrings": []
+        },
+        "status": "INACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "submission": 1,
+          "thoughts": "chi cascade beta nu pi gamma gamma beta"
+        },
+        "reward": null,
+        "info": {
+          "actionSubmitted": 1,
+          "actionSubmittedToString": "Player: 0 Action: 2s",
+          "actionApplied": 1,
+          "timeTaken": 0.0,
+          "agentSelfReportedStatus": null
+        },
+        "observation": {
+          "remainingOverageTime": 12,
+          "step": 87,
+          "observationString": "{\"phase\": \"Draw\", \"current_player\": 1, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"4h\", \"upcard\": \"2s\", \"stock_size\": 12, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\", \"2h\", \"5s\", \"7c\", \"Td\", \"8d\", \"Qc\", \"9s\", \"Kd\", \"6s\"], \"hands\": {\"0\": [\"7s\", \"Ts\", \"5c\", \"Tc\", \"Jc\", \"Ad\", \"3d\", \"9d\", \"4h\", \"Qh\"], \"1\": []}, \"deadwood\": {\"0\": 69, \"1\": null}, \"repeated_move\": 0}",
+          "currentPlayer": 1,
+          "playerId": 0,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14,0:52,0:49,1:52,1:6,0:52,0:14,1:52,1:32,0:52,0:47,1:52,1:48,0:52,0:13,1:53,-1:19,1:3,0:53,-1:34,0:48,1:52,1:49,0:53,-1:24,0:6,1:52,1:47,0:52,0:43,1:52,1:43,0:53,-1:33,0:31,1:53,-1:37,1:37,0:52,0:18,1:52,1:18,0:53,-1:30,0:7,1:53,-1:15,1:15,0:53,-1:17,0:37,1:52,1:21,0:53,-1:40,0:30,1:53,-1:9,1:19,0:52,0:40,1:53,-1:29,1:9,0:52,0:47,1:52,1:4,0:52,0:4,1:53,-1:35,1:6,0:52,0:19,1:53,-1:8,1:35,0:53,-1:26,0:33,1:53,-1:22,1:8,0:52,0:32,1:52,1:22,0:52,0:24,1:53,-1:1,1:1,0:52,0:8,1:53,-1:46,1:38,0:53,-1:23,0:5,1:53,-1:42,1:42,0:52,0:1\nmove_number=126\n__dict__=gASVdAIAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRYMgIAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAo1Mgo0OQo1Mgo2CjUyCjE0CjUyCjMyCjUyCjQ3CjUyCjQ4CjUyCjEzCjUzCjE5CjMKNTMKMzQKNDgKNTIKNDkKNTMKMjQKNgo1Mgo0Nwo1Mgo0Mwo1Mgo0Mwo1MwozMwozMQo1MwozNwozNwo1MgoxOAo1MgoxOAo1MwozMAo3CjUzCjE1CjE1CjUzCjE3CjM3CjUyCjIxCjUzCjQwCjMwCjUzCjkKMTkKNTIKNDAKNTMKMjkKOQo1Mgo0Nwo1Mgo0CjUyCjQKNTMKMzUKNgo1MgoxOQo1Mwo4CjM1CjUzCjI2CjMzCjUzCjIyCjgKNTIKMzIKNTIKMjIKNTIKMjQKNTMKMQoxCjUyCjgKNTMKNDYKMzgKNTMKMjMKNQo1Mwo0Mgo0Mgo1MgoxCgqUYnMu\n",
+          "legalActions": [],
+          "legalActionStrings": []
+        },
+        "status": "INACTIVE"
+      },
+      {
+        "action": {
+          "submission": -1
+        },
+        "reward": null,
+        "info": {},
+        "observation": {
+          "remainingOverageTime": 12,
+          "observationString": "{\"phase\": \"Draw\", \"current_player\": 1, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"4h\", \"upcard\": \"2s\", \"stock_size\": 12, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\", \"2h\", \"5s\", \"7c\", \"Td\", \"8d\", \"Qc\", \"9s\", \"Kd\", \"6s\"], \"hands\": {\"0\": [], \"1\": [\"Qs\", \"2c\", \"Kc\", \"4d\", \"7d\", \"Qd\", \"8h\", \"9h\", \"Th\", \"Kh\"]}, \"deadwood\": {\"0\": null, \"1\": 53}, \"repeated_move\": 0}",
+          "currentPlayer": 1,
+          "playerId": 1,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14,0:52,0:49,1:52,1:6,0:52,0:14,1:52,1:32,0:52,0:47,1:52,1:48,0:52,0:13,1:53,-1:19,1:3,0:53,-1:34,0:48,1:52,1:49,0:53,-1:24,0:6,1:52,1:47,0:52,0:43,1:52,1:43,0:53,-1:33,0:31,1:53,-1:37,1:37,0:52,0:18,1:52,1:18,0:53,-1:30,0:7,1:53,-1:15,1:15,0:53,-1:17,0:37,1:52,1:21,0:53,-1:40,0:30,1:53,-1:9,1:19,0:52,0:40,1:53,-1:29,1:9,0:52,0:47,1:52,1:4,0:52,0:4,1:53,-1:35,1:6,0:52,0:19,1:53,-1:8,1:35,0:53,-1:26,0:33,1:53,-1:22,1:8,0:52,0:32,1:52,1:22,0:52,0:24,1:53,-1:1,1:1,0:52,0:8,1:53,-1:46,1:38,0:53,-1:23,0:5,1:53,-1:42,1:42,0:52,0:1\nmove_number=126\n__dict__=gASVdAIAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRYMgIAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAo1Mgo0OQo1Mgo2CjUyCjE0CjUyCjMyCjUyCjQ3CjUyCjQ4CjUyCjEzCjUzCjE5CjMKNTMKMzQKNDgKNTIKNDkKNTMKMjQKNgo1Mgo0Nwo1Mgo0Mwo1Mgo0Mwo1MwozMwozMQo1MwozNwozNwo1MgoxOAo1MgoxOAo1MwozMAo3CjUzCjE1CjE1CjUzCjE3CjM3CjUyCjIxCjUzCjQwCjMwCjUzCjkKMTkKNTIKNDAKNTMKMjkKOQo1Mgo0Nwo1Mgo0CjUyCjQKNTMKMzUKNgo1MgoxOQo1Mwo4CjM1CjUzCjI2CjMzCjUzCjIyCjgKNTIKMzIKNTIKMjIKNTIKMjQKNTMKMQoxCjUyCjgKNTMKNDYKMzgKNTMKMjMKNQo1Mwo0Mgo0Mgo1MgoxCgqUYnMu\n",
+          "legalActions": [52, 53],
+          "legalActionStrings": [
+            "Player: 1 Action: Draw upcard",
+            "Player: 1 Action: Draw stock"
+          ]
+        },
+        "status": "ACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "submission": -1
+        },
+        "reward": null,
+        "info": {},
+        "observation": {
+          "remainingOverageTime": 12,
+          "step": 88,
+          "observationString": "{\"phase\": \"Discard\", \"current_player\": 1, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"2s\", \"upcard\": null, \"stock_size\": 12, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\", \"2h\", \"5s\", \"7c\", \"Td\", \"8d\", \"Qc\", \"9s\", \"Kd\", \"6s\"], \"hands\": {\"0\": [\"7s\", \"Ts\", \"5c\", \"Tc\", \"Jc\", \"Ad\", \"3d\", \"9d\", \"4h\", \"Qh\"], \"1\": []}, \"deadwood\": {\"0\": 69, \"1\": null}, \"repeated_move\": 0}",
+          "currentPlayer": 1,
+          "playerId": 0,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14,0:52,0:49,1:52,1:6,0:52,0:14,1:52,1:32,0:52,0:47,1:52,1:48,0:52,0:13,1:53,-1:19,1:3,0:53,-1:34,0:48,1:52,1:49,0:53,-1:24,0:6,1:52,1:47,0:52,0:43,1:52,1:43,0:53,-1:33,0:31,1:53,-1:37,1:37,0:52,0:18,1:52,1:18,0:53,-1:30,0:7,1:53,-1:15,1:15,0:53,-1:17,0:37,1:52,1:21,0:53,-1:40,0:30,1:53,-1:9,1:19,0:52,0:40,1:53,-1:29,1:9,0:52,0:47,1:52,1:4,0:52,0:4,1:53,-1:35,1:6,0:52,0:19,1:53,-1:8,1:35,0:53,-1:26,0:33,1:53,-1:22,1:8,0:52,0:32,1:52,1:22,0:52,0:24,1:53,-1:1,1:1,0:52,0:8,1:53,-1:46,1:38,0:53,-1:23,0:5,1:53,-1:42,1:42,0:52,0:1,1:52\nmove_number=127\n__dict__=gASVdwIAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRYNQIAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAo1Mgo0OQo1Mgo2CjUyCjE0CjUyCjMyCjUyCjQ3CjUyCjQ4CjUyCjEzCjUzCjE5CjMKNTMKMzQKNDgKNTIKNDkKNTMKMjQKNgo1Mgo0Nwo1Mgo0Mwo1Mgo0Mwo1MwozMwozMQo1MwozNwozNwo1MgoxOAo1MgoxOAo1MwozMAo3CjUzCjE1CjE1CjUzCjE3CjM3CjUyCjIxCjUzCjQwCjMwCjUzCjkKMTkKNTIKNDAKNTMKMjkKOQo1Mgo0Nwo1Mgo0CjUyCjQKNTMKMzUKNgo1MgoxOQo1Mwo4CjM1CjUzCjI2CjMzCjUzCjIyCjgKNTIKMzIKNTIKMjIKNTIKMjQKNTMKMQoxCjUyCjgKNTMKNDYKMzgKNTMKMjMKNQo1Mwo0Mgo0Mgo1MgoxCjUyCgqUYnMu\n",
+          "legalActions": [],
+          "legalActionStrings": []
+        },
+        "status": "INACTIVE"
+      },
+      {
+        "action": {
+          "submission": 52,
+          "thoughts": "wonder iota nu mu echo spark delta kappa"
+        },
+        "reward": null,
+        "info": {
+          "actionSubmitted": 52,
+          "actionSubmittedToString": "Player: 1 Action: Draw upcard",
+          "actionApplied": 52,
+          "timeTaken": 0.0,
+          "agentSelfReportedStatus": null
+        },
+        "observation": {
+          "remainingOverageTime": 12,
+          "observationString": "{\"phase\": \"Discard\", \"current_player\": 1, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"2s\", \"upcard\": null, \"stock_size\": 12, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\", \"2h\", \"5s\", \"7c\", \"Td\", \"8d\", \"Qc\", \"9s\", \"Kd\", \"6s\"], \"hands\": {\"0\": [], \"1\": [\"2s\", \"Qs\", \"2c\", \"Kc\", \"4d\", \"7d\", \"Qd\", \"8h\", \"9h\", \"Th\", \"Kh\"]}, \"deadwood\": {\"0\": null, \"1\": 45}, \"repeated_move\": 0}",
+          "currentPlayer": 1,
+          "playerId": 1,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14,0:52,0:49,1:52,1:6,0:52,0:14,1:52,1:32,0:52,0:47,1:52,1:48,0:52,0:13,1:53,-1:19,1:3,0:53,-1:34,0:48,1:52,1:49,0:53,-1:24,0:6,1:52,1:47,0:52,0:43,1:52,1:43,0:53,-1:33,0:31,1:53,-1:37,1:37,0:52,0:18,1:52,1:18,0:53,-1:30,0:7,1:53,-1:15,1:15,0:53,-1:17,0:37,1:52,1:21,0:53,-1:40,0:30,1:53,-1:9,1:19,0:52,0:40,1:53,-1:29,1:9,0:52,0:47,1:52,1:4,0:52,0:4,1:53,-1:35,1:6,0:52,0:19,1:53,-1:8,1:35,0:53,-1:26,0:33,1:53,-1:22,1:8,0:52,0:32,1:52,1:22,0:52,0:24,1:53,-1:1,1:1,0:52,0:8,1:53,-1:46,1:38,0:53,-1:23,0:5,1:53,-1:42,1:42,0:52,0:1,1:52\nmove_number=127\n__dict__=gASVdwIAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRYNQIAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAo1Mgo0OQo1Mgo2CjUyCjE0CjUyCjMyCjUyCjQ3CjUyCjQ4CjUyCjEzCjUzCjE5CjMKNTMKMzQKNDgKNTIKNDkKNTMKMjQKNgo1Mgo0Nwo1Mgo0Mwo1Mgo0Mwo1MwozMwozMQo1MwozNwozNwo1MgoxOAo1MgoxOAo1MwozMAo3CjUzCjE1CjE1CjUzCjE3CjM3CjUyCjIxCjUzCjQwCjMwCjUzCjkKMTkKNTIKNDAKNTMKMjkKOQo1Mgo0Nwo1Mgo0CjUyCjQKNTMKMzUKNgo1MgoxOQo1Mwo4CjM1CjUzCjI2CjMzCjUzCjIyCjgKNTIKMzIKNTIKMjIKNTIKMjQKNTMKMQoxCjUyCjgKNTMKNDYKMzgKNTMKMjMKNQo1Mwo0Mgo0Mgo1MgoxCjUyCgqUYnMu\n",
+          "legalActions": [1, 11, 14, 25, 29, 32, 37, 46, 47, 48, 51],
+          "legalActionStrings": [
+            "Player: 1 Action: 2s",
+            "Player: 1 Action: Qs",
+            "Player: 1 Action: 2c",
+            "Player: 1 Action: Kc",
+            "Player: 1 Action: 4d",
+            "Player: 1 Action: 7d",
+            "Player: 1 Action: Qd",
+            "Player: 1 Action: 8h",
+            "Player: 1 Action: 9h",
+            "Player: 1 Action: Th",
+            "Player: 1 Action: Kh"
+          ]
+        },
+        "status": "ACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "submission": -1
+        },
+        "reward": null,
+        "info": {},
+        "observation": {
+          "remainingOverageTime": 12,
+          "step": 89,
+          "observationString": "{\"phase\": \"Draw\", \"current_player\": 0, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"2s\", \"upcard\": \"9h\", \"stock_size\": 12, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\", \"2h\", \"5s\", \"7c\", \"Td\", \"8d\", \"Qc\", \"9s\", \"Kd\", \"6s\"], \"hands\": {\"0\": [\"7s\", \"Ts\", \"5c\", \"Tc\", \"Jc\", \"Ad\", \"3d\", \"9d\", \"4h\", \"Qh\"], \"1\": []}, \"deadwood\": {\"0\": 69, \"1\": null}, \"repeated_move\": 0}",
+          "currentPlayer": 0,
+          "playerId": 0,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14,0:52,0:49,1:52,1:6,0:52,0:14,1:52,1:32,0:52,0:47,1:52,1:48,0:52,0:13,1:53,-1:19,1:3,0:53,-1:34,0:48,1:52,1:49,0:53,-1:24,0:6,1:52,1:47,0:52,0:43,1:52,1:43,0:53,-1:33,0:31,1:53,-1:37,1:37,0:52,0:18,1:52,1:18,0:53,-1:30,0:7,1:53,-1:15,1:15,0:53,-1:17,0:37,1:52,1:21,0:53,-1:40,0:30,1:53,-1:9,1:19,0:52,0:40,1:53,-1:29,1:9,0:52,0:47,1:52,1:4,0:52,0:4,1:53,-1:35,1:6,0:52,0:19,1:53,-1:8,1:35,0:53,-1:26,0:33,1:53,-1:22,1:8,0:52,0:32,1:52,1:22,0:52,0:24,1:53,-1:1,1:1,0:52,0:8,1:53,-1:46,1:38,0:53,-1:23,0:5,1:53,-1:42,1:42,0:52,0:1,1:52,1:47\nmove_number=128\n__dict__=gASVegIAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRYOAIAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAo1Mgo0OQo1Mgo2CjUyCjE0CjUyCjMyCjUyCjQ3CjUyCjQ4CjUyCjEzCjUzCjE5CjMKNTMKMzQKNDgKNTIKNDkKNTMKMjQKNgo1Mgo0Nwo1Mgo0Mwo1Mgo0Mwo1MwozMwozMQo1MwozNwozNwo1MgoxOAo1MgoxOAo1MwozMAo3CjUzCjE1CjE1CjUzCjE3CjM3CjUyCjIxCjUzCjQwCjMwCjUzCjkKMTkKNTIKNDAKNTMKMjkKOQo1Mgo0Nwo1Mgo0CjUyCjQKNTMKMzUKNgo1MgoxOQo1Mwo4CjM1CjUzCjI2CjMzCjUzCjIyCjgKNTIKMzIKNTIKMjIKNTIKMjQKNTMKMQoxCjUyCjgKNTMKNDYKMzgKNTMKMjMKNQo1Mwo0Mgo0Mgo1MgoxCjUyCjQ3CgqUYnMu\n",
+          "legalActions": [52, 53],
+          "legalActionStrings": [
+            "Player: 0 Action: Draw upcard",
+            "Player: 0 Action: Draw stock"
+          ]
+        },
+        "status": "ACTIVE"
+      },
+      {
+        "action": {
+          "submission": 47,
+          "thoughts": "rho ember reflect lambda zeta ripple horizon ember"
+        },
+        "reward": null,
+        "info": {
+          "actionSubmitted": 47,
+          "actionSubmittedToString": "Player: 1 Action: 9h",
+          "actionApplied": 47,
+          "timeTaken": 0.0,
+          "agentSelfReportedStatus": null
+        },
+        "observation": {
+          "remainingOverageTime": 12,
+          "observationString": "{\"phase\": \"Draw\", \"current_player\": 0, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"2s\", \"upcard\": \"9h\", \"stock_size\": 12, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\", \"2h\", \"5s\", \"7c\", \"Td\", \"8d\", \"Qc\", \"9s\", \"Kd\", \"6s\"], \"hands\": {\"0\": [], \"1\": [\"2s\", \"Qs\", \"2c\", \"Kc\", \"4d\", \"7d\", \"Qd\", \"8h\", \"Th\", \"Kh\"]}, \"deadwood\": {\"0\": null, \"1\": 73}, \"repeated_move\": 0}",
+          "currentPlayer": 0,
+          "playerId": 1,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14,0:52,0:49,1:52,1:6,0:52,0:14,1:52,1:32,0:52,0:47,1:52,1:48,0:52,0:13,1:53,-1:19,1:3,0:53,-1:34,0:48,1:52,1:49,0:53,-1:24,0:6,1:52,1:47,0:52,0:43,1:52,1:43,0:53,-1:33,0:31,1:53,-1:37,1:37,0:52,0:18,1:52,1:18,0:53,-1:30,0:7,1:53,-1:15,1:15,0:53,-1:17,0:37,1:52,1:21,0:53,-1:40,0:30,1:53,-1:9,1:19,0:52,0:40,1:53,-1:29,1:9,0:52,0:47,1:52,1:4,0:52,0:4,1:53,-1:35,1:6,0:52,0:19,1:53,-1:8,1:35,0:53,-1:26,0:33,1:53,-1:22,1:8,0:52,0:32,1:52,1:22,0:52,0:24,1:53,-1:1,1:1,0:52,0:8,1:53,-1:46,1:38,0:53,-1:23,0:5,1:53,-1:42,1:42,0:52,0:1,1:52,1:47\nmove_number=128\n__dict__=gASVegIAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRYOAIAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAo1Mgo0OQo1Mgo2CjUyCjE0CjUyCjMyCjUyCjQ3CjUyCjQ4CjUyCjEzCjUzCjE5CjMKNTMKMzQKNDgKNTIKNDkKNTMKMjQKNgo1Mgo0Nwo1Mgo0Mwo1Mgo0Mwo1MwozMwozMQo1MwozNwozNwo1MgoxOAo1MgoxOAo1MwozMAo3CjUzCjE1CjE1CjUzCjE3CjM3CjUyCjIxCjUzCjQwCjMwCjUzCjkKMTkKNTIKNDAKNTMKMjkKOQo1Mgo0Nwo1Mgo0CjUyCjQKNTMKMzUKNgo1MgoxOQo1Mwo4CjM1CjUzCjI2CjMzCjUzCjIyCjgKNTIKMzIKNTIKMjIKNTIKMjQKNTMKMQoxCjUyCjgKNTMKNDYKMzgKNTMKMjMKNQo1Mwo0Mgo0Mgo1MgoxCjUyCjQ3CgqUYnMu\n",
+          "legalActions": [],
+          "legalActionStrings": []
+        },
+        "status": "INACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "submission": 52,
+          "thoughts": "explore xi ember upsilon drift wonder nu chi"
+        },
+        "reward": null,
+        "info": {
+          "actionSubmitted": 52,
+          "actionSubmittedToString": "Player: 0 Action: Draw upcard",
+          "actionApplied": 52,
+          "timeTaken": 0.0,
+          "agentSelfReportedStatus": null
+        },
+        "observation": {
+          "remainingOverageTime": 12,
+          "step": 90,
+          "observationString": "{\"phase\": \"Discard\", \"current_player\": 0, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"9h\", \"upcard\": null, \"stock_size\": 12, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\", \"2h\", \"5s\", \"7c\", \"Td\", \"8d\", \"Qc\", \"9s\", \"Kd\", \"6s\"], \"hands\": {\"0\": [\"7s\", \"Ts\", \"5c\", \"Tc\", \"Jc\", \"Ad\", \"3d\", \"9d\", \"4h\", \"9h\", \"Qh\"], \"1\": []}, \"deadwood\": {\"0\": 68, \"1\": null}, \"repeated_move\": 0}",
+          "currentPlayer": 0,
+          "playerId": 0,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14,0:52,0:49,1:52,1:6,0:52,0:14,1:52,1:32,0:52,0:47,1:52,1:48,0:52,0:13,1:53,-1:19,1:3,0:53,-1:34,0:48,1:52,1:49,0:53,-1:24,0:6,1:52,1:47,0:52,0:43,1:52,1:43,0:53,-1:33,0:31,1:53,-1:37,1:37,0:52,0:18,1:52,1:18,0:53,-1:30,0:7,1:53,-1:15,1:15,0:53,-1:17,0:37,1:52,1:21,0:53,-1:40,0:30,1:53,-1:9,1:19,0:52,0:40,1:53,-1:29,1:9,0:52,0:47,1:52,1:4,0:52,0:4,1:53,-1:35,1:6,0:52,0:19,1:53,-1:8,1:35,0:53,-1:26,0:33,1:53,-1:22,1:8,0:52,0:32,1:52,1:22,0:52,0:24,1:53,-1:1,1:1,0:52,0:8,1:53,-1:46,1:38,0:53,-1:23,0:5,1:53,-1:42,1:42,0:52,0:1,1:52,1:47,0:52\nmove_number=129\n__dict__=gASVfQIAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRYOwIAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAo1Mgo0OQo1Mgo2CjUyCjE0CjUyCjMyCjUyCjQ3CjUyCjQ4CjUyCjEzCjUzCjE5CjMKNTMKMzQKNDgKNTIKNDkKNTMKMjQKNgo1Mgo0Nwo1Mgo0Mwo1Mgo0Mwo1MwozMwozMQo1MwozNwozNwo1MgoxOAo1MgoxOAo1MwozMAo3CjUzCjE1CjE1CjUzCjE3CjM3CjUyCjIxCjUzCjQwCjMwCjUzCjkKMTkKNTIKNDAKNTMKMjkKOQo1Mgo0Nwo1Mgo0CjUyCjQKNTMKMzUKNgo1MgoxOQo1Mwo4CjM1CjUzCjI2CjMzCjUzCjIyCjgKNTIKMzIKNTIKMjIKNTIKMjQKNTMKMQoxCjUyCjgKNTMKNDYKMzgKNTMKMjMKNQo1Mwo0Mgo0Mgo1MgoxCjUyCjQ3CjUyCgqUYnMu\n",
+          "legalActions": [6, 9, 17, 22, 23, 26, 28, 34, 42, 47, 50],
+          "legalActionStrings": [
+            "Player: 0 Action: 7s",
+            "Player: 0 Action: Ts",
+            "Player: 0 Action: 5c",
+            "Player: 0 Action: Tc",
+            "Player: 0 Action: Jc",
+            "Player: 0 Action: Ad",
+            "Player: 0 Action: 3d",
+            "Player: 0 Action: 9d",
+            "Player: 0 Action: 4h",
+            "Player: 0 Action: 9h",
+            "Player: 0 Action: Qh"
+          ]
+        },
+        "status": "ACTIVE"
+      },
+      {
+        "action": {
+          "submission": -1
+        },
+        "reward": null,
+        "info": {},
+        "observation": {
+          "remainingOverageTime": 12,
+          "observationString": "{\"phase\": \"Discard\", \"current_player\": 0, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"9h\", \"upcard\": null, \"stock_size\": 12, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\", \"2h\", \"5s\", \"7c\", \"Td\", \"8d\", \"Qc\", \"9s\", \"Kd\", \"6s\"], \"hands\": {\"0\": [], \"1\": [\"2s\", \"Qs\", \"2c\", \"Kc\", \"4d\", \"7d\", \"Qd\", \"8h\", \"Th\", \"Kh\"]}, \"deadwood\": {\"0\": null, \"1\": 73}, \"repeated_move\": 0}",
+          "currentPlayer": 0,
+          "playerId": 1,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14,0:52,0:49,1:52,1:6,0:52,0:14,1:52,1:32,0:52,0:47,1:52,1:48,0:52,0:13,1:53,-1:19,1:3,0:53,-1:34,0:48,1:52,1:49,0:53,-1:24,0:6,1:52,1:47,0:52,0:43,1:52,1:43,0:53,-1:33,0:31,1:53,-1:37,1:37,0:52,0:18,1:52,1:18,0:53,-1:30,0:7,1:53,-1:15,1:15,0:53,-1:17,0:37,1:52,1:21,0:53,-1:40,0:30,1:53,-1:9,1:19,0:52,0:40,1:53,-1:29,1:9,0:52,0:47,1:52,1:4,0:52,0:4,1:53,-1:35,1:6,0:52,0:19,1:53,-1:8,1:35,0:53,-1:26,0:33,1:53,-1:22,1:8,0:52,0:32,1:52,1:22,0:52,0:24,1:53,-1:1,1:1,0:52,0:8,1:53,-1:46,1:38,0:53,-1:23,0:5,1:53,-1:42,1:42,0:52,0:1,1:52,1:47,0:52\nmove_number=129\n__dict__=gASVfQIAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRYOwIAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAo1Mgo0OQo1Mgo2CjUyCjE0CjUyCjMyCjUyCjQ3CjUyCjQ4CjUyCjEzCjUzCjE5CjMKNTMKMzQKNDgKNTIKNDkKNTMKMjQKNgo1Mgo0Nwo1Mgo0Mwo1Mgo0Mwo1MwozMwozMQo1MwozNwozNwo1MgoxOAo1MgoxOAo1MwozMAo3CjUzCjE1CjE1CjUzCjE3CjM3CjUyCjIxCjUzCjQwCjMwCjUzCjkKMTkKNTIKNDAKNTMKMjkKOQo1Mgo0Nwo1Mgo0CjUyCjQKNTMKMzUKNgo1MgoxOQo1Mwo4CjM1CjUzCjI2CjMzCjUzCjIyCjgKNTIKMzIKNTIKMjIKNTIKMjQKNTMKMQoxCjUyCjgKNTMKNDYKMzgKNTMKMjMKNQo1Mwo0Mgo0Mgo1MgoxCjUyCjQ3CjUyCgqUYnMu\n",
+          "legalActions": [],
+          "legalActionStrings": []
+        },
+        "status": "INACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "submission": 26,
+          "thoughts": "echo zeta gamma imagine omega consider beta xi"
+        },
+        "reward": null,
+        "info": {
+          "actionSubmitted": 26,
+          "actionSubmittedToString": "Player: 0 Action: Ad",
+          "actionApplied": 26,
+          "timeTaken": 0.0,
+          "agentSelfReportedStatus": null
+        },
+        "observation": {
+          "remainingOverageTime": 12,
+          "step": 91,
+          "observationString": "{\"phase\": \"Draw\", \"current_player\": 1, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"9h\", \"upcard\": \"Ad\", \"stock_size\": 12, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\", \"2h\", \"5s\", \"7c\", \"Td\", \"8d\", \"Qc\", \"9s\", \"Kd\", \"6s\"], \"hands\": {\"0\": [\"7s\", \"Ts\", \"5c\", \"Tc\", \"Jc\", \"3d\", \"9d\", \"4h\", \"9h\", \"Qh\"], \"1\": []}, \"deadwood\": {\"0\": 77, \"1\": null}, \"repeated_move\": 0}",
+          "currentPlayer": 1,
+          "playerId": 0,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14,0:52,0:49,1:52,1:6,0:52,0:14,1:52,1:32,0:52,0:47,1:52,1:48,0:52,0:13,1:53,-1:19,1:3,0:53,-1:34,0:48,1:52,1:49,0:53,-1:24,0:6,1:52,1:47,0:52,0:43,1:52,1:43,0:53,-1:33,0:31,1:53,-1:37,1:37,0:52,0:18,1:52,1:18,0:53,-1:30,0:7,1:53,-1:15,1:15,0:53,-1:17,0:37,1:52,1:21,0:53,-1:40,0:30,1:53,-1:9,1:19,0:52,0:40,1:53,-1:29,1:9,0:52,0:47,1:52,1:4,0:52,0:4,1:53,-1:35,1:6,0:52,0:19,1:53,-1:8,1:35,0:53,-1:26,0:33,1:53,-1:22,1:8,0:52,0:32,1:52,1:22,0:52,0:24,1:53,-1:1,1:1,0:52,0:8,1:53,-1:46,1:38,0:53,-1:23,0:5,1:53,-1:42,1:42,0:52,0:1,1:52,1:47,0:52,0:26\nmove_number=130\n__dict__=gASVgAIAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRYPgIAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAo1Mgo0OQo1Mgo2CjUyCjE0CjUyCjMyCjUyCjQ3CjUyCjQ4CjUyCjEzCjUzCjE5CjMKNTMKMzQKNDgKNTIKNDkKNTMKMjQKNgo1Mgo0Nwo1Mgo0Mwo1Mgo0Mwo1MwozMwozMQo1MwozNwozNwo1MgoxOAo1MgoxOAo1MwozMAo3CjUzCjE1CjE1CjUzCjE3CjM3CjUyCjIxCjUzCjQwCjMwCjUzCjkKMTkKNTIKNDAKNTMKMjkKOQo1Mgo0Nwo1Mgo0CjUyCjQKNTMKMzUKNgo1MgoxOQo1Mwo4CjM1CjUzCjI2CjMzCjUzCjIyCjgKNTIKMzIKNTIKMjIKNTIKMjQKNTMKMQoxCjUyCjgKNTMKNDYKMzgKNTMKMjMKNQo1Mwo0Mgo0Mgo1MgoxCjUyCjQ3CjUyCjI2CgqUYnMu\n",
+          "legalActions": [],
+          "legalActionStrings": []
+        },
+        "status": "INACTIVE"
+      },
+      {
+        "action": {
+          "submission": -1
+        },
+        "reward": null,
+        "info": {},
+        "observation": {
+          "remainingOverageTime": 12,
+          "observationString": "{\"phase\": \"Draw\", \"current_player\": 1, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"9h\", \"upcard\": \"Ad\", \"stock_size\": 12, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\", \"2h\", \"5s\", \"7c\", \"Td\", \"8d\", \"Qc\", \"9s\", \"Kd\", \"6s\"], \"hands\": {\"0\": [], \"1\": [\"2s\", \"Qs\", \"2c\", \"Kc\", \"4d\", \"7d\", \"Qd\", \"8h\", \"Th\", \"Kh\"]}, \"deadwood\": {\"0\": null, \"1\": 73}, \"repeated_move\": 0}",
+          "currentPlayer": 1,
+          "playerId": 1,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14,0:52,0:49,1:52,1:6,0:52,0:14,1:52,1:32,0:52,0:47,1:52,1:48,0:52,0:13,1:53,-1:19,1:3,0:53,-1:34,0:48,1:52,1:49,0:53,-1:24,0:6,1:52,1:47,0:52,0:43,1:52,1:43,0:53,-1:33,0:31,1:53,-1:37,1:37,0:52,0:18,1:52,1:18,0:53,-1:30,0:7,1:53,-1:15,1:15,0:53,-1:17,0:37,1:52,1:21,0:53,-1:40,0:30,1:53,-1:9,1:19,0:52,0:40,1:53,-1:29,1:9,0:52,0:47,1:52,1:4,0:52,0:4,1:53,-1:35,1:6,0:52,0:19,1:53,-1:8,1:35,0:53,-1:26,0:33,1:53,-1:22,1:8,0:52,0:32,1:52,1:22,0:52,0:24,1:53,-1:1,1:1,0:52,0:8,1:53,-1:46,1:38,0:53,-1:23,0:5,1:53,-1:42,1:42,0:52,0:1,1:52,1:47,0:52,0:26\nmove_number=130\n__dict__=gASVgAIAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRYPgIAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAo1Mgo0OQo1Mgo2CjUyCjE0CjUyCjMyCjUyCjQ3CjUyCjQ4CjUyCjEzCjUzCjE5CjMKNTMKMzQKNDgKNTIKNDkKNTMKMjQKNgo1Mgo0Nwo1Mgo0Mwo1Mgo0Mwo1MwozMwozMQo1MwozNwozNwo1MgoxOAo1MgoxOAo1MwozMAo3CjUzCjE1CjE1CjUzCjE3CjM3CjUyCjIxCjUzCjQwCjMwCjUzCjkKMTkKNTIKNDAKNTMKMjkKOQo1Mgo0Nwo1Mgo0CjUyCjQKNTMKMzUKNgo1MgoxOQo1Mwo4CjM1CjUzCjI2CjMzCjUzCjIyCjgKNTIKMzIKNTIKMjIKNTIKMjQKNTMKMQoxCjUyCjgKNTMKNDYKMzgKNTMKMjMKNQo1Mwo0Mgo0Mgo1MgoxCjUyCjQ3CjUyCjI2CgqUYnMu\n",
+          "legalActions": [52, 53],
+          "legalActionStrings": [
+            "Player: 1 Action: Draw upcard",
+            "Player: 1 Action: Draw stock"
+          ]
+        },
+        "status": "ACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "submission": -1
+        },
+        "reward": null,
+        "info": {},
+        "observation": {
+          "remainingOverageTime": 12,
+          "step": 92,
+          "observationString": "{\"phase\": \"Discard\", \"current_player\": 1, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"Ad\", \"upcard\": null, \"stock_size\": 11, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\", \"2h\", \"5s\", \"7c\", \"Td\", \"8d\", \"Qc\", \"9s\", \"Kd\", \"6s\", \"Ad\"], \"hands\": {\"0\": [\"7s\", \"Ts\", \"5c\", \"Tc\", \"Jc\", \"3d\", \"9d\", \"4h\", \"9h\", \"Qh\"], \"1\": []}, \"deadwood\": {\"0\": 77, \"1\": null}, \"repeated_move\": 0}",
+          "currentPlayer": 1,
+          "playerId": 0,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14,0:52,0:49,1:52,1:6,0:52,0:14,1:52,1:32,0:52,0:47,1:52,1:48,0:52,0:13,1:53,-1:19,1:3,0:53,-1:34,0:48,1:52,1:49,0:53,-1:24,0:6,1:52,1:47,0:52,0:43,1:52,1:43,0:53,-1:33,0:31,1:53,-1:37,1:37,0:52,0:18,1:52,1:18,0:53,-1:30,0:7,1:53,-1:15,1:15,0:53,-1:17,0:37,1:52,1:21,0:53,-1:40,0:30,1:53,-1:9,1:19,0:52,0:40,1:53,-1:29,1:9,0:52,0:47,1:52,1:4,0:52,0:4,1:53,-1:35,1:6,0:52,0:19,1:53,-1:8,1:35,0:53,-1:26,0:33,1:53,-1:22,1:8,0:52,0:32,1:52,1:22,0:52,0:24,1:53,-1:1,1:1,0:52,0:8,1:53,-1:46,1:38,0:53,-1:23,0:5,1:53,-1:42,1:42,0:52,0:1,1:52,1:47,0:52,0:26,1:53,-1:16\nmove_number=132\n__dict__=gASVhgIAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRYRAIAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAo1Mgo0OQo1Mgo2CjUyCjE0CjUyCjMyCjUyCjQ3CjUyCjQ4CjUyCjEzCjUzCjE5CjMKNTMKMzQKNDgKNTIKNDkKNTMKMjQKNgo1Mgo0Nwo1Mgo0Mwo1Mgo0Mwo1MwozMwozMQo1MwozNwozNwo1MgoxOAo1MgoxOAo1MwozMAo3CjUzCjE1CjE1CjUzCjE3CjM3CjUyCjIxCjUzCjQwCjMwCjUzCjkKMTkKNTIKNDAKNTMKMjkKOQo1Mgo0Nwo1Mgo0CjUyCjQKNTMKMzUKNgo1MgoxOQo1Mwo4CjM1CjUzCjI2CjMzCjUzCjIyCjgKNTIKMzIKNTIKMjIKNTIKMjQKNTMKMQoxCjUyCjgKNTMKNDYKMzgKNTMKMjMKNQo1Mwo0Mgo0Mgo1MgoxCjUyCjQ3CjUyCjI2CjUzCjE2CgqUYnMu\n",
+          "legalActions": [],
+          "legalActionStrings": []
+        },
+        "status": "INACTIVE"
+      },
+      {
+        "action": {
+          "submission": 53,
+          "thoughts": "mu xi tau sigma psi ember cascade phi"
+        },
+        "reward": null,
+        "info": {
+          "actionSubmitted": 53,
+          "actionSubmittedToString": "Player: 1 Action: Draw stock",
+          "actionApplied": 53,
+          "timeTaken": 0.0,
+          "agentSelfReportedStatus": null
+        },
+        "observation": {
+          "remainingOverageTime": 12,
+          "observationString": "{\"phase\": \"Discard\", \"current_player\": 1, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"Ad\", \"upcard\": null, \"stock_size\": 11, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\", \"2h\", \"5s\", \"7c\", \"Td\", \"8d\", \"Qc\", \"9s\", \"Kd\", \"6s\", \"Ad\"], \"hands\": {\"0\": [], \"1\": [\"2s\", \"Qs\", \"2c\", \"4c\", \"Kc\", \"4d\", \"7d\", \"Qd\", \"8h\", \"Th\", \"Kh\"]}, \"deadwood\": {\"0\": null, \"1\": 67}, \"repeated_move\": 0}",
+          "currentPlayer": 1,
+          "playerId": 1,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14,0:52,0:49,1:52,1:6,0:52,0:14,1:52,1:32,0:52,0:47,1:52,1:48,0:52,0:13,1:53,-1:19,1:3,0:53,-1:34,0:48,1:52,1:49,0:53,-1:24,0:6,1:52,1:47,0:52,0:43,1:52,1:43,0:53,-1:33,0:31,1:53,-1:37,1:37,0:52,0:18,1:52,1:18,0:53,-1:30,0:7,1:53,-1:15,1:15,0:53,-1:17,0:37,1:52,1:21,0:53,-1:40,0:30,1:53,-1:9,1:19,0:52,0:40,1:53,-1:29,1:9,0:52,0:47,1:52,1:4,0:52,0:4,1:53,-1:35,1:6,0:52,0:19,1:53,-1:8,1:35,0:53,-1:26,0:33,1:53,-1:22,1:8,0:52,0:32,1:52,1:22,0:52,0:24,1:53,-1:1,1:1,0:52,0:8,1:53,-1:46,1:38,0:53,-1:23,0:5,1:53,-1:42,1:42,0:52,0:1,1:52,1:47,0:52,0:26,1:53,-1:16\nmove_number=132\n__dict__=gASVhgIAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRYRAIAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAo1Mgo0OQo1Mgo2CjUyCjE0CjUyCjMyCjUyCjQ3CjUyCjQ4CjUyCjEzCjUzCjE5CjMKNTMKMzQKNDgKNTIKNDkKNTMKMjQKNgo1Mgo0Nwo1Mgo0Mwo1Mgo0Mwo1MwozMwozMQo1MwozNwozNwo1MgoxOAo1MgoxOAo1MwozMAo3CjUzCjE1CjE1CjUzCjE3CjM3CjUyCjIxCjUzCjQwCjMwCjUzCjkKMTkKNTIKNDAKNTMKMjkKOQo1Mgo0Nwo1Mgo0CjUyCjQKNTMKMzUKNgo1MgoxOQo1Mwo4CjM1CjUzCjI2CjMzCjUzCjIyCjgKNTIKMzIKNTIKMjIKNTIKMjQKNTMKMQoxCjUyCjgKNTMKNDYKMzgKNTMKMjMKNQo1Mwo0Mgo0Mgo1MgoxCjUyCjQ3CjUyCjI2CjUzCjE2CgqUYnMu\n",
+          "legalActions": [1, 11, 14, 16, 25, 29, 32, 37, 46, 48, 51],
+          "legalActionStrings": [
+            "Player: 1 Action: 2s",
+            "Player: 1 Action: Qs",
+            "Player: 1 Action: 2c",
+            "Player: 1 Action: 4c",
+            "Player: 1 Action: Kc",
+            "Player: 1 Action: 4d",
+            "Player: 1 Action: 7d",
+            "Player: 1 Action: Qd",
+            "Player: 1 Action: 8h",
+            "Player: 1 Action: Th",
+            "Player: 1 Action: Kh"
+          ]
+        },
+        "status": "ACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "submission": -1
+        },
+        "reward": null,
+        "info": {},
+        "observation": {
+          "remainingOverageTime": 12,
+          "step": 93,
+          "observationString": "{\"phase\": \"Draw\", \"current_player\": 0, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"Ad\", \"upcard\": \"2c\", \"stock_size\": 11, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\", \"2h\", \"5s\", \"7c\", \"Td\", \"8d\", \"Qc\", \"9s\", \"Kd\", \"6s\", \"Ad\"], \"hands\": {\"0\": [\"7s\", \"Ts\", \"5c\", \"Tc\", \"Jc\", \"3d\", \"9d\", \"4h\", \"9h\", \"Qh\"], \"1\": []}, \"deadwood\": {\"0\": 77, \"1\": null}, \"repeated_move\": 0}",
+          "currentPlayer": 0,
+          "playerId": 0,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14,0:52,0:49,1:52,1:6,0:52,0:14,1:52,1:32,0:52,0:47,1:52,1:48,0:52,0:13,1:53,-1:19,1:3,0:53,-1:34,0:48,1:52,1:49,0:53,-1:24,0:6,1:52,1:47,0:52,0:43,1:52,1:43,0:53,-1:33,0:31,1:53,-1:37,1:37,0:52,0:18,1:52,1:18,0:53,-1:30,0:7,1:53,-1:15,1:15,0:53,-1:17,0:37,1:52,1:21,0:53,-1:40,0:30,1:53,-1:9,1:19,0:52,0:40,1:53,-1:29,1:9,0:52,0:47,1:52,1:4,0:52,0:4,1:53,-1:35,1:6,0:52,0:19,1:53,-1:8,1:35,0:53,-1:26,0:33,1:53,-1:22,1:8,0:52,0:32,1:52,1:22,0:52,0:24,1:53,-1:1,1:1,0:52,0:8,1:53,-1:46,1:38,0:53,-1:23,0:5,1:53,-1:42,1:42,0:52,0:1,1:52,1:47,0:52,0:26,1:53,-1:16,1:14\nmove_number=133\n__dict__=gASViQIAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRYRwIAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAo1Mgo0OQo1Mgo2CjUyCjE0CjUyCjMyCjUyCjQ3CjUyCjQ4CjUyCjEzCjUzCjE5CjMKNTMKMzQKNDgKNTIKNDkKNTMKMjQKNgo1Mgo0Nwo1Mgo0Mwo1Mgo0Mwo1MwozMwozMQo1MwozNwozNwo1MgoxOAo1MgoxOAo1MwozMAo3CjUzCjE1CjE1CjUzCjE3CjM3CjUyCjIxCjUzCjQwCjMwCjUzCjkKMTkKNTIKNDAKNTMKMjkKOQo1Mgo0Nwo1Mgo0CjUyCjQKNTMKMzUKNgo1MgoxOQo1Mwo4CjM1CjUzCjI2CjMzCjUzCjIyCjgKNTIKMzIKNTIKMjIKNTIKMjQKNTMKMQoxCjUyCjgKNTMKNDYKMzgKNTMKMjMKNQo1Mwo0Mgo0Mgo1MgoxCjUyCjQ3CjUyCjI2CjUzCjE2CjE0CgqUYnMu\n",
+          "legalActions": [52, 53],
+          "legalActionStrings": [
+            "Player: 0 Action: Draw upcard",
+            "Player: 0 Action: Draw stock"
+          ]
+        },
+        "status": "ACTIVE"
+      },
+      {
+        "action": {
+          "submission": 14,
+          "thoughts": "rho horizon gamma gamma tau echo alpha delta"
+        },
+        "reward": null,
+        "info": {
+          "actionSubmitted": 14,
+          "actionSubmittedToString": "Player: 1 Action: 2c",
+          "actionApplied": 14,
+          "timeTaken": 0.0,
+          "agentSelfReportedStatus": null
+        },
+        "observation": {
+          "remainingOverageTime": 12,
+          "observationString": "{\"phase\": \"Draw\", \"current_player\": 0, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"Ad\", \"upcard\": \"2c\", \"stock_size\": 11, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\", \"2h\", \"5s\", \"7c\", \"Td\", \"8d\", \"Qc\", \"9s\", \"Kd\", \"6s\", \"Ad\"], \"hands\": {\"0\": [], \"1\": [\"2s\", \"Qs\", \"4c\", \"Kc\", \"4d\", \"7d\", \"Qd\", \"8h\", \"Th\", \"Kh\"]}, \"deadwood\": {\"0\": null, \"1\": 75}, \"repeated_move\": 0}",
+          "currentPlayer": 0,
+          "playerId": 1,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14,0:52,0:49,1:52,1:6,0:52,0:14,1:52,1:32,0:52,0:47,1:52,1:48,0:52,0:13,1:53,-1:19,1:3,0:53,-1:34,0:48,1:52,1:49,0:53,-1:24,0:6,1:52,1:47,0:52,0:43,1:52,1:43,0:53,-1:33,0:31,1:53,-1:37,1:37,0:52,0:18,1:52,1:18,0:53,-1:30,0:7,1:53,-1:15,1:15,0:53,-1:17,0:37,1:52,1:21,0:53,-1:40,0:30,1:53,-1:9,1:19,0:52,0:40,1:53,-1:29,1:9,0:52,0:47,1:52,1:4,0:52,0:4,1:53,-1:35,1:6,0:52,0:19,1:53,-1:8,1:35,0:53,-1:26,0:33,1:53,-1:22,1:8,0:52,0:32,1:52,1:22,0:52,0:24,1:53,-1:1,1:1,0:52,0:8,1:53,-1:46,1:38,0:53,-1:23,0:5,1:53,-1:42,1:42,0:52,0:1,1:52,1:47,0:52,0:26,1:53,-1:16,1:14\nmove_number=133\n__dict__=gASViQIAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRYRwIAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAo1Mgo0OQo1Mgo2CjUyCjE0CjUyCjMyCjUyCjQ3CjUyCjQ4CjUyCjEzCjUzCjE5CjMKNTMKMzQKNDgKNTIKNDkKNTMKMjQKNgo1Mgo0Nwo1Mgo0Mwo1Mgo0Mwo1MwozMwozMQo1MwozNwozNwo1MgoxOAo1MgoxOAo1MwozMAo3CjUzCjE1CjE1CjUzCjE3CjM3CjUyCjIxCjUzCjQwCjMwCjUzCjkKMTkKNTIKNDAKNTMKMjkKOQo1Mgo0Nwo1Mgo0CjUyCjQKNTMKMzUKNgo1MgoxOQo1Mwo4CjM1CjUzCjI2CjMzCjUzCjIyCjgKNTIKMzIKNTIKMjIKNTIKMjQKNTMKMQoxCjUyCjgKNTMKNDYKMzgKNTMKMjMKNQo1Mwo0Mgo0Mgo1MgoxCjUyCjQ3CjUyCjI2CjUzCjE2CjE0CgqUYnMu\n",
+          "legalActions": [],
+          "legalActionStrings": []
+        },
+        "status": "INACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "submission": 52,
+          "thoughts": "reflect phi spark ponder phi drift psi xi"
+        },
+        "reward": null,
+        "info": {
+          "actionSubmitted": 52,
+          "actionSubmittedToString": "Player: 0 Action: Draw upcard",
+          "actionApplied": 52,
+          "timeTaken": 0.0,
+          "agentSelfReportedStatus": null
+        },
+        "observation": {
+          "remainingOverageTime": 12,
+          "step": 94,
+          "observationString": "{\"phase\": \"Discard\", \"current_player\": 0, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"2c\", \"upcard\": null, \"stock_size\": 11, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\", \"2h\", \"5s\", \"7c\", \"Td\", \"8d\", \"Qc\", \"9s\", \"Kd\", \"6s\", \"Ad\"], \"hands\": {\"0\": [\"7s\", \"Ts\", \"2c\", \"5c\", \"Tc\", \"Jc\", \"3d\", \"9d\", \"4h\", \"9h\", \"Qh\"], \"1\": []}, \"deadwood\": {\"0\": 69, \"1\": null}, \"repeated_move\": 0}",
+          "currentPlayer": 0,
+          "playerId": 0,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14,0:52,0:49,1:52,1:6,0:52,0:14,1:52,1:32,0:52,0:47,1:52,1:48,0:52,0:13,1:53,-1:19,1:3,0:53,-1:34,0:48,1:52,1:49,0:53,-1:24,0:6,1:52,1:47,0:52,0:43,1:52,1:43,0:53,-1:33,0:31,1:53,-1:37,1:37,0:52,0:18,1:52,1:18,0:53,-1:30,0:7,1:53,-1:15,1:15,0:53,-1:17,0:37,1:52,1:21,0:53,-1:40,0:30,1:53,-1:9,1:19,0:52,0:40,1:53,-1:29,1:9,0:52,0:47,1:52,1:4,0:52,0:4,1:53,-1:35,1:6,0:52,0:19,1:53,-1:8,1:35,0:53,-1:26,0:33,1:53,-1:22,1:8,0:52,0:32,1:52,1:22,0:52,0:24,1:53,-1:1,1:1,0:52,0:8,1:53,-1:46,1:38,0:53,-1:23,0:5,1:53,-1:42,1:42,0:52,0:1,1:52,1:47,0:52,0:26,1:53,-1:16,1:14,0:52\nmove_number=134\n__dict__=gASVjAIAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRYSgIAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAo1Mgo0OQo1Mgo2CjUyCjE0CjUyCjMyCjUyCjQ3CjUyCjQ4CjUyCjEzCjUzCjE5CjMKNTMKMzQKNDgKNTIKNDkKNTMKMjQKNgo1Mgo0Nwo1Mgo0Mwo1Mgo0Mwo1MwozMwozMQo1MwozNwozNwo1MgoxOAo1MgoxOAo1MwozMAo3CjUzCjE1CjE1CjUzCjE3CjM3CjUyCjIxCjUzCjQwCjMwCjUzCjkKMTkKNTIKNDAKNTMKMjkKOQo1Mgo0Nwo1Mgo0CjUyCjQKNTMKMzUKNgo1MgoxOQo1Mwo4CjM1CjUzCjI2CjMzCjUzCjIyCjgKNTIKMzIKNTIKMjIKNTIKMjQKNTMKMQoxCjUyCjgKNTMKNDYKMzgKNTMKMjMKNQo1Mwo0Mgo0Mgo1MgoxCjUyCjQ3CjUyCjI2CjUzCjE2CjE0CjUyCgqUYnMu\n",
+          "legalActions": [6, 9, 14, 17, 22, 23, 28, 34, 42, 47, 50],
+          "legalActionStrings": [
+            "Player: 0 Action: 7s",
+            "Player: 0 Action: Ts",
+            "Player: 0 Action: 2c",
+            "Player: 0 Action: 5c",
+            "Player: 0 Action: Tc",
+            "Player: 0 Action: Jc",
+            "Player: 0 Action: 3d",
+            "Player: 0 Action: 9d",
+            "Player: 0 Action: 4h",
+            "Player: 0 Action: 9h",
+            "Player: 0 Action: Qh"
+          ]
+        },
+        "status": "ACTIVE"
+      },
+      {
+        "action": {
+          "submission": -1
+        },
+        "reward": null,
+        "info": {},
+        "observation": {
+          "remainingOverageTime": 12,
+          "observationString": "{\"phase\": \"Discard\", \"current_player\": 0, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"2c\", \"upcard\": null, \"stock_size\": 11, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\", \"2h\", \"5s\", \"7c\", \"Td\", \"8d\", \"Qc\", \"9s\", \"Kd\", \"6s\", \"Ad\"], \"hands\": {\"0\": [], \"1\": [\"2s\", \"Qs\", \"4c\", \"Kc\", \"4d\", \"7d\", \"Qd\", \"8h\", \"Th\", \"Kh\"]}, \"deadwood\": {\"0\": null, \"1\": 75}, \"repeated_move\": 0}",
+          "currentPlayer": 0,
+          "playerId": 1,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14,0:52,0:49,1:52,1:6,0:52,0:14,1:52,1:32,0:52,0:47,1:52,1:48,0:52,0:13,1:53,-1:19,1:3,0:53,-1:34,0:48,1:52,1:49,0:53,-1:24,0:6,1:52,1:47,0:52,0:43,1:52,1:43,0:53,-1:33,0:31,1:53,-1:37,1:37,0:52,0:18,1:52,1:18,0:53,-1:30,0:7,1:53,-1:15,1:15,0:53,-1:17,0:37,1:52,1:21,0:53,-1:40,0:30,1:53,-1:9,1:19,0:52,0:40,1:53,-1:29,1:9,0:52,0:47,1:52,1:4,0:52,0:4,1:53,-1:35,1:6,0:52,0:19,1:53,-1:8,1:35,0:53,-1:26,0:33,1:53,-1:22,1:8,0:52,0:32,1:52,1:22,0:52,0:24,1:53,-1:1,1:1,0:52,0:8,1:53,-1:46,1:38,0:53,-1:23,0:5,1:53,-1:42,1:42,0:52,0:1,1:52,1:47,0:52,0:26,1:53,-1:16,1:14,0:52\nmove_number=134\n__dict__=gASVjAIAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRYSgIAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAo1Mgo0OQo1Mgo2CjUyCjE0CjUyCjMyCjUyCjQ3CjUyCjQ4CjUyCjEzCjUzCjE5CjMKNTMKMzQKNDgKNTIKNDkKNTMKMjQKNgo1Mgo0Nwo1Mgo0Mwo1Mgo0Mwo1MwozMwozMQo1MwozNwozNwo1MgoxOAo1MgoxOAo1MwozMAo3CjUzCjE1CjE1CjUzCjE3CjM3CjUyCjIxCjUzCjQwCjMwCjUzCjkKMTkKNTIKNDAKNTMKMjkKOQo1Mgo0Nwo1Mgo0CjUyCjQKNTMKMzUKNgo1MgoxOQo1Mwo4CjM1CjUzCjI2CjMzCjUzCjIyCjgKNTIKMzIKNTIKMjIKNTIKMjQKNTMKMQoxCjUyCjgKNTMKNDYKMzgKNTMKMjMKNQo1Mwo0Mgo0Mgo1MgoxCjUyCjQ3CjUyCjI2CjUzCjE2CjE0CjUyCgqUYnMu\n",
+          "legalActions": [],
+          "legalActionStrings": []
+        },
+        "status": "INACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "submission": 6,
+          "thoughts": "ember ponder cascade cascade zeta ember psi ember"
+        },
+        "reward": null,
+        "info": {
+          "actionSubmitted": 6,
+          "actionSubmittedToString": "Player: 0 Action: 7s",
+          "actionApplied": 6,
+          "timeTaken": 0.0,
+          "agentSelfReportedStatus": null
+        },
+        "observation": {
+          "remainingOverageTime": 12,
+          "step": 95,
+          "observationString": "{\"phase\": \"Draw\", \"current_player\": 1, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"2c\", \"upcard\": \"7s\", \"stock_size\": 11, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\", \"2h\", \"5s\", \"7c\", \"Td\", \"8d\", \"Qc\", \"9s\", \"Kd\", \"6s\", \"Ad\"], \"hands\": {\"0\": [\"Ts\", \"2c\", \"5c\", \"Tc\", \"Jc\", \"3d\", \"9d\", \"4h\", \"9h\", \"Qh\"], \"1\": []}, \"deadwood\": {\"0\": 72, \"1\": null}, \"repeated_move\": 0}",
+          "currentPlayer": 1,
+          "playerId": 0,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14,0:52,0:49,1:52,1:6,0:52,0:14,1:52,1:32,0:52,0:47,1:52,1:48,0:52,0:13,1:53,-1:19,1:3,0:53,-1:34,0:48,1:52,1:49,0:53,-1:24,0:6,1:52,1:47,0:52,0:43,1:52,1:43,0:53,-1:33,0:31,1:53,-1:37,1:37,0:52,0:18,1:52,1:18,0:53,-1:30,0:7,1:53,-1:15,1:15,0:53,-1:17,0:37,1:52,1:21,0:53,-1:40,0:30,1:53,-1:9,1:19,0:52,0:40,1:53,-1:29,1:9,0:52,0:47,1:52,1:4,0:52,0:4,1:53,-1:35,1:6,0:52,0:19,1:53,-1:8,1:35,0:53,-1:26,0:33,1:53,-1:22,1:8,0:52,0:32,1:52,1:22,0:52,0:24,1:53,-1:1,1:1,0:52,0:8,1:53,-1:46,1:38,0:53,-1:23,0:5,1:53,-1:42,1:42,0:52,0:1,1:52,1:47,0:52,0:26,1:53,-1:16,1:14,0:52,0:6\nmove_number=135\n__dict__=gASVjgIAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRYTAIAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAo1Mgo0OQo1Mgo2CjUyCjE0CjUyCjMyCjUyCjQ3CjUyCjQ4CjUyCjEzCjUzCjE5CjMKNTMKMzQKNDgKNTIKNDkKNTMKMjQKNgo1Mgo0Nwo1Mgo0Mwo1Mgo0Mwo1MwozMwozMQo1MwozNwozNwo1MgoxOAo1MgoxOAo1MwozMAo3CjUzCjE1CjE1CjUzCjE3CjM3CjUyCjIxCjUzCjQwCjMwCjUzCjkKMTkKNTIKNDAKNTMKMjkKOQo1Mgo0Nwo1Mgo0CjUyCjQKNTMKMzUKNgo1MgoxOQo1Mwo4CjM1CjUzCjI2CjMzCjUzCjIyCjgKNTIKMzIKNTIKMjIKNTIKMjQKNTMKMQoxCjUyCjgKNTMKNDYKMzgKNTMKMjMKNQo1Mwo0Mgo0Mgo1MgoxCjUyCjQ3CjUyCjI2CjUzCjE2CjE0CjUyCjYKCpRicy4=\n",
+          "legalActions": [],
+          "legalActionStrings": []
+        },
+        "status": "INACTIVE"
+      },
+      {
+        "action": {
+          "submission": -1
+        },
+        "reward": null,
+        "info": {},
+        "observation": {
+          "remainingOverageTime": 12,
+          "observationString": "{\"phase\": \"Draw\", \"current_player\": 1, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"2c\", \"upcard\": \"7s\", \"stock_size\": 11, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\", \"2h\", \"5s\", \"7c\", \"Td\", \"8d\", \"Qc\", \"9s\", \"Kd\", \"6s\", \"Ad\"], \"hands\": {\"0\": [], \"1\": [\"2s\", \"Qs\", \"4c\", \"Kc\", \"4d\", \"7d\", \"Qd\", \"8h\", \"Th\", \"Kh\"]}, \"deadwood\": {\"0\": null, \"1\": 75}, \"repeated_move\": 0}",
+          "currentPlayer": 1,
+          "playerId": 1,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14,0:52,0:49,1:52,1:6,0:52,0:14,1:52,1:32,0:52,0:47,1:52,1:48,0:52,0:13,1:53,-1:19,1:3,0:53,-1:34,0:48,1:52,1:49,0:53,-1:24,0:6,1:52,1:47,0:52,0:43,1:52,1:43,0:53,-1:33,0:31,1:53,-1:37,1:37,0:52,0:18,1:52,1:18,0:53,-1:30,0:7,1:53,-1:15,1:15,0:53,-1:17,0:37,1:52,1:21,0:53,-1:40,0:30,1:53,-1:9,1:19,0:52,0:40,1:53,-1:29,1:9,0:52,0:47,1:52,1:4,0:52,0:4,1:53,-1:35,1:6,0:52,0:19,1:53,-1:8,1:35,0:53,-1:26,0:33,1:53,-1:22,1:8,0:52,0:32,1:52,1:22,0:52,0:24,1:53,-1:1,1:1,0:52,0:8,1:53,-1:46,1:38,0:53,-1:23,0:5,1:53,-1:42,1:42,0:52,0:1,1:52,1:47,0:52,0:26,1:53,-1:16,1:14,0:52,0:6\nmove_number=135\n__dict__=gASVjgIAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRYTAIAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAo1Mgo0OQo1Mgo2CjUyCjE0CjUyCjMyCjUyCjQ3CjUyCjQ4CjUyCjEzCjUzCjE5CjMKNTMKMzQKNDgKNTIKNDkKNTMKMjQKNgo1Mgo0Nwo1Mgo0Mwo1Mgo0Mwo1MwozMwozMQo1MwozNwozNwo1MgoxOAo1MgoxOAo1MwozMAo3CjUzCjE1CjE1CjUzCjE3CjM3CjUyCjIxCjUzCjQwCjMwCjUzCjkKMTkKNTIKNDAKNTMKMjkKOQo1Mgo0Nwo1Mgo0CjUyCjQKNTMKMzUKNgo1MgoxOQo1Mwo4CjM1CjUzCjI2CjMzCjUzCjIyCjgKNTIKMzIKNTIKMjIKNTIKMjQKNTMKMQoxCjUyCjgKNTMKNDYKMzgKNTMKMjMKNQo1Mwo0Mgo0Mgo1MgoxCjUyCjQ3CjUyCjI2CjUzCjE2CjE0CjUyCjYKCpRicy4=\n",
+          "legalActions": [52, 53],
+          "legalActionStrings": [
+            "Player: 1 Action: Draw upcard",
+            "Player: 1 Action: Draw stock"
+          ]
+        },
+        "status": "ACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "submission": -1
+        },
+        "reward": null,
+        "info": {},
+        "observation": {
+          "remainingOverageTime": 12,
+          "step": 96,
+          "observationString": "{\"phase\": \"Discard\", \"current_player\": 1, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"7s\", \"upcard\": null, \"stock_size\": 10, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\", \"2h\", \"5s\", \"7c\", \"Td\", \"8d\", \"Qc\", \"9s\", \"Kd\", \"6s\", \"Ad\", \"7s\"], \"hands\": {\"0\": [\"Ts\", \"2c\", \"5c\", \"Tc\", \"Jc\", \"3d\", \"9d\", \"4h\", \"9h\", \"Qh\"], \"1\": []}, \"deadwood\": {\"0\": 72, \"1\": null}, \"repeated_move\": 0}",
+          "currentPlayer": 1,
+          "playerId": 0,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14,0:52,0:49,1:52,1:6,0:52,0:14,1:52,1:32,0:52,0:47,1:52,1:48,0:52,0:13,1:53,-1:19,1:3,0:53,-1:34,0:48,1:52,1:49,0:53,-1:24,0:6,1:52,1:47,0:52,0:43,1:52,1:43,0:53,-1:33,0:31,1:53,-1:37,1:37,0:52,0:18,1:52,1:18,0:53,-1:30,0:7,1:53,-1:15,1:15,0:53,-1:17,0:37,1:52,1:21,0:53,-1:40,0:30,1:53,-1:9,1:19,0:52,0:40,1:53,-1:29,1:9,0:52,0:47,1:52,1:4,0:52,0:4,1:53,-1:35,1:6,0:52,0:19,1:53,-1:8,1:35,0:53,-1:26,0:33,1:53,-1:22,1:8,0:52,0:32,1:52,1:22,0:52,0:24,1:53,-1:1,1:1,0:52,0:8,1:53,-1:46,1:38,0:53,-1:23,0:5,1:53,-1:42,1:42,0:52,0:1,1:52,1:47,0:52,0:26,1:53,-1:16,1:14,0:52,0:6,1:53,-1:45\nmove_number=137\n__dict__=gASVlAIAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRYUgIAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAo1Mgo0OQo1Mgo2CjUyCjE0CjUyCjMyCjUyCjQ3CjUyCjQ4CjUyCjEzCjUzCjE5CjMKNTMKMzQKNDgKNTIKNDkKNTMKMjQKNgo1Mgo0Nwo1Mgo0Mwo1Mgo0Mwo1MwozMwozMQo1MwozNwozNwo1MgoxOAo1MgoxOAo1MwozMAo3CjUzCjE1CjE1CjUzCjE3CjM3CjUyCjIxCjUzCjQwCjMwCjUzCjkKMTkKNTIKNDAKNTMKMjkKOQo1Mgo0Nwo1Mgo0CjUyCjQKNTMKMzUKNgo1MgoxOQo1Mwo4CjM1CjUzCjI2CjMzCjUzCjIyCjgKNTIKMzIKNTIKMjIKNTIKMjQKNTMKMQoxCjUyCjgKNTMKNDYKMzgKNTMKMjMKNQo1Mwo0Mgo0Mgo1MgoxCjUyCjQ3CjUyCjI2CjUzCjE2CjE0CjUyCjYKNTMKNDUKCpRicy4=\n",
+          "legalActions": [],
+          "legalActionStrings": []
+        },
+        "status": "INACTIVE"
+      },
+      {
+        "action": {
+          "submission": 53,
+          "thoughts": "spark zeta ember sigma beta lantern explore drift"
+        },
+        "reward": null,
+        "info": {
+          "actionSubmitted": 53,
+          "actionSubmittedToString": "Player: 1 Action: Draw stock",
+          "actionApplied": 53,
+          "timeTaken": 0.0,
+          "agentSelfReportedStatus": null
+        },
+        "observation": {
+          "remainingOverageTime": 12,
+          "observationString": "{\"phase\": \"Discard\", \"current_player\": 1, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"7s\", \"upcard\": null, \"stock_size\": 10, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\", \"2h\", \"5s\", \"7c\", \"Td\", \"8d\", \"Qc\", \"9s\", \"Kd\", \"6s\", \"Ad\", \"7s\"], \"hands\": {\"0\": [], \"1\": [\"2s\", \"Qs\", \"4c\", \"Kc\", \"4d\", \"7d\", \"Qd\", \"7h\", \"8h\", \"Th\", \"Kh\"]}, \"deadwood\": {\"0\": null, \"1\": 72}, \"repeated_move\": 0}",
+          "currentPlayer": 1,
+          "playerId": 1,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14,0:52,0:49,1:52,1:6,0:52,0:14,1:52,1:32,0:52,0:47,1:52,1:48,0:52,0:13,1:53,-1:19,1:3,0:53,-1:34,0:48,1:52,1:49,0:53,-1:24,0:6,1:52,1:47,0:52,0:43,1:52,1:43,0:53,-1:33,0:31,1:53,-1:37,1:37,0:52,0:18,1:52,1:18,0:53,-1:30,0:7,1:53,-1:15,1:15,0:53,-1:17,0:37,1:52,1:21,0:53,-1:40,0:30,1:53,-1:9,1:19,0:52,0:40,1:53,-1:29,1:9,0:52,0:47,1:52,1:4,0:52,0:4,1:53,-1:35,1:6,0:52,0:19,1:53,-1:8,1:35,0:53,-1:26,0:33,1:53,-1:22,1:8,0:52,0:32,1:52,1:22,0:52,0:24,1:53,-1:1,1:1,0:52,0:8,1:53,-1:46,1:38,0:53,-1:23,0:5,1:53,-1:42,1:42,0:52,0:1,1:52,1:47,0:52,0:26,1:53,-1:16,1:14,0:52,0:6,1:53,-1:45\nmove_number=137\n__dict__=gASVlAIAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRYUgIAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAo1Mgo0OQo1Mgo2CjUyCjE0CjUyCjMyCjUyCjQ3CjUyCjQ4CjUyCjEzCjUzCjE5CjMKNTMKMzQKNDgKNTIKNDkKNTMKMjQKNgo1Mgo0Nwo1Mgo0Mwo1Mgo0Mwo1MwozMwozMQo1MwozNwozNwo1MgoxOAo1MgoxOAo1MwozMAo3CjUzCjE1CjE1CjUzCjE3CjM3CjUyCjIxCjUzCjQwCjMwCjUzCjkKMTkKNTIKNDAKNTMKMjkKOQo1Mgo0Nwo1Mgo0CjUyCjQKNTMKMzUKNgo1MgoxOQo1Mwo4CjM1CjUzCjI2CjMzCjUzCjIyCjgKNTIKMzIKNTIKMjIKNTIKMjQKNTMKMQoxCjUyCjgKNTMKNDYKMzgKNTMKMjMKNQo1Mwo0Mgo0Mgo1MgoxCjUyCjQ3CjUyCjI2CjUzCjE2CjE0CjUyCjYKNTMKNDUKCpRicy4=\n",
+          "legalActions": [1, 11, 16, 25, 29, 32, 37, 45, 46, 48, 51],
+          "legalActionStrings": [
+            "Player: 1 Action: 2s",
+            "Player: 1 Action: Qs",
+            "Player: 1 Action: 4c",
+            "Player: 1 Action: Kc",
+            "Player: 1 Action: 4d",
+            "Player: 1 Action: 7d",
+            "Player: 1 Action: Qd",
+            "Player: 1 Action: 7h",
+            "Player: 1 Action: 8h",
+            "Player: 1 Action: Th",
+            "Player: 1 Action: Kh"
+          ]
+        },
+        "status": "ACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "submission": -1
+        },
+        "reward": null,
+        "info": {},
+        "observation": {
+          "remainingOverageTime": 12,
+          "step": 97,
+          "observationString": "{\"phase\": \"Draw\", \"current_player\": 0, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"7s\", \"upcard\": \"4c\", \"stock_size\": 10, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\", \"2h\", \"5s\", \"7c\", \"Td\", \"8d\", \"Qc\", \"9s\", \"Kd\", \"6s\", \"Ad\", \"7s\"], \"hands\": {\"0\": [\"Ts\", \"2c\", \"5c\", \"Tc\", \"Jc\", \"3d\", \"9d\", \"4h\", \"9h\", \"Qh\"], \"1\": []}, \"deadwood\": {\"0\": 72, \"1\": null}, \"repeated_move\": 0}",
+          "currentPlayer": 0,
+          "playerId": 0,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14,0:52,0:49,1:52,1:6,0:52,0:14,1:52,1:32,0:52,0:47,1:52,1:48,0:52,0:13,1:53,-1:19,1:3,0:53,-1:34,0:48,1:52,1:49,0:53,-1:24,0:6,1:52,1:47,0:52,0:43,1:52,1:43,0:53,-1:33,0:31,1:53,-1:37,1:37,0:52,0:18,1:52,1:18,0:53,-1:30,0:7,1:53,-1:15,1:15,0:53,-1:17,0:37,1:52,1:21,0:53,-1:40,0:30,1:53,-1:9,1:19,0:52,0:40,1:53,-1:29,1:9,0:52,0:47,1:52,1:4,0:52,0:4,1:53,-1:35,1:6,0:52,0:19,1:53,-1:8,1:35,0:53,-1:26,0:33,1:53,-1:22,1:8,0:52,0:32,1:52,1:22,0:52,0:24,1:53,-1:1,1:1,0:52,0:8,1:53,-1:46,1:38,0:53,-1:23,0:5,1:53,-1:42,1:42,0:52,0:1,1:52,1:47,0:52,0:26,1:53,-1:16,1:14,0:52,0:6,1:53,-1:45,1:16\nmove_number=138\n__dict__=gASVlwIAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRYVQIAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAo1Mgo0OQo1Mgo2CjUyCjE0CjUyCjMyCjUyCjQ3CjUyCjQ4CjUyCjEzCjUzCjE5CjMKNTMKMzQKNDgKNTIKNDkKNTMKMjQKNgo1Mgo0Nwo1Mgo0Mwo1Mgo0Mwo1MwozMwozMQo1MwozNwozNwo1MgoxOAo1MgoxOAo1MwozMAo3CjUzCjE1CjE1CjUzCjE3CjM3CjUyCjIxCjUzCjQwCjMwCjUzCjkKMTkKNTIKNDAKNTMKMjkKOQo1Mgo0Nwo1Mgo0CjUyCjQKNTMKMzUKNgo1MgoxOQo1Mwo4CjM1CjUzCjI2CjMzCjUzCjIyCjgKNTIKMzIKNTIKMjIKNTIKMjQKNTMKMQoxCjUyCjgKNTMKNDYKMzgKNTMKMjMKNQo1Mwo0Mgo0Mgo1MgoxCjUyCjQ3CjUyCjI2CjUzCjE2CjE0CjUyCjYKNTMKNDUKMTYKCpRicy4=\n",
+          "legalActions": [52, 53],
+          "legalActionStrings": [
+            "Player: 0 Action: Draw upcard",
+            "Player: 0 Action: Draw stock"
+          ]
+        },
+        "status": "ACTIVE"
+      },
+      {
+        "action": {
+          "submission": 16,
+          "thoughts": "reflect ember explore iota theta beta muse pi"
+        },
+        "reward": null,
+        "info": {
+          "actionSubmitted": 16,
+          "actionSubmittedToString": "Player: 1 Action: 4c",
+          "actionApplied": 16,
+          "timeTaken": 0.0,
+          "agentSelfReportedStatus": null
+        },
+        "observation": {
+          "remainingOverageTime": 12,
+          "observationString": "{\"phase\": \"Draw\", \"current_player\": 0, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"7s\", \"upcard\": \"4c\", \"stock_size\": 10, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\", \"2h\", \"5s\", \"7c\", \"Td\", \"8d\", \"Qc\", \"9s\", \"Kd\", \"6s\", \"Ad\", \"7s\"], \"hands\": {\"0\": [], \"1\": [\"2s\", \"Qs\", \"Kc\", \"4d\", \"7d\", \"Qd\", \"7h\", \"8h\", \"Th\", \"Kh\"]}, \"deadwood\": {\"0\": null, \"1\": 78}, \"repeated_move\": 0}",
+          "currentPlayer": 0,
+          "playerId": 1,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14,0:52,0:49,1:52,1:6,0:52,0:14,1:52,1:32,0:52,0:47,1:52,1:48,0:52,0:13,1:53,-1:19,1:3,0:53,-1:34,0:48,1:52,1:49,0:53,-1:24,0:6,1:52,1:47,0:52,0:43,1:52,1:43,0:53,-1:33,0:31,1:53,-1:37,1:37,0:52,0:18,1:52,1:18,0:53,-1:30,0:7,1:53,-1:15,1:15,0:53,-1:17,0:37,1:52,1:21,0:53,-1:40,0:30,1:53,-1:9,1:19,0:52,0:40,1:53,-1:29,1:9,0:52,0:47,1:52,1:4,0:52,0:4,1:53,-1:35,1:6,0:52,0:19,1:53,-1:8,1:35,0:53,-1:26,0:33,1:53,-1:22,1:8,0:52,0:32,1:52,1:22,0:52,0:24,1:53,-1:1,1:1,0:52,0:8,1:53,-1:46,1:38,0:53,-1:23,0:5,1:53,-1:42,1:42,0:52,0:1,1:52,1:47,0:52,0:26,1:53,-1:16,1:14,0:52,0:6,1:53,-1:45,1:16\nmove_number=138\n__dict__=gASVlwIAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRYVQIAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAo1Mgo0OQo1Mgo2CjUyCjE0CjUyCjMyCjUyCjQ3CjUyCjQ4CjUyCjEzCjUzCjE5CjMKNTMKMzQKNDgKNTIKNDkKNTMKMjQKNgo1Mgo0Nwo1Mgo0Mwo1Mgo0Mwo1MwozMwozMQo1MwozNwozNwo1MgoxOAo1MgoxOAo1MwozMAo3CjUzCjE1CjE1CjUzCjE3CjM3CjUyCjIxCjUzCjQwCjMwCjUzCjkKMTkKNTIKNDAKNTMKMjkKOQo1Mgo0Nwo1Mgo0CjUyCjQKNTMKMzUKNgo1MgoxOQo1Mwo4CjM1CjUzCjI2CjMzCjUzCjIyCjgKNTIKMzIKNTIKMjIKNTIKMjQKNTMKMQoxCjUyCjgKNTMKNDYKMzgKNTMKMjMKNQo1Mwo0Mgo0Mgo1MgoxCjUyCjQ3CjUyCjI2CjUzCjE2CjE0CjUyCjYKNTMKNDUKMTYKCpRicy4=\n",
+          "legalActions": [],
+          "legalActionStrings": []
+        },
+        "status": "INACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "submission": 52,
+          "thoughts": "ember epsilon kappa delta drift chi lantern chi"
+        },
+        "reward": null,
+        "info": {
+          "actionSubmitted": 52,
+          "actionSubmittedToString": "Player: 0 Action: Draw upcard",
+          "actionApplied": 52,
+          "timeTaken": 0.0,
+          "agentSelfReportedStatus": null
+        },
+        "observation": {
+          "remainingOverageTime": 12,
+          "step": 98,
+          "observationString": "{\"phase\": \"Discard\", \"current_player\": 0, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"4c\", \"upcard\": null, \"stock_size\": 10, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\", \"2h\", \"5s\", \"7c\", \"Td\", \"8d\", \"Qc\", \"9s\", \"Kd\", \"6s\", \"Ad\", \"7s\"], \"hands\": {\"0\": [\"Ts\", \"2c\", \"4c\", \"5c\", \"Tc\", \"Jc\", \"3d\", \"9d\", \"4h\", \"9h\", \"Qh\"], \"1\": []}, \"deadwood\": {\"0\": 66, \"1\": null}, \"repeated_move\": 0}",
+          "currentPlayer": 0,
+          "playerId": 0,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14,0:52,0:49,1:52,1:6,0:52,0:14,1:52,1:32,0:52,0:47,1:52,1:48,0:52,0:13,1:53,-1:19,1:3,0:53,-1:34,0:48,1:52,1:49,0:53,-1:24,0:6,1:52,1:47,0:52,0:43,1:52,1:43,0:53,-1:33,0:31,1:53,-1:37,1:37,0:52,0:18,1:52,1:18,0:53,-1:30,0:7,1:53,-1:15,1:15,0:53,-1:17,0:37,1:52,1:21,0:53,-1:40,0:30,1:53,-1:9,1:19,0:52,0:40,1:53,-1:29,1:9,0:52,0:47,1:52,1:4,0:52,0:4,1:53,-1:35,1:6,0:52,0:19,1:53,-1:8,1:35,0:53,-1:26,0:33,1:53,-1:22,1:8,0:52,0:32,1:52,1:22,0:52,0:24,1:53,-1:1,1:1,0:52,0:8,1:53,-1:46,1:38,0:53,-1:23,0:5,1:53,-1:42,1:42,0:52,0:1,1:52,1:47,0:52,0:26,1:53,-1:16,1:14,0:52,0:6,1:53,-1:45,1:16,0:52\nmove_number=139\n__dict__=gASVmgIAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRYWAIAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAo1Mgo0OQo1Mgo2CjUyCjE0CjUyCjMyCjUyCjQ3CjUyCjQ4CjUyCjEzCjUzCjE5CjMKNTMKMzQKNDgKNTIKNDkKNTMKMjQKNgo1Mgo0Nwo1Mgo0Mwo1Mgo0Mwo1MwozMwozMQo1MwozNwozNwo1MgoxOAo1MgoxOAo1MwozMAo3CjUzCjE1CjE1CjUzCjE3CjM3CjUyCjIxCjUzCjQwCjMwCjUzCjkKMTkKNTIKNDAKNTMKMjkKOQo1Mgo0Nwo1Mgo0CjUyCjQKNTMKMzUKNgo1MgoxOQo1Mwo4CjM1CjUzCjI2CjMzCjUzCjIyCjgKNTIKMzIKNTIKMjIKNTIKMjQKNTMKMQoxCjUyCjgKNTMKNDYKMzgKNTMKMjMKNQo1Mwo0Mgo0Mgo1MgoxCjUyCjQ3CjUyCjI2CjUzCjE2CjE0CjUyCjYKNTMKNDUKMTYKNTIKCpRicy4=\n",
+          "legalActions": [9, 14, 16, 17, 22, 23, 28, 34, 42, 47, 50],
+          "legalActionStrings": [
+            "Player: 0 Action: Ts",
+            "Player: 0 Action: 2c",
+            "Player: 0 Action: 4c",
+            "Player: 0 Action: 5c",
+            "Player: 0 Action: Tc",
+            "Player: 0 Action: Jc",
+            "Player: 0 Action: 3d",
+            "Player: 0 Action: 9d",
+            "Player: 0 Action: 4h",
+            "Player: 0 Action: 9h",
+            "Player: 0 Action: Qh"
+          ]
+        },
+        "status": "ACTIVE"
+      },
+      {
+        "action": {
+          "submission": -1
+        },
+        "reward": null,
+        "info": {},
+        "observation": {
+          "remainingOverageTime": 12,
+          "observationString": "{\"phase\": \"Discard\", \"current_player\": 0, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"4c\", \"upcard\": null, \"stock_size\": 10, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\", \"2h\", \"5s\", \"7c\", \"Td\", \"8d\", \"Qc\", \"9s\", \"Kd\", \"6s\", \"Ad\", \"7s\"], \"hands\": {\"0\": [], \"1\": [\"2s\", \"Qs\", \"Kc\", \"4d\", \"7d\", \"Qd\", \"7h\", \"8h\", \"Th\", \"Kh\"]}, \"deadwood\": {\"0\": null, \"1\": 78}, \"repeated_move\": 0}",
+          "currentPlayer": 0,
+          "playerId": 1,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14,0:52,0:49,1:52,1:6,0:52,0:14,1:52,1:32,0:52,0:47,1:52,1:48,0:52,0:13,1:53,-1:19,1:3,0:53,-1:34,0:48,1:52,1:49,0:53,-1:24,0:6,1:52,1:47,0:52,0:43,1:52,1:43,0:53,-1:33,0:31,1:53,-1:37,1:37,0:52,0:18,1:52,1:18,0:53,-1:30,0:7,1:53,-1:15,1:15,0:53,-1:17,0:37,1:52,1:21,0:53,-1:40,0:30,1:53,-1:9,1:19,0:52,0:40,1:53,-1:29,1:9,0:52,0:47,1:52,1:4,0:52,0:4,1:53,-1:35,1:6,0:52,0:19,1:53,-1:8,1:35,0:53,-1:26,0:33,1:53,-1:22,1:8,0:52,0:32,1:52,1:22,0:52,0:24,1:53,-1:1,1:1,0:52,0:8,1:53,-1:46,1:38,0:53,-1:23,0:5,1:53,-1:42,1:42,0:52,0:1,1:52,1:47,0:52,0:26,1:53,-1:16,1:14,0:52,0:6,1:53,-1:45,1:16,0:52\nmove_number=139\n__dict__=gASVmgIAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRYWAIAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAo1Mgo0OQo1Mgo2CjUyCjE0CjUyCjMyCjUyCjQ3CjUyCjQ4CjUyCjEzCjUzCjE5CjMKNTMKMzQKNDgKNTIKNDkKNTMKMjQKNgo1Mgo0Nwo1Mgo0Mwo1Mgo0Mwo1MwozMwozMQo1MwozNwozNwo1MgoxOAo1MgoxOAo1MwozMAo3CjUzCjE1CjE1CjUzCjE3CjM3CjUyCjIxCjUzCjQwCjMwCjUzCjkKMTkKNTIKNDAKNTMKMjkKOQo1Mgo0Nwo1Mgo0CjUyCjQKNTMKMzUKNgo1MgoxOQo1Mwo4CjM1CjUzCjI2CjMzCjUzCjIyCjgKNTIKMzIKNTIKMjIKNTIKMjQKNTMKMQoxCjUyCjgKNTMKNDYKMzgKNTMKMjMKNQo1Mwo0Mgo0Mgo1MgoxCjUyCjQ3CjUyCjI2CjUzCjE2CjE0CjUyCjYKNTMKNDUKMTYKNTIKCpRicy4=\n",
+          "legalActions": [],
+          "legalActionStrings": []
+        },
+        "status": "INACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "submission": 42,
+          "thoughts": "theta psi iota lambda mu explore wonder eta"
+        },
+        "reward": null,
+        "info": {
+          "actionSubmitted": 42,
+          "actionSubmittedToString": "Player: 0 Action: 4h",
+          "actionApplied": 42,
+          "timeTaken": 0.0,
+          "agentSelfReportedStatus": null
+        },
+        "observation": {
+          "remainingOverageTime": 12,
+          "step": 99,
+          "observationString": "{\"phase\": \"Draw\", \"current_player\": 1, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"4c\", \"upcard\": \"4h\", \"stock_size\": 10, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\", \"2h\", \"5s\", \"7c\", \"Td\", \"8d\", \"Qc\", \"9s\", \"Kd\", \"6s\", \"Ad\", \"7s\"], \"hands\": {\"0\": [\"Ts\", \"2c\", \"4c\", \"5c\", \"Tc\", \"Jc\", \"3d\", \"9d\", \"9h\", \"Qh\"], \"1\": []}, \"deadwood\": {\"0\": 72, \"1\": null}, \"repeated_move\": 0}",
+          "currentPlayer": 1,
+          "playerId": 0,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14,0:52,0:49,1:52,1:6,0:52,0:14,1:52,1:32,0:52,0:47,1:52,1:48,0:52,0:13,1:53,-1:19,1:3,0:53,-1:34,0:48,1:52,1:49,0:53,-1:24,0:6,1:52,1:47,0:52,0:43,1:52,1:43,0:53,-1:33,0:31,1:53,-1:37,1:37,0:52,0:18,1:52,1:18,0:53,-1:30,0:7,1:53,-1:15,1:15,0:53,-1:17,0:37,1:52,1:21,0:53,-1:40,0:30,1:53,-1:9,1:19,0:52,0:40,1:53,-1:29,1:9,0:52,0:47,1:52,1:4,0:52,0:4,1:53,-1:35,1:6,0:52,0:19,1:53,-1:8,1:35,0:53,-1:26,0:33,1:53,-1:22,1:8,0:52,0:32,1:52,1:22,0:52,0:24,1:53,-1:1,1:1,0:52,0:8,1:53,-1:46,1:38,0:53,-1:23,0:5,1:53,-1:42,1:42,0:52,0:1,1:52,1:47,0:52,0:26,1:53,-1:16,1:14,0:52,0:6,1:53,-1:45,1:16,0:52,0:42\nmove_number=140\n__dict__=gASVnQIAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRYWwIAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAo1Mgo0OQo1Mgo2CjUyCjE0CjUyCjMyCjUyCjQ3CjUyCjQ4CjUyCjEzCjUzCjE5CjMKNTMKMzQKNDgKNTIKNDkKNTMKMjQKNgo1Mgo0Nwo1Mgo0Mwo1Mgo0Mwo1MwozMwozMQo1MwozNwozNwo1MgoxOAo1MgoxOAo1MwozMAo3CjUzCjE1CjE1CjUzCjE3CjM3CjUyCjIxCjUzCjQwCjMwCjUzCjkKMTkKNTIKNDAKNTMKMjkKOQo1Mgo0Nwo1Mgo0CjUyCjQKNTMKMzUKNgo1MgoxOQo1Mwo4CjM1CjUzCjI2CjMzCjUzCjIyCjgKNTIKMzIKNTIKMjIKNTIKMjQKNTMKMQoxCjUyCjgKNTMKNDYKMzgKNTMKMjMKNQo1Mwo0Mgo0Mgo1MgoxCjUyCjQ3CjUyCjI2CjUzCjE2CjE0CjUyCjYKNTMKNDUKMTYKNTIKNDIKCpRicy4=\n",
+          "legalActions": [],
+          "legalActionStrings": []
+        },
+        "status": "INACTIVE"
+      },
+      {
+        "action": {
+          "submission": -1
+        },
+        "reward": null,
+        "info": {},
+        "observation": {
+          "remainingOverageTime": 12,
+          "observationString": "{\"phase\": \"Draw\", \"current_player\": 1, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"4c\", \"upcard\": \"4h\", \"stock_size\": 10, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\", \"2h\", \"5s\", \"7c\", \"Td\", \"8d\", \"Qc\", \"9s\", \"Kd\", \"6s\", \"Ad\", \"7s\"], \"hands\": {\"0\": [], \"1\": [\"2s\", \"Qs\", \"Kc\", \"4d\", \"7d\", \"Qd\", \"7h\", \"8h\", \"Th\", \"Kh\"]}, \"deadwood\": {\"0\": null, \"1\": 78}, \"repeated_move\": 0}",
+          "currentPlayer": 1,
+          "playerId": 1,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14,0:52,0:49,1:52,1:6,0:52,0:14,1:52,1:32,0:52,0:47,1:52,1:48,0:52,0:13,1:53,-1:19,1:3,0:53,-1:34,0:48,1:52,1:49,0:53,-1:24,0:6,1:52,1:47,0:52,0:43,1:52,1:43,0:53,-1:33,0:31,1:53,-1:37,1:37,0:52,0:18,1:52,1:18,0:53,-1:30,0:7,1:53,-1:15,1:15,0:53,-1:17,0:37,1:52,1:21,0:53,-1:40,0:30,1:53,-1:9,1:19,0:52,0:40,1:53,-1:29,1:9,0:52,0:47,1:52,1:4,0:52,0:4,1:53,-1:35,1:6,0:52,0:19,1:53,-1:8,1:35,0:53,-1:26,0:33,1:53,-1:22,1:8,0:52,0:32,1:52,1:22,0:52,0:24,1:53,-1:1,1:1,0:52,0:8,1:53,-1:46,1:38,0:53,-1:23,0:5,1:53,-1:42,1:42,0:52,0:1,1:52,1:47,0:52,0:26,1:53,-1:16,1:14,0:52,0:6,1:53,-1:45,1:16,0:52,0:42\nmove_number=140\n__dict__=gASVnQIAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRYWwIAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAo1Mgo0OQo1Mgo2CjUyCjE0CjUyCjMyCjUyCjQ3CjUyCjQ4CjUyCjEzCjUzCjE5CjMKNTMKMzQKNDgKNTIKNDkKNTMKMjQKNgo1Mgo0Nwo1Mgo0Mwo1Mgo0Mwo1MwozMwozMQo1MwozNwozNwo1MgoxOAo1MgoxOAo1MwozMAo3CjUzCjE1CjE1CjUzCjE3CjM3CjUyCjIxCjUzCjQwCjMwCjUzCjkKMTkKNTIKNDAKNTMKMjkKOQo1Mgo0Nwo1Mgo0CjUyCjQKNTMKMzUKNgo1MgoxOQo1Mwo4CjM1CjUzCjI2CjMzCjUzCjIyCjgKNTIKMzIKNTIKMjIKNTIKMjQKNTMKMQoxCjUyCjgKNTMKNDYKMzgKNTMKMjMKNQo1Mwo0Mgo0Mgo1MgoxCjUyCjQ3CjUyCjI2CjUzCjE2CjE0CjUyCjYKNTMKNDUKMTYKNTIKNDIKCpRicy4=\n",
+          "legalActions": [52, 53],
+          "legalActionStrings": [
+            "Player: 1 Action: Draw upcard",
+            "Player: 1 Action: Draw stock"
+          ]
+        },
+        "status": "ACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "submission": -1
+        },
+        "reward": null,
+        "info": {},
+        "observation": {
+          "remainingOverageTime": 12,
+          "step": 100,
+          "observationString": "{\"phase\": \"Discard\", \"current_player\": 1, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"4h\", \"upcard\": null, \"stock_size\": 9, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\", \"2h\", \"5s\", \"7c\", \"Td\", \"8d\", \"Qc\", \"9s\", \"Kd\", \"6s\", \"Ad\", \"7s\", \"4h\"], \"hands\": {\"0\": [\"Ts\", \"2c\", \"4c\", \"5c\", \"Tc\", \"Jc\", \"3d\", \"9d\", \"9h\", \"Qh\"], \"1\": []}, \"deadwood\": {\"0\": 72, \"1\": null}, \"repeated_move\": 0}",
+          "currentPlayer": 1,
+          "playerId": 0,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14,0:52,0:49,1:52,1:6,0:52,0:14,1:52,1:32,0:52,0:47,1:52,1:48,0:52,0:13,1:53,-1:19,1:3,0:53,-1:34,0:48,1:52,1:49,0:53,-1:24,0:6,1:52,1:47,0:52,0:43,1:52,1:43,0:53,-1:33,0:31,1:53,-1:37,1:37,0:52,0:18,1:52,1:18,0:53,-1:30,0:7,1:53,-1:15,1:15,0:53,-1:17,0:37,1:52,1:21,0:53,-1:40,0:30,1:53,-1:9,1:19,0:52,0:40,1:53,-1:29,1:9,0:52,0:47,1:52,1:4,0:52,0:4,1:53,-1:35,1:6,0:52,0:19,1:53,-1:8,1:35,0:53,-1:26,0:33,1:53,-1:22,1:8,0:52,0:32,1:52,1:22,0:52,0:24,1:53,-1:1,1:1,0:52,0:8,1:53,-1:46,1:38,0:53,-1:23,0:5,1:53,-1:42,1:42,0:52,0:1,1:52,1:47,0:52,0:26,1:53,-1:16,1:14,0:52,0:6,1:53,-1:45,1:16,0:52,0:42,1:53,-1:2\nmove_number=142\n__dict__=gASVogIAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRYYAIAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAo1Mgo0OQo1Mgo2CjUyCjE0CjUyCjMyCjUyCjQ3CjUyCjQ4CjUyCjEzCjUzCjE5CjMKNTMKMzQKNDgKNTIKNDkKNTMKMjQKNgo1Mgo0Nwo1Mgo0Mwo1Mgo0Mwo1MwozMwozMQo1MwozNwozNwo1MgoxOAo1MgoxOAo1MwozMAo3CjUzCjE1CjE1CjUzCjE3CjM3CjUyCjIxCjUzCjQwCjMwCjUzCjkKMTkKNTIKNDAKNTMKMjkKOQo1Mgo0Nwo1Mgo0CjUyCjQKNTMKMzUKNgo1MgoxOQo1Mwo4CjM1CjUzCjI2CjMzCjUzCjIyCjgKNTIKMzIKNTIKMjIKNTIKMjQKNTMKMQoxCjUyCjgKNTMKNDYKMzgKNTMKMjMKNQo1Mwo0Mgo0Mgo1MgoxCjUyCjQ3CjUyCjI2CjUzCjE2CjE0CjUyCjYKNTMKNDUKMTYKNTIKNDIKNTMKMgoKlGJzLg==\n",
+          "legalActions": [],
+          "legalActionStrings": []
+        },
+        "status": "INACTIVE"
+      },
+      {
+        "action": {
+          "submission": 53,
+          "thoughts": "rho delta lambda xi delta chi shadow xi"
+        },
+        "reward": null,
+        "info": {
+          "actionSubmitted": 53,
+          "actionSubmittedToString": "Player: 1 Action: Draw stock",
+          "actionApplied": 53,
+          "timeTaken": 0.0,
+          "agentSelfReportedStatus": null
+        },
+        "observation": {
+          "remainingOverageTime": 12,
+          "observationString": "{\"phase\": \"Discard\", \"current_player\": 1, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"4h\", \"upcard\": null, \"stock_size\": 9, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\", \"2h\", \"5s\", \"7c\", \"Td\", \"8d\", \"Qc\", \"9s\", \"Kd\", \"6s\", \"Ad\", \"7s\", \"4h\"], \"hands\": {\"0\": [], \"1\": [\"2s\", \"3s\", \"Qs\", \"Kc\", \"4d\", \"7d\", \"Qd\", \"7h\", \"8h\", \"Th\", \"Kh\"]}, \"deadwood\": {\"0\": null, \"1\": 71}, \"repeated_move\": 0}",
+          "currentPlayer": 1,
+          "playerId": 1,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14,0:52,0:49,1:52,1:6,0:52,0:14,1:52,1:32,0:52,0:47,1:52,1:48,0:52,0:13,1:53,-1:19,1:3,0:53,-1:34,0:48,1:52,1:49,0:53,-1:24,0:6,1:52,1:47,0:52,0:43,1:52,1:43,0:53,-1:33,0:31,1:53,-1:37,1:37,0:52,0:18,1:52,1:18,0:53,-1:30,0:7,1:53,-1:15,1:15,0:53,-1:17,0:37,1:52,1:21,0:53,-1:40,0:30,1:53,-1:9,1:19,0:52,0:40,1:53,-1:29,1:9,0:52,0:47,1:52,1:4,0:52,0:4,1:53,-1:35,1:6,0:52,0:19,1:53,-1:8,1:35,0:53,-1:26,0:33,1:53,-1:22,1:8,0:52,0:32,1:52,1:22,0:52,0:24,1:53,-1:1,1:1,0:52,0:8,1:53,-1:46,1:38,0:53,-1:23,0:5,1:53,-1:42,1:42,0:52,0:1,1:52,1:47,0:52,0:26,1:53,-1:16,1:14,0:52,0:6,1:53,-1:45,1:16,0:52,0:42,1:53,-1:2\nmove_number=142\n__dict__=gASVogIAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRYYAIAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAo1Mgo0OQo1Mgo2CjUyCjE0CjUyCjMyCjUyCjQ3CjUyCjQ4CjUyCjEzCjUzCjE5CjMKNTMKMzQKNDgKNTIKNDkKNTMKMjQKNgo1Mgo0Nwo1Mgo0Mwo1Mgo0Mwo1MwozMwozMQo1MwozNwozNwo1MgoxOAo1MgoxOAo1MwozMAo3CjUzCjE1CjE1CjUzCjE3CjM3CjUyCjIxCjUzCjQwCjMwCjUzCjkKMTkKNTIKNDAKNTMKMjkKOQo1Mgo0Nwo1Mgo0CjUyCjQKNTMKMzUKNgo1MgoxOQo1Mwo4CjM1CjUzCjI2CjMzCjUzCjIyCjgKNTIKMzIKNTIKMjIKNTIKMjQKNTMKMQoxCjUyCjgKNTMKNDYKMzgKNTMKMjMKNQo1Mwo0Mgo0Mgo1MgoxCjUyCjQ3CjUyCjI2CjUzCjE2CjE0CjUyCjYKNTMKNDUKMTYKNTIKNDIKNTMKMgoKlGJzLg==\n",
+          "legalActions": [1, 2, 11, 25, 29, 32, 37, 45, 46, 48, 51],
+          "legalActionStrings": [
+            "Player: 1 Action: 2s",
+            "Player: 1 Action: 3s",
+            "Player: 1 Action: Qs",
+            "Player: 1 Action: Kc",
+            "Player: 1 Action: 4d",
+            "Player: 1 Action: 7d",
+            "Player: 1 Action: Qd",
+            "Player: 1 Action: 7h",
+            "Player: 1 Action: 8h",
+            "Player: 1 Action: Th",
+            "Player: 1 Action: Kh"
+          ]
+        },
+        "status": "ACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "submission": -1
+        },
+        "reward": null,
+        "info": {},
+        "observation": {
+          "remainingOverageTime": 12,
+          "step": 101,
+          "observationString": "{\"phase\": \"Draw\", \"current_player\": 0, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"4h\", \"upcard\": \"4d\", \"stock_size\": 9, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\", \"2h\", \"5s\", \"7c\", \"Td\", \"8d\", \"Qc\", \"9s\", \"Kd\", \"6s\", \"Ad\", \"7s\", \"4h\"], \"hands\": {\"0\": [\"Ts\", \"2c\", \"4c\", \"5c\", \"Tc\", \"Jc\", \"3d\", \"9d\", \"9h\", \"Qh\"], \"1\": []}, \"deadwood\": {\"0\": 72, \"1\": null}, \"repeated_move\": 0}",
+          "currentPlayer": 0,
+          "playerId": 0,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14,0:52,0:49,1:52,1:6,0:52,0:14,1:52,1:32,0:52,0:47,1:52,1:48,0:52,0:13,1:53,-1:19,1:3,0:53,-1:34,0:48,1:52,1:49,0:53,-1:24,0:6,1:52,1:47,0:52,0:43,1:52,1:43,0:53,-1:33,0:31,1:53,-1:37,1:37,0:52,0:18,1:52,1:18,0:53,-1:30,0:7,1:53,-1:15,1:15,0:53,-1:17,0:37,1:52,1:21,0:53,-1:40,0:30,1:53,-1:9,1:19,0:52,0:40,1:53,-1:29,1:9,0:52,0:47,1:52,1:4,0:52,0:4,1:53,-1:35,1:6,0:52,0:19,1:53,-1:8,1:35,0:53,-1:26,0:33,1:53,-1:22,1:8,0:52,0:32,1:52,1:22,0:52,0:24,1:53,-1:1,1:1,0:52,0:8,1:53,-1:46,1:38,0:53,-1:23,0:5,1:53,-1:42,1:42,0:52,0:1,1:52,1:47,0:52,0:26,1:53,-1:16,1:14,0:52,0:6,1:53,-1:45,1:16,0:52,0:42,1:53,-1:2,1:29\nmove_number=143\n__dict__=gASVpQIAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRYYwIAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAo1Mgo0OQo1Mgo2CjUyCjE0CjUyCjMyCjUyCjQ3CjUyCjQ4CjUyCjEzCjUzCjE5CjMKNTMKMzQKNDgKNTIKNDkKNTMKMjQKNgo1Mgo0Nwo1Mgo0Mwo1Mgo0Mwo1MwozMwozMQo1MwozNwozNwo1MgoxOAo1MgoxOAo1MwozMAo3CjUzCjE1CjE1CjUzCjE3CjM3CjUyCjIxCjUzCjQwCjMwCjUzCjkKMTkKNTIKNDAKNTMKMjkKOQo1Mgo0Nwo1Mgo0CjUyCjQKNTMKMzUKNgo1MgoxOQo1Mwo4CjM1CjUzCjI2CjMzCjUzCjIyCjgKNTIKMzIKNTIKMjIKNTIKMjQKNTMKMQoxCjUyCjgKNTMKNDYKMzgKNTMKMjMKNQo1Mwo0Mgo0Mgo1MgoxCjUyCjQ3CjUyCjI2CjUzCjE2CjE0CjUyCjYKNTMKNDUKMTYKNTIKNDIKNTMKMgoyOQoKlGJzLg==\n",
+          "legalActions": [52, 53],
+          "legalActionStrings": [
+            "Player: 0 Action: Draw upcard",
+            "Player: 0 Action: Draw stock"
+          ]
+        },
+        "status": "ACTIVE"
+      },
+      {
+        "action": {
+          "submission": 29,
+          "thoughts": "upsilon tau epsilon omicron nu theta consider kappa"
+        },
+        "reward": null,
+        "info": {
+          "actionSubmitted": 29,
+          "actionSubmittedToString": "Player: 1 Action: 4d",
+          "actionApplied": 29,
+          "timeTaken": 0.0,
+          "agentSelfReportedStatus": null
+        },
+        "observation": {
+          "remainingOverageTime": 12,
+          "observationString": "{\"phase\": \"Draw\", \"current_player\": 0, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"4h\", \"upcard\": \"4d\", \"stock_size\": 9, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\", \"2h\", \"5s\", \"7c\", \"Td\", \"8d\", \"Qc\", \"9s\", \"Kd\", \"6s\", \"Ad\", \"7s\", \"4h\"], \"hands\": {\"0\": [], \"1\": [\"2s\", \"3s\", \"Qs\", \"Kc\", \"7d\", \"Qd\", \"7h\", \"8h\", \"Th\", \"Kh\"]}, \"deadwood\": {\"0\": null, \"1\": 77}, \"repeated_move\": 0}",
+          "currentPlayer": 0,
+          "playerId": 1,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14,0:52,0:49,1:52,1:6,0:52,0:14,1:52,1:32,0:52,0:47,1:52,1:48,0:52,0:13,1:53,-1:19,1:3,0:53,-1:34,0:48,1:52,1:49,0:53,-1:24,0:6,1:52,1:47,0:52,0:43,1:52,1:43,0:53,-1:33,0:31,1:53,-1:37,1:37,0:52,0:18,1:52,1:18,0:53,-1:30,0:7,1:53,-1:15,1:15,0:53,-1:17,0:37,1:52,1:21,0:53,-1:40,0:30,1:53,-1:9,1:19,0:52,0:40,1:53,-1:29,1:9,0:52,0:47,1:52,1:4,0:52,0:4,1:53,-1:35,1:6,0:52,0:19,1:53,-1:8,1:35,0:53,-1:26,0:33,1:53,-1:22,1:8,0:52,0:32,1:52,1:22,0:52,0:24,1:53,-1:1,1:1,0:52,0:8,1:53,-1:46,1:38,0:53,-1:23,0:5,1:53,-1:42,1:42,0:52,0:1,1:52,1:47,0:52,0:26,1:53,-1:16,1:14,0:52,0:6,1:53,-1:45,1:16,0:52,0:42,1:53,-1:2,1:29\nmove_number=143\n__dict__=gASVpQIAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRYYwIAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAo1Mgo0OQo1Mgo2CjUyCjE0CjUyCjMyCjUyCjQ3CjUyCjQ4CjUyCjEzCjUzCjE5CjMKNTMKMzQKNDgKNTIKNDkKNTMKMjQKNgo1Mgo0Nwo1Mgo0Mwo1Mgo0Mwo1MwozMwozMQo1MwozNwozNwo1MgoxOAo1MgoxOAo1MwozMAo3CjUzCjE1CjE1CjUzCjE3CjM3CjUyCjIxCjUzCjQwCjMwCjUzCjkKMTkKNTIKNDAKNTMKMjkKOQo1Mgo0Nwo1Mgo0CjUyCjQKNTMKMzUKNgo1MgoxOQo1Mwo4CjM1CjUzCjI2CjMzCjUzCjIyCjgKNTIKMzIKNTIKMjIKNTIKMjQKNTMKMQoxCjUyCjgKNTMKNDYKMzgKNTMKMjMKNQo1Mwo0Mgo0Mgo1MgoxCjUyCjQ3CjUyCjI2CjUzCjE2CjE0CjUyCjYKNTMKNDUKMTYKNTIKNDIKNTMKMgoyOQoKlGJzLg==\n",
+          "legalActions": [],
+          "legalActionStrings": []
+        },
+        "status": "INACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "submission": 53,
+          "thoughts": "drift consider epsilon ponder chi explore horizon phi"
+        },
+        "reward": null,
+        "info": {
+          "actionSubmitted": 53,
+          "actionSubmittedToString": "Player: 0 Action: Draw stock",
+          "actionApplied": 53,
+          "timeTaken": 0.0,
+          "agentSelfReportedStatus": null
+        },
+        "observation": {
+          "remainingOverageTime": 12,
+          "step": 102,
+          "observationString": "{\"phase\": \"Discard\", \"current_player\": 0, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"4d\", \"upcard\": null, \"stock_size\": 8, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\", \"2h\", \"5s\", \"7c\", \"Td\", \"8d\", \"Qc\", \"9s\", \"Kd\", \"6s\", \"Ad\", \"7s\", \"4h\", \"4d\"], \"hands\": {\"0\": [\"Ts\", \"2c\", \"4c\", \"5c\", \"Tc\", \"Jc\", \"3d\", \"9d\", \"6h\", \"9h\", \"Qh\"], \"1\": []}, \"deadwood\": {\"0\": 68, \"1\": null}, \"repeated_move\": 0}",
+          "currentPlayer": 0,
+          "playerId": 0,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14,0:52,0:49,1:52,1:6,0:52,0:14,1:52,1:32,0:52,0:47,1:52,1:48,0:52,0:13,1:53,-1:19,1:3,0:53,-1:34,0:48,1:52,1:49,0:53,-1:24,0:6,1:52,1:47,0:52,0:43,1:52,1:43,0:53,-1:33,0:31,1:53,-1:37,1:37,0:52,0:18,1:52,1:18,0:53,-1:30,0:7,1:53,-1:15,1:15,0:53,-1:17,0:37,1:52,1:21,0:53,-1:40,0:30,1:53,-1:9,1:19,0:52,0:40,1:53,-1:29,1:9,0:52,0:47,1:52,1:4,0:52,0:4,1:53,-1:35,1:6,0:52,0:19,1:53,-1:8,1:35,0:53,-1:26,0:33,1:53,-1:22,1:8,0:52,0:32,1:52,1:22,0:52,0:24,1:53,-1:1,1:1,0:52,0:8,1:53,-1:46,1:38,0:53,-1:23,0:5,1:53,-1:42,1:42,0:52,0:1,1:52,1:47,0:52,0:26,1:53,-1:16,1:14,0:52,0:6,1:53,-1:45,1:16,0:52,0:42,1:53,-1:2,1:29,0:53,-1:44\nmove_number=145\n__dict__=gASVqwIAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRYaQIAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAo1Mgo0OQo1Mgo2CjUyCjE0CjUyCjMyCjUyCjQ3CjUyCjQ4CjUyCjEzCjUzCjE5CjMKNTMKMzQKNDgKNTIKNDkKNTMKMjQKNgo1Mgo0Nwo1Mgo0Mwo1Mgo0Mwo1MwozMwozMQo1MwozNwozNwo1MgoxOAo1MgoxOAo1MwozMAo3CjUzCjE1CjE1CjUzCjE3CjM3CjUyCjIxCjUzCjQwCjMwCjUzCjkKMTkKNTIKNDAKNTMKMjkKOQo1Mgo0Nwo1Mgo0CjUyCjQKNTMKMzUKNgo1MgoxOQo1Mwo4CjM1CjUzCjI2CjMzCjUzCjIyCjgKNTIKMzIKNTIKMjIKNTIKMjQKNTMKMQoxCjUyCjgKNTMKNDYKMzgKNTMKMjMKNQo1Mwo0Mgo0Mgo1MgoxCjUyCjQ3CjUyCjI2CjUzCjE2CjE0CjUyCjYKNTMKNDUKMTYKNTIKNDIKNTMKMgoyOQo1Mwo0NAoKlGJzLg==\n",
+          "legalActions": [9, 14, 16, 17, 22, 23, 28, 34, 44, 47, 50],
+          "legalActionStrings": [
+            "Player: 0 Action: Ts",
+            "Player: 0 Action: 2c",
+            "Player: 0 Action: 4c",
+            "Player: 0 Action: 5c",
+            "Player: 0 Action: Tc",
+            "Player: 0 Action: Jc",
+            "Player: 0 Action: 3d",
+            "Player: 0 Action: 9d",
+            "Player: 0 Action: 6h",
+            "Player: 0 Action: 9h",
+            "Player: 0 Action: Qh"
+          ]
+        },
+        "status": "ACTIVE"
+      },
+      {
+        "action": {
+          "submission": -1
+        },
+        "reward": null,
+        "info": {},
+        "observation": {
+          "remainingOverageTime": 12,
+          "observationString": "{\"phase\": \"Discard\", \"current_player\": 0, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"4d\", \"upcard\": null, \"stock_size\": 8, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\", \"2h\", \"5s\", \"7c\", \"Td\", \"8d\", \"Qc\", \"9s\", \"Kd\", \"6s\", \"Ad\", \"7s\", \"4h\", \"4d\"], \"hands\": {\"0\": [], \"1\": [\"2s\", \"3s\", \"Qs\", \"Kc\", \"7d\", \"Qd\", \"7h\", \"8h\", \"Th\", \"Kh\"]}, \"deadwood\": {\"0\": null, \"1\": 77}, \"repeated_move\": 0}",
+          "currentPlayer": 0,
+          "playerId": 1,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14,0:52,0:49,1:52,1:6,0:52,0:14,1:52,1:32,0:52,0:47,1:52,1:48,0:52,0:13,1:53,-1:19,1:3,0:53,-1:34,0:48,1:52,1:49,0:53,-1:24,0:6,1:52,1:47,0:52,0:43,1:52,1:43,0:53,-1:33,0:31,1:53,-1:37,1:37,0:52,0:18,1:52,1:18,0:53,-1:30,0:7,1:53,-1:15,1:15,0:53,-1:17,0:37,1:52,1:21,0:53,-1:40,0:30,1:53,-1:9,1:19,0:52,0:40,1:53,-1:29,1:9,0:52,0:47,1:52,1:4,0:52,0:4,1:53,-1:35,1:6,0:52,0:19,1:53,-1:8,1:35,0:53,-1:26,0:33,1:53,-1:22,1:8,0:52,0:32,1:52,1:22,0:52,0:24,1:53,-1:1,1:1,0:52,0:8,1:53,-1:46,1:38,0:53,-1:23,0:5,1:53,-1:42,1:42,0:52,0:1,1:52,1:47,0:52,0:26,1:53,-1:16,1:14,0:52,0:6,1:53,-1:45,1:16,0:52,0:42,1:53,-1:2,1:29,0:53,-1:44\nmove_number=145\n__dict__=gASVqwIAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRYaQIAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAo1Mgo0OQo1Mgo2CjUyCjE0CjUyCjMyCjUyCjQ3CjUyCjQ4CjUyCjEzCjUzCjE5CjMKNTMKMzQKNDgKNTIKNDkKNTMKMjQKNgo1Mgo0Nwo1Mgo0Mwo1Mgo0Mwo1MwozMwozMQo1MwozNwozNwo1MgoxOAo1MgoxOAo1MwozMAo3CjUzCjE1CjE1CjUzCjE3CjM3CjUyCjIxCjUzCjQwCjMwCjUzCjkKMTkKNTIKNDAKNTMKMjkKOQo1Mgo0Nwo1Mgo0CjUyCjQKNTMKMzUKNgo1MgoxOQo1Mwo4CjM1CjUzCjI2CjMzCjUzCjIyCjgKNTIKMzIKNTIKMjIKNTIKMjQKNTMKMQoxCjUyCjgKNTMKNDYKMzgKNTMKMjMKNQo1Mwo0Mgo0Mgo1MgoxCjUyCjQ3CjUyCjI2CjUzCjE2CjE0CjUyCjYKNTMKNDUKMTYKNTIKNDIKNTMKMgoyOQo1Mwo0NAoKlGJzLg==\n",
+          "legalActions": [],
+          "legalActionStrings": []
+        },
+        "status": "INACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "submission": 50,
+          "thoughts": "lambda ember explore kappa nu ripple imagine ponder"
+        },
+        "reward": null,
+        "info": {
+          "actionSubmitted": 50,
+          "actionSubmittedToString": "Player: 0 Action: Qh",
+          "actionApplied": 50,
+          "timeTaken": 0.0,
+          "agentSelfReportedStatus": null
+        },
+        "observation": {
+          "remainingOverageTime": 12,
+          "step": 103,
+          "observationString": "{\"phase\": \"Draw\", \"current_player\": 1, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"4d\", \"upcard\": \"Qh\", \"stock_size\": 8, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\", \"2h\", \"5s\", \"7c\", \"Td\", \"8d\", \"Qc\", \"9s\", \"Kd\", \"6s\", \"Ad\", \"7s\", \"4h\", \"4d\"], \"hands\": {\"0\": [\"Ts\", \"2c\", \"4c\", \"5c\", \"Tc\", \"Jc\", \"3d\", \"9d\", \"6h\", \"9h\"], \"1\": []}, \"deadwood\": {\"0\": 68, \"1\": null}, \"repeated_move\": 0}",
+          "currentPlayer": 1,
+          "playerId": 0,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14,0:52,0:49,1:52,1:6,0:52,0:14,1:52,1:32,0:52,0:47,1:52,1:48,0:52,0:13,1:53,-1:19,1:3,0:53,-1:34,0:48,1:52,1:49,0:53,-1:24,0:6,1:52,1:47,0:52,0:43,1:52,1:43,0:53,-1:33,0:31,1:53,-1:37,1:37,0:52,0:18,1:52,1:18,0:53,-1:30,0:7,1:53,-1:15,1:15,0:53,-1:17,0:37,1:52,1:21,0:53,-1:40,0:30,1:53,-1:9,1:19,0:52,0:40,1:53,-1:29,1:9,0:52,0:47,1:52,1:4,0:52,0:4,1:53,-1:35,1:6,0:52,0:19,1:53,-1:8,1:35,0:53,-1:26,0:33,1:53,-1:22,1:8,0:52,0:32,1:52,1:22,0:52,0:24,1:53,-1:1,1:1,0:52,0:8,1:53,-1:46,1:38,0:53,-1:23,0:5,1:53,-1:42,1:42,0:52,0:1,1:52,1:47,0:52,0:26,1:53,-1:16,1:14,0:52,0:6,1:53,-1:45,1:16,0:52,0:42,1:53,-1:2,1:29,0:53,-1:44,0:50\nmove_number=146\n__dict__=gASVrgIAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRYbAIAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAo1Mgo0OQo1Mgo2CjUyCjE0CjUyCjMyCjUyCjQ3CjUyCjQ4CjUyCjEzCjUzCjE5CjMKNTMKMzQKNDgKNTIKNDkKNTMKMjQKNgo1Mgo0Nwo1Mgo0Mwo1Mgo0Mwo1MwozMwozMQo1MwozNwozNwo1MgoxOAo1MgoxOAo1MwozMAo3CjUzCjE1CjE1CjUzCjE3CjM3CjUyCjIxCjUzCjQwCjMwCjUzCjkKMTkKNTIKNDAKNTMKMjkKOQo1Mgo0Nwo1Mgo0CjUyCjQKNTMKMzUKNgo1MgoxOQo1Mwo4CjM1CjUzCjI2CjMzCjUzCjIyCjgKNTIKMzIKNTIKMjIKNTIKMjQKNTMKMQoxCjUyCjgKNTMKNDYKMzgKNTMKMjMKNQo1Mwo0Mgo0Mgo1MgoxCjUyCjQ3CjUyCjI2CjUzCjE2CjE0CjUyCjYKNTMKNDUKMTYKNTIKNDIKNTMKMgoyOQo1Mwo0NAo1MAoKlGJzLg==\n",
+          "legalActions": [],
+          "legalActionStrings": []
+        },
+        "status": "INACTIVE"
+      },
+      {
+        "action": {
+          "submission": -1
+        },
+        "reward": null,
+        "info": {},
+        "observation": {
+          "remainingOverageTime": 12,
+          "observationString": "{\"phase\": \"Draw\", \"current_player\": 1, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"4d\", \"upcard\": \"Qh\", \"stock_size\": 8, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\", \"2h\", \"5s\", \"7c\", \"Td\", \"8d\", \"Qc\", \"9s\", \"Kd\", \"6s\", \"Ad\", \"7s\", \"4h\", \"4d\"], \"hands\": {\"0\": [], \"1\": [\"2s\", \"3s\", \"Qs\", \"Kc\", \"7d\", \"Qd\", \"7h\", \"8h\", \"Th\", \"Kh\"]}, \"deadwood\": {\"0\": null, \"1\": 77}, \"repeated_move\": 0}",
+          "currentPlayer": 1,
+          "playerId": 1,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14,0:52,0:49,1:52,1:6,0:52,0:14,1:52,1:32,0:52,0:47,1:52,1:48,0:52,0:13,1:53,-1:19,1:3,0:53,-1:34,0:48,1:52,1:49,0:53,-1:24,0:6,1:52,1:47,0:52,0:43,1:52,1:43,0:53,-1:33,0:31,1:53,-1:37,1:37,0:52,0:18,1:52,1:18,0:53,-1:30,0:7,1:53,-1:15,1:15,0:53,-1:17,0:37,1:52,1:21,0:53,-1:40,0:30,1:53,-1:9,1:19,0:52,0:40,1:53,-1:29,1:9,0:52,0:47,1:52,1:4,0:52,0:4,1:53,-1:35,1:6,0:52,0:19,1:53,-1:8,1:35,0:53,-1:26,0:33,1:53,-1:22,1:8,0:52,0:32,1:52,1:22,0:52,0:24,1:53,-1:1,1:1,0:52,0:8,1:53,-1:46,1:38,0:53,-1:23,0:5,1:53,-1:42,1:42,0:52,0:1,1:52,1:47,0:52,0:26,1:53,-1:16,1:14,0:52,0:6,1:53,-1:45,1:16,0:52,0:42,1:53,-1:2,1:29,0:53,-1:44,0:50\nmove_number=146\n__dict__=gASVrgIAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRYbAIAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAo1Mgo0OQo1Mgo2CjUyCjE0CjUyCjMyCjUyCjQ3CjUyCjQ4CjUyCjEzCjUzCjE5CjMKNTMKMzQKNDgKNTIKNDkKNTMKMjQKNgo1Mgo0Nwo1Mgo0Mwo1Mgo0Mwo1MwozMwozMQo1MwozNwozNwo1MgoxOAo1MgoxOAo1MwozMAo3CjUzCjE1CjE1CjUzCjE3CjM3CjUyCjIxCjUzCjQwCjMwCjUzCjkKMTkKNTIKNDAKNTMKMjkKOQo1Mgo0Nwo1Mgo0CjUyCjQKNTMKMzUKNgo1MgoxOQo1Mwo4CjM1CjUzCjI2CjMzCjUzCjIyCjgKNTIKMzIKNTIKMjIKNTIKMjQKNTMKMQoxCjUyCjgKNTMKNDYKMzgKNTMKMjMKNQo1Mwo0Mgo0Mgo1MgoxCjUyCjQ3CjUyCjI2CjUzCjE2CjE0CjUyCjYKNTMKNDUKMTYKNTIKNDIKNTMKMgoyOQo1Mwo0NAo1MAoKlGJzLg==\n",
+          "legalActions": [52, 53],
+          "legalActionStrings": [
+            "Player: 1 Action: Draw upcard",
+            "Player: 1 Action: Draw stock"
+          ]
+        },
+        "status": "ACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "submission": -1
+        },
+        "reward": null,
+        "info": {},
+        "observation": {
+          "remainingOverageTime": 12,
+          "step": 104,
+          "observationString": "{\"phase\": \"Discard\", \"current_player\": 1, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"Qh\", \"upcard\": null, \"stock_size\": 8, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\", \"2h\", \"5s\", \"7c\", \"Td\", \"8d\", \"Qc\", \"9s\", \"Kd\", \"6s\", \"Ad\", \"7s\", \"4h\", \"4d\"], \"hands\": {\"0\": [\"Ts\", \"2c\", \"4c\", \"5c\", \"Tc\", \"Jc\", \"3d\", \"9d\", \"6h\", \"9h\"], \"1\": []}, \"deadwood\": {\"0\": 68, \"1\": null}, \"repeated_move\": 0}",
+          "currentPlayer": 1,
+          "playerId": 0,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14,0:52,0:49,1:52,1:6,0:52,0:14,1:52,1:32,0:52,0:47,1:52,1:48,0:52,0:13,1:53,-1:19,1:3,0:53,-1:34,0:48,1:52,1:49,0:53,-1:24,0:6,1:52,1:47,0:52,0:43,1:52,1:43,0:53,-1:33,0:31,1:53,-1:37,1:37,0:52,0:18,1:52,1:18,0:53,-1:30,0:7,1:53,-1:15,1:15,0:53,-1:17,0:37,1:52,1:21,0:53,-1:40,0:30,1:53,-1:9,1:19,0:52,0:40,1:53,-1:29,1:9,0:52,0:47,1:52,1:4,0:52,0:4,1:53,-1:35,1:6,0:52,0:19,1:53,-1:8,1:35,0:53,-1:26,0:33,1:53,-1:22,1:8,0:52,0:32,1:52,1:22,0:52,0:24,1:53,-1:1,1:1,0:52,0:8,1:53,-1:46,1:38,0:53,-1:23,0:5,1:53,-1:42,1:42,0:52,0:1,1:52,1:47,0:52,0:26,1:53,-1:16,1:14,0:52,0:6,1:53,-1:45,1:16,0:52,0:42,1:53,-1:2,1:29,0:53,-1:44,0:50,1:52\nmove_number=147\n__dict__=gASVsQIAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRYbwIAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAo1Mgo0OQo1Mgo2CjUyCjE0CjUyCjMyCjUyCjQ3CjUyCjQ4CjUyCjEzCjUzCjE5CjMKNTMKMzQKNDgKNTIKNDkKNTMKMjQKNgo1Mgo0Nwo1Mgo0Mwo1Mgo0Mwo1MwozMwozMQo1MwozNwozNwo1MgoxOAo1MgoxOAo1MwozMAo3CjUzCjE1CjE1CjUzCjE3CjM3CjUyCjIxCjUzCjQwCjMwCjUzCjkKMTkKNTIKNDAKNTMKMjkKOQo1Mgo0Nwo1Mgo0CjUyCjQKNTMKMzUKNgo1MgoxOQo1Mwo4CjM1CjUzCjI2CjMzCjUzCjIyCjgKNTIKMzIKNTIKMjIKNTIKMjQKNTMKMQoxCjUyCjgKNTMKNDYKMzgKNTMKMjMKNQo1Mwo0Mgo0Mgo1MgoxCjUyCjQ3CjUyCjI2CjUzCjE2CjE0CjUyCjYKNTMKNDUKMTYKNTIKNDIKNTMKMgoyOQo1Mwo0NAo1MAo1MgoKlGJzLg==\n",
+          "legalActions": [],
+          "legalActionStrings": []
+        },
+        "status": "INACTIVE"
+      },
+      {
+        "action": {
+          "submission": 52,
+          "thoughts": "wonder wonder zeta upsilon zeta muse iota eta"
+        },
+        "reward": null,
+        "info": {
+          "actionSubmitted": 52,
+          "actionSubmittedToString": "Player: 1 Action: Draw upcard",
+          "actionApplied": 52,
+          "timeTaken": 0.0,
+          "agentSelfReportedStatus": null
+        },
+        "observation": {
+          "remainingOverageTime": 12,
+          "observationString": "{\"phase\": \"Discard\", \"current_player\": 1, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"Qh\", \"upcard\": null, \"stock_size\": 8, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\", \"2h\", \"5s\", \"7c\", \"Td\", \"8d\", \"Qc\", \"9s\", \"Kd\", \"6s\", \"Ad\", \"7s\", \"4h\", \"4d\"], \"hands\": {\"0\": [], \"1\": [\"2s\", \"3s\", \"Qs\", \"Kc\", \"7d\", \"Qd\", \"7h\", \"8h\", \"Th\", \"Qh\", \"Kh\"]}, \"deadwood\": {\"0\": null, \"1\": 47}, \"repeated_move\": 0}",
+          "currentPlayer": 1,
+          "playerId": 1,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14,0:52,0:49,1:52,1:6,0:52,0:14,1:52,1:32,0:52,0:47,1:52,1:48,0:52,0:13,1:53,-1:19,1:3,0:53,-1:34,0:48,1:52,1:49,0:53,-1:24,0:6,1:52,1:47,0:52,0:43,1:52,1:43,0:53,-1:33,0:31,1:53,-1:37,1:37,0:52,0:18,1:52,1:18,0:53,-1:30,0:7,1:53,-1:15,1:15,0:53,-1:17,0:37,1:52,1:21,0:53,-1:40,0:30,1:53,-1:9,1:19,0:52,0:40,1:53,-1:29,1:9,0:52,0:47,1:52,1:4,0:52,0:4,1:53,-1:35,1:6,0:52,0:19,1:53,-1:8,1:35,0:53,-1:26,0:33,1:53,-1:22,1:8,0:52,0:32,1:52,1:22,0:52,0:24,1:53,-1:1,1:1,0:52,0:8,1:53,-1:46,1:38,0:53,-1:23,0:5,1:53,-1:42,1:42,0:52,0:1,1:52,1:47,0:52,0:26,1:53,-1:16,1:14,0:52,0:6,1:53,-1:45,1:16,0:52,0:42,1:53,-1:2,1:29,0:53,-1:44,0:50,1:52\nmove_number=147\n__dict__=gASVsQIAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRYbwIAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAo1Mgo0OQo1Mgo2CjUyCjE0CjUyCjMyCjUyCjQ3CjUyCjQ4CjUyCjEzCjUzCjE5CjMKNTMKMzQKNDgKNTIKNDkKNTMKMjQKNgo1Mgo0Nwo1Mgo0Mwo1Mgo0Mwo1MwozMwozMQo1MwozNwozNwo1MgoxOAo1MgoxOAo1MwozMAo3CjUzCjE1CjE1CjUzCjE3CjM3CjUyCjIxCjUzCjQwCjMwCjUzCjkKMTkKNTIKNDAKNTMKMjkKOQo1Mgo0Nwo1Mgo0CjUyCjQKNTMKMzUKNgo1MgoxOQo1Mwo4CjM1CjUzCjI2CjMzCjUzCjIyCjgKNTIKMzIKNTIKMjIKNTIKMjQKNTMKMQoxCjUyCjgKNTMKNDYKMzgKNTMKMjMKNQo1Mwo0Mgo0Mgo1MgoxCjUyCjQ3CjUyCjI2CjUzCjE2CjE0CjUyCjYKNTMKNDUKMTYKNTIKNDIKNTMKMgoyOQo1Mwo0NAo1MAo1MgoKlGJzLg==\n",
+          "legalActions": [1, 2, 11, 25, 32, 37, 45, 46, 48, 50, 51],
+          "legalActionStrings": [
+            "Player: 1 Action: 2s",
+            "Player: 1 Action: 3s",
+            "Player: 1 Action: Qs",
+            "Player: 1 Action: Kc",
+            "Player: 1 Action: 7d",
+            "Player: 1 Action: Qd",
+            "Player: 1 Action: 7h",
+            "Player: 1 Action: 8h",
+            "Player: 1 Action: Th",
+            "Player: 1 Action: Qh",
+            "Player: 1 Action: Kh"
+          ]
+        },
+        "status": "ACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "submission": -1
+        },
+        "reward": null,
+        "info": {},
+        "observation": {
+          "remainingOverageTime": 12,
+          "step": 105,
+          "observationString": "{\"phase\": \"Draw\", \"current_player\": 0, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"Qh\", \"upcard\": \"7d\", \"stock_size\": 8, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\", \"2h\", \"5s\", \"7c\", \"Td\", \"8d\", \"Qc\", \"9s\", \"Kd\", \"6s\", \"Ad\", \"7s\", \"4h\", \"4d\"], \"hands\": {\"0\": [\"Ts\", \"2c\", \"4c\", \"5c\", \"Tc\", \"Jc\", \"3d\", \"9d\", \"6h\", \"9h\"], \"1\": []}, \"deadwood\": {\"0\": 68, \"1\": null}, \"repeated_move\": 0}",
+          "currentPlayer": 0,
+          "playerId": 0,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14,0:52,0:49,1:52,1:6,0:52,0:14,1:52,1:32,0:52,0:47,1:52,1:48,0:52,0:13,1:53,-1:19,1:3,0:53,-1:34,0:48,1:52,1:49,0:53,-1:24,0:6,1:52,1:47,0:52,0:43,1:52,1:43,0:53,-1:33,0:31,1:53,-1:37,1:37,0:52,0:18,1:52,1:18,0:53,-1:30,0:7,1:53,-1:15,1:15,0:53,-1:17,0:37,1:52,1:21,0:53,-1:40,0:30,1:53,-1:9,1:19,0:52,0:40,1:53,-1:29,1:9,0:52,0:47,1:52,1:4,0:52,0:4,1:53,-1:35,1:6,0:52,0:19,1:53,-1:8,1:35,0:53,-1:26,0:33,1:53,-1:22,1:8,0:52,0:32,1:52,1:22,0:52,0:24,1:53,-1:1,1:1,0:52,0:8,1:53,-1:46,1:38,0:53,-1:23,0:5,1:53,-1:42,1:42,0:52,0:1,1:52,1:47,0:52,0:26,1:53,-1:16,1:14,0:52,0:6,1:53,-1:45,1:16,0:52,0:42,1:53,-1:2,1:29,0:53,-1:44,0:50,1:52,1:32\nmove_number=148\n__dict__=gASVtAIAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRYcgIAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAo1Mgo0OQo1Mgo2CjUyCjE0CjUyCjMyCjUyCjQ3CjUyCjQ4CjUyCjEzCjUzCjE5CjMKNTMKMzQKNDgKNTIKNDkKNTMKMjQKNgo1Mgo0Nwo1Mgo0Mwo1Mgo0Mwo1MwozMwozMQo1MwozNwozNwo1MgoxOAo1MgoxOAo1MwozMAo3CjUzCjE1CjE1CjUzCjE3CjM3CjUyCjIxCjUzCjQwCjMwCjUzCjkKMTkKNTIKNDAKNTMKMjkKOQo1Mgo0Nwo1Mgo0CjUyCjQKNTMKMzUKNgo1MgoxOQo1Mwo4CjM1CjUzCjI2CjMzCjUzCjIyCjgKNTIKMzIKNTIKMjIKNTIKMjQKNTMKMQoxCjUyCjgKNTMKNDYKMzgKNTMKMjMKNQo1Mwo0Mgo0Mgo1MgoxCjUyCjQ3CjUyCjI2CjUzCjE2CjE0CjUyCjYKNTMKNDUKMTYKNTIKNDIKNTMKMgoyOQo1Mwo0NAo1MAo1MgozMgoKlGJzLg==\n",
+          "legalActions": [52, 53],
+          "legalActionStrings": [
+            "Player: 0 Action: Draw upcard",
+            "Player: 0 Action: Draw stock"
+          ]
+        },
+        "status": "ACTIVE"
+      },
+      {
+        "action": {
+          "submission": 32,
+          "thoughts": "echo omicron ripple rho shadow lambda alpha psi"
+        },
+        "reward": null,
+        "info": {
+          "actionSubmitted": 32,
+          "actionSubmittedToString": "Player: 1 Action: 7d",
+          "actionApplied": 32,
+          "timeTaken": 0.0,
+          "agentSelfReportedStatus": null
+        },
+        "observation": {
+          "remainingOverageTime": 12,
+          "observationString": "{\"phase\": \"Draw\", \"current_player\": 0, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"Qh\", \"upcard\": \"7d\", \"stock_size\": 8, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\", \"2h\", \"5s\", \"7c\", \"Td\", \"8d\", \"Qc\", \"9s\", \"Kd\", \"6s\", \"Ad\", \"7s\", \"4h\", \"4d\"], \"hands\": {\"0\": [], \"1\": [\"2s\", \"3s\", \"Qs\", \"Kc\", \"Qd\", \"7h\", \"8h\", \"Th\", \"Qh\", \"Kh\"]}, \"deadwood\": {\"0\": null, \"1\": 50}, \"repeated_move\": 0}",
+          "currentPlayer": 0,
+          "playerId": 1,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14,0:52,0:49,1:52,1:6,0:52,0:14,1:52,1:32,0:52,0:47,1:52,1:48,0:52,0:13,1:53,-1:19,1:3,0:53,-1:34,0:48,1:52,1:49,0:53,-1:24,0:6,1:52,1:47,0:52,0:43,1:52,1:43,0:53,-1:33,0:31,1:53,-1:37,1:37,0:52,0:18,1:52,1:18,0:53,-1:30,0:7,1:53,-1:15,1:15,0:53,-1:17,0:37,1:52,1:21,0:53,-1:40,0:30,1:53,-1:9,1:19,0:52,0:40,1:53,-1:29,1:9,0:52,0:47,1:52,1:4,0:52,0:4,1:53,-1:35,1:6,0:52,0:19,1:53,-1:8,1:35,0:53,-1:26,0:33,1:53,-1:22,1:8,0:52,0:32,1:52,1:22,0:52,0:24,1:53,-1:1,1:1,0:52,0:8,1:53,-1:46,1:38,0:53,-1:23,0:5,1:53,-1:42,1:42,0:52,0:1,1:52,1:47,0:52,0:26,1:53,-1:16,1:14,0:52,0:6,1:53,-1:45,1:16,0:52,0:42,1:53,-1:2,1:29,0:53,-1:44,0:50,1:52,1:32\nmove_number=148\n__dict__=gASVtAIAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRYcgIAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAo1Mgo0OQo1Mgo2CjUyCjE0CjUyCjMyCjUyCjQ3CjUyCjQ4CjUyCjEzCjUzCjE5CjMKNTMKMzQKNDgKNTIKNDkKNTMKMjQKNgo1Mgo0Nwo1Mgo0Mwo1Mgo0Mwo1MwozMwozMQo1MwozNwozNwo1MgoxOAo1MgoxOAo1MwozMAo3CjUzCjE1CjE1CjUzCjE3CjM3CjUyCjIxCjUzCjQwCjMwCjUzCjkKMTkKNTIKNDAKNTMKMjkKOQo1Mgo0Nwo1Mgo0CjUyCjQKNTMKMzUKNgo1MgoxOQo1Mwo4CjM1CjUzCjI2CjMzCjUzCjIyCjgKNTIKMzIKNTIKMjIKNTIKMjQKNTMKMQoxCjUyCjgKNTMKNDYKMzgKNTMKMjMKNQo1Mwo0Mgo0Mgo1MgoxCjUyCjQ3CjUyCjI2CjUzCjE2CjE0CjUyCjYKNTMKNDUKMTYKNTIKNDIKNTMKMgoyOQo1Mwo0NAo1MAo1MgozMgoKlGJzLg==\n",
+          "legalActions": [],
+          "legalActionStrings": []
+        },
+        "status": "INACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "submission": 52,
+          "thoughts": "psi phi shadow horizon epsilon nu alpha drift"
+        },
+        "reward": null,
+        "info": {
+          "actionSubmitted": 52,
+          "actionSubmittedToString": "Player: 0 Action: Draw upcard",
+          "actionApplied": 52,
+          "timeTaken": 0.0,
+          "agentSelfReportedStatus": null
+        },
+        "observation": {
+          "remainingOverageTime": 12,
+          "step": 106,
+          "observationString": "{\"phase\": \"Discard\", \"current_player\": 0, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"7d\", \"upcard\": null, \"stock_size\": 8, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\", \"2h\", \"5s\", \"7c\", \"Td\", \"8d\", \"Qc\", \"9s\", \"Kd\", \"6s\", \"Ad\", \"7s\", \"4h\", \"4d\"], \"hands\": {\"0\": [\"Ts\", \"2c\", \"4c\", \"5c\", \"Tc\", \"Jc\", \"3d\", \"7d\", \"9d\", \"6h\", \"9h\"], \"1\": []}, \"deadwood\": {\"0\": 65, \"1\": null}, \"repeated_move\": 0}",
+          "currentPlayer": 0,
+          "playerId": 0,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14,0:52,0:49,1:52,1:6,0:52,0:14,1:52,1:32,0:52,0:47,1:52,1:48,0:52,0:13,1:53,-1:19,1:3,0:53,-1:34,0:48,1:52,1:49,0:53,-1:24,0:6,1:52,1:47,0:52,0:43,1:52,1:43,0:53,-1:33,0:31,1:53,-1:37,1:37,0:52,0:18,1:52,1:18,0:53,-1:30,0:7,1:53,-1:15,1:15,0:53,-1:17,0:37,1:52,1:21,0:53,-1:40,0:30,1:53,-1:9,1:19,0:52,0:40,1:53,-1:29,1:9,0:52,0:47,1:52,1:4,0:52,0:4,1:53,-1:35,1:6,0:52,0:19,1:53,-1:8,1:35,0:53,-1:26,0:33,1:53,-1:22,1:8,0:52,0:32,1:52,1:22,0:52,0:24,1:53,-1:1,1:1,0:52,0:8,1:53,-1:46,1:38,0:53,-1:23,0:5,1:53,-1:42,1:42,0:52,0:1,1:52,1:47,0:52,0:26,1:53,-1:16,1:14,0:52,0:6,1:53,-1:45,1:16,0:52,0:42,1:53,-1:2,1:29,0:53,-1:44,0:50,1:52,1:32,0:52\nmove_number=149\n__dict__=gASVtwIAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRYdQIAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAo1Mgo0OQo1Mgo2CjUyCjE0CjUyCjMyCjUyCjQ3CjUyCjQ4CjUyCjEzCjUzCjE5CjMKNTMKMzQKNDgKNTIKNDkKNTMKMjQKNgo1Mgo0Nwo1Mgo0Mwo1Mgo0Mwo1MwozMwozMQo1MwozNwozNwo1MgoxOAo1MgoxOAo1MwozMAo3CjUzCjE1CjE1CjUzCjE3CjM3CjUyCjIxCjUzCjQwCjMwCjUzCjkKMTkKNTIKNDAKNTMKMjkKOQo1Mgo0Nwo1Mgo0CjUyCjQKNTMKMzUKNgo1MgoxOQo1Mwo4CjM1CjUzCjI2CjMzCjUzCjIyCjgKNTIKMzIKNTIKMjIKNTIKMjQKNTMKMQoxCjUyCjgKNTMKNDYKMzgKNTMKMjMKNQo1Mwo0Mgo0Mgo1MgoxCjUyCjQ3CjUyCjI2CjUzCjE2CjE0CjUyCjYKNTMKNDUKMTYKNTIKNDIKNTMKMgoyOQo1Mwo0NAo1MAo1MgozMgo1MgoKlGJzLg==\n",
+          "legalActions": [9, 14, 16, 17, 22, 23, 28, 32, 34, 44, 47],
+          "legalActionStrings": [
+            "Player: 0 Action: Ts",
+            "Player: 0 Action: 2c",
+            "Player: 0 Action: 4c",
+            "Player: 0 Action: 5c",
+            "Player: 0 Action: Tc",
+            "Player: 0 Action: Jc",
+            "Player: 0 Action: 3d",
+            "Player: 0 Action: 7d",
+            "Player: 0 Action: 9d",
+            "Player: 0 Action: 6h",
+            "Player: 0 Action: 9h"
+          ]
+        },
+        "status": "ACTIVE"
+      },
+      {
+        "action": {
+          "submission": -1
+        },
+        "reward": null,
+        "info": {},
+        "observation": {
+          "remainingOverageTime": 12,
+          "observationString": "{\"phase\": \"Discard\", \"current_player\": 0, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"7d\", \"upcard\": null, \"stock_size\": 8, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\", \"2h\", \"5s\", \"7c\", \"Td\", \"8d\", \"Qc\", \"9s\", \"Kd\", \"6s\", \"Ad\", \"7s\", \"4h\", \"4d\"], \"hands\": {\"0\": [], \"1\": [\"2s\", \"3s\", \"Qs\", \"Kc\", \"Qd\", \"7h\", \"8h\", \"Th\", \"Qh\", \"Kh\"]}, \"deadwood\": {\"0\": null, \"1\": 50}, \"repeated_move\": 0}",
+          "currentPlayer": 0,
+          "playerId": 1,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14,0:52,0:49,1:52,1:6,0:52,0:14,1:52,1:32,0:52,0:47,1:52,1:48,0:52,0:13,1:53,-1:19,1:3,0:53,-1:34,0:48,1:52,1:49,0:53,-1:24,0:6,1:52,1:47,0:52,0:43,1:52,1:43,0:53,-1:33,0:31,1:53,-1:37,1:37,0:52,0:18,1:52,1:18,0:53,-1:30,0:7,1:53,-1:15,1:15,0:53,-1:17,0:37,1:52,1:21,0:53,-1:40,0:30,1:53,-1:9,1:19,0:52,0:40,1:53,-1:29,1:9,0:52,0:47,1:52,1:4,0:52,0:4,1:53,-1:35,1:6,0:52,0:19,1:53,-1:8,1:35,0:53,-1:26,0:33,1:53,-1:22,1:8,0:52,0:32,1:52,1:22,0:52,0:24,1:53,-1:1,1:1,0:52,0:8,1:53,-1:46,1:38,0:53,-1:23,0:5,1:53,-1:42,1:42,0:52,0:1,1:52,1:47,0:52,0:26,1:53,-1:16,1:14,0:52,0:6,1:53,-1:45,1:16,0:52,0:42,1:53,-1:2,1:29,0:53,-1:44,0:50,1:52,1:32,0:52\nmove_number=149\n__dict__=gASVtwIAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRYdQIAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAo1Mgo0OQo1Mgo2CjUyCjE0CjUyCjMyCjUyCjQ3CjUyCjQ4CjUyCjEzCjUzCjE5CjMKNTMKMzQKNDgKNTIKNDkKNTMKMjQKNgo1Mgo0Nwo1Mgo0Mwo1Mgo0Mwo1MwozMwozMQo1MwozNwozNwo1MgoxOAo1MgoxOAo1MwozMAo3CjUzCjE1CjE1CjUzCjE3CjM3CjUyCjIxCjUzCjQwCjMwCjUzCjkKMTkKNTIKNDAKNTMKMjkKOQo1Mgo0Nwo1Mgo0CjUyCjQKNTMKMzUKNgo1MgoxOQo1Mwo4CjM1CjUzCjI2CjMzCjUzCjIyCjgKNTIKMzIKNTIKMjIKNTIKMjQKNTMKMQoxCjUyCjgKNTMKNDYKMzgKNTMKMjMKNQo1Mwo0Mgo0Mgo1MgoxCjUyCjQ3CjUyCjI2CjUzCjE2CjE0CjUyCjYKNTMKNDUKMTYKNTIKNDIKNTMKMgoyOQo1Mwo0NAo1MAo1MgozMgo1MgoKlGJzLg==\n",
+          "legalActions": [],
+          "legalActionStrings": []
+        },
+        "status": "INACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "submission": 32,
+          "thoughts": "psi cascade wonder kappa imagine wonder lantern ripple"
+        },
+        "reward": null,
+        "info": {
+          "actionSubmitted": 32,
+          "actionSubmittedToString": "Player: 0 Action: 7d",
+          "actionApplied": 32,
+          "timeTaken": 0.0,
+          "agentSelfReportedStatus": null
+        },
+        "observation": {
+          "remainingOverageTime": 12,
+          "step": 107,
+          "observationString": "{\"phase\": \"Draw\", \"current_player\": 1, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"7d\", \"upcard\": \"7d\", \"stock_size\": 8, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\", \"2h\", \"5s\", \"7c\", \"Td\", \"8d\", \"Qc\", \"9s\", \"Kd\", \"6s\", \"Ad\", \"7s\", \"4h\", \"4d\"], \"hands\": {\"0\": [\"Ts\", \"2c\", \"4c\", \"5c\", \"Tc\", \"Jc\", \"3d\", \"9d\", \"6h\", \"9h\"], \"1\": []}, \"deadwood\": {\"0\": 68, \"1\": null}, \"repeated_move\": 1}",
+          "currentPlayer": 1,
+          "playerId": 0,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14,0:52,0:49,1:52,1:6,0:52,0:14,1:52,1:32,0:52,0:47,1:52,1:48,0:52,0:13,1:53,-1:19,1:3,0:53,-1:34,0:48,1:52,1:49,0:53,-1:24,0:6,1:52,1:47,0:52,0:43,1:52,1:43,0:53,-1:33,0:31,1:53,-1:37,1:37,0:52,0:18,1:52,1:18,0:53,-1:30,0:7,1:53,-1:15,1:15,0:53,-1:17,0:37,1:52,1:21,0:53,-1:40,0:30,1:53,-1:9,1:19,0:52,0:40,1:53,-1:29,1:9,0:52,0:47,1:52,1:4,0:52,0:4,1:53,-1:35,1:6,0:52,0:19,1:53,-1:8,1:35,0:53,-1:26,0:33,1:53,-1:22,1:8,0:52,0:32,1:52,1:22,0:52,0:24,1:53,-1:1,1:1,0:52,0:8,1:53,-1:46,1:38,0:53,-1:23,0:5,1:53,-1:42,1:42,0:52,0:1,1:52,1:47,0:52,0:26,1:53,-1:16,1:14,0:52,0:6,1:53,-1:45,1:16,0:52,0:42,1:53,-1:2,1:29,0:53,-1:44,0:50,1:52,1:32,0:52,0:32\nmove_number=150\n__dict__=gASVugIAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRYeAIAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAo1Mgo0OQo1Mgo2CjUyCjE0CjUyCjMyCjUyCjQ3CjUyCjQ4CjUyCjEzCjUzCjE5CjMKNTMKMzQKNDgKNTIKNDkKNTMKMjQKNgo1Mgo0Nwo1Mgo0Mwo1Mgo0Mwo1MwozMwozMQo1MwozNwozNwo1MgoxOAo1MgoxOAo1MwozMAo3CjUzCjE1CjE1CjUzCjE3CjM3CjUyCjIxCjUzCjQwCjMwCjUzCjkKMTkKNTIKNDAKNTMKMjkKOQo1Mgo0Nwo1Mgo0CjUyCjQKNTMKMzUKNgo1MgoxOQo1Mwo4CjM1CjUzCjI2CjMzCjUzCjIyCjgKNTIKMzIKNTIKMjIKNTIKMjQKNTMKMQoxCjUyCjgKNTMKNDYKMzgKNTMKMjMKNQo1Mwo0Mgo0Mgo1MgoxCjUyCjQ3CjUyCjI2CjUzCjE2CjE0CjUyCjYKNTMKNDUKMTYKNTIKNDIKNTMKMgoyOQo1Mwo0NAo1MAo1MgozMgo1MgozMgoKlGJzLg==\n",
+          "legalActions": [],
+          "legalActionStrings": []
+        },
+        "status": "INACTIVE"
+      },
+      {
+        "action": {
+          "submission": -1
+        },
+        "reward": null,
+        "info": {},
+        "observation": {
+          "remainingOverageTime": 12,
+          "observationString": "{\"phase\": \"Draw\", \"current_player\": 1, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"7d\", \"upcard\": \"7d\", \"stock_size\": 8, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\", \"2h\", \"5s\", \"7c\", \"Td\", \"8d\", \"Qc\", \"9s\", \"Kd\", \"6s\", \"Ad\", \"7s\", \"4h\", \"4d\"], \"hands\": {\"0\": [], \"1\": [\"2s\", \"3s\", \"Qs\", \"Kc\", \"Qd\", \"7h\", \"8h\", \"Th\", \"Qh\", \"Kh\"]}, \"deadwood\": {\"0\": null, \"1\": 50}, \"repeated_move\": 1}",
+          "currentPlayer": 1,
+          "playerId": 1,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14,0:52,0:49,1:52,1:6,0:52,0:14,1:52,1:32,0:52,0:47,1:52,1:48,0:52,0:13,1:53,-1:19,1:3,0:53,-1:34,0:48,1:52,1:49,0:53,-1:24,0:6,1:52,1:47,0:52,0:43,1:52,1:43,0:53,-1:33,0:31,1:53,-1:37,1:37,0:52,0:18,1:52,1:18,0:53,-1:30,0:7,1:53,-1:15,1:15,0:53,-1:17,0:37,1:52,1:21,0:53,-1:40,0:30,1:53,-1:9,1:19,0:52,0:40,1:53,-1:29,1:9,0:52,0:47,1:52,1:4,0:52,0:4,1:53,-1:35,1:6,0:52,0:19,1:53,-1:8,1:35,0:53,-1:26,0:33,1:53,-1:22,1:8,0:52,0:32,1:52,1:22,0:52,0:24,1:53,-1:1,1:1,0:52,0:8,1:53,-1:46,1:38,0:53,-1:23,0:5,1:53,-1:42,1:42,0:52,0:1,1:52,1:47,0:52,0:26,1:53,-1:16,1:14,0:52,0:6,1:53,-1:45,1:16,0:52,0:42,1:53,-1:2,1:29,0:53,-1:44,0:50,1:52,1:32,0:52,0:32\nmove_number=150\n__dict__=gASVugIAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRYeAIAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAo1Mgo0OQo1Mgo2CjUyCjE0CjUyCjMyCjUyCjQ3CjUyCjQ4CjUyCjEzCjUzCjE5CjMKNTMKMzQKNDgKNTIKNDkKNTMKMjQKNgo1Mgo0Nwo1Mgo0Mwo1Mgo0Mwo1MwozMwozMQo1MwozNwozNwo1MgoxOAo1MgoxOAo1MwozMAo3CjUzCjE1CjE1CjUzCjE3CjM3CjUyCjIxCjUzCjQwCjMwCjUzCjkKMTkKNTIKNDAKNTMKMjkKOQo1Mgo0Nwo1Mgo0CjUyCjQKNTMKMzUKNgo1MgoxOQo1Mwo4CjM1CjUzCjI2CjMzCjUzCjIyCjgKNTIKMzIKNTIKMjIKNTIKMjQKNTMKMQoxCjUyCjgKNTMKNDYKMzgKNTMKMjMKNQo1Mwo0Mgo0Mgo1MgoxCjUyCjQ3CjUyCjI2CjUzCjE2CjE0CjUyCjYKNTMKNDUKMTYKNTIKNDIKNTMKMgoyOQo1Mwo0NAo1MAo1MgozMgo1MgozMgoKlGJzLg==\n",
+          "legalActions": [52, 53],
+          "legalActionStrings": [
+            "Player: 1 Action: Draw upcard",
+            "Player: 1 Action: Draw stock"
+          ]
+        },
+        "status": "ACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "submission": -1
+        },
+        "reward": null,
+        "info": {},
+        "observation": {
+          "remainingOverageTime": 12,
+          "step": 108,
+          "observationString": "{\"phase\": \"Discard\", \"current_player\": 1, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"7d\", \"upcard\": null, \"stock_size\": 8, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\", \"2h\", \"5s\", \"7c\", \"Td\", \"8d\", \"Qc\", \"9s\", \"Kd\", \"6s\", \"Ad\", \"7s\", \"4h\", \"4d\"], \"hands\": {\"0\": [\"Ts\", \"2c\", \"4c\", \"5c\", \"Tc\", \"Jc\", \"3d\", \"9d\", \"6h\", \"9h\"], \"1\": []}, \"deadwood\": {\"0\": 68, \"1\": null}, \"repeated_move\": 1}",
+          "currentPlayer": 1,
+          "playerId": 0,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14,0:52,0:49,1:52,1:6,0:52,0:14,1:52,1:32,0:52,0:47,1:52,1:48,0:52,0:13,1:53,-1:19,1:3,0:53,-1:34,0:48,1:52,1:49,0:53,-1:24,0:6,1:52,1:47,0:52,0:43,1:52,1:43,0:53,-1:33,0:31,1:53,-1:37,1:37,0:52,0:18,1:52,1:18,0:53,-1:30,0:7,1:53,-1:15,1:15,0:53,-1:17,0:37,1:52,1:21,0:53,-1:40,0:30,1:53,-1:9,1:19,0:52,0:40,1:53,-1:29,1:9,0:52,0:47,1:52,1:4,0:52,0:4,1:53,-1:35,1:6,0:52,0:19,1:53,-1:8,1:35,0:53,-1:26,0:33,1:53,-1:22,1:8,0:52,0:32,1:52,1:22,0:52,0:24,1:53,-1:1,1:1,0:52,0:8,1:53,-1:46,1:38,0:53,-1:23,0:5,1:53,-1:42,1:42,0:52,0:1,1:52,1:47,0:52,0:26,1:53,-1:16,1:14,0:52,0:6,1:53,-1:45,1:16,0:52,0:42,1:53,-1:2,1:29,0:53,-1:44,0:50,1:52,1:32,0:52,0:32,1:52\nmove_number=151\n__dict__=gASVvQIAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRYewIAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAo1Mgo0OQo1Mgo2CjUyCjE0CjUyCjMyCjUyCjQ3CjUyCjQ4CjUyCjEzCjUzCjE5CjMKNTMKMzQKNDgKNTIKNDkKNTMKMjQKNgo1Mgo0Nwo1Mgo0Mwo1Mgo0Mwo1MwozMwozMQo1MwozNwozNwo1MgoxOAo1MgoxOAo1MwozMAo3CjUzCjE1CjE1CjUzCjE3CjM3CjUyCjIxCjUzCjQwCjMwCjUzCjkKMTkKNTIKNDAKNTMKMjkKOQo1Mgo0Nwo1Mgo0CjUyCjQKNTMKMzUKNgo1MgoxOQo1Mwo4CjM1CjUzCjI2CjMzCjUzCjIyCjgKNTIKMzIKNTIKMjIKNTIKMjQKNTMKMQoxCjUyCjgKNTMKNDYKMzgKNTMKMjMKNQo1Mwo0Mgo0Mgo1MgoxCjUyCjQ3CjUyCjI2CjUzCjE2CjE0CjUyCjYKNTMKNDUKMTYKNTIKNDIKNTMKMgoyOQo1Mwo0NAo1MAo1MgozMgo1MgozMgo1MgoKlGJzLg==\n",
+          "legalActions": [],
+          "legalActionStrings": []
+        },
+        "status": "INACTIVE"
+      },
+      {
+        "action": {
+          "submission": 52,
+          "thoughts": "chi horizon alpha iota shadow epsilon explore theta"
+        },
+        "reward": null,
+        "info": {
+          "actionSubmitted": 52,
+          "actionSubmittedToString": "Player: 1 Action: Draw upcard",
+          "actionApplied": 52,
+          "timeTaken": 0.0,
+          "agentSelfReportedStatus": null
+        },
+        "observation": {
+          "remainingOverageTime": 12,
+          "observationString": "{\"phase\": \"Discard\", \"current_player\": 1, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"7d\", \"upcard\": null, \"stock_size\": 8, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\", \"2h\", \"5s\", \"7c\", \"Td\", \"8d\", \"Qc\", \"9s\", \"Kd\", \"6s\", \"Ad\", \"7s\", \"4h\", \"4d\"], \"hands\": {\"0\": [], \"1\": [\"2s\", \"3s\", \"Qs\", \"Kc\", \"7d\", \"Qd\", \"7h\", \"8h\", \"Th\", \"Qh\", \"Kh\"]}, \"deadwood\": {\"0\": null, \"1\": 47}, \"repeated_move\": 1}",
+          "currentPlayer": 1,
+          "playerId": 1,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14,0:52,0:49,1:52,1:6,0:52,0:14,1:52,1:32,0:52,0:47,1:52,1:48,0:52,0:13,1:53,-1:19,1:3,0:53,-1:34,0:48,1:52,1:49,0:53,-1:24,0:6,1:52,1:47,0:52,0:43,1:52,1:43,0:53,-1:33,0:31,1:53,-1:37,1:37,0:52,0:18,1:52,1:18,0:53,-1:30,0:7,1:53,-1:15,1:15,0:53,-1:17,0:37,1:52,1:21,0:53,-1:40,0:30,1:53,-1:9,1:19,0:52,0:40,1:53,-1:29,1:9,0:52,0:47,1:52,1:4,0:52,0:4,1:53,-1:35,1:6,0:52,0:19,1:53,-1:8,1:35,0:53,-1:26,0:33,1:53,-1:22,1:8,0:52,0:32,1:52,1:22,0:52,0:24,1:53,-1:1,1:1,0:52,0:8,1:53,-1:46,1:38,0:53,-1:23,0:5,1:53,-1:42,1:42,0:52,0:1,1:52,1:47,0:52,0:26,1:53,-1:16,1:14,0:52,0:6,1:53,-1:45,1:16,0:52,0:42,1:53,-1:2,1:29,0:53,-1:44,0:50,1:52,1:32,0:52,0:32,1:52\nmove_number=151\n__dict__=gASVvQIAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRYewIAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAo1Mgo0OQo1Mgo2CjUyCjE0CjUyCjMyCjUyCjQ3CjUyCjQ4CjUyCjEzCjUzCjE5CjMKNTMKMzQKNDgKNTIKNDkKNTMKMjQKNgo1Mgo0Nwo1Mgo0Mwo1Mgo0Mwo1MwozMwozMQo1MwozNwozNwo1MgoxOAo1MgoxOAo1MwozMAo3CjUzCjE1CjE1CjUzCjE3CjM3CjUyCjIxCjUzCjQwCjMwCjUzCjkKMTkKNTIKNDAKNTMKMjkKOQo1Mgo0Nwo1Mgo0CjUyCjQKNTMKMzUKNgo1MgoxOQo1Mwo4CjM1CjUzCjI2CjMzCjUzCjIyCjgKNTIKMzIKNTIKMjIKNTIKMjQKNTMKMQoxCjUyCjgKNTMKNDYKMzgKNTMKMjMKNQo1Mwo0Mgo0Mgo1MgoxCjUyCjQ3CjUyCjI2CjUzCjE2CjE0CjUyCjYKNTMKNDUKMTYKNTIKNDIKNTMKMgoyOQo1Mwo0NAo1MAo1MgozMgo1MgozMgo1MgoKlGJzLg==\n",
+          "legalActions": [1, 2, 11, 25, 32, 37, 45, 46, 48, 50, 51],
+          "legalActionStrings": [
+            "Player: 1 Action: 2s",
+            "Player: 1 Action: 3s",
+            "Player: 1 Action: Qs",
+            "Player: 1 Action: Kc",
+            "Player: 1 Action: 7d",
+            "Player: 1 Action: Qd",
+            "Player: 1 Action: 7h",
+            "Player: 1 Action: 8h",
+            "Player: 1 Action: Th",
+            "Player: 1 Action: Qh",
+            "Player: 1 Action: Kh"
+          ]
+        },
+        "status": "ACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "submission": -1
+        },
+        "reward": null,
+        "info": {},
+        "observation": {
+          "remainingOverageTime": 12,
+          "step": 109,
+          "observationString": "{\"phase\": \"Draw\", \"current_player\": 0, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"7d\", \"upcard\": \"8h\", \"stock_size\": 8, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\", \"2h\", \"5s\", \"7c\", \"Td\", \"8d\", \"Qc\", \"9s\", \"Kd\", \"6s\", \"Ad\", \"7s\", \"4h\", \"4d\"], \"hands\": {\"0\": [\"Ts\", \"2c\", \"4c\", \"5c\", \"Tc\", \"Jc\", \"3d\", \"9d\", \"6h\", \"9h\"], \"1\": []}, \"deadwood\": {\"0\": 68, \"1\": null}, \"repeated_move\": 0}",
+          "currentPlayer": 0,
+          "playerId": 0,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14,0:52,0:49,1:52,1:6,0:52,0:14,1:52,1:32,0:52,0:47,1:52,1:48,0:52,0:13,1:53,-1:19,1:3,0:53,-1:34,0:48,1:52,1:49,0:53,-1:24,0:6,1:52,1:47,0:52,0:43,1:52,1:43,0:53,-1:33,0:31,1:53,-1:37,1:37,0:52,0:18,1:52,1:18,0:53,-1:30,0:7,1:53,-1:15,1:15,0:53,-1:17,0:37,1:52,1:21,0:53,-1:40,0:30,1:53,-1:9,1:19,0:52,0:40,1:53,-1:29,1:9,0:52,0:47,1:52,1:4,0:52,0:4,1:53,-1:35,1:6,0:52,0:19,1:53,-1:8,1:35,0:53,-1:26,0:33,1:53,-1:22,1:8,0:52,0:32,1:52,1:22,0:52,0:24,1:53,-1:1,1:1,0:52,0:8,1:53,-1:46,1:38,0:53,-1:23,0:5,1:53,-1:42,1:42,0:52,0:1,1:52,1:47,0:52,0:26,1:53,-1:16,1:14,0:52,0:6,1:53,-1:45,1:16,0:52,0:42,1:53,-1:2,1:29,0:53,-1:44,0:50,1:52,1:32,0:52,0:32,1:52,1:46\nmove_number=152\n__dict__=gASVwAIAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRYfgIAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAo1Mgo0OQo1Mgo2CjUyCjE0CjUyCjMyCjUyCjQ3CjUyCjQ4CjUyCjEzCjUzCjE5CjMKNTMKMzQKNDgKNTIKNDkKNTMKMjQKNgo1Mgo0Nwo1Mgo0Mwo1Mgo0Mwo1MwozMwozMQo1MwozNwozNwo1MgoxOAo1MgoxOAo1MwozMAo3CjUzCjE1CjE1CjUzCjE3CjM3CjUyCjIxCjUzCjQwCjMwCjUzCjkKMTkKNTIKNDAKNTMKMjkKOQo1Mgo0Nwo1Mgo0CjUyCjQKNTMKMzUKNgo1MgoxOQo1Mwo4CjM1CjUzCjI2CjMzCjUzCjIyCjgKNTIKMzIKNTIKMjIKNTIKMjQKNTMKMQoxCjUyCjgKNTMKNDYKMzgKNTMKMjMKNQo1Mwo0Mgo0Mgo1MgoxCjUyCjQ3CjUyCjI2CjUzCjE2CjE0CjUyCjYKNTMKNDUKMTYKNTIKNDIKNTMKMgoyOQo1Mwo0NAo1MAo1MgozMgo1MgozMgo1Mgo0NgoKlGJzLg==\n",
+          "legalActions": [52, 53],
+          "legalActionStrings": [
+            "Player: 0 Action: Draw upcard",
+            "Player: 0 Action: Draw stock"
+          ]
+        },
+        "status": "ACTIVE"
+      },
+      {
+        "action": {
+          "submission": 46,
+          "thoughts": "eta xi shadow theta chi omicron lantern lambda"
+        },
+        "reward": null,
+        "info": {
+          "actionSubmitted": 46,
+          "actionSubmittedToString": "Player: 1 Action: 8h",
+          "actionApplied": 46,
+          "timeTaken": 0.0,
+          "agentSelfReportedStatus": null
+        },
+        "observation": {
+          "remainingOverageTime": 12,
+          "observationString": "{\"phase\": \"Draw\", \"current_player\": 0, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"7d\", \"upcard\": \"8h\", \"stock_size\": 8, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\", \"2h\", \"5s\", \"7c\", \"Td\", \"8d\", \"Qc\", \"9s\", \"Kd\", \"6s\", \"Ad\", \"7s\", \"4h\", \"4d\"], \"hands\": {\"0\": [], \"1\": [\"2s\", \"3s\", \"Qs\", \"Kc\", \"7d\", \"Qd\", \"7h\", \"Th\", \"Qh\", \"Kh\"]}, \"deadwood\": {\"0\": null, \"1\": 49}, \"repeated_move\": 0}",
+          "currentPlayer": 0,
+          "playerId": 1,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14,0:52,0:49,1:52,1:6,0:52,0:14,1:52,1:32,0:52,0:47,1:52,1:48,0:52,0:13,1:53,-1:19,1:3,0:53,-1:34,0:48,1:52,1:49,0:53,-1:24,0:6,1:52,1:47,0:52,0:43,1:52,1:43,0:53,-1:33,0:31,1:53,-1:37,1:37,0:52,0:18,1:52,1:18,0:53,-1:30,0:7,1:53,-1:15,1:15,0:53,-1:17,0:37,1:52,1:21,0:53,-1:40,0:30,1:53,-1:9,1:19,0:52,0:40,1:53,-1:29,1:9,0:52,0:47,1:52,1:4,0:52,0:4,1:53,-1:35,1:6,0:52,0:19,1:53,-1:8,1:35,0:53,-1:26,0:33,1:53,-1:22,1:8,0:52,0:32,1:52,1:22,0:52,0:24,1:53,-1:1,1:1,0:52,0:8,1:53,-1:46,1:38,0:53,-1:23,0:5,1:53,-1:42,1:42,0:52,0:1,1:52,1:47,0:52,0:26,1:53,-1:16,1:14,0:52,0:6,1:53,-1:45,1:16,0:52,0:42,1:53,-1:2,1:29,0:53,-1:44,0:50,1:52,1:32,0:52,0:32,1:52,1:46\nmove_number=152\n__dict__=gASVwAIAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRYfgIAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAo1Mgo0OQo1Mgo2CjUyCjE0CjUyCjMyCjUyCjQ3CjUyCjQ4CjUyCjEzCjUzCjE5CjMKNTMKMzQKNDgKNTIKNDkKNTMKMjQKNgo1Mgo0Nwo1Mgo0Mwo1Mgo0Mwo1MwozMwozMQo1MwozNwozNwo1MgoxOAo1MgoxOAo1MwozMAo3CjUzCjE1CjE1CjUzCjE3CjM3CjUyCjIxCjUzCjQwCjMwCjUzCjkKMTkKNTIKNDAKNTMKMjkKOQo1Mgo0Nwo1Mgo0CjUyCjQKNTMKMzUKNgo1MgoxOQo1Mwo4CjM1CjUzCjI2CjMzCjUzCjIyCjgKNTIKMzIKNTIKMjIKNTIKMjQKNTMKMQoxCjUyCjgKNTMKNDYKMzgKNTMKMjMKNQo1Mwo0Mgo0Mgo1MgoxCjUyCjQ3CjUyCjI2CjUzCjE2CjE0CjUyCjYKNTMKNDUKMTYKNTIKNDIKNTMKMgoyOQo1Mwo0NAo1MAo1MgozMgo1MgozMgo1Mgo0NgoKlGJzLg==\n",
+          "legalActions": [],
+          "legalActionStrings": []
+        },
+        "status": "INACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "submission": 53,
+          "thoughts": "beta xi theta ponder delta muse reflect reflect"
+        },
+        "reward": null,
+        "info": {
+          "actionSubmitted": 53,
+          "actionSubmittedToString": "Player: 0 Action: Draw stock",
+          "actionApplied": 53,
+          "timeTaken": 0.0,
+          "agentSelfReportedStatus": null
+        },
+        "observation": {
+          "remainingOverageTime": 12,
+          "step": 110,
+          "observationString": "{\"phase\": \"Discard\", \"current_player\": 0, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"8h\", \"upcard\": null, \"stock_size\": 7, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\", \"2h\", \"5s\", \"7c\", \"Td\", \"8d\", \"Qc\", \"9s\", \"Kd\", \"6s\", \"Ad\", \"7s\", \"4h\", \"4d\", \"8h\"], \"hands\": {\"0\": [\"Ts\", \"2c\", \"4c\", \"5c\", \"Tc\", \"Jc\", \"3d\", \"9d\", \"Jd\", \"6h\", \"9h\"], \"1\": []}, \"deadwood\": {\"0\": 68, \"1\": null}, \"repeated_move\": 0}",
+          "currentPlayer": 0,
+          "playerId": 0,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14,0:52,0:49,1:52,1:6,0:52,0:14,1:52,1:32,0:52,0:47,1:52,1:48,0:52,0:13,1:53,-1:19,1:3,0:53,-1:34,0:48,1:52,1:49,0:53,-1:24,0:6,1:52,1:47,0:52,0:43,1:52,1:43,0:53,-1:33,0:31,1:53,-1:37,1:37,0:52,0:18,1:52,1:18,0:53,-1:30,0:7,1:53,-1:15,1:15,0:53,-1:17,0:37,1:52,1:21,0:53,-1:40,0:30,1:53,-1:9,1:19,0:52,0:40,1:53,-1:29,1:9,0:52,0:47,1:52,1:4,0:52,0:4,1:53,-1:35,1:6,0:52,0:19,1:53,-1:8,1:35,0:53,-1:26,0:33,1:53,-1:22,1:8,0:52,0:32,1:52,1:22,0:52,0:24,1:53,-1:1,1:1,0:52,0:8,1:53,-1:46,1:38,0:53,-1:23,0:5,1:53,-1:42,1:42,0:52,0:1,1:52,1:47,0:52,0:26,1:53,-1:16,1:14,0:52,0:6,1:53,-1:45,1:16,0:52,0:42,1:53,-1:2,1:29,0:53,-1:44,0:50,1:52,1:32,0:52,0:32,1:52,1:46,0:53,-1:36\nmove_number=154\n__dict__=gASVxgIAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRYhAIAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAo1Mgo0OQo1Mgo2CjUyCjE0CjUyCjMyCjUyCjQ3CjUyCjQ4CjUyCjEzCjUzCjE5CjMKNTMKMzQKNDgKNTIKNDkKNTMKMjQKNgo1Mgo0Nwo1Mgo0Mwo1Mgo0Mwo1MwozMwozMQo1MwozNwozNwo1MgoxOAo1MgoxOAo1MwozMAo3CjUzCjE1CjE1CjUzCjE3CjM3CjUyCjIxCjUzCjQwCjMwCjUzCjkKMTkKNTIKNDAKNTMKMjkKOQo1Mgo0Nwo1Mgo0CjUyCjQKNTMKMzUKNgo1MgoxOQo1Mwo4CjM1CjUzCjI2CjMzCjUzCjIyCjgKNTIKMzIKNTIKMjIKNTIKMjQKNTMKMQoxCjUyCjgKNTMKNDYKMzgKNTMKMjMKNQo1Mwo0Mgo0Mgo1MgoxCjUyCjQ3CjUyCjI2CjUzCjE2CjE0CjUyCjYKNTMKNDUKMTYKNTIKNDIKNTMKMgoyOQo1Mwo0NAo1MAo1MgozMgo1MgozMgo1Mgo0Ngo1MwozNgoKlGJzLg==\n",
+          "legalActions": [9, 14, 16, 17, 22, 23, 28, 34, 36, 44, 47],
+          "legalActionStrings": [
+            "Player: 0 Action: Ts",
+            "Player: 0 Action: 2c",
+            "Player: 0 Action: 4c",
+            "Player: 0 Action: 5c",
+            "Player: 0 Action: Tc",
+            "Player: 0 Action: Jc",
+            "Player: 0 Action: 3d",
+            "Player: 0 Action: 9d",
+            "Player: 0 Action: Jd",
+            "Player: 0 Action: 6h",
+            "Player: 0 Action: 9h"
+          ]
+        },
+        "status": "ACTIVE"
+      },
+      {
+        "action": {
+          "submission": -1
+        },
+        "reward": null,
+        "info": {},
+        "observation": {
+          "remainingOverageTime": 12,
+          "observationString": "{\"phase\": \"Discard\", \"current_player\": 0, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"8h\", \"upcard\": null, \"stock_size\": 7, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\", \"2h\", \"5s\", \"7c\", \"Td\", \"8d\", \"Qc\", \"9s\", \"Kd\", \"6s\", \"Ad\", \"7s\", \"4h\", \"4d\", \"8h\"], \"hands\": {\"0\": [], \"1\": [\"2s\", \"3s\", \"Qs\", \"Kc\", \"7d\", \"Qd\", \"7h\", \"Th\", \"Qh\", \"Kh\"]}, \"deadwood\": {\"0\": null, \"1\": 49}, \"repeated_move\": 0}",
+          "currentPlayer": 0,
+          "playerId": 1,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14,0:52,0:49,1:52,1:6,0:52,0:14,1:52,1:32,0:52,0:47,1:52,1:48,0:52,0:13,1:53,-1:19,1:3,0:53,-1:34,0:48,1:52,1:49,0:53,-1:24,0:6,1:52,1:47,0:52,0:43,1:52,1:43,0:53,-1:33,0:31,1:53,-1:37,1:37,0:52,0:18,1:52,1:18,0:53,-1:30,0:7,1:53,-1:15,1:15,0:53,-1:17,0:37,1:52,1:21,0:53,-1:40,0:30,1:53,-1:9,1:19,0:52,0:40,1:53,-1:29,1:9,0:52,0:47,1:52,1:4,0:52,0:4,1:53,-1:35,1:6,0:52,0:19,1:53,-1:8,1:35,0:53,-1:26,0:33,1:53,-1:22,1:8,0:52,0:32,1:52,1:22,0:52,0:24,1:53,-1:1,1:1,0:52,0:8,1:53,-1:46,1:38,0:53,-1:23,0:5,1:53,-1:42,1:42,0:52,0:1,1:52,1:47,0:52,0:26,1:53,-1:16,1:14,0:52,0:6,1:53,-1:45,1:16,0:52,0:42,1:53,-1:2,1:29,0:53,-1:44,0:50,1:52,1:32,0:52,0:32,1:52,1:46,0:53,-1:36\nmove_number=154\n__dict__=gASVxgIAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRYhAIAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAo1Mgo0OQo1Mgo2CjUyCjE0CjUyCjMyCjUyCjQ3CjUyCjQ4CjUyCjEzCjUzCjE5CjMKNTMKMzQKNDgKNTIKNDkKNTMKMjQKNgo1Mgo0Nwo1Mgo0Mwo1Mgo0Mwo1MwozMwozMQo1MwozNwozNwo1MgoxOAo1MgoxOAo1MwozMAo3CjUzCjE1CjE1CjUzCjE3CjM3CjUyCjIxCjUzCjQwCjMwCjUzCjkKMTkKNTIKNDAKNTMKMjkKOQo1Mgo0Nwo1Mgo0CjUyCjQKNTMKMzUKNgo1MgoxOQo1Mwo4CjM1CjUzCjI2CjMzCjUzCjIyCjgKNTIKMzIKNTIKMjIKNTIKMjQKNTMKMQoxCjUyCjgKNTMKNDYKMzgKNTMKMjMKNQo1Mwo0Mgo0Mgo1MgoxCjUyCjQ3CjUyCjI2CjUzCjE2CjE0CjUyCjYKNTMKNDUKMTYKNTIKNDIKNTMKMgoyOQo1Mwo0NAo1MAo1MgozMgo1MgozMgo1Mgo0Ngo1MwozNgoKlGJzLg==\n",
+          "legalActions": [],
+          "legalActionStrings": []
+        },
+        "status": "INACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "submission": 16,
+          "thoughts": "spark horizon drift drift muse shadow psi lambda"
+        },
+        "reward": null,
+        "info": {
+          "actionSubmitted": 16,
+          "actionSubmittedToString": "Player: 0 Action: 4c",
+          "actionApplied": 16,
+          "timeTaken": 0.0,
+          "agentSelfReportedStatus": null
+        },
+        "observation": {
+          "remainingOverageTime": 12,
+          "step": 111,
+          "observationString": "{\"phase\": \"Draw\", \"current_player\": 1, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"8h\", \"upcard\": \"4c\", \"stock_size\": 7, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\", \"2h\", \"5s\", \"7c\", \"Td\", \"8d\", \"Qc\", \"9s\", \"Kd\", \"6s\", \"Ad\", \"7s\", \"4h\", \"4d\", \"8h\"], \"hands\": {\"0\": [\"Ts\", \"2c\", \"5c\", \"Tc\", \"Jc\", \"3d\", \"9d\", \"Jd\", \"6h\", \"9h\"], \"1\": []}, \"deadwood\": {\"0\": 74, \"1\": null}, \"repeated_move\": 0}",
+          "currentPlayer": 1,
+          "playerId": 0,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14,0:52,0:49,1:52,1:6,0:52,0:14,1:52,1:32,0:52,0:47,1:52,1:48,0:52,0:13,1:53,-1:19,1:3,0:53,-1:34,0:48,1:52,1:49,0:53,-1:24,0:6,1:52,1:47,0:52,0:43,1:52,1:43,0:53,-1:33,0:31,1:53,-1:37,1:37,0:52,0:18,1:52,1:18,0:53,-1:30,0:7,1:53,-1:15,1:15,0:53,-1:17,0:37,1:52,1:21,0:53,-1:40,0:30,1:53,-1:9,1:19,0:52,0:40,1:53,-1:29,1:9,0:52,0:47,1:52,1:4,0:52,0:4,1:53,-1:35,1:6,0:52,0:19,1:53,-1:8,1:35,0:53,-1:26,0:33,1:53,-1:22,1:8,0:52,0:32,1:52,1:22,0:52,0:24,1:53,-1:1,1:1,0:52,0:8,1:53,-1:46,1:38,0:53,-1:23,0:5,1:53,-1:42,1:42,0:52,0:1,1:52,1:47,0:52,0:26,1:53,-1:16,1:14,0:52,0:6,1:53,-1:45,1:16,0:52,0:42,1:53,-1:2,1:29,0:53,-1:44,0:50,1:52,1:32,0:52,0:32,1:52,1:46,0:53,-1:36,0:16\nmove_number=155\n__dict__=gASVyQIAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRYhwIAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAo1Mgo0OQo1Mgo2CjUyCjE0CjUyCjMyCjUyCjQ3CjUyCjQ4CjUyCjEzCjUzCjE5CjMKNTMKMzQKNDgKNTIKNDkKNTMKMjQKNgo1Mgo0Nwo1Mgo0Mwo1Mgo0Mwo1MwozMwozMQo1MwozNwozNwo1MgoxOAo1MgoxOAo1MwozMAo3CjUzCjE1CjE1CjUzCjE3CjM3CjUyCjIxCjUzCjQwCjMwCjUzCjkKMTkKNTIKNDAKNTMKMjkKOQo1Mgo0Nwo1Mgo0CjUyCjQKNTMKMzUKNgo1MgoxOQo1Mwo4CjM1CjUzCjI2CjMzCjUzCjIyCjgKNTIKMzIKNTIKMjIKNTIKMjQKNTMKMQoxCjUyCjgKNTMKNDYKMzgKNTMKMjMKNQo1Mwo0Mgo0Mgo1MgoxCjUyCjQ3CjUyCjI2CjUzCjE2CjE0CjUyCjYKNTMKNDUKMTYKNTIKNDIKNTMKMgoyOQo1Mwo0NAo1MAo1MgozMgo1MgozMgo1Mgo0Ngo1MwozNgoxNgoKlGJzLg==\n",
+          "legalActions": [],
+          "legalActionStrings": []
+        },
+        "status": "INACTIVE"
+      },
+      {
+        "action": {
+          "submission": -1
+        },
+        "reward": null,
+        "info": {},
+        "observation": {
+          "remainingOverageTime": 12,
+          "observationString": "{\"phase\": \"Draw\", \"current_player\": 1, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"8h\", \"upcard\": \"4c\", \"stock_size\": 7, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\", \"2h\", \"5s\", \"7c\", \"Td\", \"8d\", \"Qc\", \"9s\", \"Kd\", \"6s\", \"Ad\", \"7s\", \"4h\", \"4d\", \"8h\"], \"hands\": {\"0\": [], \"1\": [\"2s\", \"3s\", \"Qs\", \"Kc\", \"7d\", \"Qd\", \"7h\", \"Th\", \"Qh\", \"Kh\"]}, \"deadwood\": {\"0\": null, \"1\": 49}, \"repeated_move\": 0}",
+          "currentPlayer": 1,
+          "playerId": 1,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14,0:52,0:49,1:52,1:6,0:52,0:14,1:52,1:32,0:52,0:47,1:52,1:48,0:52,0:13,1:53,-1:19,1:3,0:53,-1:34,0:48,1:52,1:49,0:53,-1:24,0:6,1:52,1:47,0:52,0:43,1:52,1:43,0:53,-1:33,0:31,1:53,-1:37,1:37,0:52,0:18,1:52,1:18,0:53,-1:30,0:7,1:53,-1:15,1:15,0:53,-1:17,0:37,1:52,1:21,0:53,-1:40,0:30,1:53,-1:9,1:19,0:52,0:40,1:53,-1:29,1:9,0:52,0:47,1:52,1:4,0:52,0:4,1:53,-1:35,1:6,0:52,0:19,1:53,-1:8,1:35,0:53,-1:26,0:33,1:53,-1:22,1:8,0:52,0:32,1:52,1:22,0:52,0:24,1:53,-1:1,1:1,0:52,0:8,1:53,-1:46,1:38,0:53,-1:23,0:5,1:53,-1:42,1:42,0:52,0:1,1:52,1:47,0:52,0:26,1:53,-1:16,1:14,0:52,0:6,1:53,-1:45,1:16,0:52,0:42,1:53,-1:2,1:29,0:53,-1:44,0:50,1:52,1:32,0:52,0:32,1:52,1:46,0:53,-1:36,0:16\nmove_number=155\n__dict__=gASVyQIAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRYhwIAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAo1Mgo0OQo1Mgo2CjUyCjE0CjUyCjMyCjUyCjQ3CjUyCjQ4CjUyCjEzCjUzCjE5CjMKNTMKMzQKNDgKNTIKNDkKNTMKMjQKNgo1Mgo0Nwo1Mgo0Mwo1Mgo0Mwo1MwozMwozMQo1MwozNwozNwo1MgoxOAo1MgoxOAo1MwozMAo3CjUzCjE1CjE1CjUzCjE3CjM3CjUyCjIxCjUzCjQwCjMwCjUzCjkKMTkKNTIKNDAKNTMKMjkKOQo1Mgo0Nwo1Mgo0CjUyCjQKNTMKMzUKNgo1MgoxOQo1Mwo4CjM1CjUzCjI2CjMzCjUzCjIyCjgKNTIKMzIKNTIKMjIKNTIKMjQKNTMKMQoxCjUyCjgKNTMKNDYKMzgKNTMKMjMKNQo1Mwo0Mgo0Mgo1MgoxCjUyCjQ3CjUyCjI2CjUzCjE2CjE0CjUyCjYKNTMKNDUKMTYKNTIKNDIKNTMKMgoyOQo1Mwo0NAo1MAo1MgozMgo1MgozMgo1Mgo0Ngo1MwozNgoxNgoKlGJzLg==\n",
+          "legalActions": [52, 53],
+          "legalActionStrings": [
+            "Player: 1 Action: Draw upcard",
+            "Player: 1 Action: Draw stock"
+          ]
+        },
+        "status": "ACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "submission": -1
+        },
+        "reward": null,
+        "info": {},
+        "observation": {
+          "remainingOverageTime": 12,
+          "step": 112,
+          "observationString": "{\"phase\": \"Discard\", \"current_player\": 1, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"4c\", \"upcard\": null, \"stock_size\": 7, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\", \"2h\", \"5s\", \"7c\", \"Td\", \"8d\", \"Qc\", \"9s\", \"Kd\", \"6s\", \"Ad\", \"7s\", \"4h\", \"4d\", \"8h\"], \"hands\": {\"0\": [\"Ts\", \"2c\", \"5c\", \"Tc\", \"Jc\", \"3d\", \"9d\", \"Jd\", \"6h\", \"9h\"], \"1\": []}, \"deadwood\": {\"0\": 74, \"1\": null}, \"repeated_move\": 0}",
+          "currentPlayer": 1,
+          "playerId": 0,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14,0:52,0:49,1:52,1:6,0:52,0:14,1:52,1:32,0:52,0:47,1:52,1:48,0:52,0:13,1:53,-1:19,1:3,0:53,-1:34,0:48,1:52,1:49,0:53,-1:24,0:6,1:52,1:47,0:52,0:43,1:52,1:43,0:53,-1:33,0:31,1:53,-1:37,1:37,0:52,0:18,1:52,1:18,0:53,-1:30,0:7,1:53,-1:15,1:15,0:53,-1:17,0:37,1:52,1:21,0:53,-1:40,0:30,1:53,-1:9,1:19,0:52,0:40,1:53,-1:29,1:9,0:52,0:47,1:52,1:4,0:52,0:4,1:53,-1:35,1:6,0:52,0:19,1:53,-1:8,1:35,0:53,-1:26,0:33,1:53,-1:22,1:8,0:52,0:32,1:52,1:22,0:52,0:24,1:53,-1:1,1:1,0:52,0:8,1:53,-1:46,1:38,0:53,-1:23,0:5,1:53,-1:42,1:42,0:52,0:1,1:52,1:47,0:52,0:26,1:53,-1:16,1:14,0:52,0:6,1:53,-1:45,1:16,0:52,0:42,1:53,-1:2,1:29,0:53,-1:44,0:50,1:52,1:32,0:52,0:32,1:52,1:46,0:53,-1:36,0:16,1:52\nmove_number=156\n__dict__=gASVzAIAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRYigIAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAo1Mgo0OQo1Mgo2CjUyCjE0CjUyCjMyCjUyCjQ3CjUyCjQ4CjUyCjEzCjUzCjE5CjMKNTMKMzQKNDgKNTIKNDkKNTMKMjQKNgo1Mgo0Nwo1Mgo0Mwo1Mgo0Mwo1MwozMwozMQo1MwozNwozNwo1MgoxOAo1MgoxOAo1MwozMAo3CjUzCjE1CjE1CjUzCjE3CjM3CjUyCjIxCjUzCjQwCjMwCjUzCjkKMTkKNTIKNDAKNTMKMjkKOQo1Mgo0Nwo1Mgo0CjUyCjQKNTMKMzUKNgo1MgoxOQo1Mwo4CjM1CjUzCjI2CjMzCjUzCjIyCjgKNTIKMzIKNTIKMjIKNTIKMjQKNTMKMQoxCjUyCjgKNTMKNDYKMzgKNTMKMjMKNQo1Mwo0Mgo0Mgo1MgoxCjUyCjQ3CjUyCjI2CjUzCjE2CjE0CjUyCjYKNTMKNDUKMTYKNTIKNDIKNTMKMgoyOQo1Mwo0NAo1MAo1MgozMgo1MgozMgo1Mgo0Ngo1MwozNgoxNgo1MgoKlGJzLg==\n",
+          "legalActions": [],
+          "legalActionStrings": []
+        },
+        "status": "INACTIVE"
+      },
+      {
+        "action": {
+          "submission": 52,
+          "thoughts": "ponder reflect epsilon beta echo shadow pi omega"
+        },
+        "reward": null,
+        "info": {
+          "actionSubmitted": 52,
+          "actionSubmittedToString": "Player: 1 Action: Draw upcard",
+          "actionApplied": 52,
+          "timeTaken": 0.0,
+          "agentSelfReportedStatus": null
+        },
+        "observation": {
+          "remainingOverageTime": 12,
+          "observationString": "{\"phase\": \"Discard\", \"current_player\": 1, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"4c\", \"upcard\": null, \"stock_size\": 7, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\", \"2h\", \"5s\", \"7c\", \"Td\", \"8d\", \"Qc\", \"9s\", \"Kd\", \"6s\", \"Ad\", \"7s\", \"4h\", \"4d\", \"8h\"], \"hands\": {\"0\": [], \"1\": [\"2s\", \"3s\", \"Qs\", \"4c\", \"Kc\", \"7d\", \"Qd\", \"7h\", \"Th\", \"Qh\", \"Kh\"]}, \"deadwood\": {\"0\": null, \"1\": 43}, \"repeated_move\": 0}",
+          "currentPlayer": 1,
+          "playerId": 1,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14,0:52,0:49,1:52,1:6,0:52,0:14,1:52,1:32,0:52,0:47,1:52,1:48,0:52,0:13,1:53,-1:19,1:3,0:53,-1:34,0:48,1:52,1:49,0:53,-1:24,0:6,1:52,1:47,0:52,0:43,1:52,1:43,0:53,-1:33,0:31,1:53,-1:37,1:37,0:52,0:18,1:52,1:18,0:53,-1:30,0:7,1:53,-1:15,1:15,0:53,-1:17,0:37,1:52,1:21,0:53,-1:40,0:30,1:53,-1:9,1:19,0:52,0:40,1:53,-1:29,1:9,0:52,0:47,1:52,1:4,0:52,0:4,1:53,-1:35,1:6,0:52,0:19,1:53,-1:8,1:35,0:53,-1:26,0:33,1:53,-1:22,1:8,0:52,0:32,1:52,1:22,0:52,0:24,1:53,-1:1,1:1,0:52,0:8,1:53,-1:46,1:38,0:53,-1:23,0:5,1:53,-1:42,1:42,0:52,0:1,1:52,1:47,0:52,0:26,1:53,-1:16,1:14,0:52,0:6,1:53,-1:45,1:16,0:52,0:42,1:53,-1:2,1:29,0:53,-1:44,0:50,1:52,1:32,0:52,0:32,1:52,1:46,0:53,-1:36,0:16,1:52\nmove_number=156\n__dict__=gASVzAIAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRYigIAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAo1Mgo0OQo1Mgo2CjUyCjE0CjUyCjMyCjUyCjQ3CjUyCjQ4CjUyCjEzCjUzCjE5CjMKNTMKMzQKNDgKNTIKNDkKNTMKMjQKNgo1Mgo0Nwo1Mgo0Mwo1Mgo0Mwo1MwozMwozMQo1MwozNwozNwo1MgoxOAo1MgoxOAo1MwozMAo3CjUzCjE1CjE1CjUzCjE3CjM3CjUyCjIxCjUzCjQwCjMwCjUzCjkKMTkKNTIKNDAKNTMKMjkKOQo1Mgo0Nwo1Mgo0CjUyCjQKNTMKMzUKNgo1MgoxOQo1Mwo4CjM1CjUzCjI2CjMzCjUzCjIyCjgKNTIKMzIKNTIKMjIKNTIKMjQKNTMKMQoxCjUyCjgKNTMKNDYKMzgKNTMKMjMKNQo1Mwo0Mgo0Mgo1MgoxCjUyCjQ3CjUyCjI2CjUzCjE2CjE0CjUyCjYKNTMKNDUKMTYKNTIKNDIKNTMKMgoyOQo1Mwo0NAo1MAo1MgozMgo1MgozMgo1Mgo0Ngo1MwozNgoxNgo1MgoKlGJzLg==\n",
+          "legalActions": [1, 2, 11, 16, 25, 32, 37, 45, 48, 50, 51],
+          "legalActionStrings": [
+            "Player: 1 Action: 2s",
+            "Player: 1 Action: 3s",
+            "Player: 1 Action: Qs",
+            "Player: 1 Action: 4c",
+            "Player: 1 Action: Kc",
+            "Player: 1 Action: 7d",
+            "Player: 1 Action: Qd",
+            "Player: 1 Action: 7h",
+            "Player: 1 Action: Th",
+            "Player: 1 Action: Qh",
+            "Player: 1 Action: Kh"
+          ]
+        },
+        "status": "ACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "submission": -1
+        },
+        "reward": null,
+        "info": {},
+        "observation": {
+          "remainingOverageTime": 12,
+          "step": 113,
+          "observationString": "{\"phase\": \"Draw\", \"current_player\": 0, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"4c\", \"upcard\": \"Kh\", \"stock_size\": 7, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\", \"2h\", \"5s\", \"7c\", \"Td\", \"8d\", \"Qc\", \"9s\", \"Kd\", \"6s\", \"Ad\", \"7s\", \"4h\", \"4d\", \"8h\"], \"hands\": {\"0\": [\"Ts\", \"2c\", \"5c\", \"Tc\", \"Jc\", \"3d\", \"9d\", \"Jd\", \"6h\", \"9h\"], \"1\": []}, \"deadwood\": {\"0\": 74, \"1\": null}, \"repeated_move\": 0}",
+          "currentPlayer": 0,
+          "playerId": 0,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14,0:52,0:49,1:52,1:6,0:52,0:14,1:52,1:32,0:52,0:47,1:52,1:48,0:52,0:13,1:53,-1:19,1:3,0:53,-1:34,0:48,1:52,1:49,0:53,-1:24,0:6,1:52,1:47,0:52,0:43,1:52,1:43,0:53,-1:33,0:31,1:53,-1:37,1:37,0:52,0:18,1:52,1:18,0:53,-1:30,0:7,1:53,-1:15,1:15,0:53,-1:17,0:37,1:52,1:21,0:53,-1:40,0:30,1:53,-1:9,1:19,0:52,0:40,1:53,-1:29,1:9,0:52,0:47,1:52,1:4,0:52,0:4,1:53,-1:35,1:6,0:52,0:19,1:53,-1:8,1:35,0:53,-1:26,0:33,1:53,-1:22,1:8,0:52,0:32,1:52,1:22,0:52,0:24,1:53,-1:1,1:1,0:52,0:8,1:53,-1:46,1:38,0:53,-1:23,0:5,1:53,-1:42,1:42,0:52,0:1,1:52,1:47,0:52,0:26,1:53,-1:16,1:14,0:52,0:6,1:53,-1:45,1:16,0:52,0:42,1:53,-1:2,1:29,0:53,-1:44,0:50,1:52,1:32,0:52,0:32,1:52,1:46,0:53,-1:36,0:16,1:52,1:51\nmove_number=157\n__dict__=gASVzwIAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRYjQIAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAo1Mgo0OQo1Mgo2CjUyCjE0CjUyCjMyCjUyCjQ3CjUyCjQ4CjUyCjEzCjUzCjE5CjMKNTMKMzQKNDgKNTIKNDkKNTMKMjQKNgo1Mgo0Nwo1Mgo0Mwo1Mgo0Mwo1MwozMwozMQo1MwozNwozNwo1MgoxOAo1MgoxOAo1MwozMAo3CjUzCjE1CjE1CjUzCjE3CjM3CjUyCjIxCjUzCjQwCjMwCjUzCjkKMTkKNTIKNDAKNTMKMjkKOQo1Mgo0Nwo1Mgo0CjUyCjQKNTMKMzUKNgo1MgoxOQo1Mwo4CjM1CjUzCjI2CjMzCjUzCjIyCjgKNTIKMzIKNTIKMjIKNTIKMjQKNTMKMQoxCjUyCjgKNTMKNDYKMzgKNTMKMjMKNQo1Mwo0Mgo0Mgo1MgoxCjUyCjQ3CjUyCjI2CjUzCjE2CjE0CjUyCjYKNTMKNDUKMTYKNTIKNDIKNTMKMgoyOQo1Mwo0NAo1MAo1MgozMgo1MgozMgo1Mgo0Ngo1MwozNgoxNgo1Mgo1MQoKlGJzLg==\n",
+          "legalActions": [52, 53],
+          "legalActionStrings": [
+            "Player: 0 Action: Draw upcard",
+            "Player: 0 Action: Draw stock"
+          ]
+        },
+        "status": "ACTIVE"
+      },
+      {
+        "action": {
+          "submission": 51,
+          "thoughts": "mu horizon psi phi upsilon ember psi wonder"
+        },
+        "reward": null,
+        "info": {
+          "actionSubmitted": 51,
+          "actionSubmittedToString": "Player: 1 Action: Kh",
+          "actionApplied": 51,
+          "timeTaken": 0.0,
+          "agentSelfReportedStatus": null
+        },
+        "observation": {
+          "remainingOverageTime": 12,
+          "observationString": "{\"phase\": \"Draw\", \"current_player\": 0, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"4c\", \"upcard\": \"Kh\", \"stock_size\": 7, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\", \"2h\", \"5s\", \"7c\", \"Td\", \"8d\", \"Qc\", \"9s\", \"Kd\", \"6s\", \"Ad\", \"7s\", \"4h\", \"4d\", \"8h\"], \"hands\": {\"0\": [], \"1\": [\"2s\", \"3s\", \"Qs\", \"4c\", \"Kc\", \"7d\", \"Qd\", \"7h\", \"Th\", \"Qh\"]}, \"deadwood\": {\"0\": null, \"1\": 43}, \"repeated_move\": 0}",
+          "currentPlayer": 0,
+          "playerId": 1,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14,0:52,0:49,1:52,1:6,0:52,0:14,1:52,1:32,0:52,0:47,1:52,1:48,0:52,0:13,1:53,-1:19,1:3,0:53,-1:34,0:48,1:52,1:49,0:53,-1:24,0:6,1:52,1:47,0:52,0:43,1:52,1:43,0:53,-1:33,0:31,1:53,-1:37,1:37,0:52,0:18,1:52,1:18,0:53,-1:30,0:7,1:53,-1:15,1:15,0:53,-1:17,0:37,1:52,1:21,0:53,-1:40,0:30,1:53,-1:9,1:19,0:52,0:40,1:53,-1:29,1:9,0:52,0:47,1:52,1:4,0:52,0:4,1:53,-1:35,1:6,0:52,0:19,1:53,-1:8,1:35,0:53,-1:26,0:33,1:53,-1:22,1:8,0:52,0:32,1:52,1:22,0:52,0:24,1:53,-1:1,1:1,0:52,0:8,1:53,-1:46,1:38,0:53,-1:23,0:5,1:53,-1:42,1:42,0:52,0:1,1:52,1:47,0:52,0:26,1:53,-1:16,1:14,0:52,0:6,1:53,-1:45,1:16,0:52,0:42,1:53,-1:2,1:29,0:53,-1:44,0:50,1:52,1:32,0:52,0:32,1:52,1:46,0:53,-1:36,0:16,1:52,1:51\nmove_number=157\n__dict__=gASVzwIAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRYjQIAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAo1Mgo0OQo1Mgo2CjUyCjE0CjUyCjMyCjUyCjQ3CjUyCjQ4CjUyCjEzCjUzCjE5CjMKNTMKMzQKNDgKNTIKNDkKNTMKMjQKNgo1Mgo0Nwo1Mgo0Mwo1Mgo0Mwo1MwozMwozMQo1MwozNwozNwo1MgoxOAo1MgoxOAo1MwozMAo3CjUzCjE1CjE1CjUzCjE3CjM3CjUyCjIxCjUzCjQwCjMwCjUzCjkKMTkKNTIKNDAKNTMKMjkKOQo1Mgo0Nwo1Mgo0CjUyCjQKNTMKMzUKNgo1MgoxOQo1Mwo4CjM1CjUzCjI2CjMzCjUzCjIyCjgKNTIKMzIKNTIKMjIKNTIKMjQKNTMKMQoxCjUyCjgKNTMKNDYKMzgKNTMKMjMKNQo1Mwo0Mgo0Mgo1MgoxCjUyCjQ3CjUyCjI2CjUzCjE2CjE0CjUyCjYKNTMKNDUKMTYKNTIKNDIKNTMKMgoyOQo1Mwo0NAo1MAo1MgozMgo1MgozMgo1Mgo0Ngo1MwozNgoxNgo1Mgo1MQoKlGJzLg==\n",
+          "legalActions": [],
+          "legalActionStrings": []
+        },
+        "status": "INACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "submission": 53,
+          "thoughts": "echo beta drift rho wonder ponder consider beta"
+        },
+        "reward": null,
+        "info": {
+          "actionSubmitted": 53,
+          "actionSubmittedToString": "Player: 0 Action: Draw stock",
+          "actionApplied": 53,
+          "timeTaken": 0.0,
+          "agentSelfReportedStatus": null
+        },
+        "observation": {
+          "remainingOverageTime": 12,
+          "step": 114,
+          "observationString": "{\"phase\": \"Discard\", \"current_player\": 0, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"Kh\", \"upcard\": null, \"stock_size\": 6, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\", \"2h\", \"5s\", \"7c\", \"Td\", \"8d\", \"Qc\", \"9s\", \"Kd\", \"6s\", \"Ad\", \"7s\", \"4h\", \"4d\", \"8h\", \"Kh\"], \"hands\": {\"0\": [\"Ts\", \"Js\", \"2c\", \"5c\", \"Tc\", \"Jc\", \"3d\", \"9d\", \"Jd\", \"6h\", \"9h\"], \"1\": []}, \"deadwood\": {\"0\": 44, \"1\": null}, \"repeated_move\": 0}",
+          "currentPlayer": 0,
+          "playerId": 0,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14,0:52,0:49,1:52,1:6,0:52,0:14,1:52,1:32,0:52,0:47,1:52,1:48,0:52,0:13,1:53,-1:19,1:3,0:53,-1:34,0:48,1:52,1:49,0:53,-1:24,0:6,1:52,1:47,0:52,0:43,1:52,1:43,0:53,-1:33,0:31,1:53,-1:37,1:37,0:52,0:18,1:52,1:18,0:53,-1:30,0:7,1:53,-1:15,1:15,0:53,-1:17,0:37,1:52,1:21,0:53,-1:40,0:30,1:53,-1:9,1:19,0:52,0:40,1:53,-1:29,1:9,0:52,0:47,1:52,1:4,0:52,0:4,1:53,-1:35,1:6,0:52,0:19,1:53,-1:8,1:35,0:53,-1:26,0:33,1:53,-1:22,1:8,0:52,0:32,1:52,1:22,0:52,0:24,1:53,-1:1,1:1,0:52,0:8,1:53,-1:46,1:38,0:53,-1:23,0:5,1:53,-1:42,1:42,0:52,0:1,1:52,1:47,0:52,0:26,1:53,-1:16,1:14,0:52,0:6,1:53,-1:45,1:16,0:52,0:42,1:53,-1:2,1:29,0:53,-1:44,0:50,1:52,1:32,0:52,0:32,1:52,1:46,0:53,-1:36,0:16,1:52,1:51,0:53,-1:10\nmove_number=159\n__dict__=gASV1QIAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRYkwIAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAo1Mgo0OQo1Mgo2CjUyCjE0CjUyCjMyCjUyCjQ3CjUyCjQ4CjUyCjEzCjUzCjE5CjMKNTMKMzQKNDgKNTIKNDkKNTMKMjQKNgo1Mgo0Nwo1Mgo0Mwo1Mgo0Mwo1MwozMwozMQo1MwozNwozNwo1MgoxOAo1MgoxOAo1MwozMAo3CjUzCjE1CjE1CjUzCjE3CjM3CjUyCjIxCjUzCjQwCjMwCjUzCjkKMTkKNTIKNDAKNTMKMjkKOQo1Mgo0Nwo1Mgo0CjUyCjQKNTMKMzUKNgo1MgoxOQo1Mwo4CjM1CjUzCjI2CjMzCjUzCjIyCjgKNTIKMzIKNTIKMjIKNTIKMjQKNTMKMQoxCjUyCjgKNTMKNDYKMzgKNTMKMjMKNQo1Mwo0Mgo0Mgo1MgoxCjUyCjQ3CjUyCjI2CjUzCjE2CjE0CjUyCjYKNTMKNDUKMTYKNTIKNDIKNTMKMgoyOQo1Mwo0NAo1MAo1MgozMgo1MgozMgo1Mgo0Ngo1MwozNgoxNgo1Mgo1MQo1MwoxMAoKlGJzLg==\n",
+          "legalActions": [9, 10, 14, 17, 22, 23, 28, 34, 36, 44, 47],
+          "legalActionStrings": [
+            "Player: 0 Action: Ts",
+            "Player: 0 Action: Js",
+            "Player: 0 Action: 2c",
+            "Player: 0 Action: 5c",
+            "Player: 0 Action: Tc",
+            "Player: 0 Action: Jc",
+            "Player: 0 Action: 3d",
+            "Player: 0 Action: 9d",
+            "Player: 0 Action: Jd",
+            "Player: 0 Action: 6h",
+            "Player: 0 Action: 9h"
+          ]
+        },
+        "status": "ACTIVE"
+      },
+      {
+        "action": {
+          "submission": -1
+        },
+        "reward": null,
+        "info": {},
+        "observation": {
+          "remainingOverageTime": 12,
+          "observationString": "{\"phase\": \"Discard\", \"current_player\": 0, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"Kh\", \"upcard\": null, \"stock_size\": 6, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\", \"2h\", \"5s\", \"7c\", \"Td\", \"8d\", \"Qc\", \"9s\", \"Kd\", \"6s\", \"Ad\", \"7s\", \"4h\", \"4d\", \"8h\", \"Kh\"], \"hands\": {\"0\": [], \"1\": [\"2s\", \"3s\", \"Qs\", \"4c\", \"Kc\", \"7d\", \"Qd\", \"7h\", \"Th\", \"Qh\"]}, \"deadwood\": {\"0\": null, \"1\": 43}, \"repeated_move\": 0}",
+          "currentPlayer": 0,
+          "playerId": 1,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14,0:52,0:49,1:52,1:6,0:52,0:14,1:52,1:32,0:52,0:47,1:52,1:48,0:52,0:13,1:53,-1:19,1:3,0:53,-1:34,0:48,1:52,1:49,0:53,-1:24,0:6,1:52,1:47,0:52,0:43,1:52,1:43,0:53,-1:33,0:31,1:53,-1:37,1:37,0:52,0:18,1:52,1:18,0:53,-1:30,0:7,1:53,-1:15,1:15,0:53,-1:17,0:37,1:52,1:21,0:53,-1:40,0:30,1:53,-1:9,1:19,0:52,0:40,1:53,-1:29,1:9,0:52,0:47,1:52,1:4,0:52,0:4,1:53,-1:35,1:6,0:52,0:19,1:53,-1:8,1:35,0:53,-1:26,0:33,1:53,-1:22,1:8,0:52,0:32,1:52,1:22,0:52,0:24,1:53,-1:1,1:1,0:52,0:8,1:53,-1:46,1:38,0:53,-1:23,0:5,1:53,-1:42,1:42,0:52,0:1,1:52,1:47,0:52,0:26,1:53,-1:16,1:14,0:52,0:6,1:53,-1:45,1:16,0:52,0:42,1:53,-1:2,1:29,0:53,-1:44,0:50,1:52,1:32,0:52,0:32,1:52,1:46,0:53,-1:36,0:16,1:52,1:51,0:53,-1:10\nmove_number=159\n__dict__=gASV1QIAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRYkwIAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAo1Mgo0OQo1Mgo2CjUyCjE0CjUyCjMyCjUyCjQ3CjUyCjQ4CjUyCjEzCjUzCjE5CjMKNTMKMzQKNDgKNTIKNDkKNTMKMjQKNgo1Mgo0Nwo1Mgo0Mwo1Mgo0Mwo1MwozMwozMQo1MwozNwozNwo1MgoxOAo1MgoxOAo1MwozMAo3CjUzCjE1CjE1CjUzCjE3CjM3CjUyCjIxCjUzCjQwCjMwCjUzCjkKMTkKNTIKNDAKNTMKMjkKOQo1Mgo0Nwo1Mgo0CjUyCjQKNTMKMzUKNgo1MgoxOQo1Mwo4CjM1CjUzCjI2CjMzCjUzCjIyCjgKNTIKMzIKNTIKMjIKNTIKMjQKNTMKMQoxCjUyCjgKNTMKNDYKMzgKNTMKMjMKNQo1Mwo0Mgo0Mgo1MgoxCjUyCjQ3CjUyCjI2CjUzCjE2CjE0CjUyCjYKNTMKNDUKMTYKNTIKNDIKNTMKMgoyOQo1Mwo0NAo1MAo1MgozMgo1MgozMgo1Mgo0Ngo1MwozNgoxNgo1Mgo1MQo1MwoxMAoKlGJzLg==\n",
+          "legalActions": [],
+          "legalActionStrings": []
+        },
+        "status": "INACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "submission": 36,
+          "thoughts": "tau kappa wonder kappa consider phi reflect chi"
+        },
+        "reward": null,
+        "info": {
+          "actionSubmitted": 36,
+          "actionSubmittedToString": "Player: 0 Action: Jd",
+          "actionApplied": 36,
+          "timeTaken": 0.0,
+          "agentSelfReportedStatus": null
+        },
+        "observation": {
+          "remainingOverageTime": 12,
+          "step": 115,
+          "observationString": "{\"phase\": \"Draw\", \"current_player\": 1, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"Kh\", \"upcard\": \"Jd\", \"stock_size\": 6, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\", \"2h\", \"5s\", \"7c\", \"Td\", \"8d\", \"Qc\", \"9s\", \"Kd\", \"6s\", \"Ad\", \"7s\", \"4h\", \"4d\", \"8h\", \"Kh\"], \"hands\": {\"0\": [\"Ts\", \"Js\", \"2c\", \"5c\", \"Tc\", \"Jc\", \"3d\", \"9d\", \"6h\", \"9h\"], \"1\": []}, \"deadwood\": {\"0\": 74, \"1\": null}, \"repeated_move\": 0}",
+          "currentPlayer": 1,
+          "playerId": 0,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14,0:52,0:49,1:52,1:6,0:52,0:14,1:52,1:32,0:52,0:47,1:52,1:48,0:52,0:13,1:53,-1:19,1:3,0:53,-1:34,0:48,1:52,1:49,0:53,-1:24,0:6,1:52,1:47,0:52,0:43,1:52,1:43,0:53,-1:33,0:31,1:53,-1:37,1:37,0:52,0:18,1:52,1:18,0:53,-1:30,0:7,1:53,-1:15,1:15,0:53,-1:17,0:37,1:52,1:21,0:53,-1:40,0:30,1:53,-1:9,1:19,0:52,0:40,1:53,-1:29,1:9,0:52,0:47,1:52,1:4,0:52,0:4,1:53,-1:35,1:6,0:52,0:19,1:53,-1:8,1:35,0:53,-1:26,0:33,1:53,-1:22,1:8,0:52,0:32,1:52,1:22,0:52,0:24,1:53,-1:1,1:1,0:52,0:8,1:53,-1:46,1:38,0:53,-1:23,0:5,1:53,-1:42,1:42,0:52,0:1,1:52,1:47,0:52,0:26,1:53,-1:16,1:14,0:52,0:6,1:53,-1:45,1:16,0:52,0:42,1:53,-1:2,1:29,0:53,-1:44,0:50,1:52,1:32,0:52,0:32,1:52,1:46,0:53,-1:36,0:16,1:52,1:51,0:53,-1:10,0:36\nmove_number=160\n__dict__=gASV2AIAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRYlgIAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAo1Mgo0OQo1Mgo2CjUyCjE0CjUyCjMyCjUyCjQ3CjUyCjQ4CjUyCjEzCjUzCjE5CjMKNTMKMzQKNDgKNTIKNDkKNTMKMjQKNgo1Mgo0Nwo1Mgo0Mwo1Mgo0Mwo1MwozMwozMQo1MwozNwozNwo1MgoxOAo1MgoxOAo1MwozMAo3CjUzCjE1CjE1CjUzCjE3CjM3CjUyCjIxCjUzCjQwCjMwCjUzCjkKMTkKNTIKNDAKNTMKMjkKOQo1Mgo0Nwo1Mgo0CjUyCjQKNTMKMzUKNgo1MgoxOQo1Mwo4CjM1CjUzCjI2CjMzCjUzCjIyCjgKNTIKMzIKNTIKMjIKNTIKMjQKNTMKMQoxCjUyCjgKNTMKNDYKMzgKNTMKMjMKNQo1Mwo0Mgo0Mgo1MgoxCjUyCjQ3CjUyCjI2CjUzCjE2CjE0CjUyCjYKNTMKNDUKMTYKNTIKNDIKNTMKMgoyOQo1Mwo0NAo1MAo1MgozMgo1MgozMgo1Mgo0Ngo1MwozNgoxNgo1Mgo1MQo1MwoxMAozNgoKlGJzLg==\n",
+          "legalActions": [],
+          "legalActionStrings": []
+        },
+        "status": "INACTIVE"
+      },
+      {
+        "action": {
+          "submission": -1
+        },
+        "reward": null,
+        "info": {},
+        "observation": {
+          "remainingOverageTime": 12,
+          "observationString": "{\"phase\": \"Draw\", \"current_player\": 1, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"Kh\", \"upcard\": \"Jd\", \"stock_size\": 6, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\", \"2h\", \"5s\", \"7c\", \"Td\", \"8d\", \"Qc\", \"9s\", \"Kd\", \"6s\", \"Ad\", \"7s\", \"4h\", \"4d\", \"8h\", \"Kh\"], \"hands\": {\"0\": [], \"1\": [\"2s\", \"3s\", \"Qs\", \"4c\", \"Kc\", \"7d\", \"Qd\", \"7h\", \"Th\", \"Qh\"]}, \"deadwood\": {\"0\": null, \"1\": 43}, \"repeated_move\": 0}",
+          "currentPlayer": 1,
+          "playerId": 1,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14,0:52,0:49,1:52,1:6,0:52,0:14,1:52,1:32,0:52,0:47,1:52,1:48,0:52,0:13,1:53,-1:19,1:3,0:53,-1:34,0:48,1:52,1:49,0:53,-1:24,0:6,1:52,1:47,0:52,0:43,1:52,1:43,0:53,-1:33,0:31,1:53,-1:37,1:37,0:52,0:18,1:52,1:18,0:53,-1:30,0:7,1:53,-1:15,1:15,0:53,-1:17,0:37,1:52,1:21,0:53,-1:40,0:30,1:53,-1:9,1:19,0:52,0:40,1:53,-1:29,1:9,0:52,0:47,1:52,1:4,0:52,0:4,1:53,-1:35,1:6,0:52,0:19,1:53,-1:8,1:35,0:53,-1:26,0:33,1:53,-1:22,1:8,0:52,0:32,1:52,1:22,0:52,0:24,1:53,-1:1,1:1,0:52,0:8,1:53,-1:46,1:38,0:53,-1:23,0:5,1:53,-1:42,1:42,0:52,0:1,1:52,1:47,0:52,0:26,1:53,-1:16,1:14,0:52,0:6,1:53,-1:45,1:16,0:52,0:42,1:53,-1:2,1:29,0:53,-1:44,0:50,1:52,1:32,0:52,0:32,1:52,1:46,0:53,-1:36,0:16,1:52,1:51,0:53,-1:10,0:36\nmove_number=160\n__dict__=gASV2AIAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRYlgIAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAo1Mgo0OQo1Mgo2CjUyCjE0CjUyCjMyCjUyCjQ3CjUyCjQ4CjUyCjEzCjUzCjE5CjMKNTMKMzQKNDgKNTIKNDkKNTMKMjQKNgo1Mgo0Nwo1Mgo0Mwo1Mgo0Mwo1MwozMwozMQo1MwozNwozNwo1MgoxOAo1MgoxOAo1MwozMAo3CjUzCjE1CjE1CjUzCjE3CjM3CjUyCjIxCjUzCjQwCjMwCjUzCjkKMTkKNTIKNDAKNTMKMjkKOQo1Mgo0Nwo1Mgo0CjUyCjQKNTMKMzUKNgo1MgoxOQo1Mwo4CjM1CjUzCjI2CjMzCjUzCjIyCjgKNTIKMzIKNTIKMjIKNTIKMjQKNTMKMQoxCjUyCjgKNTMKNDYKMzgKNTMKMjMKNQo1Mwo0Mgo0Mgo1MgoxCjUyCjQ3CjUyCjI2CjUzCjE2CjE0CjUyCjYKNTMKNDUKMTYKNTIKNDIKNTMKMgoyOQo1Mwo0NAo1MAo1MgozMgo1MgozMgo1Mgo0Ngo1MwozNgoxNgo1Mgo1MQo1MwoxMAozNgoKlGJzLg==\n",
+          "legalActions": [52, 53],
+          "legalActionStrings": [
+            "Player: 1 Action: Draw upcard",
+            "Player: 1 Action: Draw stock"
+          ]
+        },
+        "status": "ACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "submission": -1
+        },
+        "reward": null,
+        "info": {},
+        "observation": {
+          "remainingOverageTime": 12,
+          "step": 116,
+          "observationString": "{\"phase\": \"Discard\", \"current_player\": 1, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"Jd\", \"upcard\": null, \"stock_size\": 6, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\", \"2h\", \"5s\", \"7c\", \"Td\", \"8d\", \"Qc\", \"9s\", \"Kd\", \"6s\", \"Ad\", \"7s\", \"4h\", \"4d\", \"8h\", \"Kh\"], \"hands\": {\"0\": [\"Ts\", \"Js\", \"2c\", \"5c\", \"Tc\", \"Jc\", \"3d\", \"9d\", \"6h\", \"9h\"], \"1\": []}, \"deadwood\": {\"0\": 74, \"1\": null}, \"repeated_move\": 0}",
+          "currentPlayer": 1,
+          "playerId": 0,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14,0:52,0:49,1:52,1:6,0:52,0:14,1:52,1:32,0:52,0:47,1:52,1:48,0:52,0:13,1:53,-1:19,1:3,0:53,-1:34,0:48,1:52,1:49,0:53,-1:24,0:6,1:52,1:47,0:52,0:43,1:52,1:43,0:53,-1:33,0:31,1:53,-1:37,1:37,0:52,0:18,1:52,1:18,0:53,-1:30,0:7,1:53,-1:15,1:15,0:53,-1:17,0:37,1:52,1:21,0:53,-1:40,0:30,1:53,-1:9,1:19,0:52,0:40,1:53,-1:29,1:9,0:52,0:47,1:52,1:4,0:52,0:4,1:53,-1:35,1:6,0:52,0:19,1:53,-1:8,1:35,0:53,-1:26,0:33,1:53,-1:22,1:8,0:52,0:32,1:52,1:22,0:52,0:24,1:53,-1:1,1:1,0:52,0:8,1:53,-1:46,1:38,0:53,-1:23,0:5,1:53,-1:42,1:42,0:52,0:1,1:52,1:47,0:52,0:26,1:53,-1:16,1:14,0:52,0:6,1:53,-1:45,1:16,0:52,0:42,1:53,-1:2,1:29,0:53,-1:44,0:50,1:52,1:32,0:52,0:32,1:52,1:46,0:53,-1:36,0:16,1:52,1:51,0:53,-1:10,0:36,1:52\nmove_number=161\n__dict__=gASV2wIAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRYmQIAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAo1Mgo0OQo1Mgo2CjUyCjE0CjUyCjMyCjUyCjQ3CjUyCjQ4CjUyCjEzCjUzCjE5CjMKNTMKMzQKNDgKNTIKNDkKNTMKMjQKNgo1Mgo0Nwo1Mgo0Mwo1Mgo0Mwo1MwozMwozMQo1MwozNwozNwo1MgoxOAo1MgoxOAo1MwozMAo3CjUzCjE1CjE1CjUzCjE3CjM3CjUyCjIxCjUzCjQwCjMwCjUzCjkKMTkKNTIKNDAKNTMKMjkKOQo1Mgo0Nwo1Mgo0CjUyCjQKNTMKMzUKNgo1MgoxOQo1Mwo4CjM1CjUzCjI2CjMzCjUzCjIyCjgKNTIKMzIKNTIKMjIKNTIKMjQKNTMKMQoxCjUyCjgKNTMKNDYKMzgKNTMKMjMKNQo1Mwo0Mgo0Mgo1MgoxCjUyCjQ3CjUyCjI2CjUzCjE2CjE0CjUyCjYKNTMKNDUKMTYKNTIKNDIKNTMKMgoyOQo1Mwo0NAo1MAo1MgozMgo1MgozMgo1Mgo0Ngo1MwozNgoxNgo1Mgo1MQo1MwoxMAozNgo1MgoKlGJzLg==\n",
+          "legalActions": [],
+          "legalActionStrings": []
+        },
+        "status": "INACTIVE"
+      },
+      {
+        "action": {
+          "submission": 52,
+          "thoughts": "lantern upsilon alpha kappa ripple xi omicron shadow"
+        },
+        "reward": null,
+        "info": {
+          "actionSubmitted": 52,
+          "actionSubmittedToString": "Player: 1 Action: Draw upcard",
+          "actionApplied": 52,
+          "timeTaken": 0.0,
+          "agentSelfReportedStatus": null
+        },
+        "observation": {
+          "remainingOverageTime": 12,
+          "observationString": "{\"phase\": \"Discard\", \"current_player\": 1, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"Jd\", \"upcard\": null, \"stock_size\": 6, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\", \"2h\", \"5s\", \"7c\", \"Td\", \"8d\", \"Qc\", \"9s\", \"Kd\", \"6s\", \"Ad\", \"7s\", \"4h\", \"4d\", \"8h\", \"Kh\"], \"hands\": {\"0\": [], \"1\": [\"2s\", \"3s\", \"Qs\", \"4c\", \"Kc\", \"7d\", \"Jd\", \"Qd\", \"7h\", \"Th\", \"Qh\"]}, \"deadwood\": {\"0\": null, \"1\": 43}, \"repeated_move\": 0}",
+          "currentPlayer": 1,
+          "playerId": 1,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14,0:52,0:49,1:52,1:6,0:52,0:14,1:52,1:32,0:52,0:47,1:52,1:48,0:52,0:13,1:53,-1:19,1:3,0:53,-1:34,0:48,1:52,1:49,0:53,-1:24,0:6,1:52,1:47,0:52,0:43,1:52,1:43,0:53,-1:33,0:31,1:53,-1:37,1:37,0:52,0:18,1:52,1:18,0:53,-1:30,0:7,1:53,-1:15,1:15,0:53,-1:17,0:37,1:52,1:21,0:53,-1:40,0:30,1:53,-1:9,1:19,0:52,0:40,1:53,-1:29,1:9,0:52,0:47,1:52,1:4,0:52,0:4,1:53,-1:35,1:6,0:52,0:19,1:53,-1:8,1:35,0:53,-1:26,0:33,1:53,-1:22,1:8,0:52,0:32,1:52,1:22,0:52,0:24,1:53,-1:1,1:1,0:52,0:8,1:53,-1:46,1:38,0:53,-1:23,0:5,1:53,-1:42,1:42,0:52,0:1,1:52,1:47,0:52,0:26,1:53,-1:16,1:14,0:52,0:6,1:53,-1:45,1:16,0:52,0:42,1:53,-1:2,1:29,0:53,-1:44,0:50,1:52,1:32,0:52,0:32,1:52,1:46,0:53,-1:36,0:16,1:52,1:51,0:53,-1:10,0:36,1:52\nmove_number=161\n__dict__=gASV2wIAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRYmQIAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAo1Mgo0OQo1Mgo2CjUyCjE0CjUyCjMyCjUyCjQ3CjUyCjQ4CjUyCjEzCjUzCjE5CjMKNTMKMzQKNDgKNTIKNDkKNTMKMjQKNgo1Mgo0Nwo1Mgo0Mwo1Mgo0Mwo1MwozMwozMQo1MwozNwozNwo1MgoxOAo1MgoxOAo1MwozMAo3CjUzCjE1CjE1CjUzCjE3CjM3CjUyCjIxCjUzCjQwCjMwCjUzCjkKMTkKNTIKNDAKNTMKMjkKOQo1Mgo0Nwo1Mgo0CjUyCjQKNTMKMzUKNgo1MgoxOQo1Mwo4CjM1CjUzCjI2CjMzCjUzCjIyCjgKNTIKMzIKNTIKMjIKNTIKMjQKNTMKMQoxCjUyCjgKNTMKNDYKMzgKNTMKMjMKNQo1Mwo0Mgo0Mgo1MgoxCjUyCjQ3CjUyCjI2CjUzCjE2CjE0CjUyCjYKNTMKNDUKMTYKNTIKNDIKNTMKMgoyOQo1Mwo0NAo1MAo1MgozMgo1MgozMgo1Mgo0Ngo1MwozNgoxNgo1Mgo1MQo1MwoxMAozNgo1MgoKlGJzLg==\n",
+          "legalActions": [1, 2, 11, 16, 25, 32, 36, 37, 45, 48, 50],
+          "legalActionStrings": [
+            "Player: 1 Action: 2s",
+            "Player: 1 Action: 3s",
+            "Player: 1 Action: Qs",
+            "Player: 1 Action: 4c",
+            "Player: 1 Action: Kc",
+            "Player: 1 Action: 7d",
+            "Player: 1 Action: Jd",
+            "Player: 1 Action: Qd",
+            "Player: 1 Action: 7h",
+            "Player: 1 Action: Th",
+            "Player: 1 Action: Qh"
+          ]
+        },
+        "status": "ACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "submission": -1
+        },
+        "reward": null,
+        "info": {},
+        "observation": {
+          "remainingOverageTime": 12,
+          "step": 117,
+          "observationString": "{\"phase\": \"Draw\", \"current_player\": 0, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"Jd\", \"upcard\": \"Qs\", \"stock_size\": 6, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\", \"2h\", \"5s\", \"7c\", \"Td\", \"8d\", \"Qc\", \"9s\", \"Kd\", \"6s\", \"Ad\", \"7s\", \"4h\", \"4d\", \"8h\", \"Kh\"], \"hands\": {\"0\": [\"Ts\", \"Js\", \"2c\", \"5c\", \"Tc\", \"Jc\", \"3d\", \"9d\", \"6h\", \"9h\"], \"1\": []}, \"deadwood\": {\"0\": 74, \"1\": null}, \"repeated_move\": 0}",
+          "currentPlayer": 0,
+          "playerId": 0,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14,0:52,0:49,1:52,1:6,0:52,0:14,1:52,1:32,0:52,0:47,1:52,1:48,0:52,0:13,1:53,-1:19,1:3,0:53,-1:34,0:48,1:52,1:49,0:53,-1:24,0:6,1:52,1:47,0:52,0:43,1:52,1:43,0:53,-1:33,0:31,1:53,-1:37,1:37,0:52,0:18,1:52,1:18,0:53,-1:30,0:7,1:53,-1:15,1:15,0:53,-1:17,0:37,1:52,1:21,0:53,-1:40,0:30,1:53,-1:9,1:19,0:52,0:40,1:53,-1:29,1:9,0:52,0:47,1:52,1:4,0:52,0:4,1:53,-1:35,1:6,0:52,0:19,1:53,-1:8,1:35,0:53,-1:26,0:33,1:53,-1:22,1:8,0:52,0:32,1:52,1:22,0:52,0:24,1:53,-1:1,1:1,0:52,0:8,1:53,-1:46,1:38,0:53,-1:23,0:5,1:53,-1:42,1:42,0:52,0:1,1:52,1:47,0:52,0:26,1:53,-1:16,1:14,0:52,0:6,1:53,-1:45,1:16,0:52,0:42,1:53,-1:2,1:29,0:53,-1:44,0:50,1:52,1:32,0:52,0:32,1:52,1:46,0:53,-1:36,0:16,1:52,1:51,0:53,-1:10,0:36,1:52,1:11\nmove_number=162\n__dict__=gASV3gIAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRYnAIAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAo1Mgo0OQo1Mgo2CjUyCjE0CjUyCjMyCjUyCjQ3CjUyCjQ4CjUyCjEzCjUzCjE5CjMKNTMKMzQKNDgKNTIKNDkKNTMKMjQKNgo1Mgo0Nwo1Mgo0Mwo1Mgo0Mwo1MwozMwozMQo1MwozNwozNwo1MgoxOAo1MgoxOAo1MwozMAo3CjUzCjE1CjE1CjUzCjE3CjM3CjUyCjIxCjUzCjQwCjMwCjUzCjkKMTkKNTIKNDAKNTMKMjkKOQo1Mgo0Nwo1Mgo0CjUyCjQKNTMKMzUKNgo1MgoxOQo1Mwo4CjM1CjUzCjI2CjMzCjUzCjIyCjgKNTIKMzIKNTIKMjIKNTIKMjQKNTMKMQoxCjUyCjgKNTMKNDYKMzgKNTMKMjMKNQo1Mwo0Mgo0Mgo1MgoxCjUyCjQ3CjUyCjI2CjUzCjE2CjE0CjUyCjYKNTMKNDUKMTYKNTIKNDIKNTMKMgoyOQo1Mwo0NAo1MAo1MgozMgo1MgozMgo1Mgo0Ngo1MwozNgoxNgo1Mgo1MQo1MwoxMAozNgo1MgoxMQoKlGJzLg==\n",
+          "legalActions": [52, 53],
+          "legalActionStrings": [
+            "Player: 0 Action: Draw upcard",
+            "Player: 0 Action: Draw stock"
+          ]
+        },
+        "status": "ACTIVE"
+      },
+      {
+        "action": {
+          "submission": 11,
+          "thoughts": "beta wonder shadow spark explore lantern drift imagine"
+        },
+        "reward": null,
+        "info": {
+          "actionSubmitted": 11,
+          "actionSubmittedToString": "Player: 1 Action: Qs",
+          "actionApplied": 11,
+          "timeTaken": 0.0,
+          "agentSelfReportedStatus": null
+        },
+        "observation": {
+          "remainingOverageTime": 12,
+          "observationString": "{\"phase\": \"Draw\", \"current_player\": 0, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"Jd\", \"upcard\": \"Qs\", \"stock_size\": 6, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\", \"2h\", \"5s\", \"7c\", \"Td\", \"8d\", \"Qc\", \"9s\", \"Kd\", \"6s\", \"Ad\", \"7s\", \"4h\", \"4d\", \"8h\", \"Kh\"], \"hands\": {\"0\": [], \"1\": [\"2s\", \"3s\", \"4c\", \"Kc\", \"7d\", \"Jd\", \"Qd\", \"7h\", \"Th\", \"Qh\"]}, \"deadwood\": {\"0\": null, \"1\": 73}, \"repeated_move\": 0}",
+          "currentPlayer": 0,
+          "playerId": 1,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14,0:52,0:49,1:52,1:6,0:52,0:14,1:52,1:32,0:52,0:47,1:52,1:48,0:52,0:13,1:53,-1:19,1:3,0:53,-1:34,0:48,1:52,1:49,0:53,-1:24,0:6,1:52,1:47,0:52,0:43,1:52,1:43,0:53,-1:33,0:31,1:53,-1:37,1:37,0:52,0:18,1:52,1:18,0:53,-1:30,0:7,1:53,-1:15,1:15,0:53,-1:17,0:37,1:52,1:21,0:53,-1:40,0:30,1:53,-1:9,1:19,0:52,0:40,1:53,-1:29,1:9,0:52,0:47,1:52,1:4,0:52,0:4,1:53,-1:35,1:6,0:52,0:19,1:53,-1:8,1:35,0:53,-1:26,0:33,1:53,-1:22,1:8,0:52,0:32,1:52,1:22,0:52,0:24,1:53,-1:1,1:1,0:52,0:8,1:53,-1:46,1:38,0:53,-1:23,0:5,1:53,-1:42,1:42,0:52,0:1,1:52,1:47,0:52,0:26,1:53,-1:16,1:14,0:52,0:6,1:53,-1:45,1:16,0:52,0:42,1:53,-1:2,1:29,0:53,-1:44,0:50,1:52,1:32,0:52,0:32,1:52,1:46,0:53,-1:36,0:16,1:52,1:51,0:53,-1:10,0:36,1:52,1:11\nmove_number=162\n__dict__=gASV3gIAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRYnAIAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAo1Mgo0OQo1Mgo2CjUyCjE0CjUyCjMyCjUyCjQ3CjUyCjQ4CjUyCjEzCjUzCjE5CjMKNTMKMzQKNDgKNTIKNDkKNTMKMjQKNgo1Mgo0Nwo1Mgo0Mwo1Mgo0Mwo1MwozMwozMQo1MwozNwozNwo1MgoxOAo1MgoxOAo1MwozMAo3CjUzCjE1CjE1CjUzCjE3CjM3CjUyCjIxCjUzCjQwCjMwCjUzCjkKMTkKNTIKNDAKNTMKMjkKOQo1Mgo0Nwo1Mgo0CjUyCjQKNTMKMzUKNgo1MgoxOQo1Mwo4CjM1CjUzCjI2CjMzCjUzCjIyCjgKNTIKMzIKNTIKMjIKNTIKMjQKNTMKMQoxCjUyCjgKNTMKNDYKMzgKNTMKMjMKNQo1Mwo0Mgo0Mgo1MgoxCjUyCjQ3CjUyCjI2CjUzCjE2CjE0CjUyCjYKNTMKNDUKMTYKNTIKNDIKNTMKMgoyOQo1Mwo0NAo1MAo1MgozMgo1MgozMgo1Mgo0Ngo1MwozNgoxNgo1Mgo1MQo1MwoxMAozNgo1MgoxMQoKlGJzLg==\n",
+          "legalActions": [],
+          "legalActionStrings": []
+        },
+        "status": "INACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "submission": 52,
+          "thoughts": "imagine kappa rho omicron upsilon beta reflect imagine"
+        },
+        "reward": null,
+        "info": {
+          "actionSubmitted": 52,
+          "actionSubmittedToString": "Player: 0 Action: Draw upcard",
+          "actionApplied": 52,
+          "timeTaken": 0.0,
+          "agentSelfReportedStatus": null
+        },
+        "observation": {
+          "remainingOverageTime": 12,
+          "step": 118,
+          "observationString": "{\"phase\": \"Discard\", \"current_player\": 0, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"Qs\", \"upcard\": null, \"stock_size\": 6, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\", \"2h\", \"5s\", \"7c\", \"Td\", \"8d\", \"Qc\", \"9s\", \"Kd\", \"6s\", \"Ad\", \"7s\", \"4h\", \"4d\", \"8h\", \"Kh\"], \"hands\": {\"0\": [\"Ts\", \"Js\", \"Qs\", \"2c\", \"5c\", \"Tc\", \"Jc\", \"3d\", \"9d\", \"6h\", \"9h\"], \"1\": []}, \"deadwood\": {\"0\": 44, \"1\": null}, \"repeated_move\": 0}",
+          "currentPlayer": 0,
+          "playerId": 0,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14,0:52,0:49,1:52,1:6,0:52,0:14,1:52,1:32,0:52,0:47,1:52,1:48,0:52,0:13,1:53,-1:19,1:3,0:53,-1:34,0:48,1:52,1:49,0:53,-1:24,0:6,1:52,1:47,0:52,0:43,1:52,1:43,0:53,-1:33,0:31,1:53,-1:37,1:37,0:52,0:18,1:52,1:18,0:53,-1:30,0:7,1:53,-1:15,1:15,0:53,-1:17,0:37,1:52,1:21,0:53,-1:40,0:30,1:53,-1:9,1:19,0:52,0:40,1:53,-1:29,1:9,0:52,0:47,1:52,1:4,0:52,0:4,1:53,-1:35,1:6,0:52,0:19,1:53,-1:8,1:35,0:53,-1:26,0:33,1:53,-1:22,1:8,0:52,0:32,1:52,1:22,0:52,0:24,1:53,-1:1,1:1,0:52,0:8,1:53,-1:46,1:38,0:53,-1:23,0:5,1:53,-1:42,1:42,0:52,0:1,1:52,1:47,0:52,0:26,1:53,-1:16,1:14,0:52,0:6,1:53,-1:45,1:16,0:52,0:42,1:53,-1:2,1:29,0:53,-1:44,0:50,1:52,1:32,0:52,0:32,1:52,1:46,0:53,-1:36,0:16,1:52,1:51,0:53,-1:10,0:36,1:52,1:11,0:52\nmove_number=163\n__dict__=gASV4QIAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRYnwIAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAo1Mgo0OQo1Mgo2CjUyCjE0CjUyCjMyCjUyCjQ3CjUyCjQ4CjUyCjEzCjUzCjE5CjMKNTMKMzQKNDgKNTIKNDkKNTMKMjQKNgo1Mgo0Nwo1Mgo0Mwo1Mgo0Mwo1MwozMwozMQo1MwozNwozNwo1MgoxOAo1MgoxOAo1MwozMAo3CjUzCjE1CjE1CjUzCjE3CjM3CjUyCjIxCjUzCjQwCjMwCjUzCjkKMTkKNTIKNDAKNTMKMjkKOQo1Mgo0Nwo1Mgo0CjUyCjQKNTMKMzUKNgo1MgoxOQo1Mwo4CjM1CjUzCjI2CjMzCjUzCjIyCjgKNTIKMzIKNTIKMjIKNTIKMjQKNTMKMQoxCjUyCjgKNTMKNDYKMzgKNTMKMjMKNQo1Mwo0Mgo0Mgo1MgoxCjUyCjQ3CjUyCjI2CjUzCjE2CjE0CjUyCjYKNTMKNDUKMTYKNTIKNDIKNTMKMgoyOQo1Mwo0NAo1MAo1MgozMgo1MgozMgo1Mgo0Ngo1MwozNgoxNgo1Mgo1MQo1MwoxMAozNgo1MgoxMQo1MgoKlGJzLg==\n",
+          "legalActions": [9, 10, 11, 14, 17, 22, 23, 28, 34, 44, 47],
+          "legalActionStrings": [
+            "Player: 0 Action: Ts",
+            "Player: 0 Action: Js",
+            "Player: 0 Action: Qs",
+            "Player: 0 Action: 2c",
+            "Player: 0 Action: 5c",
+            "Player: 0 Action: Tc",
+            "Player: 0 Action: Jc",
+            "Player: 0 Action: 3d",
+            "Player: 0 Action: 9d",
+            "Player: 0 Action: 6h",
+            "Player: 0 Action: 9h"
+          ]
+        },
+        "status": "ACTIVE"
+      },
+      {
+        "action": {
+          "submission": -1
+        },
+        "reward": null,
+        "info": {},
+        "observation": {
+          "remainingOverageTime": 12,
+          "observationString": "{\"phase\": \"Discard\", \"current_player\": 0, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"Qs\", \"upcard\": null, \"stock_size\": 6, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\", \"2h\", \"5s\", \"7c\", \"Td\", \"8d\", \"Qc\", \"9s\", \"Kd\", \"6s\", \"Ad\", \"7s\", \"4h\", \"4d\", \"8h\", \"Kh\"], \"hands\": {\"0\": [], \"1\": [\"2s\", \"3s\", \"4c\", \"Kc\", \"7d\", \"Jd\", \"Qd\", \"7h\", \"Th\", \"Qh\"]}, \"deadwood\": {\"0\": null, \"1\": 73}, \"repeated_move\": 0}",
+          "currentPlayer": 0,
+          "playerId": 1,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14,0:52,0:49,1:52,1:6,0:52,0:14,1:52,1:32,0:52,0:47,1:52,1:48,0:52,0:13,1:53,-1:19,1:3,0:53,-1:34,0:48,1:52,1:49,0:53,-1:24,0:6,1:52,1:47,0:52,0:43,1:52,1:43,0:53,-1:33,0:31,1:53,-1:37,1:37,0:52,0:18,1:52,1:18,0:53,-1:30,0:7,1:53,-1:15,1:15,0:53,-1:17,0:37,1:52,1:21,0:53,-1:40,0:30,1:53,-1:9,1:19,0:52,0:40,1:53,-1:29,1:9,0:52,0:47,1:52,1:4,0:52,0:4,1:53,-1:35,1:6,0:52,0:19,1:53,-1:8,1:35,0:53,-1:26,0:33,1:53,-1:22,1:8,0:52,0:32,1:52,1:22,0:52,0:24,1:53,-1:1,1:1,0:52,0:8,1:53,-1:46,1:38,0:53,-1:23,0:5,1:53,-1:42,1:42,0:52,0:1,1:52,1:47,0:52,0:26,1:53,-1:16,1:14,0:52,0:6,1:53,-1:45,1:16,0:52,0:42,1:53,-1:2,1:29,0:53,-1:44,0:50,1:52,1:32,0:52,0:32,1:52,1:46,0:53,-1:36,0:16,1:52,1:51,0:53,-1:10,0:36,1:52,1:11,0:52\nmove_number=163\n__dict__=gASV4QIAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRYnwIAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAo1Mgo0OQo1Mgo2CjUyCjE0CjUyCjMyCjUyCjQ3CjUyCjQ4CjUyCjEzCjUzCjE5CjMKNTMKMzQKNDgKNTIKNDkKNTMKMjQKNgo1Mgo0Nwo1Mgo0Mwo1Mgo0Mwo1MwozMwozMQo1MwozNwozNwo1MgoxOAo1MgoxOAo1MwozMAo3CjUzCjE1CjE1CjUzCjE3CjM3CjUyCjIxCjUzCjQwCjMwCjUzCjkKMTkKNTIKNDAKNTMKMjkKOQo1Mgo0Nwo1Mgo0CjUyCjQKNTMKMzUKNgo1MgoxOQo1Mwo4CjM1CjUzCjI2CjMzCjUzCjIyCjgKNTIKMzIKNTIKMjIKNTIKMjQKNTMKMQoxCjUyCjgKNTMKNDYKMzgKNTMKMjMKNQo1Mwo0Mgo0Mgo1MgoxCjUyCjQ3CjUyCjI2CjUzCjE2CjE0CjUyCjYKNTMKNDUKMTYKNTIKNDIKNTMKMgoyOQo1Mwo0NAo1MAo1MgozMgo1MgozMgo1Mgo0Ngo1MwozNgoxNgo1Mgo1MQo1MwoxMAozNgo1MgoxMQo1MgoKlGJzLg==\n",
+          "legalActions": [],
+          "legalActionStrings": []
+        },
+        "status": "INACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "submission": 47,
+          "thoughts": "eta omicron kappa upsilon epsilon consider theta lantern"
+        },
+        "reward": null,
+        "info": {
+          "actionSubmitted": 47,
+          "actionSubmittedToString": "Player: 0 Action: 9h",
+          "actionApplied": 47,
+          "timeTaken": 0.0,
+          "agentSelfReportedStatus": null
+        },
+        "observation": {
+          "remainingOverageTime": 12,
+          "step": 119,
+          "observationString": "{\"phase\": \"Draw\", \"current_player\": 1, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"Qs\", \"upcard\": \"9h\", \"stock_size\": 6, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\", \"2h\", \"5s\", \"7c\", \"Td\", \"8d\", \"Qc\", \"9s\", \"Kd\", \"6s\", \"Ad\", \"7s\", \"4h\", \"4d\", \"8h\", \"Kh\"], \"hands\": {\"0\": [\"Ts\", \"Js\", \"Qs\", \"2c\", \"5c\", \"Tc\", \"Jc\", \"3d\", \"9d\", \"6h\"], \"1\": []}, \"deadwood\": {\"0\": 45, \"1\": null}, \"repeated_move\": 0}",
+          "currentPlayer": 1,
+          "playerId": 0,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14,0:52,0:49,1:52,1:6,0:52,0:14,1:52,1:32,0:52,0:47,1:52,1:48,0:52,0:13,1:53,-1:19,1:3,0:53,-1:34,0:48,1:52,1:49,0:53,-1:24,0:6,1:52,1:47,0:52,0:43,1:52,1:43,0:53,-1:33,0:31,1:53,-1:37,1:37,0:52,0:18,1:52,1:18,0:53,-1:30,0:7,1:53,-1:15,1:15,0:53,-1:17,0:37,1:52,1:21,0:53,-1:40,0:30,1:53,-1:9,1:19,0:52,0:40,1:53,-1:29,1:9,0:52,0:47,1:52,1:4,0:52,0:4,1:53,-1:35,1:6,0:52,0:19,1:53,-1:8,1:35,0:53,-1:26,0:33,1:53,-1:22,1:8,0:52,0:32,1:52,1:22,0:52,0:24,1:53,-1:1,1:1,0:52,0:8,1:53,-1:46,1:38,0:53,-1:23,0:5,1:53,-1:42,1:42,0:52,0:1,1:52,1:47,0:52,0:26,1:53,-1:16,1:14,0:52,0:6,1:53,-1:45,1:16,0:52,0:42,1:53,-1:2,1:29,0:53,-1:44,0:50,1:52,1:32,0:52,0:32,1:52,1:46,0:53,-1:36,0:16,1:52,1:51,0:53,-1:10,0:36,1:52,1:11,0:52,0:47\nmove_number=164\n__dict__=gASV5AIAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRYogIAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAo1Mgo0OQo1Mgo2CjUyCjE0CjUyCjMyCjUyCjQ3CjUyCjQ4CjUyCjEzCjUzCjE5CjMKNTMKMzQKNDgKNTIKNDkKNTMKMjQKNgo1Mgo0Nwo1Mgo0Mwo1Mgo0Mwo1MwozMwozMQo1MwozNwozNwo1MgoxOAo1MgoxOAo1MwozMAo3CjUzCjE1CjE1CjUzCjE3CjM3CjUyCjIxCjUzCjQwCjMwCjUzCjkKMTkKNTIKNDAKNTMKMjkKOQo1Mgo0Nwo1Mgo0CjUyCjQKNTMKMzUKNgo1MgoxOQo1Mwo4CjM1CjUzCjI2CjMzCjUzCjIyCjgKNTIKMzIKNTIKMjIKNTIKMjQKNTMKMQoxCjUyCjgKNTMKNDYKMzgKNTMKMjMKNQo1Mwo0Mgo0Mgo1MgoxCjUyCjQ3CjUyCjI2CjUzCjE2CjE0CjUyCjYKNTMKNDUKMTYKNTIKNDIKNTMKMgoyOQo1Mwo0NAo1MAo1MgozMgo1MgozMgo1Mgo0Ngo1MwozNgoxNgo1Mgo1MQo1MwoxMAozNgo1MgoxMQo1Mgo0NwoKlGJzLg==\n",
+          "legalActions": [],
+          "legalActionStrings": []
+        },
+        "status": "INACTIVE"
+      },
+      {
+        "action": {
+          "submission": -1
+        },
+        "reward": null,
+        "info": {},
+        "observation": {
+          "remainingOverageTime": 12,
+          "observationString": "{\"phase\": \"Draw\", \"current_player\": 1, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"Qs\", \"upcard\": \"9h\", \"stock_size\": 6, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\", \"2h\", \"5s\", \"7c\", \"Td\", \"8d\", \"Qc\", \"9s\", \"Kd\", \"6s\", \"Ad\", \"7s\", \"4h\", \"4d\", \"8h\", \"Kh\"], \"hands\": {\"0\": [], \"1\": [\"2s\", \"3s\", \"4c\", \"Kc\", \"7d\", \"Jd\", \"Qd\", \"7h\", \"Th\", \"Qh\"]}, \"deadwood\": {\"0\": null, \"1\": 73}, \"repeated_move\": 0}",
+          "currentPlayer": 1,
+          "playerId": 1,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14,0:52,0:49,1:52,1:6,0:52,0:14,1:52,1:32,0:52,0:47,1:52,1:48,0:52,0:13,1:53,-1:19,1:3,0:53,-1:34,0:48,1:52,1:49,0:53,-1:24,0:6,1:52,1:47,0:52,0:43,1:52,1:43,0:53,-1:33,0:31,1:53,-1:37,1:37,0:52,0:18,1:52,1:18,0:53,-1:30,0:7,1:53,-1:15,1:15,0:53,-1:17,0:37,1:52,1:21,0:53,-1:40,0:30,1:53,-1:9,1:19,0:52,0:40,1:53,-1:29,1:9,0:52,0:47,1:52,1:4,0:52,0:4,1:53,-1:35,1:6,0:52,0:19,1:53,-1:8,1:35,0:53,-1:26,0:33,1:53,-1:22,1:8,0:52,0:32,1:52,1:22,0:52,0:24,1:53,-1:1,1:1,0:52,0:8,1:53,-1:46,1:38,0:53,-1:23,0:5,1:53,-1:42,1:42,0:52,0:1,1:52,1:47,0:52,0:26,1:53,-1:16,1:14,0:52,0:6,1:53,-1:45,1:16,0:52,0:42,1:53,-1:2,1:29,0:53,-1:44,0:50,1:52,1:32,0:52,0:32,1:52,1:46,0:53,-1:36,0:16,1:52,1:51,0:53,-1:10,0:36,1:52,1:11,0:52,0:47\nmove_number=164\n__dict__=gASV5AIAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRYogIAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAo1Mgo0OQo1Mgo2CjUyCjE0CjUyCjMyCjUyCjQ3CjUyCjQ4CjUyCjEzCjUzCjE5CjMKNTMKMzQKNDgKNTIKNDkKNTMKMjQKNgo1Mgo0Nwo1Mgo0Mwo1Mgo0Mwo1MwozMwozMQo1MwozNwozNwo1MgoxOAo1MgoxOAo1MwozMAo3CjUzCjE1CjE1CjUzCjE3CjM3CjUyCjIxCjUzCjQwCjMwCjUzCjkKMTkKNTIKNDAKNTMKMjkKOQo1Mgo0Nwo1Mgo0CjUyCjQKNTMKMzUKNgo1MgoxOQo1Mwo4CjM1CjUzCjI2CjMzCjUzCjIyCjgKNTIKMzIKNTIKMjIKNTIKMjQKNTMKMQoxCjUyCjgKNTMKNDYKMzgKNTMKMjMKNQo1Mwo0Mgo0Mgo1MgoxCjUyCjQ3CjUyCjI2CjUzCjE2CjE0CjUyCjYKNTMKNDUKMTYKNTIKNDIKNTMKMgoyOQo1Mwo0NAo1MAo1MgozMgo1MgozMgo1Mgo0Ngo1MwozNgoxNgo1Mgo1MQo1MwoxMAozNgo1MgoxMQo1Mgo0NwoKlGJzLg==\n",
+          "legalActions": [52, 53],
+          "legalActionStrings": [
+            "Player: 1 Action: Draw upcard",
+            "Player: 1 Action: Draw stock"
+          ]
+        },
+        "status": "ACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "submission": -1
+        },
+        "reward": null,
+        "info": {},
+        "observation": {
+          "remainingOverageTime": 12,
+          "step": 120,
+          "observationString": "{\"phase\": \"Discard\", \"current_player\": 1, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"9h\", \"upcard\": null, \"stock_size\": 5, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\", \"2h\", \"5s\", \"7c\", \"Td\", \"8d\", \"Qc\", \"9s\", \"Kd\", \"6s\", \"Ad\", \"7s\", \"4h\", \"4d\", \"8h\", \"Kh\", \"9h\"], \"hands\": {\"0\": [\"Ts\", \"Js\", \"Qs\", \"2c\", \"5c\", \"Tc\", \"Jc\", \"3d\", \"9d\", \"6h\"], \"1\": []}, \"deadwood\": {\"0\": 45, \"1\": null}, \"repeated_move\": 0}",
+          "currentPlayer": 1,
+          "playerId": 0,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14,0:52,0:49,1:52,1:6,0:52,0:14,1:52,1:32,0:52,0:47,1:52,1:48,0:52,0:13,1:53,-1:19,1:3,0:53,-1:34,0:48,1:52,1:49,0:53,-1:24,0:6,1:52,1:47,0:52,0:43,1:52,1:43,0:53,-1:33,0:31,1:53,-1:37,1:37,0:52,0:18,1:52,1:18,0:53,-1:30,0:7,1:53,-1:15,1:15,0:53,-1:17,0:37,1:52,1:21,0:53,-1:40,0:30,1:53,-1:9,1:19,0:52,0:40,1:53,-1:29,1:9,0:52,0:47,1:52,1:4,0:52,0:4,1:53,-1:35,1:6,0:52,0:19,1:53,-1:8,1:35,0:53,-1:26,0:33,1:53,-1:22,1:8,0:52,0:32,1:52,1:22,0:52,0:24,1:53,-1:1,1:1,0:52,0:8,1:53,-1:46,1:38,0:53,-1:23,0:5,1:53,-1:42,1:42,0:52,0:1,1:52,1:47,0:52,0:26,1:53,-1:16,1:14,0:52,0:6,1:53,-1:45,1:16,0:52,0:42,1:53,-1:2,1:29,0:53,-1:44,0:50,1:52,1:32,0:52,0:32,1:52,1:46,0:53,-1:36,0:16,1:52,1:51,0:53,-1:10,0:36,1:52,1:11,0:52,0:47,1:53,-1:27\nmove_number=166\n__dict__=gASV6gIAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRYqAIAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAo1Mgo0OQo1Mgo2CjUyCjE0CjUyCjMyCjUyCjQ3CjUyCjQ4CjUyCjEzCjUzCjE5CjMKNTMKMzQKNDgKNTIKNDkKNTMKMjQKNgo1Mgo0Nwo1Mgo0Mwo1Mgo0Mwo1MwozMwozMQo1MwozNwozNwo1MgoxOAo1MgoxOAo1MwozMAo3CjUzCjE1CjE1CjUzCjE3CjM3CjUyCjIxCjUzCjQwCjMwCjUzCjkKMTkKNTIKNDAKNTMKMjkKOQo1Mgo0Nwo1Mgo0CjUyCjQKNTMKMzUKNgo1MgoxOQo1Mwo4CjM1CjUzCjI2CjMzCjUzCjIyCjgKNTIKMzIKNTIKMjIKNTIKMjQKNTMKMQoxCjUyCjgKNTMKNDYKMzgKNTMKMjMKNQo1Mwo0Mgo0Mgo1MgoxCjUyCjQ3CjUyCjI2CjUzCjE2CjE0CjUyCjYKNTMKNDUKMTYKNTIKNDIKNTMKMgoyOQo1Mwo0NAo1MAo1MgozMgo1MgozMgo1Mgo0Ngo1MwozNgoxNgo1Mgo1MQo1MwoxMAozNgo1MgoxMQo1Mgo0Nwo1MwoyNwoKlGJzLg==\n",
+          "legalActions": [],
+          "legalActionStrings": []
+        },
+        "status": "INACTIVE"
+      },
+      {
+        "action": {
+          "submission": 53,
+          "thoughts": "pi horizon zeta epsilon phi wonder kappa epsilon"
+        },
+        "reward": null,
+        "info": {
+          "actionSubmitted": 53,
+          "actionSubmittedToString": "Player: 1 Action: Draw stock",
+          "actionApplied": 53,
+          "timeTaken": 0.0,
+          "agentSelfReportedStatus": null
+        },
+        "observation": {
+          "remainingOverageTime": 12,
+          "observationString": "{\"phase\": \"Discard\", \"current_player\": 1, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"9h\", \"upcard\": null, \"stock_size\": 5, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\", \"2h\", \"5s\", \"7c\", \"Td\", \"8d\", \"Qc\", \"9s\", \"Kd\", \"6s\", \"Ad\", \"7s\", \"4h\", \"4d\", \"8h\", \"Kh\", \"9h\"], \"hands\": {\"0\": [], \"1\": [\"2s\", \"3s\", \"4c\", \"Kc\", \"2d\", \"7d\", \"Jd\", \"Qd\", \"7h\", \"Th\", \"Qh\"]}, \"deadwood\": {\"0\": null, \"1\": 65}, \"repeated_move\": 0}",
+          "currentPlayer": 1,
+          "playerId": 1,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14,0:52,0:49,1:52,1:6,0:52,0:14,1:52,1:32,0:52,0:47,1:52,1:48,0:52,0:13,1:53,-1:19,1:3,0:53,-1:34,0:48,1:52,1:49,0:53,-1:24,0:6,1:52,1:47,0:52,0:43,1:52,1:43,0:53,-1:33,0:31,1:53,-1:37,1:37,0:52,0:18,1:52,1:18,0:53,-1:30,0:7,1:53,-1:15,1:15,0:53,-1:17,0:37,1:52,1:21,0:53,-1:40,0:30,1:53,-1:9,1:19,0:52,0:40,1:53,-1:29,1:9,0:52,0:47,1:52,1:4,0:52,0:4,1:53,-1:35,1:6,0:52,0:19,1:53,-1:8,1:35,0:53,-1:26,0:33,1:53,-1:22,1:8,0:52,0:32,1:52,1:22,0:52,0:24,1:53,-1:1,1:1,0:52,0:8,1:53,-1:46,1:38,0:53,-1:23,0:5,1:53,-1:42,1:42,0:52,0:1,1:52,1:47,0:52,0:26,1:53,-1:16,1:14,0:52,0:6,1:53,-1:45,1:16,0:52,0:42,1:53,-1:2,1:29,0:53,-1:44,0:50,1:52,1:32,0:52,0:32,1:52,1:46,0:53,-1:36,0:16,1:52,1:51,0:53,-1:10,0:36,1:52,1:11,0:52,0:47,1:53,-1:27\nmove_number=166\n__dict__=gASV6gIAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRYqAIAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAo1Mgo0OQo1Mgo2CjUyCjE0CjUyCjMyCjUyCjQ3CjUyCjQ4CjUyCjEzCjUzCjE5CjMKNTMKMzQKNDgKNTIKNDkKNTMKMjQKNgo1Mgo0Nwo1Mgo0Mwo1Mgo0Mwo1MwozMwozMQo1MwozNwozNwo1MgoxOAo1MgoxOAo1MwozMAo3CjUzCjE1CjE1CjUzCjE3CjM3CjUyCjIxCjUzCjQwCjMwCjUzCjkKMTkKNTIKNDAKNTMKMjkKOQo1Mgo0Nwo1Mgo0CjUyCjQKNTMKMzUKNgo1MgoxOQo1Mwo4CjM1CjUzCjI2CjMzCjUzCjIyCjgKNTIKMzIKNTIKMjIKNTIKMjQKNTMKMQoxCjUyCjgKNTMKNDYKMzgKNTMKMjMKNQo1Mwo0Mgo0Mgo1MgoxCjUyCjQ3CjUyCjI2CjUzCjE2CjE0CjUyCjYKNTMKNDUKMTYKNTIKNDIKNTMKMgoyOQo1Mwo0NAo1MAo1MgozMgo1MgozMgo1Mgo0Ngo1MwozNgoxNgo1Mgo1MQo1MwoxMAozNgo1MgoxMQo1Mgo0Nwo1MwoyNwoKlGJzLg==\n",
+          "legalActions": [1, 2, 16, 25, 27, 32, 36, 37, 45, 48, 50],
+          "legalActionStrings": [
+            "Player: 1 Action: 2s",
+            "Player: 1 Action: 3s",
+            "Player: 1 Action: 4c",
+            "Player: 1 Action: Kc",
+            "Player: 1 Action: 2d",
+            "Player: 1 Action: 7d",
+            "Player: 1 Action: Jd",
+            "Player: 1 Action: Qd",
+            "Player: 1 Action: 7h",
+            "Player: 1 Action: Th",
+            "Player: 1 Action: Qh"
+          ]
+        },
+        "status": "ACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "submission": -1
+        },
+        "reward": null,
+        "info": {},
+        "observation": {
+          "remainingOverageTime": 12,
+          "step": 121,
+          "observationString": "{\"phase\": \"Draw\", \"current_player\": 0, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"9h\", \"upcard\": \"4c\", \"stock_size\": 5, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\", \"2h\", \"5s\", \"7c\", \"Td\", \"8d\", \"Qc\", \"9s\", \"Kd\", \"6s\", \"Ad\", \"7s\", \"4h\", \"4d\", \"8h\", \"Kh\", \"9h\"], \"hands\": {\"0\": [\"Ts\", \"Js\", \"Qs\", \"2c\", \"5c\", \"Tc\", \"Jc\", \"3d\", \"9d\", \"6h\"], \"1\": []}, \"deadwood\": {\"0\": 45, \"1\": null}, \"repeated_move\": 0}",
+          "currentPlayer": 0,
+          "playerId": 0,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14,0:52,0:49,1:52,1:6,0:52,0:14,1:52,1:32,0:52,0:47,1:52,1:48,0:52,0:13,1:53,-1:19,1:3,0:53,-1:34,0:48,1:52,1:49,0:53,-1:24,0:6,1:52,1:47,0:52,0:43,1:52,1:43,0:53,-1:33,0:31,1:53,-1:37,1:37,0:52,0:18,1:52,1:18,0:53,-1:30,0:7,1:53,-1:15,1:15,0:53,-1:17,0:37,1:52,1:21,0:53,-1:40,0:30,1:53,-1:9,1:19,0:52,0:40,1:53,-1:29,1:9,0:52,0:47,1:52,1:4,0:52,0:4,1:53,-1:35,1:6,0:52,0:19,1:53,-1:8,1:35,0:53,-1:26,0:33,1:53,-1:22,1:8,0:52,0:32,1:52,1:22,0:52,0:24,1:53,-1:1,1:1,0:52,0:8,1:53,-1:46,1:38,0:53,-1:23,0:5,1:53,-1:42,1:42,0:52,0:1,1:52,1:47,0:52,0:26,1:53,-1:16,1:14,0:52,0:6,1:53,-1:45,1:16,0:52,0:42,1:53,-1:2,1:29,0:53,-1:44,0:50,1:52,1:32,0:52,0:32,1:52,1:46,0:53,-1:36,0:16,1:52,1:51,0:53,-1:10,0:36,1:52,1:11,0:52,0:47,1:53,-1:27,1:16\nmove_number=167\n__dict__=gASV7QIAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRYqwIAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAo1Mgo0OQo1Mgo2CjUyCjE0CjUyCjMyCjUyCjQ3CjUyCjQ4CjUyCjEzCjUzCjE5CjMKNTMKMzQKNDgKNTIKNDkKNTMKMjQKNgo1Mgo0Nwo1Mgo0Mwo1Mgo0Mwo1MwozMwozMQo1MwozNwozNwo1MgoxOAo1MgoxOAo1MwozMAo3CjUzCjE1CjE1CjUzCjE3CjM3CjUyCjIxCjUzCjQwCjMwCjUzCjkKMTkKNTIKNDAKNTMKMjkKOQo1Mgo0Nwo1Mgo0CjUyCjQKNTMKMzUKNgo1MgoxOQo1Mwo4CjM1CjUzCjI2CjMzCjUzCjIyCjgKNTIKMzIKNTIKMjIKNTIKMjQKNTMKMQoxCjUyCjgKNTMKNDYKMzgKNTMKMjMKNQo1Mwo0Mgo0Mgo1MgoxCjUyCjQ3CjUyCjI2CjUzCjE2CjE0CjUyCjYKNTMKNDUKMTYKNTIKNDIKNTMKMgoyOQo1Mwo0NAo1MAo1MgozMgo1MgozMgo1Mgo0Ngo1MwozNgoxNgo1Mgo1MQo1MwoxMAozNgo1MgoxMQo1Mgo0Nwo1MwoyNwoxNgoKlGJzLg==\n",
+          "legalActions": [52, 53],
+          "legalActionStrings": [
+            "Player: 0 Action: Draw upcard",
+            "Player: 0 Action: Draw stock"
+          ]
+        },
+        "status": "ACTIVE"
+      },
+      {
+        "action": {
+          "submission": 16,
+          "thoughts": "shadow lambda horizon shadow chi omega alpha upsilon"
+        },
+        "reward": null,
+        "info": {
+          "actionSubmitted": 16,
+          "actionSubmittedToString": "Player: 1 Action: 4c",
+          "actionApplied": 16,
+          "timeTaken": 0.0,
+          "agentSelfReportedStatus": null
+        },
+        "observation": {
+          "remainingOverageTime": 12,
+          "observationString": "{\"phase\": \"Draw\", \"current_player\": 0, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"9h\", \"upcard\": \"4c\", \"stock_size\": 5, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\", \"2h\", \"5s\", \"7c\", \"Td\", \"8d\", \"Qc\", \"9s\", \"Kd\", \"6s\", \"Ad\", \"7s\", \"4h\", \"4d\", \"8h\", \"Kh\", \"9h\"], \"hands\": {\"0\": [], \"1\": [\"2s\", \"3s\", \"Kc\", \"2d\", \"7d\", \"Jd\", \"Qd\", \"7h\", \"Th\", \"Qh\"]}, \"deadwood\": {\"0\": null, \"1\": 71}, \"repeated_move\": 0}",
+          "currentPlayer": 0,
+          "playerId": 1,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14,0:52,0:49,1:52,1:6,0:52,0:14,1:52,1:32,0:52,0:47,1:52,1:48,0:52,0:13,1:53,-1:19,1:3,0:53,-1:34,0:48,1:52,1:49,0:53,-1:24,0:6,1:52,1:47,0:52,0:43,1:52,1:43,0:53,-1:33,0:31,1:53,-1:37,1:37,0:52,0:18,1:52,1:18,0:53,-1:30,0:7,1:53,-1:15,1:15,0:53,-1:17,0:37,1:52,1:21,0:53,-1:40,0:30,1:53,-1:9,1:19,0:52,0:40,1:53,-1:29,1:9,0:52,0:47,1:52,1:4,0:52,0:4,1:53,-1:35,1:6,0:52,0:19,1:53,-1:8,1:35,0:53,-1:26,0:33,1:53,-1:22,1:8,0:52,0:32,1:52,1:22,0:52,0:24,1:53,-1:1,1:1,0:52,0:8,1:53,-1:46,1:38,0:53,-1:23,0:5,1:53,-1:42,1:42,0:52,0:1,1:52,1:47,0:52,0:26,1:53,-1:16,1:14,0:52,0:6,1:53,-1:45,1:16,0:52,0:42,1:53,-1:2,1:29,0:53,-1:44,0:50,1:52,1:32,0:52,0:32,1:52,1:46,0:53,-1:36,0:16,1:52,1:51,0:53,-1:10,0:36,1:52,1:11,0:52,0:47,1:53,-1:27,1:16\nmove_number=167\n__dict__=gASV7QIAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRYqwIAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAo1Mgo0OQo1Mgo2CjUyCjE0CjUyCjMyCjUyCjQ3CjUyCjQ4CjUyCjEzCjUzCjE5CjMKNTMKMzQKNDgKNTIKNDkKNTMKMjQKNgo1Mgo0Nwo1Mgo0Mwo1Mgo0Mwo1MwozMwozMQo1MwozNwozNwo1MgoxOAo1MgoxOAo1MwozMAo3CjUzCjE1CjE1CjUzCjE3CjM3CjUyCjIxCjUzCjQwCjMwCjUzCjkKMTkKNTIKNDAKNTMKMjkKOQo1Mgo0Nwo1Mgo0CjUyCjQKNTMKMzUKNgo1MgoxOQo1Mwo4CjM1CjUzCjI2CjMzCjUzCjIyCjgKNTIKMzIKNTIKMjIKNTIKMjQKNTMKMQoxCjUyCjgKNTMKNDYKMzgKNTMKMjMKNQo1Mwo0Mgo0Mgo1MgoxCjUyCjQ3CjUyCjI2CjUzCjE2CjE0CjUyCjYKNTMKNDUKMTYKNTIKNDIKNTMKMgoyOQo1Mwo0NAo1MAo1MgozMgo1MgozMgo1Mgo0Ngo1MwozNgoxNgo1Mgo1MQo1MwoxMAozNgo1MgoxMQo1Mgo0Nwo1MwoyNwoxNgoKlGJzLg==\n",
+          "legalActions": [],
+          "legalActionStrings": []
+        },
+        "status": "INACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "submission": 52,
+          "thoughts": "cascade lambda iota drift iota drift iota iota"
+        },
+        "reward": null,
+        "info": {
+          "actionSubmitted": 52,
+          "actionSubmittedToString": "Player: 0 Action: Draw upcard",
+          "actionApplied": 52,
+          "timeTaken": 0.0,
+          "agentSelfReportedStatus": null
+        },
+        "observation": {
+          "remainingOverageTime": 12,
+          "step": 122,
+          "observationString": "{\"phase\": \"Discard\", \"current_player\": 0, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"4c\", \"upcard\": null, \"stock_size\": 5, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\", \"2h\", \"5s\", \"7c\", \"Td\", \"8d\", \"Qc\", \"9s\", \"Kd\", \"6s\", \"Ad\", \"7s\", \"4h\", \"4d\", \"8h\", \"Kh\", \"9h\"], \"hands\": {\"0\": [\"Ts\", \"Js\", \"Qs\", \"2c\", \"4c\", \"5c\", \"Tc\", \"Jc\", \"3d\", \"9d\", \"6h\"], \"1\": []}, \"deadwood\": {\"0\": 39, \"1\": null}, \"repeated_move\": 0}",
+          "currentPlayer": 0,
+          "playerId": 0,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14,0:52,0:49,1:52,1:6,0:52,0:14,1:52,1:32,0:52,0:47,1:52,1:48,0:52,0:13,1:53,-1:19,1:3,0:53,-1:34,0:48,1:52,1:49,0:53,-1:24,0:6,1:52,1:47,0:52,0:43,1:52,1:43,0:53,-1:33,0:31,1:53,-1:37,1:37,0:52,0:18,1:52,1:18,0:53,-1:30,0:7,1:53,-1:15,1:15,0:53,-1:17,0:37,1:52,1:21,0:53,-1:40,0:30,1:53,-1:9,1:19,0:52,0:40,1:53,-1:29,1:9,0:52,0:47,1:52,1:4,0:52,0:4,1:53,-1:35,1:6,0:52,0:19,1:53,-1:8,1:35,0:53,-1:26,0:33,1:53,-1:22,1:8,0:52,0:32,1:52,1:22,0:52,0:24,1:53,-1:1,1:1,0:52,0:8,1:53,-1:46,1:38,0:53,-1:23,0:5,1:53,-1:42,1:42,0:52,0:1,1:52,1:47,0:52,0:26,1:53,-1:16,1:14,0:52,0:6,1:53,-1:45,1:16,0:52,0:42,1:53,-1:2,1:29,0:53,-1:44,0:50,1:52,1:32,0:52,0:32,1:52,1:46,0:53,-1:36,0:16,1:52,1:51,0:53,-1:10,0:36,1:52,1:11,0:52,0:47,1:53,-1:27,1:16,0:52\nmove_number=168\n__dict__=gASV8AIAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRYrgIAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAo1Mgo0OQo1Mgo2CjUyCjE0CjUyCjMyCjUyCjQ3CjUyCjQ4CjUyCjEzCjUzCjE5CjMKNTMKMzQKNDgKNTIKNDkKNTMKMjQKNgo1Mgo0Nwo1Mgo0Mwo1Mgo0Mwo1MwozMwozMQo1MwozNwozNwo1MgoxOAo1MgoxOAo1MwozMAo3CjUzCjE1CjE1CjUzCjE3CjM3CjUyCjIxCjUzCjQwCjMwCjUzCjkKMTkKNTIKNDAKNTMKMjkKOQo1Mgo0Nwo1Mgo0CjUyCjQKNTMKMzUKNgo1MgoxOQo1Mwo4CjM1CjUzCjI2CjMzCjUzCjIyCjgKNTIKMzIKNTIKMjIKNTIKMjQKNTMKMQoxCjUyCjgKNTMKNDYKMzgKNTMKMjMKNQo1Mwo0Mgo0Mgo1MgoxCjUyCjQ3CjUyCjI2CjUzCjE2CjE0CjUyCjYKNTMKNDUKMTYKNTIKNDIKNTMKMgoyOQo1Mwo0NAo1MAo1MgozMgo1MgozMgo1Mgo0Ngo1MwozNgoxNgo1Mgo1MQo1MwoxMAozNgo1MgoxMQo1Mgo0Nwo1MwoyNwoxNgo1MgoKlGJzLg==\n",
+          "legalActions": [9, 10, 11, 14, 16, 17, 22, 23, 28, 34, 44],
+          "legalActionStrings": [
+            "Player: 0 Action: Ts",
+            "Player: 0 Action: Js",
+            "Player: 0 Action: Qs",
+            "Player: 0 Action: 2c",
+            "Player: 0 Action: 4c",
+            "Player: 0 Action: 5c",
+            "Player: 0 Action: Tc",
+            "Player: 0 Action: Jc",
+            "Player: 0 Action: 3d",
+            "Player: 0 Action: 9d",
+            "Player: 0 Action: 6h"
+          ]
+        },
+        "status": "ACTIVE"
+      },
+      {
+        "action": {
+          "submission": -1
+        },
+        "reward": null,
+        "info": {},
+        "observation": {
+          "remainingOverageTime": 12,
+          "observationString": "{\"phase\": \"Discard\", \"current_player\": 0, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"4c\", \"upcard\": null, \"stock_size\": 5, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\", \"2h\", \"5s\", \"7c\", \"Td\", \"8d\", \"Qc\", \"9s\", \"Kd\", \"6s\", \"Ad\", \"7s\", \"4h\", \"4d\", \"8h\", \"Kh\", \"9h\"], \"hands\": {\"0\": [], \"1\": [\"2s\", \"3s\", \"Kc\", \"2d\", \"7d\", \"Jd\", \"Qd\", \"7h\", \"Th\", \"Qh\"]}, \"deadwood\": {\"0\": null, \"1\": 71}, \"repeated_move\": 0}",
+          "currentPlayer": 0,
+          "playerId": 1,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14,0:52,0:49,1:52,1:6,0:52,0:14,1:52,1:32,0:52,0:47,1:52,1:48,0:52,0:13,1:53,-1:19,1:3,0:53,-1:34,0:48,1:52,1:49,0:53,-1:24,0:6,1:52,1:47,0:52,0:43,1:52,1:43,0:53,-1:33,0:31,1:53,-1:37,1:37,0:52,0:18,1:52,1:18,0:53,-1:30,0:7,1:53,-1:15,1:15,0:53,-1:17,0:37,1:52,1:21,0:53,-1:40,0:30,1:53,-1:9,1:19,0:52,0:40,1:53,-1:29,1:9,0:52,0:47,1:52,1:4,0:52,0:4,1:53,-1:35,1:6,0:52,0:19,1:53,-1:8,1:35,0:53,-1:26,0:33,1:53,-1:22,1:8,0:52,0:32,1:52,1:22,0:52,0:24,1:53,-1:1,1:1,0:52,0:8,1:53,-1:46,1:38,0:53,-1:23,0:5,1:53,-1:42,1:42,0:52,0:1,1:52,1:47,0:52,0:26,1:53,-1:16,1:14,0:52,0:6,1:53,-1:45,1:16,0:52,0:42,1:53,-1:2,1:29,0:53,-1:44,0:50,1:52,1:32,0:52,0:32,1:52,1:46,0:53,-1:36,0:16,1:52,1:51,0:53,-1:10,0:36,1:52,1:11,0:52,0:47,1:53,-1:27,1:16,0:52\nmove_number=168\n__dict__=gASV8AIAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRYrgIAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAo1Mgo0OQo1Mgo2CjUyCjE0CjUyCjMyCjUyCjQ3CjUyCjQ4CjUyCjEzCjUzCjE5CjMKNTMKMzQKNDgKNTIKNDkKNTMKMjQKNgo1Mgo0Nwo1Mgo0Mwo1Mgo0Mwo1MwozMwozMQo1MwozNwozNwo1MgoxOAo1MgoxOAo1MwozMAo3CjUzCjE1CjE1CjUzCjE3CjM3CjUyCjIxCjUzCjQwCjMwCjUzCjkKMTkKNTIKNDAKNTMKMjkKOQo1Mgo0Nwo1Mgo0CjUyCjQKNTMKMzUKNgo1MgoxOQo1Mwo4CjM1CjUzCjI2CjMzCjUzCjIyCjgKNTIKMzIKNTIKMjIKNTIKMjQKNTMKMQoxCjUyCjgKNTMKNDYKMzgKNTMKMjMKNQo1Mwo0Mgo0Mgo1MgoxCjUyCjQ3CjUyCjI2CjUzCjE2CjE0CjUyCjYKNTMKNDUKMTYKNTIKNDIKNTMKMgoyOQo1Mwo0NAo1MAo1MgozMgo1MgozMgo1Mgo0Ngo1MwozNgoxNgo1Mgo1MQo1MwoxMAozNgo1MgoxMQo1Mgo0Nwo1MwoyNwoxNgo1MgoKlGJzLg==\n",
+          "legalActions": [],
+          "legalActionStrings": []
+        },
+        "status": "INACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "submission": 10,
+          "thoughts": "sigma delta ember omicron lantern explore eta psi"
+        },
+        "reward": null,
+        "info": {
+          "actionSubmitted": 10,
+          "actionSubmittedToString": "Player: 0 Action: Js",
+          "actionApplied": 10,
+          "timeTaken": 0.0,
+          "agentSelfReportedStatus": null
+        },
+        "observation": {
+          "remainingOverageTime": 12,
+          "step": 123,
+          "observationString": "{\"phase\": \"Draw\", \"current_player\": 1, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"4c\", \"upcard\": \"Js\", \"stock_size\": 5, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\", \"2h\", \"5s\", \"7c\", \"Td\", \"8d\", \"Qc\", \"9s\", \"Kd\", \"6s\", \"Ad\", \"7s\", \"4h\", \"4d\", \"8h\", \"Kh\", \"9h\"], \"hands\": {\"0\": [\"Ts\", \"Qs\", \"2c\", \"4c\", \"5c\", \"Tc\", \"Jc\", \"3d\", \"9d\", \"6h\"], \"1\": []}, \"deadwood\": {\"0\": 69, \"1\": null}, \"repeated_move\": 0}",
+          "currentPlayer": 1,
+          "playerId": 0,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14,0:52,0:49,1:52,1:6,0:52,0:14,1:52,1:32,0:52,0:47,1:52,1:48,0:52,0:13,1:53,-1:19,1:3,0:53,-1:34,0:48,1:52,1:49,0:53,-1:24,0:6,1:52,1:47,0:52,0:43,1:52,1:43,0:53,-1:33,0:31,1:53,-1:37,1:37,0:52,0:18,1:52,1:18,0:53,-1:30,0:7,1:53,-1:15,1:15,0:53,-1:17,0:37,1:52,1:21,0:53,-1:40,0:30,1:53,-1:9,1:19,0:52,0:40,1:53,-1:29,1:9,0:52,0:47,1:52,1:4,0:52,0:4,1:53,-1:35,1:6,0:52,0:19,1:53,-1:8,1:35,0:53,-1:26,0:33,1:53,-1:22,1:8,0:52,0:32,1:52,1:22,0:52,0:24,1:53,-1:1,1:1,0:52,0:8,1:53,-1:46,1:38,0:53,-1:23,0:5,1:53,-1:42,1:42,0:52,0:1,1:52,1:47,0:52,0:26,1:53,-1:16,1:14,0:52,0:6,1:53,-1:45,1:16,0:52,0:42,1:53,-1:2,1:29,0:53,-1:44,0:50,1:52,1:32,0:52,0:32,1:52,1:46,0:53,-1:36,0:16,1:52,1:51,0:53,-1:10,0:36,1:52,1:11,0:52,0:47,1:53,-1:27,1:16,0:52,0:10\nmove_number=169\n__dict__=gASV8wIAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRYsQIAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAo1Mgo0OQo1Mgo2CjUyCjE0CjUyCjMyCjUyCjQ3CjUyCjQ4CjUyCjEzCjUzCjE5CjMKNTMKMzQKNDgKNTIKNDkKNTMKMjQKNgo1Mgo0Nwo1Mgo0Mwo1Mgo0Mwo1MwozMwozMQo1MwozNwozNwo1MgoxOAo1MgoxOAo1MwozMAo3CjUzCjE1CjE1CjUzCjE3CjM3CjUyCjIxCjUzCjQwCjMwCjUzCjkKMTkKNTIKNDAKNTMKMjkKOQo1Mgo0Nwo1Mgo0CjUyCjQKNTMKMzUKNgo1MgoxOQo1Mwo4CjM1CjUzCjI2CjMzCjUzCjIyCjgKNTIKMzIKNTIKMjIKNTIKMjQKNTMKMQoxCjUyCjgKNTMKNDYKMzgKNTMKMjMKNQo1Mwo0Mgo0Mgo1MgoxCjUyCjQ3CjUyCjI2CjUzCjE2CjE0CjUyCjYKNTMKNDUKMTYKNTIKNDIKNTMKMgoyOQo1Mwo0NAo1MAo1MgozMgo1MgozMgo1Mgo0Ngo1MwozNgoxNgo1Mgo1MQo1MwoxMAozNgo1MgoxMQo1Mgo0Nwo1MwoyNwoxNgo1MgoxMAoKlGJzLg==\n",
+          "legalActions": [],
+          "legalActionStrings": []
+        },
+        "status": "INACTIVE"
+      },
+      {
+        "action": {
+          "submission": -1
+        },
+        "reward": null,
+        "info": {},
+        "observation": {
+          "remainingOverageTime": 12,
+          "observationString": "{\"phase\": \"Draw\", \"current_player\": 1, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"4c\", \"upcard\": \"Js\", \"stock_size\": 5, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\", \"2h\", \"5s\", \"7c\", \"Td\", \"8d\", \"Qc\", \"9s\", \"Kd\", \"6s\", \"Ad\", \"7s\", \"4h\", \"4d\", \"8h\", \"Kh\", \"9h\"], \"hands\": {\"0\": [], \"1\": [\"2s\", \"3s\", \"Kc\", \"2d\", \"7d\", \"Jd\", \"Qd\", \"7h\", \"Th\", \"Qh\"]}, \"deadwood\": {\"0\": null, \"1\": 71}, \"repeated_move\": 0}",
+          "currentPlayer": 1,
+          "playerId": 1,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14,0:52,0:49,1:52,1:6,0:52,0:14,1:52,1:32,0:52,0:47,1:52,1:48,0:52,0:13,1:53,-1:19,1:3,0:53,-1:34,0:48,1:52,1:49,0:53,-1:24,0:6,1:52,1:47,0:52,0:43,1:52,1:43,0:53,-1:33,0:31,1:53,-1:37,1:37,0:52,0:18,1:52,1:18,0:53,-1:30,0:7,1:53,-1:15,1:15,0:53,-1:17,0:37,1:52,1:21,0:53,-1:40,0:30,1:53,-1:9,1:19,0:52,0:40,1:53,-1:29,1:9,0:52,0:47,1:52,1:4,0:52,0:4,1:53,-1:35,1:6,0:52,0:19,1:53,-1:8,1:35,0:53,-1:26,0:33,1:53,-1:22,1:8,0:52,0:32,1:52,1:22,0:52,0:24,1:53,-1:1,1:1,0:52,0:8,1:53,-1:46,1:38,0:53,-1:23,0:5,1:53,-1:42,1:42,0:52,0:1,1:52,1:47,0:52,0:26,1:53,-1:16,1:14,0:52,0:6,1:53,-1:45,1:16,0:52,0:42,1:53,-1:2,1:29,0:53,-1:44,0:50,1:52,1:32,0:52,0:32,1:52,1:46,0:53,-1:36,0:16,1:52,1:51,0:53,-1:10,0:36,1:52,1:11,0:52,0:47,1:53,-1:27,1:16,0:52,0:10\nmove_number=169\n__dict__=gASV8wIAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRYsQIAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAo1Mgo0OQo1Mgo2CjUyCjE0CjUyCjMyCjUyCjQ3CjUyCjQ4CjUyCjEzCjUzCjE5CjMKNTMKMzQKNDgKNTIKNDkKNTMKMjQKNgo1Mgo0Nwo1Mgo0Mwo1Mgo0Mwo1MwozMwozMQo1MwozNwozNwo1MgoxOAo1MgoxOAo1MwozMAo3CjUzCjE1CjE1CjUzCjE3CjM3CjUyCjIxCjUzCjQwCjMwCjUzCjkKMTkKNTIKNDAKNTMKMjkKOQo1Mgo0Nwo1Mgo0CjUyCjQKNTMKMzUKNgo1MgoxOQo1Mwo4CjM1CjUzCjI2CjMzCjUzCjIyCjgKNTIKMzIKNTIKMjIKNTIKMjQKNTMKMQoxCjUyCjgKNTMKNDYKMzgKNTMKMjMKNQo1Mwo0Mgo0Mgo1MgoxCjUyCjQ3CjUyCjI2CjUzCjE2CjE0CjUyCjYKNTMKNDUKMTYKNTIKNDIKNTMKMgoyOQo1Mwo0NAo1MAo1MgozMgo1MgozMgo1Mgo0Ngo1MwozNgoxNgo1Mgo1MQo1MwoxMAozNgo1MgoxMQo1Mgo0Nwo1MwoyNwoxNgo1MgoxMAoKlGJzLg==\n",
+          "legalActions": [52, 53],
+          "legalActionStrings": [
+            "Player: 1 Action: Draw upcard",
+            "Player: 1 Action: Draw stock"
+          ]
+        },
+        "status": "ACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "submission": -1
+        },
+        "reward": null,
+        "info": {},
+        "observation": {
+          "remainingOverageTime": 12,
+          "step": 124,
+          "observationString": "{\"phase\": \"Discard\", \"current_player\": 1, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"Js\", \"upcard\": null, \"stock_size\": 4, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\", \"2h\", \"5s\", \"7c\", \"Td\", \"8d\", \"Qc\", \"9s\", \"Kd\", \"6s\", \"Ad\", \"7s\", \"4h\", \"4d\", \"8h\", \"Kh\", \"9h\", \"Js\"], \"hands\": {\"0\": [\"Ts\", \"Qs\", \"2c\", \"4c\", \"5c\", \"Tc\", \"Jc\", \"3d\", \"9d\", \"6h\"], \"1\": []}, \"deadwood\": {\"0\": 69, \"1\": null}, \"repeated_move\": 0}",
+          "currentPlayer": 1,
+          "playerId": 0,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14,0:52,0:49,1:52,1:6,0:52,0:14,1:52,1:32,0:52,0:47,1:52,1:48,0:52,0:13,1:53,-1:19,1:3,0:53,-1:34,0:48,1:52,1:49,0:53,-1:24,0:6,1:52,1:47,0:52,0:43,1:52,1:43,0:53,-1:33,0:31,1:53,-1:37,1:37,0:52,0:18,1:52,1:18,0:53,-1:30,0:7,1:53,-1:15,1:15,0:53,-1:17,0:37,1:52,1:21,0:53,-1:40,0:30,1:53,-1:9,1:19,0:52,0:40,1:53,-1:29,1:9,0:52,0:47,1:52,1:4,0:52,0:4,1:53,-1:35,1:6,0:52,0:19,1:53,-1:8,1:35,0:53,-1:26,0:33,1:53,-1:22,1:8,0:52,0:32,1:52,1:22,0:52,0:24,1:53,-1:1,1:1,0:52,0:8,1:53,-1:46,1:38,0:53,-1:23,0:5,1:53,-1:42,1:42,0:52,0:1,1:52,1:47,0:52,0:26,1:53,-1:16,1:14,0:52,0:6,1:53,-1:45,1:16,0:52,0:42,1:53,-1:2,1:29,0:53,-1:44,0:50,1:52,1:32,0:52,0:32,1:52,1:46,0:53,-1:36,0:16,1:52,1:51,0:53,-1:10,0:36,1:52,1:11,0:52,0:47,1:53,-1:27,1:16,0:52,0:10,1:53,-1:39\nmove_number=171\n__dict__=gASV+QIAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRYtwIAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAo1Mgo0OQo1Mgo2CjUyCjE0CjUyCjMyCjUyCjQ3CjUyCjQ4CjUyCjEzCjUzCjE5CjMKNTMKMzQKNDgKNTIKNDkKNTMKMjQKNgo1Mgo0Nwo1Mgo0Mwo1Mgo0Mwo1MwozMwozMQo1MwozNwozNwo1MgoxOAo1MgoxOAo1MwozMAo3CjUzCjE1CjE1CjUzCjE3CjM3CjUyCjIxCjUzCjQwCjMwCjUzCjkKMTkKNTIKNDAKNTMKMjkKOQo1Mgo0Nwo1Mgo0CjUyCjQKNTMKMzUKNgo1MgoxOQo1Mwo4CjM1CjUzCjI2CjMzCjUzCjIyCjgKNTIKMzIKNTIKMjIKNTIKMjQKNTMKMQoxCjUyCjgKNTMKNDYKMzgKNTMKMjMKNQo1Mwo0Mgo0Mgo1MgoxCjUyCjQ3CjUyCjI2CjUzCjE2CjE0CjUyCjYKNTMKNDUKMTYKNTIKNDIKNTMKMgoyOQo1Mwo0NAo1MAo1MgozMgo1MgozMgo1Mgo0Ngo1MwozNgoxNgo1Mgo1MQo1MwoxMAozNgo1MgoxMQo1Mgo0Nwo1MwoyNwoxNgo1MgoxMAo1MwozOQoKlGJzLg==\n",
+          "legalActions": [],
+          "legalActionStrings": []
+        },
+        "status": "INACTIVE"
+      },
+      {
+        "action": {
+          "submission": 53,
+          "thoughts": "alpha ember ponder epsilon spark drift delta rho"
+        },
+        "reward": null,
+        "info": {
+          "actionSubmitted": 53,
+          "actionSubmittedToString": "Player: 1 Action: Draw stock",
+          "actionApplied": 53,
+          "timeTaken": 0.0,
+          "agentSelfReportedStatus": null
+        },
+        "observation": {
+          "remainingOverageTime": 12,
+          "observationString": "{\"phase\": \"Discard\", \"current_player\": 1, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"Js\", \"upcard\": null, \"stock_size\": 4, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\", \"2h\", \"5s\", \"7c\", \"Td\", \"8d\", \"Qc\", \"9s\", \"Kd\", \"6s\", \"Ad\", \"7s\", \"4h\", \"4d\", \"8h\", \"Kh\", \"9h\", \"Js\"], \"hands\": {\"0\": [], \"1\": [\"2s\", \"3s\", \"Kc\", \"2d\", \"7d\", \"Jd\", \"Qd\", \"Ah\", \"7h\", \"Th\", \"Qh\"]}, \"deadwood\": {\"0\": null, \"1\": 62}, \"repeated_move\": 0}",
+          "currentPlayer": 1,
+          "playerId": 1,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14,0:52,0:49,1:52,1:6,0:52,0:14,1:52,1:32,0:52,0:47,1:52,1:48,0:52,0:13,1:53,-1:19,1:3,0:53,-1:34,0:48,1:52,1:49,0:53,-1:24,0:6,1:52,1:47,0:52,0:43,1:52,1:43,0:53,-1:33,0:31,1:53,-1:37,1:37,0:52,0:18,1:52,1:18,0:53,-1:30,0:7,1:53,-1:15,1:15,0:53,-1:17,0:37,1:52,1:21,0:53,-1:40,0:30,1:53,-1:9,1:19,0:52,0:40,1:53,-1:29,1:9,0:52,0:47,1:52,1:4,0:52,0:4,1:53,-1:35,1:6,0:52,0:19,1:53,-1:8,1:35,0:53,-1:26,0:33,1:53,-1:22,1:8,0:52,0:32,1:52,1:22,0:52,0:24,1:53,-1:1,1:1,0:52,0:8,1:53,-1:46,1:38,0:53,-1:23,0:5,1:53,-1:42,1:42,0:52,0:1,1:52,1:47,0:52,0:26,1:53,-1:16,1:14,0:52,0:6,1:53,-1:45,1:16,0:52,0:42,1:53,-1:2,1:29,0:53,-1:44,0:50,1:52,1:32,0:52,0:32,1:52,1:46,0:53,-1:36,0:16,1:52,1:51,0:53,-1:10,0:36,1:52,1:11,0:52,0:47,1:53,-1:27,1:16,0:52,0:10,1:53,-1:39\nmove_number=171\n__dict__=gASV+QIAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRYtwIAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAo1Mgo0OQo1Mgo2CjUyCjE0CjUyCjMyCjUyCjQ3CjUyCjQ4CjUyCjEzCjUzCjE5CjMKNTMKMzQKNDgKNTIKNDkKNTMKMjQKNgo1Mgo0Nwo1Mgo0Mwo1Mgo0Mwo1MwozMwozMQo1MwozNwozNwo1MgoxOAo1MgoxOAo1MwozMAo3CjUzCjE1CjE1CjUzCjE3CjM3CjUyCjIxCjUzCjQwCjMwCjUzCjkKMTkKNTIKNDAKNTMKMjkKOQo1Mgo0Nwo1Mgo0CjUyCjQKNTMKMzUKNgo1MgoxOQo1Mwo4CjM1CjUzCjI2CjMzCjUzCjIyCjgKNTIKMzIKNTIKMjIKNTIKMjQKNTMKMQoxCjUyCjgKNTMKNDYKMzgKNTMKMjMKNQo1Mwo0Mgo0Mgo1MgoxCjUyCjQ3CjUyCjI2CjUzCjE2CjE0CjUyCjYKNTMKNDUKMTYKNTIKNDIKNTMKMgoyOQo1Mwo0NAo1MAo1MgozMgo1MgozMgo1Mgo0Ngo1MwozNgoxNgo1Mgo1MQo1MwoxMAozNgo1MgoxMQo1Mgo0Nwo1MwoyNwoxNgo1MgoxMAo1MwozOQoKlGJzLg==\n",
+          "legalActions": [1, 2, 25, 27, 32, 36, 37, 39, 45, 48, 50],
+          "legalActionStrings": [
+            "Player: 1 Action: 2s",
+            "Player: 1 Action: 3s",
+            "Player: 1 Action: Kc",
+            "Player: 1 Action: 2d",
+            "Player: 1 Action: 7d",
+            "Player: 1 Action: Jd",
+            "Player: 1 Action: Qd",
+            "Player: 1 Action: Ah",
+            "Player: 1 Action: 7h",
+            "Player: 1 Action: Th",
+            "Player: 1 Action: Qh"
+          ]
+        },
+        "status": "ACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "submission": -1
+        },
+        "reward": null,
+        "info": {},
+        "observation": {
+          "remainingOverageTime": 12,
+          "step": 125,
+          "observationString": "{\"phase\": \"Draw\", \"current_player\": 0, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"Js\", \"upcard\": \"3s\", \"stock_size\": 4, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\", \"2h\", \"5s\", \"7c\", \"Td\", \"8d\", \"Qc\", \"9s\", \"Kd\", \"6s\", \"Ad\", \"7s\", \"4h\", \"4d\", \"8h\", \"Kh\", \"9h\", \"Js\"], \"hands\": {\"0\": [\"Ts\", \"Qs\", \"2c\", \"4c\", \"5c\", \"Tc\", \"Jc\", \"3d\", \"9d\", \"6h\"], \"1\": []}, \"deadwood\": {\"0\": 69, \"1\": null}, \"repeated_move\": 0}",
+          "currentPlayer": 0,
+          "playerId": 0,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14,0:52,0:49,1:52,1:6,0:52,0:14,1:52,1:32,0:52,0:47,1:52,1:48,0:52,0:13,1:53,-1:19,1:3,0:53,-1:34,0:48,1:52,1:49,0:53,-1:24,0:6,1:52,1:47,0:52,0:43,1:52,1:43,0:53,-1:33,0:31,1:53,-1:37,1:37,0:52,0:18,1:52,1:18,0:53,-1:30,0:7,1:53,-1:15,1:15,0:53,-1:17,0:37,1:52,1:21,0:53,-1:40,0:30,1:53,-1:9,1:19,0:52,0:40,1:53,-1:29,1:9,0:52,0:47,1:52,1:4,0:52,0:4,1:53,-1:35,1:6,0:52,0:19,1:53,-1:8,1:35,0:53,-1:26,0:33,1:53,-1:22,1:8,0:52,0:32,1:52,1:22,0:52,0:24,1:53,-1:1,1:1,0:52,0:8,1:53,-1:46,1:38,0:53,-1:23,0:5,1:53,-1:42,1:42,0:52,0:1,1:52,1:47,0:52,0:26,1:53,-1:16,1:14,0:52,0:6,1:53,-1:45,1:16,0:52,0:42,1:53,-1:2,1:29,0:53,-1:44,0:50,1:52,1:32,0:52,0:32,1:52,1:46,0:53,-1:36,0:16,1:52,1:51,0:53,-1:10,0:36,1:52,1:11,0:52,0:47,1:53,-1:27,1:16,0:52,0:10,1:53,-1:39,1:2\nmove_number=172\n__dict__=gASV+wIAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRYuQIAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAo1Mgo0OQo1Mgo2CjUyCjE0CjUyCjMyCjUyCjQ3CjUyCjQ4CjUyCjEzCjUzCjE5CjMKNTMKMzQKNDgKNTIKNDkKNTMKMjQKNgo1Mgo0Nwo1Mgo0Mwo1Mgo0Mwo1MwozMwozMQo1MwozNwozNwo1MgoxOAo1MgoxOAo1MwozMAo3CjUzCjE1CjE1CjUzCjE3CjM3CjUyCjIxCjUzCjQwCjMwCjUzCjkKMTkKNTIKNDAKNTMKMjkKOQo1Mgo0Nwo1Mgo0CjUyCjQKNTMKMzUKNgo1MgoxOQo1Mwo4CjM1CjUzCjI2CjMzCjUzCjIyCjgKNTIKMzIKNTIKMjIKNTIKMjQKNTMKMQoxCjUyCjgKNTMKNDYKMzgKNTMKMjMKNQo1Mwo0Mgo0Mgo1MgoxCjUyCjQ3CjUyCjI2CjUzCjE2CjE0CjUyCjYKNTMKNDUKMTYKNTIKNDIKNTMKMgoyOQo1Mwo0NAo1MAo1MgozMgo1MgozMgo1Mgo0Ngo1MwozNgoxNgo1Mgo1MQo1MwoxMAozNgo1MgoxMQo1Mgo0Nwo1MwoyNwoxNgo1MgoxMAo1MwozOQoyCgqUYnMu\n",
+          "legalActions": [52, 53],
+          "legalActionStrings": [
+            "Player: 0 Action: Draw upcard",
+            "Player: 0 Action: Draw stock"
+          ]
+        },
+        "status": "ACTIVE"
+      },
+      {
+        "action": {
+          "submission": 2,
+          "thoughts": "mu delta ripple iota eta omicron gamma rho"
+        },
+        "reward": null,
+        "info": {
+          "actionSubmitted": 2,
+          "actionSubmittedToString": "Player: 1 Action: 3s",
+          "actionApplied": 2,
+          "timeTaken": 0.0,
+          "agentSelfReportedStatus": null
+        },
+        "observation": {
+          "remainingOverageTime": 12,
+          "observationString": "{\"phase\": \"Draw\", \"current_player\": 0, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"Js\", \"upcard\": \"3s\", \"stock_size\": 4, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\", \"2h\", \"5s\", \"7c\", \"Td\", \"8d\", \"Qc\", \"9s\", \"Kd\", \"6s\", \"Ad\", \"7s\", \"4h\", \"4d\", \"8h\", \"Kh\", \"9h\", \"Js\"], \"hands\": {\"0\": [], \"1\": [\"2s\", \"Kc\", \"2d\", \"7d\", \"Jd\", \"Qd\", \"Ah\", \"7h\", \"Th\", \"Qh\"]}, \"deadwood\": {\"0\": null, \"1\": 69}, \"repeated_move\": 0}",
+          "currentPlayer": 0,
+          "playerId": 1,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14,0:52,0:49,1:52,1:6,0:52,0:14,1:52,1:32,0:52,0:47,1:52,1:48,0:52,0:13,1:53,-1:19,1:3,0:53,-1:34,0:48,1:52,1:49,0:53,-1:24,0:6,1:52,1:47,0:52,0:43,1:52,1:43,0:53,-1:33,0:31,1:53,-1:37,1:37,0:52,0:18,1:52,1:18,0:53,-1:30,0:7,1:53,-1:15,1:15,0:53,-1:17,0:37,1:52,1:21,0:53,-1:40,0:30,1:53,-1:9,1:19,0:52,0:40,1:53,-1:29,1:9,0:52,0:47,1:52,1:4,0:52,0:4,1:53,-1:35,1:6,0:52,0:19,1:53,-1:8,1:35,0:53,-1:26,0:33,1:53,-1:22,1:8,0:52,0:32,1:52,1:22,0:52,0:24,1:53,-1:1,1:1,0:52,0:8,1:53,-1:46,1:38,0:53,-1:23,0:5,1:53,-1:42,1:42,0:52,0:1,1:52,1:47,0:52,0:26,1:53,-1:16,1:14,0:52,0:6,1:53,-1:45,1:16,0:52,0:42,1:53,-1:2,1:29,0:53,-1:44,0:50,1:52,1:32,0:52,0:32,1:52,1:46,0:53,-1:36,0:16,1:52,1:51,0:53,-1:10,0:36,1:52,1:11,0:52,0:47,1:53,-1:27,1:16,0:52,0:10,1:53,-1:39,1:2\nmove_number=172\n__dict__=gASV+wIAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRYuQIAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAo1Mgo0OQo1Mgo2CjUyCjE0CjUyCjMyCjUyCjQ3CjUyCjQ4CjUyCjEzCjUzCjE5CjMKNTMKMzQKNDgKNTIKNDkKNTMKMjQKNgo1Mgo0Nwo1Mgo0Mwo1Mgo0Mwo1MwozMwozMQo1MwozNwozNwo1MgoxOAo1MgoxOAo1MwozMAo3CjUzCjE1CjE1CjUzCjE3CjM3CjUyCjIxCjUzCjQwCjMwCjUzCjkKMTkKNTIKNDAKNTMKMjkKOQo1Mgo0Nwo1Mgo0CjUyCjQKNTMKMzUKNgo1MgoxOQo1Mwo4CjM1CjUzCjI2CjMzCjUzCjIyCjgKNTIKMzIKNTIKMjIKNTIKMjQKNTMKMQoxCjUyCjgKNTMKNDYKMzgKNTMKMjMKNQo1Mwo0Mgo0Mgo1MgoxCjUyCjQ3CjUyCjI2CjUzCjE2CjE0CjUyCjYKNTMKNDUKMTYKNTIKNDIKNTMKMgoyOQo1Mwo0NAo1MAo1MgozMgo1MgozMgo1Mgo0Ngo1MwozNgoxNgo1Mgo1MQo1MwoxMAozNgo1MgoxMQo1Mgo0Nwo1MwoyNwoxNgo1MgoxMAo1MwozOQoyCgqUYnMu\n",
+          "legalActions": [],
+          "legalActionStrings": []
+        },
+        "status": "INACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "submission": 53,
+          "thoughts": "lambda delta alpha mu delta imagine reflect horizon"
+        },
+        "reward": null,
+        "info": {
+          "actionSubmitted": 53,
+          "actionSubmittedToString": "Player: 0 Action: Draw stock",
+          "actionApplied": 53,
+          "timeTaken": 0.0,
+          "agentSelfReportedStatus": null
+        },
+        "observation": {
+          "remainingOverageTime": 12,
+          "step": 126,
+          "observationString": "{\"phase\": \"Discard\", \"current_player\": 0, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"3s\", \"upcard\": null, \"stock_size\": 3, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\", \"2h\", \"5s\", \"7c\", \"Td\", \"8d\", \"Qc\", \"9s\", \"Kd\", \"6s\", \"Ad\", \"7s\", \"4h\", \"4d\", \"8h\", \"Kh\", \"9h\", \"Js\", \"3s\"], \"hands\": {\"0\": [\"As\", \"Ts\", \"Qs\", \"2c\", \"4c\", \"5c\", \"Tc\", \"Jc\", \"3d\", \"9d\", \"6h\"], \"1\": []}, \"deadwood\": {\"0\": 60, \"1\": null}, \"repeated_move\": 0}",
+          "currentPlayer": 0,
+          "playerId": 0,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14,0:52,0:49,1:52,1:6,0:52,0:14,1:52,1:32,0:52,0:47,1:52,1:48,0:52,0:13,1:53,-1:19,1:3,0:53,-1:34,0:48,1:52,1:49,0:53,-1:24,0:6,1:52,1:47,0:52,0:43,1:52,1:43,0:53,-1:33,0:31,1:53,-1:37,1:37,0:52,0:18,1:52,1:18,0:53,-1:30,0:7,1:53,-1:15,1:15,0:53,-1:17,0:37,1:52,1:21,0:53,-1:40,0:30,1:53,-1:9,1:19,0:52,0:40,1:53,-1:29,1:9,0:52,0:47,1:52,1:4,0:52,0:4,1:53,-1:35,1:6,0:52,0:19,1:53,-1:8,1:35,0:53,-1:26,0:33,1:53,-1:22,1:8,0:52,0:32,1:52,1:22,0:52,0:24,1:53,-1:1,1:1,0:52,0:8,1:53,-1:46,1:38,0:53,-1:23,0:5,1:53,-1:42,1:42,0:52,0:1,1:52,1:47,0:52,0:26,1:53,-1:16,1:14,0:52,0:6,1:53,-1:45,1:16,0:52,0:42,1:53,-1:2,1:29,0:53,-1:44,0:50,1:52,1:32,0:52,0:32,1:52,1:46,0:53,-1:36,0:16,1:52,1:51,0:53,-1:10,0:36,1:52,1:11,0:52,0:47,1:53,-1:27,1:16,0:52,0:10,1:53,-1:39,1:2,0:53,-1:0\nmove_number=174\n__dict__=gASVAAMAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRYvgIAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAo1Mgo0OQo1Mgo2CjUyCjE0CjUyCjMyCjUyCjQ3CjUyCjQ4CjUyCjEzCjUzCjE5CjMKNTMKMzQKNDgKNTIKNDkKNTMKMjQKNgo1Mgo0Nwo1Mgo0Mwo1Mgo0Mwo1MwozMwozMQo1MwozNwozNwo1MgoxOAo1MgoxOAo1MwozMAo3CjUzCjE1CjE1CjUzCjE3CjM3CjUyCjIxCjUzCjQwCjMwCjUzCjkKMTkKNTIKNDAKNTMKMjkKOQo1Mgo0Nwo1Mgo0CjUyCjQKNTMKMzUKNgo1MgoxOQo1Mwo4CjM1CjUzCjI2CjMzCjUzCjIyCjgKNTIKMzIKNTIKMjIKNTIKMjQKNTMKMQoxCjUyCjgKNTMKNDYKMzgKNTMKMjMKNQo1Mwo0Mgo0Mgo1MgoxCjUyCjQ3CjUyCjI2CjUzCjE2CjE0CjUyCjYKNTMKNDUKMTYKNTIKNDIKNTMKMgoyOQo1Mwo0NAo1MAo1MgozMgo1MgozMgo1Mgo0Ngo1MwozNgoxNgo1Mgo1MQo1MwoxMAozNgo1MgoxMQo1Mgo0Nwo1MwoyNwoxNgo1MgoxMAo1MwozOQoyCjUzCjAKCpRicy4=\n",
+          "legalActions": [0, 9, 11, 14, 16, 17, 22, 23, 28, 34, 44],
+          "legalActionStrings": [
+            "Player: 0 Action: As",
+            "Player: 0 Action: Ts",
+            "Player: 0 Action: Qs",
+            "Player: 0 Action: 2c",
+            "Player: 0 Action: 4c",
+            "Player: 0 Action: 5c",
+            "Player: 0 Action: Tc",
+            "Player: 0 Action: Jc",
+            "Player: 0 Action: 3d",
+            "Player: 0 Action: 9d",
+            "Player: 0 Action: 6h"
+          ]
+        },
+        "status": "ACTIVE"
+      },
+      {
+        "action": {
+          "submission": -1
+        },
+        "reward": null,
+        "info": {},
+        "observation": {
+          "remainingOverageTime": 12,
+          "observationString": "{\"phase\": \"Discard\", \"current_player\": 0, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"3s\", \"upcard\": null, \"stock_size\": 3, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\", \"2h\", \"5s\", \"7c\", \"Td\", \"8d\", \"Qc\", \"9s\", \"Kd\", \"6s\", \"Ad\", \"7s\", \"4h\", \"4d\", \"8h\", \"Kh\", \"9h\", \"Js\", \"3s\"], \"hands\": {\"0\": [], \"1\": [\"2s\", \"Kc\", \"2d\", \"7d\", \"Jd\", \"Qd\", \"Ah\", \"7h\", \"Th\", \"Qh\"]}, \"deadwood\": {\"0\": null, \"1\": 69}, \"repeated_move\": 0}",
+          "currentPlayer": 0,
+          "playerId": 1,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14,0:52,0:49,1:52,1:6,0:52,0:14,1:52,1:32,0:52,0:47,1:52,1:48,0:52,0:13,1:53,-1:19,1:3,0:53,-1:34,0:48,1:52,1:49,0:53,-1:24,0:6,1:52,1:47,0:52,0:43,1:52,1:43,0:53,-1:33,0:31,1:53,-1:37,1:37,0:52,0:18,1:52,1:18,0:53,-1:30,0:7,1:53,-1:15,1:15,0:53,-1:17,0:37,1:52,1:21,0:53,-1:40,0:30,1:53,-1:9,1:19,0:52,0:40,1:53,-1:29,1:9,0:52,0:47,1:52,1:4,0:52,0:4,1:53,-1:35,1:6,0:52,0:19,1:53,-1:8,1:35,0:53,-1:26,0:33,1:53,-1:22,1:8,0:52,0:32,1:52,1:22,0:52,0:24,1:53,-1:1,1:1,0:52,0:8,1:53,-1:46,1:38,0:53,-1:23,0:5,1:53,-1:42,1:42,0:52,0:1,1:52,1:47,0:52,0:26,1:53,-1:16,1:14,0:52,0:6,1:53,-1:45,1:16,0:52,0:42,1:53,-1:2,1:29,0:53,-1:44,0:50,1:52,1:32,0:52,0:32,1:52,1:46,0:53,-1:36,0:16,1:52,1:51,0:53,-1:10,0:36,1:52,1:11,0:52,0:47,1:53,-1:27,1:16,0:52,0:10,1:53,-1:39,1:2,0:53,-1:0\nmove_number=174\n__dict__=gASVAAMAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRYvgIAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAo1Mgo0OQo1Mgo2CjUyCjE0CjUyCjMyCjUyCjQ3CjUyCjQ4CjUyCjEzCjUzCjE5CjMKNTMKMzQKNDgKNTIKNDkKNTMKMjQKNgo1Mgo0Nwo1Mgo0Mwo1Mgo0Mwo1MwozMwozMQo1MwozNwozNwo1MgoxOAo1MgoxOAo1MwozMAo3CjUzCjE1CjE1CjUzCjE3CjM3CjUyCjIxCjUzCjQwCjMwCjUzCjkKMTkKNTIKNDAKNTMKMjkKOQo1Mgo0Nwo1Mgo0CjUyCjQKNTMKMzUKNgo1MgoxOQo1Mwo4CjM1CjUzCjI2CjMzCjUzCjIyCjgKNTIKMzIKNTIKMjIKNTIKMjQKNTMKMQoxCjUyCjgKNTMKNDYKMzgKNTMKMjMKNQo1Mwo0Mgo0Mgo1MgoxCjUyCjQ3CjUyCjI2CjUzCjE2CjE0CjUyCjYKNTMKNDUKMTYKNTIKNDIKNTMKMgoyOQo1Mwo0NAo1MAo1MgozMgo1MgozMgo1Mgo0Ngo1MwozNgoxNgo1Mgo1MQo1MwoxMAozNgo1MgoxMQo1Mgo0Nwo1MwoyNwoxNgo1MgoxMAo1MwozOQoyCjUzCjAKCpRicy4=\n",
+          "legalActions": [],
+          "legalActionStrings": []
+        },
+        "status": "INACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "submission": 44,
+          "thoughts": "omega tau chi kappa reflect kappa muse cascade"
+        },
+        "reward": null,
+        "info": {
+          "actionSubmitted": 44,
+          "actionSubmittedToString": "Player: 0 Action: 6h",
+          "actionApplied": 44,
+          "timeTaken": 0.0,
+          "agentSelfReportedStatus": null
+        },
+        "observation": {
+          "remainingOverageTime": 12,
+          "step": 127,
+          "observationString": "{\"phase\": \"Draw\", \"current_player\": 1, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"3s\", \"upcard\": \"6h\", \"stock_size\": 3, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\", \"2h\", \"5s\", \"7c\", \"Td\", \"8d\", \"Qc\", \"9s\", \"Kd\", \"6s\", \"Ad\", \"7s\", \"4h\", \"4d\", \"8h\", \"Kh\", \"9h\", \"Js\", \"3s\"], \"hands\": {\"0\": [\"As\", \"Ts\", \"Qs\", \"2c\", \"4c\", \"5c\", \"Tc\", \"Jc\", \"3d\", \"9d\"], \"1\": []}, \"deadwood\": {\"0\": 64, \"1\": null}, \"repeated_move\": 0}",
+          "currentPlayer": 1,
+          "playerId": 0,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14,0:52,0:49,1:52,1:6,0:52,0:14,1:52,1:32,0:52,0:47,1:52,1:48,0:52,0:13,1:53,-1:19,1:3,0:53,-1:34,0:48,1:52,1:49,0:53,-1:24,0:6,1:52,1:47,0:52,0:43,1:52,1:43,0:53,-1:33,0:31,1:53,-1:37,1:37,0:52,0:18,1:52,1:18,0:53,-1:30,0:7,1:53,-1:15,1:15,0:53,-1:17,0:37,1:52,1:21,0:53,-1:40,0:30,1:53,-1:9,1:19,0:52,0:40,1:53,-1:29,1:9,0:52,0:47,1:52,1:4,0:52,0:4,1:53,-1:35,1:6,0:52,0:19,1:53,-1:8,1:35,0:53,-1:26,0:33,1:53,-1:22,1:8,0:52,0:32,1:52,1:22,0:52,0:24,1:53,-1:1,1:1,0:52,0:8,1:53,-1:46,1:38,0:53,-1:23,0:5,1:53,-1:42,1:42,0:52,0:1,1:52,1:47,0:52,0:26,1:53,-1:16,1:14,0:52,0:6,1:53,-1:45,1:16,0:52,0:42,1:53,-1:2,1:29,0:53,-1:44,0:50,1:52,1:32,0:52,0:32,1:52,1:46,0:53,-1:36,0:16,1:52,1:51,0:53,-1:10,0:36,1:52,1:11,0:52,0:47,1:53,-1:27,1:16,0:52,0:10,1:53,-1:39,1:2,0:53,-1:0,0:44\nmove_number=175\n__dict__=gASVAwMAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRYwQIAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAo1Mgo0OQo1Mgo2CjUyCjE0CjUyCjMyCjUyCjQ3CjUyCjQ4CjUyCjEzCjUzCjE5CjMKNTMKMzQKNDgKNTIKNDkKNTMKMjQKNgo1Mgo0Nwo1Mgo0Mwo1Mgo0Mwo1MwozMwozMQo1MwozNwozNwo1MgoxOAo1MgoxOAo1MwozMAo3CjUzCjE1CjE1CjUzCjE3CjM3CjUyCjIxCjUzCjQwCjMwCjUzCjkKMTkKNTIKNDAKNTMKMjkKOQo1Mgo0Nwo1Mgo0CjUyCjQKNTMKMzUKNgo1MgoxOQo1Mwo4CjM1CjUzCjI2CjMzCjUzCjIyCjgKNTIKMzIKNTIKMjIKNTIKMjQKNTMKMQoxCjUyCjgKNTMKNDYKMzgKNTMKMjMKNQo1Mwo0Mgo0Mgo1MgoxCjUyCjQ3CjUyCjI2CjUzCjE2CjE0CjUyCjYKNTMKNDUKMTYKNTIKNDIKNTMKMgoyOQo1Mwo0NAo1MAo1MgozMgo1MgozMgo1Mgo0Ngo1MwozNgoxNgo1Mgo1MQo1MwoxMAozNgo1MgoxMQo1Mgo0Nwo1MwoyNwoxNgo1MgoxMAo1MwozOQoyCjUzCjAKNDQKCpRicy4=\n",
+          "legalActions": [],
+          "legalActionStrings": []
+        },
+        "status": "INACTIVE"
+      },
+      {
+        "action": {
+          "submission": -1
+        },
+        "reward": null,
+        "info": {},
+        "observation": {
+          "remainingOverageTime": 12,
+          "observationString": "{\"phase\": \"Draw\", \"current_player\": 1, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"3s\", \"upcard\": \"6h\", \"stock_size\": 3, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\", \"2h\", \"5s\", \"7c\", \"Td\", \"8d\", \"Qc\", \"9s\", \"Kd\", \"6s\", \"Ad\", \"7s\", \"4h\", \"4d\", \"8h\", \"Kh\", \"9h\", \"Js\", \"3s\"], \"hands\": {\"0\": [], \"1\": [\"2s\", \"Kc\", \"2d\", \"7d\", \"Jd\", \"Qd\", \"Ah\", \"7h\", \"Th\", \"Qh\"]}, \"deadwood\": {\"0\": null, \"1\": 69}, \"repeated_move\": 0}",
+          "currentPlayer": 1,
+          "playerId": 1,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14,0:52,0:49,1:52,1:6,0:52,0:14,1:52,1:32,0:52,0:47,1:52,1:48,0:52,0:13,1:53,-1:19,1:3,0:53,-1:34,0:48,1:52,1:49,0:53,-1:24,0:6,1:52,1:47,0:52,0:43,1:52,1:43,0:53,-1:33,0:31,1:53,-1:37,1:37,0:52,0:18,1:52,1:18,0:53,-1:30,0:7,1:53,-1:15,1:15,0:53,-1:17,0:37,1:52,1:21,0:53,-1:40,0:30,1:53,-1:9,1:19,0:52,0:40,1:53,-1:29,1:9,0:52,0:47,1:52,1:4,0:52,0:4,1:53,-1:35,1:6,0:52,0:19,1:53,-1:8,1:35,0:53,-1:26,0:33,1:53,-1:22,1:8,0:52,0:32,1:52,1:22,0:52,0:24,1:53,-1:1,1:1,0:52,0:8,1:53,-1:46,1:38,0:53,-1:23,0:5,1:53,-1:42,1:42,0:52,0:1,1:52,1:47,0:52,0:26,1:53,-1:16,1:14,0:52,0:6,1:53,-1:45,1:16,0:52,0:42,1:53,-1:2,1:29,0:53,-1:44,0:50,1:52,1:32,0:52,0:32,1:52,1:46,0:53,-1:36,0:16,1:52,1:51,0:53,-1:10,0:36,1:52,1:11,0:52,0:47,1:53,-1:27,1:16,0:52,0:10,1:53,-1:39,1:2,0:53,-1:0,0:44\nmove_number=175\n__dict__=gASVAwMAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRYwQIAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAo1Mgo0OQo1Mgo2CjUyCjE0CjUyCjMyCjUyCjQ3CjUyCjQ4CjUyCjEzCjUzCjE5CjMKNTMKMzQKNDgKNTIKNDkKNTMKMjQKNgo1Mgo0Nwo1Mgo0Mwo1Mgo0Mwo1MwozMwozMQo1MwozNwozNwo1MgoxOAo1MgoxOAo1MwozMAo3CjUzCjE1CjE1CjUzCjE3CjM3CjUyCjIxCjUzCjQwCjMwCjUzCjkKMTkKNTIKNDAKNTMKMjkKOQo1Mgo0Nwo1Mgo0CjUyCjQKNTMKMzUKNgo1MgoxOQo1Mwo4CjM1CjUzCjI2CjMzCjUzCjIyCjgKNTIKMzIKNTIKMjIKNTIKMjQKNTMKMQoxCjUyCjgKNTMKNDYKMzgKNTMKMjMKNQo1Mwo0Mgo0Mgo1MgoxCjUyCjQ3CjUyCjI2CjUzCjE2CjE0CjUyCjYKNTMKNDUKMTYKNTIKNDIKNTMKMgoyOQo1Mwo0NAo1MAo1MgozMgo1MgozMgo1Mgo0Ngo1MwozNgoxNgo1Mgo1MQo1MwoxMAozNgo1MgoxMQo1Mgo0Nwo1MwoyNwoxNgo1MgoxMAo1MwozOQoyCjUzCjAKNDQKCpRicy4=\n",
+          "legalActions": [52, 53],
+          "legalActionStrings": [
+            "Player: 1 Action: Draw upcard",
+            "Player: 1 Action: Draw stock"
+          ]
+        },
+        "status": "ACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "submission": -1
+        },
+        "reward": null,
+        "info": {},
+        "observation": {
+          "remainingOverageTime": 12,
+          "step": 128,
+          "observationString": "{\"phase\": \"Discard\", \"current_player\": 1, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"6h\", \"upcard\": null, \"stock_size\": 2, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\", \"2h\", \"5s\", \"7c\", \"Td\", \"8d\", \"Qc\", \"9s\", \"Kd\", \"6s\", \"Ad\", \"7s\", \"4h\", \"4d\", \"8h\", \"Kh\", \"9h\", \"Js\", \"3s\", \"6h\"], \"hands\": {\"0\": [\"As\", \"Ts\", \"Qs\", \"2c\", \"4c\", \"5c\", \"Tc\", \"Jc\", \"3d\", \"9d\"], \"1\": []}, \"deadwood\": {\"0\": 64, \"1\": null}, \"repeated_move\": 0}",
+          "currentPlayer": 1,
+          "playerId": 0,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14,0:52,0:49,1:52,1:6,0:52,0:14,1:52,1:32,0:52,0:47,1:52,1:48,0:52,0:13,1:53,-1:19,1:3,0:53,-1:34,0:48,1:52,1:49,0:53,-1:24,0:6,1:52,1:47,0:52,0:43,1:52,1:43,0:53,-1:33,0:31,1:53,-1:37,1:37,0:52,0:18,1:52,1:18,0:53,-1:30,0:7,1:53,-1:15,1:15,0:53,-1:17,0:37,1:52,1:21,0:53,-1:40,0:30,1:53,-1:9,1:19,0:52,0:40,1:53,-1:29,1:9,0:52,0:47,1:52,1:4,0:52,0:4,1:53,-1:35,1:6,0:52,0:19,1:53,-1:8,1:35,0:53,-1:26,0:33,1:53,-1:22,1:8,0:52,0:32,1:52,1:22,0:52,0:24,1:53,-1:1,1:1,0:52,0:8,1:53,-1:46,1:38,0:53,-1:23,0:5,1:53,-1:42,1:42,0:52,0:1,1:52,1:47,0:52,0:26,1:53,-1:16,1:14,0:52,0:6,1:53,-1:45,1:16,0:52,0:42,1:53,-1:2,1:29,0:53,-1:44,0:50,1:52,1:32,0:52,0:32,1:52,1:46,0:53,-1:36,0:16,1:52,1:51,0:53,-1:10,0:36,1:52,1:11,0:52,0:47,1:53,-1:27,1:16,0:52,0:10,1:53,-1:39,1:2,0:53,-1:0,0:44,1:53,-1:41\nmove_number=177\n__dict__=gASVCQMAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRYxwIAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAo1Mgo0OQo1Mgo2CjUyCjE0CjUyCjMyCjUyCjQ3CjUyCjQ4CjUyCjEzCjUzCjE5CjMKNTMKMzQKNDgKNTIKNDkKNTMKMjQKNgo1Mgo0Nwo1Mgo0Mwo1Mgo0Mwo1MwozMwozMQo1MwozNwozNwo1MgoxOAo1MgoxOAo1MwozMAo3CjUzCjE1CjE1CjUzCjE3CjM3CjUyCjIxCjUzCjQwCjMwCjUzCjkKMTkKNTIKNDAKNTMKMjkKOQo1Mgo0Nwo1Mgo0CjUyCjQKNTMKMzUKNgo1MgoxOQo1Mwo4CjM1CjUzCjI2CjMzCjUzCjIyCjgKNTIKMzIKNTIKMjIKNTIKMjQKNTMKMQoxCjUyCjgKNTMKNDYKMzgKNTMKMjMKNQo1Mwo0Mgo0Mgo1MgoxCjUyCjQ3CjUyCjI2CjUzCjE2CjE0CjUyCjYKNTMKNDUKMTYKNTIKNDIKNTMKMgoyOQo1Mwo0NAo1MAo1MgozMgo1MgozMgo1Mgo0Ngo1MwozNgoxNgo1Mgo1MQo1MwoxMAozNgo1MgoxMQo1Mgo0Nwo1MwoyNwoxNgo1MgoxMAo1MwozOQoyCjUzCjAKNDQKNTMKNDEKCpRicy4=\n",
+          "legalActions": [],
+          "legalActionStrings": []
+        },
+        "status": "INACTIVE"
+      },
+      {
+        "action": {
+          "submission": 53,
+          "thoughts": "shadow explore drift sigma shadow sigma imagine xi"
+        },
+        "reward": null,
+        "info": {
+          "actionSubmitted": 53,
+          "actionSubmittedToString": "Player: 1 Action: Draw stock",
+          "actionApplied": 53,
+          "timeTaken": 0.0,
+          "agentSelfReportedStatus": null
+        },
+        "observation": {
+          "remainingOverageTime": 12,
+          "observationString": "{\"phase\": \"Discard\", \"current_player\": 1, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"6h\", \"upcard\": null, \"stock_size\": 2, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\", \"2h\", \"5s\", \"7c\", \"Td\", \"8d\", \"Qc\", \"9s\", \"Kd\", \"6s\", \"Ad\", \"7s\", \"4h\", \"4d\", \"8h\", \"Kh\", \"9h\", \"Js\", \"3s\", \"6h\"], \"hands\": {\"0\": [], \"1\": [\"2s\", \"Kc\", \"2d\", \"7d\", \"Jd\", \"Qd\", \"Ah\", \"3h\", \"7h\", \"Th\", \"Qh\"]}, \"deadwood\": {\"0\": null, \"1\": 62}, \"repeated_move\": 0}",
+          "currentPlayer": 1,
+          "playerId": 1,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14,0:52,0:49,1:52,1:6,0:52,0:14,1:52,1:32,0:52,0:47,1:52,1:48,0:52,0:13,1:53,-1:19,1:3,0:53,-1:34,0:48,1:52,1:49,0:53,-1:24,0:6,1:52,1:47,0:52,0:43,1:52,1:43,0:53,-1:33,0:31,1:53,-1:37,1:37,0:52,0:18,1:52,1:18,0:53,-1:30,0:7,1:53,-1:15,1:15,0:53,-1:17,0:37,1:52,1:21,0:53,-1:40,0:30,1:53,-1:9,1:19,0:52,0:40,1:53,-1:29,1:9,0:52,0:47,1:52,1:4,0:52,0:4,1:53,-1:35,1:6,0:52,0:19,1:53,-1:8,1:35,0:53,-1:26,0:33,1:53,-1:22,1:8,0:52,0:32,1:52,1:22,0:52,0:24,1:53,-1:1,1:1,0:52,0:8,1:53,-1:46,1:38,0:53,-1:23,0:5,1:53,-1:42,1:42,0:52,0:1,1:52,1:47,0:52,0:26,1:53,-1:16,1:14,0:52,0:6,1:53,-1:45,1:16,0:52,0:42,1:53,-1:2,1:29,0:53,-1:44,0:50,1:52,1:32,0:52,0:32,1:52,1:46,0:53,-1:36,0:16,1:52,1:51,0:53,-1:10,0:36,1:52,1:11,0:52,0:47,1:53,-1:27,1:16,0:52,0:10,1:53,-1:39,1:2,0:53,-1:0,0:44,1:53,-1:41\nmove_number=177\n__dict__=gASVCQMAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRYxwIAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAo1Mgo0OQo1Mgo2CjUyCjE0CjUyCjMyCjUyCjQ3CjUyCjQ4CjUyCjEzCjUzCjE5CjMKNTMKMzQKNDgKNTIKNDkKNTMKMjQKNgo1Mgo0Nwo1Mgo0Mwo1Mgo0Mwo1MwozMwozMQo1MwozNwozNwo1MgoxOAo1MgoxOAo1MwozMAo3CjUzCjE1CjE1CjUzCjE3CjM3CjUyCjIxCjUzCjQwCjMwCjUzCjkKMTkKNTIKNDAKNTMKMjkKOQo1Mgo0Nwo1Mgo0CjUyCjQKNTMKMzUKNgo1MgoxOQo1Mwo4CjM1CjUzCjI2CjMzCjUzCjIyCjgKNTIKMzIKNTIKMjIKNTIKMjQKNTMKMQoxCjUyCjgKNTMKNDYKMzgKNTMKMjMKNQo1Mwo0Mgo0Mgo1MgoxCjUyCjQ3CjUyCjI2CjUzCjE2CjE0CjUyCjYKNTMKNDUKMTYKNTIKNDIKNTMKMgoyOQo1Mwo0NAo1MAo1MgozMgo1MgozMgo1Mgo0Ngo1MwozNgoxNgo1Mgo1MQo1MwoxMAozNgo1MgoxMQo1Mgo0Nwo1MwoyNwoxNgo1MgoxMAo1MwozOQoyCjUzCjAKNDQKNTMKNDEKCpRicy4=\n",
+          "legalActions": [1, 25, 27, 32, 36, 37, 39, 41, 45, 48, 50],
+          "legalActionStrings": [
+            "Player: 1 Action: 2s",
+            "Player: 1 Action: Kc",
+            "Player: 1 Action: 2d",
+            "Player: 1 Action: 7d",
+            "Player: 1 Action: Jd",
+            "Player: 1 Action: Qd",
+            "Player: 1 Action: Ah",
+            "Player: 1 Action: 3h",
+            "Player: 1 Action: 7h",
+            "Player: 1 Action: Th",
+            "Player: 1 Action: Qh"
+          ]
+        },
+        "status": "ACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "submission": -1
+        },
+        "reward": null,
+        "info": {},
+        "observation": {
+          "remainingOverageTime": 12,
+          "step": 129,
+          "observationString": "{\"phase\": \"Wall\", \"current_player\": 0, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"6h\", \"upcard\": \"Jd\", \"stock_size\": 2, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\", \"2h\", \"5s\", \"7c\", \"Td\", \"8d\", \"Qc\", \"9s\", \"Kd\", \"6s\", \"Ad\", \"7s\", \"4h\", \"4d\", \"8h\", \"Kh\", \"9h\", \"Js\", \"3s\", \"6h\"], \"hands\": {\"0\": [\"As\", \"Ts\", \"Qs\", \"2c\", \"4c\", \"5c\", \"Tc\", \"Jc\", \"3d\", \"9d\"], \"1\": []}, \"deadwood\": {\"0\": 64, \"1\": null}, \"repeated_move\": 0}",
+          "currentPlayer": 0,
+          "playerId": 0,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14,0:52,0:49,1:52,1:6,0:52,0:14,1:52,1:32,0:52,0:47,1:52,1:48,0:52,0:13,1:53,-1:19,1:3,0:53,-1:34,0:48,1:52,1:49,0:53,-1:24,0:6,1:52,1:47,0:52,0:43,1:52,1:43,0:53,-1:33,0:31,1:53,-1:37,1:37,0:52,0:18,1:52,1:18,0:53,-1:30,0:7,1:53,-1:15,1:15,0:53,-1:17,0:37,1:52,1:21,0:53,-1:40,0:30,1:53,-1:9,1:19,0:52,0:40,1:53,-1:29,1:9,0:52,0:47,1:52,1:4,0:52,0:4,1:53,-1:35,1:6,0:52,0:19,1:53,-1:8,1:35,0:53,-1:26,0:33,1:53,-1:22,1:8,0:52,0:32,1:52,1:22,0:52,0:24,1:53,-1:1,1:1,0:52,0:8,1:53,-1:46,1:38,0:53,-1:23,0:5,1:53,-1:42,1:42,0:52,0:1,1:52,1:47,0:52,0:26,1:53,-1:16,1:14,0:52,0:6,1:53,-1:45,1:16,0:52,0:42,1:53,-1:2,1:29,0:53,-1:44,0:50,1:52,1:32,0:52,0:32,1:52,1:46,0:53,-1:36,0:16,1:52,1:51,0:53,-1:10,0:36,1:52,1:11,0:52,0:47,1:53,-1:27,1:16,0:52,0:10,1:53,-1:39,1:2,0:53,-1:0,0:44,1:53,-1:41,1:36\nmove_number=178\n__dict__=gASVDAMAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRYygIAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAo1Mgo0OQo1Mgo2CjUyCjE0CjUyCjMyCjUyCjQ3CjUyCjQ4CjUyCjEzCjUzCjE5CjMKNTMKMzQKNDgKNTIKNDkKNTMKMjQKNgo1Mgo0Nwo1Mgo0Mwo1Mgo0Mwo1MwozMwozMQo1MwozNwozNwo1MgoxOAo1MgoxOAo1MwozMAo3CjUzCjE1CjE1CjUzCjE3CjM3CjUyCjIxCjUzCjQwCjMwCjUzCjkKMTkKNTIKNDAKNTMKMjkKOQo1Mgo0Nwo1Mgo0CjUyCjQKNTMKMzUKNgo1MgoxOQo1Mwo4CjM1CjUzCjI2CjMzCjUzCjIyCjgKNTIKMzIKNTIKMjIKNTIKMjQKNTMKMQoxCjUyCjgKNTMKNDYKMzgKNTMKMjMKNQo1Mwo0Mgo0Mgo1MgoxCjUyCjQ3CjUyCjI2CjUzCjE2CjE0CjUyCjYKNTMKNDUKMTYKNTIKNDIKNTMKMgoyOQo1Mwo0NAo1MAo1MgozMgo1MgozMgo1Mgo0Ngo1MwozNgoxNgo1Mgo1MQo1MwoxMAozNgo1MgoxMQo1Mgo0Nwo1MwoyNwoxNgo1MgoxMAo1MwozOQoyCjUzCjAKNDQKNTMKNDEKMzYKCpRicy4=\n",
+          "legalActions": [54],
+          "legalActionStrings": ["Player: 0 Action: Pass"]
+        },
+        "status": "ACTIVE"
+      },
+      {
+        "action": {
+          "submission": 36,
+          "thoughts": "delta horizon gamma shadow chi omega gamma xi"
+        },
+        "reward": null,
+        "info": {
+          "actionSubmitted": 36,
+          "actionSubmittedToString": "Player: 1 Action: Jd",
+          "actionApplied": 36,
+          "timeTaken": 0.0,
+          "agentSelfReportedStatus": null
+        },
+        "observation": {
+          "remainingOverageTime": 12,
+          "observationString": "{\"phase\": \"Wall\", \"current_player\": 0, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"6h\", \"upcard\": \"Jd\", \"stock_size\": 2, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\", \"2h\", \"5s\", \"7c\", \"Td\", \"8d\", \"Qc\", \"9s\", \"Kd\", \"6s\", \"Ad\", \"7s\", \"4h\", \"4d\", \"8h\", \"Kh\", \"9h\", \"Js\", \"3s\", \"6h\"], \"hands\": {\"0\": [], \"1\": [\"2s\", \"Kc\", \"2d\", \"7d\", \"Qd\", \"Ah\", \"3h\", \"7h\", \"Th\", \"Qh\"]}, \"deadwood\": {\"0\": null, \"1\": 62}, \"repeated_move\": 0}",
+          "currentPlayer": 0,
+          "playerId": 1,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14,0:52,0:49,1:52,1:6,0:52,0:14,1:52,1:32,0:52,0:47,1:52,1:48,0:52,0:13,1:53,-1:19,1:3,0:53,-1:34,0:48,1:52,1:49,0:53,-1:24,0:6,1:52,1:47,0:52,0:43,1:52,1:43,0:53,-1:33,0:31,1:53,-1:37,1:37,0:52,0:18,1:52,1:18,0:53,-1:30,0:7,1:53,-1:15,1:15,0:53,-1:17,0:37,1:52,1:21,0:53,-1:40,0:30,1:53,-1:9,1:19,0:52,0:40,1:53,-1:29,1:9,0:52,0:47,1:52,1:4,0:52,0:4,1:53,-1:35,1:6,0:52,0:19,1:53,-1:8,1:35,0:53,-1:26,0:33,1:53,-1:22,1:8,0:52,0:32,1:52,1:22,0:52,0:24,1:53,-1:1,1:1,0:52,0:8,1:53,-1:46,1:38,0:53,-1:23,0:5,1:53,-1:42,1:42,0:52,0:1,1:52,1:47,0:52,0:26,1:53,-1:16,1:14,0:52,0:6,1:53,-1:45,1:16,0:52,0:42,1:53,-1:2,1:29,0:53,-1:44,0:50,1:52,1:32,0:52,0:32,1:52,1:46,0:53,-1:36,0:16,1:52,1:51,0:53,-1:10,0:36,1:52,1:11,0:52,0:47,1:53,-1:27,1:16,0:52,0:10,1:53,-1:39,1:2,0:53,-1:0,0:44,1:53,-1:41,1:36\nmove_number=178\n__dict__=gASVDAMAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRYygIAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAo1Mgo0OQo1Mgo2CjUyCjE0CjUyCjMyCjUyCjQ3CjUyCjQ4CjUyCjEzCjUzCjE5CjMKNTMKMzQKNDgKNTIKNDkKNTMKMjQKNgo1Mgo0Nwo1Mgo0Mwo1Mgo0Mwo1MwozMwozMQo1MwozNwozNwo1MgoxOAo1MgoxOAo1MwozMAo3CjUzCjE1CjE1CjUzCjE3CjM3CjUyCjIxCjUzCjQwCjMwCjUzCjkKMTkKNTIKNDAKNTMKMjkKOQo1Mgo0Nwo1Mgo0CjUyCjQKNTMKMzUKNgo1MgoxOQo1Mwo4CjM1CjUzCjI2CjMzCjUzCjIyCjgKNTIKMzIKNTIKMjIKNTIKMjQKNTMKMQoxCjUyCjgKNTMKNDYKMzgKNTMKMjMKNQo1Mwo0Mgo0Mgo1MgoxCjUyCjQ3CjUyCjI2CjUzCjE2CjE0CjUyCjYKNTMKNDUKMTYKNTIKNDIKNTMKMgoyOQo1Mwo0NAo1MAo1MgozMgo1MgozMgo1Mgo0Ngo1MwozNgoxNgo1Mgo1MQo1MwoxMAozNgo1MgoxMQo1Mgo0Nwo1MwoyNwoxNgo1MgoxMAo1MwozOQoyCjUzCjAKNDQKNTMKNDEKMzYKCpRicy4=\n",
+          "legalActions": [],
+          "legalActionStrings": []
+        },
+        "status": "INACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "submission": 54,
+          "thoughts": "theta wonder kappa ponder pi kappa ripple xi"
+        },
+        "reward": 0.0,
+        "info": {
+          "actionSubmitted": 54,
+          "actionSubmittedToString": "Player: 0 Action: Pass",
+          "actionApplied": 54,
+          "timeTaken": 0.0,
+          "agentSelfReportedStatus": null
+        },
+        "observation": {
+          "remainingOverageTime": 12,
+          "step": 130,
+          "observationString": "{\"phase\": \"GameOver\", \"current_player\": -4, \"is_terminal\": true, \"winner\": \"draw\", \"returns\": [0.0, 0.0], \"knock_card\": 10, \"prev_upcard\": \"6h\", \"upcard\": \"Jd\", \"stock_size\": 2, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\", \"2h\", \"5s\", \"7c\", \"Td\", \"8d\", \"Qc\", \"9s\", \"Kd\", \"6s\", \"Ad\", \"7s\", \"4h\", \"4d\", \"8h\", \"Kh\", \"9h\", \"Js\", \"3s\", \"6h\"], \"hands\": {\"0\": [\"As\", \"Ts\", \"Qs\", \"2c\", \"4c\", \"5c\", \"Tc\", \"Jc\", \"3d\", \"9d\"], \"1\": []}, \"deadwood\": {\"0\": 64, \"1\": null}, \"repeated_move\": 0}",
+          "currentPlayer": -4,
+          "playerId": 0,
+          "isTerminal": true,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14,0:52,0:49,1:52,1:6,0:52,0:14,1:52,1:32,0:52,0:47,1:52,1:48,0:52,0:13,1:53,-1:19,1:3,0:53,-1:34,0:48,1:52,1:49,0:53,-1:24,0:6,1:52,1:47,0:52,0:43,1:52,1:43,0:53,-1:33,0:31,1:53,-1:37,1:37,0:52,0:18,1:52,1:18,0:53,-1:30,0:7,1:53,-1:15,1:15,0:53,-1:17,0:37,1:52,1:21,0:53,-1:40,0:30,1:53,-1:9,1:19,0:52,0:40,1:53,-1:29,1:9,0:52,0:47,1:52,1:4,0:52,0:4,1:53,-1:35,1:6,0:52,0:19,1:53,-1:8,1:35,0:53,-1:26,0:33,1:53,-1:22,1:8,0:52,0:32,1:52,1:22,0:52,0:24,1:53,-1:1,1:1,0:52,0:8,1:53,-1:46,1:38,0:53,-1:23,0:5,1:53,-1:42,1:42,0:52,0:1,1:52,1:47,0:52,0:26,1:53,-1:16,1:14,0:52,0:6,1:53,-1:45,1:16,0:52,0:42,1:53,-1:2,1:29,0:53,-1:44,0:50,1:52,1:32,0:52,0:32,1:52,1:46,0:53,-1:36,0:16,1:52,1:51,0:53,-1:10,0:36,1:52,1:11,0:52,0:47,1:53,-1:27,1:16,0:52,0:10,1:53,-1:39,1:2,0:53,-1:0,0:44,1:53,-1:41,1:36,0:54\nmove_number=179\n__dict__=gASVDwMAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRYzQIAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAo1Mgo0OQo1Mgo2CjUyCjE0CjUyCjMyCjUyCjQ3CjUyCjQ4CjUyCjEzCjUzCjE5CjMKNTMKMzQKNDgKNTIKNDkKNTMKMjQKNgo1Mgo0Nwo1Mgo0Mwo1Mgo0Mwo1MwozMwozMQo1MwozNwozNwo1MgoxOAo1MgoxOAo1MwozMAo3CjUzCjE1CjE1CjUzCjE3CjM3CjUyCjIxCjUzCjQwCjMwCjUzCjkKMTkKNTIKNDAKNTMKMjkKOQo1Mgo0Nwo1Mgo0CjUyCjQKNTMKMzUKNgo1MgoxOQo1Mwo4CjM1CjUzCjI2CjMzCjUzCjIyCjgKNTIKMzIKNTIKMjIKNTIKMjQKNTMKMQoxCjUyCjgKNTMKNDYKMzgKNTMKMjMKNQo1Mwo0Mgo0Mgo1MgoxCjUyCjQ3CjUyCjI2CjUzCjE2CjE0CjUyCjYKNTMKNDUKMTYKNTIKNDIKNTMKMgoyOQo1Mwo0NAo1MAo1MgozMgo1MgozMgo1Mgo0Ngo1MwozNgoxNgo1Mgo1MQo1MwoxMAozNgo1MgoxMQo1Mgo0Nwo1MwoyNwoxNgo1MgoxMAo1MwozOQoyCjUzCjAKNDQKNTMKNDEKMzYKNTQKCpRicy4=\n",
+          "legalActions": [],
+          "legalActionStrings": []
+        },
+        "status": "DONE"
+      },
+      {
+        "action": {
+          "submission": -1
+        },
+        "reward": 0.0,
+        "info": {},
+        "observation": {
+          "remainingOverageTime": 12,
+          "observationString": "{\"phase\": \"GameOver\", \"current_player\": -4, \"is_terminal\": true, \"winner\": \"draw\", \"returns\": [0.0, 0.0], \"knock_card\": 10, \"prev_upcard\": \"6h\", \"upcard\": \"Jd\", \"stock_size\": 2, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\", \"2h\", \"5s\", \"7c\", \"Td\", \"8d\", \"Qc\", \"9s\", \"Kd\", \"6s\", \"Ad\", \"7s\", \"4h\", \"4d\", \"8h\", \"Kh\", \"9h\", \"Js\", \"3s\", \"6h\"], \"hands\": {\"0\": [], \"1\": [\"2s\", \"Kc\", \"2d\", \"7d\", \"Qd\", \"Ah\", \"3h\", \"7h\", \"Th\", \"Qh\"]}, \"deadwood\": {\"0\": null, \"1\": 62}, \"repeated_move\": 0}",
+          "currentPlayer": -4,
+          "playerId": 1,
+          "isTerminal": true,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\ngin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)\n[State]\nhistory=-1:43,-1:7,-1:5,-1:31,-1:28,-1:13,-1:49,-1:18,-1:47,-1:50,-1:3,-1:51,-1:21,-1:6,-1:38,-1:11,-1:48,-1:25,-1:32,-1:4,-1:14,0:52,0:49,1:52,1:6,0:52,0:14,1:52,1:32,0:52,0:47,1:52,1:48,0:52,0:13,1:53,-1:19,1:3,0:53,-1:34,0:48,1:52,1:49,0:53,-1:24,0:6,1:52,1:47,0:52,0:43,1:52,1:43,0:53,-1:33,0:31,1:53,-1:37,1:37,0:52,0:18,1:52,1:18,0:53,-1:30,0:7,1:53,-1:15,1:15,0:53,-1:17,0:37,1:52,1:21,0:53,-1:40,0:30,1:53,-1:9,1:19,0:52,0:40,1:53,-1:29,1:9,0:52,0:47,1:52,1:4,0:52,0:4,1:53,-1:35,1:6,0:52,0:19,1:53,-1:8,1:35,0:53,-1:26,0:33,1:53,-1:22,1:8,0:52,0:32,1:52,1:22,0:52,0:24,1:53,-1:1,1:1,0:52,0:8,1:53,-1:46,1:38,0:53,-1:23,0:5,1:53,-1:42,1:42,0:52,0:1,1:52,1:47,0:52,0:26,1:53,-1:16,1:14,0:52,0:6,1:53,-1:45,1:16,0:52,0:42,1:53,-1:2,1:29,0:53,-1:44,0:50,1:52,1:32,0:52,0:32,1:52,1:46,0:53,-1:36,0:16,1:52,1:51,0:53,-1:10,0:36,1:52,1:11,0:52,0:47,1:53,-1:27,1:16,0:52,0:10,1:53,-1:39,1:2,0:53,-1:0,0:44,1:53,-1:41,1:36,0:54\nmove_number=179\n__dict__=gASVDwMAAAAAAAB9lIwLX193cmFwcGVkX1+UjBFweXNwaWVsLmdpbl9ydW1teZSMDUdpblJ1bW15U3RhdGWUk5QpgZRYzQIAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCmdpbl9ydW1teShnaW5fYm9udXM9MjUsaGFuZF9zaXplPTEwLGtub2NrX2NhcmQ9MTAsbnVtX3JhbmtzPTEzLG51bV9zdWl0cz00LG9rbGFob21hPUZhbHNlLHVuZGVyY3V0X2JvbnVzPTI1KQpbU3RhdGVdCjQzCjcKNQozMQoyOAoxMwo0OQoxOAo0Nwo1MAozCjUxCjIxCjYKMzgKMTEKNDgKMjUKMzIKNAoxNAo1Mgo0OQo1Mgo2CjUyCjE0CjUyCjMyCjUyCjQ3CjUyCjQ4CjUyCjEzCjUzCjE5CjMKNTMKMzQKNDgKNTIKNDkKNTMKMjQKNgo1Mgo0Nwo1Mgo0Mwo1Mgo0Mwo1MwozMwozMQo1MwozNwozNwo1MgoxOAo1MgoxOAo1MwozMAo3CjUzCjE1CjE1CjUzCjE3CjM3CjUyCjIxCjUzCjQwCjMwCjUzCjkKMTkKNTIKNDAKNTMKMjkKOQo1Mgo0Nwo1Mgo0CjUyCjQKNTMKMzUKNgo1MgoxOQo1Mwo4CjM1CjUzCjI2CjMzCjUzCjIyCjgKNTIKMzIKNTIKMjIKNTIKMjQKNTMKMQoxCjUyCjgKNTMKNDYKMzgKNTMKMjMKNQo1Mwo0Mgo0Mgo1MgoxCjUyCjQ3CjUyCjI2CjUzCjE2CjE0CjUyCjYKNTMKNDUKMTYKNTIKNDIKNTMKMgoyOQo1Mwo0NAo1MAo1MgozMgo1MgozMgo1Mgo0Ngo1MwozNgoxNgo1Mgo1MQo1MwoxMAozNgo1MgoxMQo1Mgo0Nwo1MwoyNwoxNgo1MgoxMAo1MwozOQoyCjUzCjAKNDQKNTMKNDEKMzYKNTQKCpRicy4=\n",
+          "legalActions": [],
+          "legalActionStrings": []
+        },
+        "status": "DONE"
+      }
+    ]
+  ],
+  "rewards": [0.0, 0.0],
+  "statuses": ["DONE", "DONE"],
+  "schema_version": 1,
+  "info": {
+    "openSpielGameStringResolved": "gin_rummy_proxy(gin_bonus=25,hand_size=10,knock_card=10,num_ranks=13,num_suits=4,oklahoma=False,undercut_bonus=25)",
+    "stateHistory": [
+      "{\"phase\": \"Deal\", \"current_player\": -1, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": null, \"upcard\": null, \"stock_size\": 52, \"discard_pile\": [], \"hands\": {\"0\": [], \"1\": []}, \"deadwood\": {\"0\": 0, \"1\": null}, \"repeated_move\": 0}",
+      "{\"phase\": \"Deal\", \"current_player\": -1, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": null, \"upcard\": null, \"stock_size\": 51, \"discard_pile\": [], \"hands\": {\"0\": [\"5h\"], \"1\": []}, \"deadwood\": {\"0\": 0, \"1\": null}, \"repeated_move\": 0}",
+      "{\"phase\": \"Deal\", \"current_player\": -1, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": null, \"upcard\": null, \"stock_size\": 50, \"discard_pile\": [], \"hands\": {\"0\": [\"8s\", \"5h\"], \"1\": []}, \"deadwood\": {\"0\": 0, \"1\": null}, \"repeated_move\": 0}",
+      "{\"phase\": \"Deal\", \"current_player\": -1, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": null, \"upcard\": null, \"stock_size\": 49, \"discard_pile\": [], \"hands\": {\"0\": [\"6s\", \"8s\", \"5h\"], \"1\": []}, \"deadwood\": {\"0\": 0, \"1\": null}, \"repeated_move\": 0}",
+      "{\"phase\": \"Deal\", \"current_player\": -1, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": null, \"upcard\": null, \"stock_size\": 48, \"discard_pile\": [], \"hands\": {\"0\": [\"6s\", \"8s\", \"6d\", \"5h\"], \"1\": []}, \"deadwood\": {\"0\": 0, \"1\": null}, \"repeated_move\": 0}",
+      "{\"phase\": \"Deal\", \"current_player\": -1, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": null, \"upcard\": null, \"stock_size\": 47, \"discard_pile\": [], \"hands\": {\"0\": [\"6s\", \"8s\", \"3d\", \"6d\", \"5h\"], \"1\": []}, \"deadwood\": {\"0\": 0, \"1\": null}, \"repeated_move\": 0}",
+      "{\"phase\": \"Deal\", \"current_player\": -1, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": null, \"upcard\": null, \"stock_size\": 46, \"discard_pile\": [], \"hands\": {\"0\": [\"6s\", \"8s\", \"Ac\", \"3d\", \"6d\", \"5h\"], \"1\": []}, \"deadwood\": {\"0\": 0, \"1\": null}, \"repeated_move\": 0}",
+      "{\"phase\": \"Deal\", \"current_player\": -1, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": null, \"upcard\": null, \"stock_size\": 45, \"discard_pile\": [], \"hands\": {\"0\": [\"6s\", \"8s\", \"Ac\", \"3d\", \"6d\", \"5h\", \"Jh\"], \"1\": []}, \"deadwood\": {\"0\": 0, \"1\": null}, \"repeated_move\": 0}",
+      "{\"phase\": \"Deal\", \"current_player\": -1, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": null, \"upcard\": null, \"stock_size\": 44, \"discard_pile\": [], \"hands\": {\"0\": [\"6s\", \"8s\", \"Ac\", \"6c\", \"3d\", \"6d\", \"5h\", \"Jh\"], \"1\": []}, \"deadwood\": {\"0\": 0, \"1\": null}, \"repeated_move\": 0}",
+      "{\"phase\": \"Deal\", \"current_player\": -1, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": null, \"upcard\": null, \"stock_size\": 43, \"discard_pile\": [], \"hands\": {\"0\": [\"6s\", \"8s\", \"Ac\", \"6c\", \"3d\", \"6d\", \"5h\", \"9h\", \"Jh\"], \"1\": []}, \"deadwood\": {\"0\": 0, \"1\": null}, \"repeated_move\": 0}",
+      "{\"phase\": \"Deal\", \"current_player\": -1, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": null, \"upcard\": null, \"stock_size\": 42, \"discard_pile\": [], \"hands\": {\"0\": [\"6s\", \"8s\", \"Ac\", \"6c\", \"3d\", \"6d\", \"5h\", \"9h\", \"Jh\", \"Qh\"], \"1\": []}, \"deadwood\": {\"0\": 0, \"1\": null}, \"repeated_move\": 0}",
+      "{\"phase\": \"Deal\", \"current_player\": -1, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": null, \"upcard\": null, \"stock_size\": 41, \"discard_pile\": [], \"hands\": {\"0\": [\"6s\", \"8s\", \"Ac\", \"6c\", \"3d\", \"6d\", \"5h\", \"9h\", \"Jh\", \"Qh\"], \"1\": []}, \"deadwood\": {\"0\": 0, \"1\": null}, \"repeated_move\": 0}",
+      "{\"phase\": \"Deal\", \"current_player\": -1, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": null, \"upcard\": null, \"stock_size\": 40, \"discard_pile\": [], \"hands\": {\"0\": [\"6s\", \"8s\", \"Ac\", \"6c\", \"3d\", \"6d\", \"5h\", \"9h\", \"Jh\", \"Qh\"], \"1\": []}, \"deadwood\": {\"0\": 0, \"1\": null}, \"repeated_move\": 0}",
+      "{\"phase\": \"Deal\", \"current_player\": -1, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": null, \"upcard\": null, \"stock_size\": 39, \"discard_pile\": [], \"hands\": {\"0\": [\"6s\", \"8s\", \"Ac\", \"6c\", \"3d\", \"6d\", \"5h\", \"9h\", \"Jh\", \"Qh\"], \"1\": []}, \"deadwood\": {\"0\": 0, \"1\": null}, \"repeated_move\": 0}",
+      "{\"phase\": \"Deal\", \"current_player\": -1, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": null, \"upcard\": null, \"stock_size\": 38, \"discard_pile\": [], \"hands\": {\"0\": [\"6s\", \"8s\", \"Ac\", \"6c\", \"3d\", \"6d\", \"5h\", \"9h\", \"Jh\", \"Qh\"], \"1\": []}, \"deadwood\": {\"0\": 0, \"1\": null}, \"repeated_move\": 0}",
+      "{\"phase\": \"Deal\", \"current_player\": -1, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": null, \"upcard\": null, \"stock_size\": 37, \"discard_pile\": [], \"hands\": {\"0\": [\"6s\", \"8s\", \"Ac\", \"6c\", \"3d\", \"6d\", \"5h\", \"9h\", \"Jh\", \"Qh\"], \"1\": []}, \"deadwood\": {\"0\": 0, \"1\": null}, \"repeated_move\": 0}",
+      "{\"phase\": \"Deal\", \"current_player\": -1, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": null, \"upcard\": null, \"stock_size\": 36, \"discard_pile\": [], \"hands\": {\"0\": [\"6s\", \"8s\", \"Ac\", \"6c\", \"3d\", \"6d\", \"5h\", \"9h\", \"Jh\", \"Qh\"], \"1\": []}, \"deadwood\": {\"0\": 0, \"1\": null}, \"repeated_move\": 0}",
+      "{\"phase\": \"Deal\", \"current_player\": -1, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": null, \"upcard\": null, \"stock_size\": 35, \"discard_pile\": [], \"hands\": {\"0\": [\"6s\", \"8s\", \"Ac\", \"6c\", \"3d\", \"6d\", \"5h\", \"9h\", \"Jh\", \"Qh\"], \"1\": []}, \"deadwood\": {\"0\": 0, \"1\": null}, \"repeated_move\": 0}",
+      "{\"phase\": \"Deal\", \"current_player\": -1, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": null, \"upcard\": null, \"stock_size\": 34, \"discard_pile\": [], \"hands\": {\"0\": [\"6s\", \"8s\", \"Ac\", \"6c\", \"3d\", \"6d\", \"5h\", \"9h\", \"Jh\", \"Qh\"], \"1\": []}, \"deadwood\": {\"0\": 0, \"1\": null}, \"repeated_move\": 0}",
+      "{\"phase\": \"Deal\", \"current_player\": -1, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": null, \"upcard\": null, \"stock_size\": 33, \"discard_pile\": [], \"hands\": {\"0\": [\"6s\", \"8s\", \"Ac\", \"6c\", \"3d\", \"6d\", \"5h\", \"9h\", \"Jh\", \"Qh\"], \"1\": []}, \"deadwood\": {\"0\": 0, \"1\": null}, \"repeated_move\": 0}",
+      "{\"phase\": \"Deal\", \"current_player\": -1, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": null, \"upcard\": null, \"stock_size\": 32, \"discard_pile\": [], \"hands\": {\"0\": [\"6s\", \"8s\", \"Ac\", \"6c\", \"3d\", \"6d\", \"5h\", \"9h\", \"Jh\", \"Qh\"], \"1\": []}, \"deadwood\": {\"0\": 0, \"1\": null}, \"repeated_move\": 0}",
+      "{\"phase\": \"FirstUpcard\", \"current_player\": 0, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": null, \"upcard\": \"2c\", \"stock_size\": 31, \"discard_pile\": [], \"hands\": {\"0\": [\"6s\", \"8s\", \"Ac\", \"6c\", \"3d\", \"6d\", \"5h\", \"9h\", \"Jh\", \"Qh\"], \"1\": []}, \"deadwood\": {\"0\": 46, \"1\": null}, \"repeated_move\": 0}",
+      "{\"phase\": \"Discard\", \"current_player\": 0, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"2c\", \"upcard\": null, \"stock_size\": 31, \"discard_pile\": [], \"hands\": {\"0\": [\"6s\", \"8s\", \"Ac\", \"2c\", \"6c\", \"3d\", \"6d\", \"5h\", \"9h\", \"Jh\", \"Qh\"], \"1\": []}, \"deadwood\": {\"0\": 38, \"1\": null}, \"repeated_move\": 0}",
+      "{\"phase\": \"Draw\", \"current_player\": 1, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"2c\", \"upcard\": \"Jh\", \"stock_size\": 31, \"discard_pile\": [], \"hands\": {\"0\": [\"6s\", \"8s\", \"Ac\", \"2c\", \"6c\", \"3d\", \"6d\", \"5h\", \"9h\", \"Qh\"], \"1\": []}, \"deadwood\": {\"0\": 38, \"1\": null}, \"repeated_move\": 0}",
+      "{\"phase\": \"Discard\", \"current_player\": 1, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"Jh\", \"upcard\": null, \"stock_size\": 31, \"discard_pile\": [], \"hands\": {\"0\": [\"6s\", \"8s\", \"Ac\", \"2c\", \"6c\", \"3d\", \"6d\", \"5h\", \"9h\", \"Qh\"], \"1\": []}, \"deadwood\": {\"0\": 38, \"1\": null}, \"repeated_move\": 0}",
+      "{\"phase\": \"Draw\", \"current_player\": 0, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"Jh\", \"upcard\": \"7s\", \"stock_size\": 31, \"discard_pile\": [], \"hands\": {\"0\": [\"6s\", \"8s\", \"Ac\", \"2c\", \"6c\", \"3d\", \"6d\", \"5h\", \"9h\", \"Qh\"], \"1\": []}, \"deadwood\": {\"0\": 38, \"1\": null}, \"repeated_move\": 0}",
+      "{\"phase\": \"Discard\", \"current_player\": 0, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"7s\", \"upcard\": null, \"stock_size\": 31, \"discard_pile\": [], \"hands\": {\"0\": [\"6s\", \"7s\", \"8s\", \"Ac\", \"2c\", \"6c\", \"3d\", \"6d\", \"5h\", \"9h\", \"Qh\"], \"1\": []}, \"deadwood\": {\"0\": 32, \"1\": null}, \"repeated_move\": 0}",
+      "{\"phase\": \"Draw\", \"current_player\": 1, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"7s\", \"upcard\": \"2c\", \"stock_size\": 31, \"discard_pile\": [], \"hands\": {\"0\": [\"6s\", \"7s\", \"8s\", \"Ac\", \"6c\", \"3d\", \"6d\", \"5h\", \"9h\", \"Qh\"], \"1\": []}, \"deadwood\": {\"0\": 40, \"1\": null}, \"repeated_move\": 0}",
+      "{\"phase\": \"Discard\", \"current_player\": 1, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"2c\", \"upcard\": null, \"stock_size\": 31, \"discard_pile\": [], \"hands\": {\"0\": [\"6s\", \"7s\", \"8s\", \"Ac\", \"6c\", \"3d\", \"6d\", \"5h\", \"9h\", \"Qh\"], \"1\": []}, \"deadwood\": {\"0\": 40, \"1\": null}, \"repeated_move\": 0}",
+      "{\"phase\": \"Draw\", \"current_player\": 0, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"2c\", \"upcard\": \"7d\", \"stock_size\": 31, \"discard_pile\": [], \"hands\": {\"0\": [\"6s\", \"7s\", \"8s\", \"Ac\", \"6c\", \"3d\", \"6d\", \"5h\", \"9h\", \"Qh\"], \"1\": []}, \"deadwood\": {\"0\": 40, \"1\": null}, \"repeated_move\": 0}",
+      "{\"phase\": \"Discard\", \"current_player\": 0, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"7d\", \"upcard\": null, \"stock_size\": 31, \"discard_pile\": [], \"hands\": {\"0\": [\"6s\", \"7s\", \"8s\", \"Ac\", \"6c\", \"3d\", \"6d\", \"7d\", \"5h\", \"9h\", \"Qh\"], \"1\": []}, \"deadwood\": {\"0\": 37, \"1\": null}, \"repeated_move\": 0}",
+      "{\"phase\": \"Draw\", \"current_player\": 1, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"7d\", \"upcard\": \"9h\", \"stock_size\": 31, \"discard_pile\": [], \"hands\": {\"0\": [\"6s\", \"7s\", \"8s\", \"Ac\", \"6c\", \"3d\", \"6d\", \"7d\", \"5h\", \"Qh\"], \"1\": []}, \"deadwood\": {\"0\": 38, \"1\": null}, \"repeated_move\": 0}",
+      "{\"phase\": \"Discard\", \"current_player\": 1, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"9h\", \"upcard\": null, \"stock_size\": 31, \"discard_pile\": [], \"hands\": {\"0\": [\"6s\", \"7s\", \"8s\", \"Ac\", \"6c\", \"3d\", \"6d\", \"7d\", \"5h\", \"Qh\"], \"1\": []}, \"deadwood\": {\"0\": 38, \"1\": null}, \"repeated_move\": 0}",
+      "{\"phase\": \"Draw\", \"current_player\": 0, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"9h\", \"upcard\": \"Th\", \"stock_size\": 31, \"discard_pile\": [], \"hands\": {\"0\": [\"6s\", \"7s\", \"8s\", \"Ac\", \"6c\", \"3d\", \"6d\", \"7d\", \"5h\", \"Qh\"], \"1\": []}, \"deadwood\": {\"0\": 38, \"1\": null}, \"repeated_move\": 0}",
+      "{\"phase\": \"Discard\", \"current_player\": 0, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"Th\", \"upcard\": null, \"stock_size\": 31, \"discard_pile\": [], \"hands\": {\"0\": [\"6s\", \"7s\", \"8s\", \"Ac\", \"6c\", \"3d\", \"6d\", \"7d\", \"5h\", \"Th\", \"Qh\"], \"1\": []}, \"deadwood\": {\"0\": 38, \"1\": null}, \"repeated_move\": 0}",
+      "{\"phase\": \"Draw\", \"current_player\": 1, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"Th\", \"upcard\": \"Ac\", \"stock_size\": 31, \"discard_pile\": [], \"hands\": {\"0\": [\"6s\", \"7s\", \"8s\", \"6c\", \"3d\", \"6d\", \"7d\", \"5h\", \"Th\", \"Qh\"], \"1\": []}, \"deadwood\": {\"0\": 47, \"1\": null}, \"repeated_move\": 0}",
+      "{\"phase\": \"Deal\", \"current_player\": -1, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"Ac\", \"upcard\": null, \"stock_size\": 31, \"discard_pile\": [\"Ac\"], \"hands\": {\"0\": [\"6s\", \"7s\", \"8s\", \"6c\", \"3d\", \"6d\", \"7d\", \"5h\", \"Th\", \"Qh\"], \"1\": []}, \"deadwood\": {\"0\": 47, \"1\": null}, \"repeated_move\": 0}",
+      "{\"phase\": \"Discard\", \"current_player\": 1, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"Ac\", \"upcard\": null, \"stock_size\": 30, \"discard_pile\": [\"Ac\"], \"hands\": {\"0\": [\"6s\", \"7s\", \"8s\", \"6c\", \"3d\", \"6d\", \"7d\", \"5h\", \"Th\", \"Qh\"], \"1\": []}, \"deadwood\": {\"0\": 47, \"1\": null}, \"repeated_move\": 0}",
+      "{\"phase\": \"Draw\", \"current_player\": 0, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"Ac\", \"upcard\": \"4s\", \"stock_size\": 30, \"discard_pile\": [\"Ac\"], \"hands\": {\"0\": [\"6s\", \"7s\", \"8s\", \"6c\", \"3d\", \"6d\", \"7d\", \"5h\", \"Th\", \"Qh\"], \"1\": []}, \"deadwood\": {\"0\": 47, \"1\": null}, \"repeated_move\": 0}",
+      "{\"phase\": \"Deal\", \"current_player\": -1, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"4s\", \"upcard\": null, \"stock_size\": 30, \"discard_pile\": [\"Ac\", \"4s\"], \"hands\": {\"0\": [\"6s\", \"7s\", \"8s\", \"6c\", \"3d\", \"6d\", \"7d\", \"5h\", \"Th\", \"Qh\"], \"1\": []}, \"deadwood\": {\"0\": 47, \"1\": null}, \"repeated_move\": 0}",
+      "{\"phase\": \"Discard\", \"current_player\": 0, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"4s\", \"upcard\": null, \"stock_size\": 29, \"discard_pile\": [\"Ac\", \"4s\"], \"hands\": {\"0\": [\"6s\", \"7s\", \"8s\", \"6c\", \"3d\", \"6d\", \"7d\", \"9d\", \"5h\", \"Th\", \"Qh\"], \"1\": []}, \"deadwood\": {\"0\": 46, \"1\": null}, \"repeated_move\": 0}",
+      "{\"phase\": \"Draw\", \"current_player\": 1, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"4s\", \"upcard\": \"Th\", \"stock_size\": 29, \"discard_pile\": [\"Ac\", \"4s\"], \"hands\": {\"0\": [\"6s\", \"7s\", \"8s\", \"6c\", \"3d\", \"6d\", \"7d\", \"9d\", \"5h\", \"Qh\"], \"1\": []}, \"deadwood\": {\"0\": 46, \"1\": null}, \"repeated_move\": 0}",
+      "{\"phase\": \"Discard\", \"current_player\": 1, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"Th\", \"upcard\": null, \"stock_size\": 29, \"discard_pile\": [\"Ac\", \"4s\"], \"hands\": {\"0\": [\"6s\", \"7s\", \"8s\", \"6c\", \"3d\", \"6d\", \"7d\", \"9d\", \"5h\", \"Qh\"], \"1\": []}, \"deadwood\": {\"0\": 46, \"1\": null}, \"repeated_move\": 0}",
+      "{\"phase\": \"Draw\", \"current_player\": 0, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"Th\", \"upcard\": \"Jh\", \"stock_size\": 29, \"discard_pile\": [\"Ac\", \"4s\"], \"hands\": {\"0\": [\"6s\", \"7s\", \"8s\", \"6c\", \"3d\", \"6d\", \"7d\", \"9d\", \"5h\", \"Qh\"], \"1\": []}, \"deadwood\": {\"0\": 46, \"1\": null}, \"repeated_move\": 0}",
+      "{\"phase\": \"Deal\", \"current_player\": -1, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"Jh\", \"upcard\": null, \"stock_size\": 29, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\"], \"hands\": {\"0\": [\"6s\", \"7s\", \"8s\", \"6c\", \"3d\", \"6d\", \"7d\", \"9d\", \"5h\", \"Qh\"], \"1\": []}, \"deadwood\": {\"0\": 46, \"1\": null}, \"repeated_move\": 0}",
+      "{\"phase\": \"Discard\", \"current_player\": 0, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"Jh\", \"upcard\": null, \"stock_size\": 28, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\"], \"hands\": {\"0\": [\"6s\", \"7s\", \"8s\", \"6c\", \"Qc\", \"3d\", \"6d\", \"7d\", \"9d\", \"5h\", \"Qh\"], \"1\": []}, \"deadwood\": {\"0\": 46, \"1\": null}, \"repeated_move\": 0}",
+      "{\"phase\": \"Draw\", \"current_player\": 1, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"Jh\", \"upcard\": \"7s\", \"stock_size\": 28, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\"], \"hands\": {\"0\": [\"6s\", \"8s\", \"6c\", \"Qc\", \"3d\", \"6d\", \"7d\", \"9d\", \"5h\", \"Qh\"], \"1\": []}, \"deadwood\": {\"0\": 52, \"1\": null}, \"repeated_move\": 0}",
+      "{\"phase\": \"Discard\", \"current_player\": 1, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"7s\", \"upcard\": null, \"stock_size\": 28, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\"], \"hands\": {\"0\": [\"6s\", \"8s\", \"6c\", \"Qc\", \"3d\", \"6d\", \"7d\", \"9d\", \"5h\", \"Qh\"], \"1\": []}, \"deadwood\": {\"0\": 52, \"1\": null}, \"repeated_move\": 0}",
+      "{\"phase\": \"Draw\", \"current_player\": 0, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"7s\", \"upcard\": \"9h\", \"stock_size\": 28, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\"], \"hands\": {\"0\": [\"6s\", \"8s\", \"6c\", \"Qc\", \"3d\", \"6d\", \"7d\", \"9d\", \"5h\", \"Qh\"], \"1\": []}, \"deadwood\": {\"0\": 52, \"1\": null}, \"repeated_move\": 0}",
+      "{\"phase\": \"Discard\", \"current_player\": 0, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"9h\", \"upcard\": null, \"stock_size\": 28, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\"], \"hands\": {\"0\": [\"6s\", \"8s\", \"6c\", \"Qc\", \"3d\", \"6d\", \"7d\", \"9d\", \"5h\", \"9h\", \"Qh\"], \"1\": []}, \"deadwood\": {\"0\": 51, \"1\": null}, \"repeated_move\": 0}",
+      "{\"phase\": \"Draw\", \"current_player\": 1, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"9h\", \"upcard\": \"5h\", \"stock_size\": 28, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\"], \"hands\": {\"0\": [\"6s\", \"8s\", \"6c\", \"Qc\", \"3d\", \"6d\", \"7d\", \"9d\", \"9h\", \"Qh\"], \"1\": []}, \"deadwood\": {\"0\": 56, \"1\": null}, \"repeated_move\": 0}",
+      "{\"phase\": \"Discard\", \"current_player\": 1, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"5h\", \"upcard\": null, \"stock_size\": 28, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\"], \"hands\": {\"0\": [\"6s\", \"8s\", \"6c\", \"Qc\", \"3d\", \"6d\", \"7d\", \"9d\", \"9h\", \"Qh\"], \"1\": []}, \"deadwood\": {\"0\": 56, \"1\": null}, \"repeated_move\": 0}",
+      "{\"phase\": \"Draw\", \"current_player\": 0, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"5h\", \"upcard\": \"5h\", \"stock_size\": 28, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\"], \"hands\": {\"0\": [\"6s\", \"8s\", \"6c\", \"Qc\", \"3d\", \"6d\", \"7d\", \"9d\", \"9h\", \"Qh\"], \"1\": []}, \"deadwood\": {\"0\": 56, \"1\": null}, \"repeated_move\": 1}",
+      "{\"phase\": \"Deal\", \"current_player\": -1, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"5h\", \"upcard\": null, \"stock_size\": 28, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\"], \"hands\": {\"0\": [\"6s\", \"8s\", \"6c\", \"Qc\", \"3d\", \"6d\", \"7d\", \"9d\", \"9h\", \"Qh\"], \"1\": []}, \"deadwood\": {\"0\": 56, \"1\": null}, \"repeated_move\": 1}",
+      "{\"phase\": \"Discard\", \"current_player\": 0, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"5h\", \"upcard\": null, \"stock_size\": 27, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\"], \"hands\": {\"0\": [\"6s\", \"8s\", \"6c\", \"Qc\", \"3d\", \"6d\", \"7d\", \"8d\", \"9d\", \"9h\", \"Qh\"], \"1\": []}, \"deadwood\": {\"0\": 30, \"1\": null}, \"repeated_move\": 1}",
+      "{\"phase\": \"Draw\", \"current_player\": 1, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"5h\", \"upcard\": \"6d\", \"stock_size\": 27, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\"], \"hands\": {\"0\": [\"6s\", \"8s\", \"6c\", \"Qc\", \"3d\", \"7d\", \"8d\", \"9d\", \"9h\", \"Qh\"], \"1\": []}, \"deadwood\": {\"0\": 52, \"1\": null}, \"repeated_move\": 0}",
+      "{\"phase\": \"Deal\", \"current_player\": -1, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"6d\", \"upcard\": null, \"stock_size\": 27, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\"], \"hands\": {\"0\": [\"6s\", \"8s\", \"6c\", \"Qc\", \"3d\", \"7d\", \"8d\", \"9d\", \"9h\", \"Qh\"], \"1\": []}, \"deadwood\": {\"0\": 52, \"1\": null}, \"repeated_move\": 0}",
+      "{\"phase\": \"Discard\", \"current_player\": 1, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"6d\", \"upcard\": null, \"stock_size\": 26, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\"], \"hands\": {\"0\": [\"6s\", \"8s\", \"6c\", \"Qc\", \"3d\", \"7d\", \"8d\", \"9d\", \"9h\", \"Qh\"], \"1\": []}, \"deadwood\": {\"0\": 52, \"1\": null}, \"repeated_move\": 0}",
+      "{\"phase\": \"Draw\", \"current_player\": 0, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"6d\", \"upcard\": \"Qd\", \"stock_size\": 26, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\"], \"hands\": {\"0\": [\"6s\", \"8s\", \"6c\", \"Qc\", \"3d\", \"7d\", \"8d\", \"9d\", \"9h\", \"Qh\"], \"1\": []}, \"deadwood\": {\"0\": 52, \"1\": null}, \"repeated_move\": 0}",
+      "{\"phase\": \"Discard\", \"current_player\": 0, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"Qd\", \"upcard\": null, \"stock_size\": 26, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\"], \"hands\": {\"0\": [\"6s\", \"8s\", \"6c\", \"Qc\", \"3d\", \"7d\", \"8d\", \"9d\", \"Qd\", \"9h\", \"Qh\"], \"1\": []}, \"deadwood\": {\"0\": 23, \"1\": null}, \"repeated_move\": 0}",
+      "{\"phase\": \"Draw\", \"current_player\": 1, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"Qd\", \"upcard\": \"6c\", \"stock_size\": 26, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\"], \"hands\": {\"0\": [\"6s\", \"8s\", \"Qc\", \"3d\", \"7d\", \"8d\", \"9d\", \"Qd\", \"9h\", \"Qh\"], \"1\": []}, \"deadwood\": {\"0\": 26, \"1\": null}, \"repeated_move\": 0}",
+      "{\"phase\": \"Discard\", \"current_player\": 1, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"6c\", \"upcard\": null, \"stock_size\": 26, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\"], \"hands\": {\"0\": [\"6s\", \"8s\", \"Qc\", \"3d\", \"7d\", \"8d\", \"9d\", \"Qd\", \"9h\", \"Qh\"], \"1\": []}, \"deadwood\": {\"0\": 26, \"1\": null}, \"repeated_move\": 0}",
+      "{\"phase\": \"Draw\", \"current_player\": 0, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"6c\", \"upcard\": \"6c\", \"stock_size\": 26, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\"], \"hands\": {\"0\": [\"6s\", \"8s\", \"Qc\", \"3d\", \"7d\", \"8d\", \"9d\", \"Qd\", \"9h\", \"Qh\"], \"1\": []}, \"deadwood\": {\"0\": 26, \"1\": null}, \"repeated_move\": 1}",
+      "{\"phase\": \"Deal\", \"current_player\": -1, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"6c\", \"upcard\": null, \"stock_size\": 26, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\"], \"hands\": {\"0\": [\"6s\", \"8s\", \"Qc\", \"3d\", \"7d\", \"8d\", \"9d\", \"Qd\", \"9h\", \"Qh\"], \"1\": []}, \"deadwood\": {\"0\": 26, \"1\": null}, \"repeated_move\": 1}",
+      "{\"phase\": \"Discard\", \"current_player\": 0, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"6c\", \"upcard\": null, \"stock_size\": 25, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\"], \"hands\": {\"0\": [\"6s\", \"8s\", \"Qc\", \"3d\", \"5d\", \"7d\", \"8d\", \"9d\", \"Qd\", \"9h\", \"Qh\"], \"1\": []}, \"deadwood\": {\"0\": 22, \"1\": null}, \"repeated_move\": 1}",
+      "{\"phase\": \"Draw\", \"current_player\": 1, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"6c\", \"upcard\": \"8s\", \"stock_size\": 25, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\"], \"hands\": {\"0\": [\"6s\", \"Qc\", \"3d\", \"5d\", \"7d\", \"8d\", \"9d\", \"Qd\", \"9h\", \"Qh\"], \"1\": []}, \"deadwood\": {\"0\": 23, \"1\": null}, \"repeated_move\": 0}",
+      "{\"phase\": \"Deal\", \"current_player\": -1, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"8s\", \"upcard\": null, \"stock_size\": 25, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\"], \"hands\": {\"0\": [\"6s\", \"Qc\", \"3d\", \"5d\", \"7d\", \"8d\", \"9d\", \"Qd\", \"9h\", \"Qh\"], \"1\": []}, \"deadwood\": {\"0\": 23, \"1\": null}, \"repeated_move\": 0}",
+      "{\"phase\": \"Discard\", \"current_player\": 1, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"8s\", \"upcard\": null, \"stock_size\": 24, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\"], \"hands\": {\"0\": [\"6s\", \"Qc\", \"3d\", \"5d\", \"7d\", \"8d\", \"9d\", \"Qd\", \"9h\", \"Qh\"], \"1\": []}, \"deadwood\": {\"0\": 23, \"1\": null}, \"repeated_move\": 0}",
+      "{\"phase\": \"Draw\", \"current_player\": 0, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"8s\", \"upcard\": \"3c\", \"stock_size\": 24, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\"], \"hands\": {\"0\": [\"6s\", \"Qc\", \"3d\", \"5d\", \"7d\", \"8d\", \"9d\", \"Qd\", \"9h\", \"Qh\"], \"1\": []}, \"deadwood\": {\"0\": 23, \"1\": null}, \"repeated_move\": 0}",
+      "{\"phase\": \"Deal\", \"current_player\": -1, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"3c\", \"upcard\": null, \"stock_size\": 24, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\"], \"hands\": {\"0\": [\"6s\", \"Qc\", \"3d\", \"5d\", \"7d\", \"8d\", \"9d\", \"Qd\", \"9h\", \"Qh\"], \"1\": []}, \"deadwood\": {\"0\": 23, \"1\": null}, \"repeated_move\": 0}",
+      "{\"phase\": \"Discard\", \"current_player\": 0, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"3c\", \"upcard\": null, \"stock_size\": 23, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\"], \"hands\": {\"0\": [\"6s\", \"5c\", \"Qc\", \"3d\", \"5d\", \"7d\", \"8d\", \"9d\", \"Qd\", \"9h\", \"Qh\"], \"1\": []}, \"deadwood\": {\"0\": 19, \"1\": null}, \"repeated_move\": 0}",
+      "{\"phase\": \"Draw\", \"current_player\": 1, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"3c\", \"upcard\": \"Qd\", \"stock_size\": 23, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\"], \"hands\": {\"0\": [\"6s\", \"5c\", \"Qc\", \"3d\", \"5d\", \"7d\", \"8d\", \"9d\", \"9h\", \"Qh\"], \"1\": []}, \"deadwood\": {\"0\": 48, \"1\": null}, \"repeated_move\": 0}",
+      "{\"phase\": \"Discard\", \"current_player\": 1, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"Qd\", \"upcard\": null, \"stock_size\": 23, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\"], \"hands\": {\"0\": [\"6s\", \"5c\", \"Qc\", \"3d\", \"5d\", \"7d\", \"8d\", \"9d\", \"9h\", \"Qh\"], \"1\": []}, \"deadwood\": {\"0\": 48, \"1\": null}, \"repeated_move\": 0}",
+      "{\"phase\": \"Draw\", \"current_player\": 0, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"Qd\", \"upcard\": \"9c\", \"stock_size\": 23, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\"], \"hands\": {\"0\": [\"6s\", \"5c\", \"Qc\", \"3d\", \"5d\", \"7d\", \"8d\", \"9d\", \"9h\", \"Qh\"], \"1\": []}, \"deadwood\": {\"0\": 48, \"1\": null}, \"repeated_move\": 0}",
+      "{\"phase\": \"Deal\", \"current_player\": -1, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"9c\", \"upcard\": null, \"stock_size\": 23, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\"], \"hands\": {\"0\": [\"6s\", \"5c\", \"Qc\", \"3d\", \"5d\", \"7d\", \"8d\", \"9d\", \"9h\", \"Qh\"], \"1\": []}, \"deadwood\": {\"0\": 48, \"1\": null}, \"repeated_move\": 0}",
+      "{\"phase\": \"Discard\", \"current_player\": 0, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"9c\", \"upcard\": null, \"stock_size\": 22, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\"], \"hands\": {\"0\": [\"6s\", \"5c\", \"Qc\", \"3d\", \"5d\", \"7d\", \"8d\", \"9d\", \"2h\", \"9h\", \"Qh\"], \"1\": []}, \"deadwood\": {\"0\": 40, \"1\": null}, \"repeated_move\": 0}",
+      "{\"phase\": \"Draw\", \"current_player\": 1, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"9c\", \"upcard\": \"5d\", \"stock_size\": 22, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\"], \"hands\": {\"0\": [\"6s\", \"5c\", \"Qc\", \"3d\", \"7d\", \"8d\", \"9d\", \"2h\", \"9h\", \"Qh\"], \"1\": []}, \"deadwood\": {\"0\": 45, \"1\": null}, \"repeated_move\": 0}",
+      "{\"phase\": \"Deal\", \"current_player\": -1, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"5d\", \"upcard\": null, \"stock_size\": 22, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\"], \"hands\": {\"0\": [\"6s\", \"5c\", \"Qc\", \"3d\", \"7d\", \"8d\", \"9d\", \"2h\", \"9h\", \"Qh\"], \"1\": []}, \"deadwood\": {\"0\": 45, \"1\": null}, \"repeated_move\": 0}",
+      "{\"phase\": \"Discard\", \"current_player\": 1, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"5d\", \"upcard\": null, \"stock_size\": 21, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\"], \"hands\": {\"0\": [\"6s\", \"5c\", \"Qc\", \"3d\", \"7d\", \"8d\", \"9d\", \"2h\", \"9h\", \"Qh\"], \"1\": []}, \"deadwood\": {\"0\": 45, \"1\": null}, \"repeated_move\": 0}",
+      "{\"phase\": \"Draw\", \"current_player\": 0, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"5d\", \"upcard\": \"7c\", \"stock_size\": 21, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\"], \"hands\": {\"0\": [\"6s\", \"5c\", \"Qc\", \"3d\", \"7d\", \"8d\", \"9d\", \"2h\", \"9h\", \"Qh\"], \"1\": []}, \"deadwood\": {\"0\": 45, \"1\": null}, \"repeated_move\": 0}",
+      "{\"phase\": \"Discard\", \"current_player\": 0, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"7c\", \"upcard\": null, \"stock_size\": 21, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\"], \"hands\": {\"0\": [\"6s\", \"5c\", \"7c\", \"Qc\", \"3d\", \"7d\", \"8d\", \"9d\", \"2h\", \"9h\", \"Qh\"], \"1\": []}, \"deadwood\": {\"0\": 42, \"1\": null}, \"repeated_move\": 0}",
+      "{\"phase\": \"Draw\", \"current_player\": 1, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"7c\", \"upcard\": \"2h\", \"stock_size\": 21, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\"], \"hands\": {\"0\": [\"6s\", \"5c\", \"7c\", \"Qc\", \"3d\", \"7d\", \"8d\", \"9d\", \"9h\", \"Qh\"], \"1\": []}, \"deadwood\": {\"0\": 50, \"1\": null}, \"repeated_move\": 0}",
+      "{\"phase\": \"Deal\", \"current_player\": -1, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"2h\", \"upcard\": null, \"stock_size\": 21, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\", \"2h\"], \"hands\": {\"0\": [\"6s\", \"5c\", \"7c\", \"Qc\", \"3d\", \"7d\", \"8d\", \"9d\", \"9h\", \"Qh\"], \"1\": []}, \"deadwood\": {\"0\": 50, \"1\": null}, \"repeated_move\": 0}",
+      "{\"phase\": \"Discard\", \"current_player\": 1, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"2h\", \"upcard\": null, \"stock_size\": 20, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\", \"2h\"], \"hands\": {\"0\": [\"6s\", \"5c\", \"7c\", \"Qc\", \"3d\", \"7d\", \"8d\", \"9d\", \"9h\", \"Qh\"], \"1\": []}, \"deadwood\": {\"0\": 50, \"1\": null}, \"repeated_move\": 0}",
+      "{\"phase\": \"Draw\", \"current_player\": 0, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"2h\", \"upcard\": \"Ts\", \"stock_size\": 20, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\", \"2h\"], \"hands\": {\"0\": [\"6s\", \"5c\", \"7c\", \"Qc\", \"3d\", \"7d\", \"8d\", \"9d\", \"9h\", \"Qh\"], \"1\": []}, \"deadwood\": {\"0\": 50, \"1\": null}, \"repeated_move\": 0}",
+      "{\"phase\": \"Discard\", \"current_player\": 0, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"Ts\", \"upcard\": null, \"stock_size\": 20, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\", \"2h\"], \"hands\": {\"0\": [\"6s\", \"Ts\", \"5c\", \"7c\", \"Qc\", \"3d\", \"7d\", \"8d\", \"9d\", \"9h\", \"Qh\"], \"1\": []}, \"deadwood\": {\"0\": 50, \"1\": null}, \"repeated_move\": 0}",
+      "{\"phase\": \"Draw\", \"current_player\": 1, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"Ts\", \"upcard\": \"9h\", \"stock_size\": 20, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\", \"2h\"], \"hands\": {\"0\": [\"6s\", \"Ts\", \"5c\", \"7c\", \"Qc\", \"3d\", \"7d\", \"8d\", \"9d\", \"Qh\"], \"1\": []}, \"deadwood\": {\"0\": 51, \"1\": null}, \"repeated_move\": 0}",
+      "{\"phase\": \"Discard\", \"current_player\": 1, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"9h\", \"upcard\": null, \"stock_size\": 20, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\", \"2h\"], \"hands\": {\"0\": [\"6s\", \"Ts\", \"5c\", \"7c\", \"Qc\", \"3d\", \"7d\", \"8d\", \"9d\", \"Qh\"], \"1\": []}, \"deadwood\": {\"0\": 51, \"1\": null}, \"repeated_move\": 0}",
+      "{\"phase\": \"Draw\", \"current_player\": 0, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"9h\", \"upcard\": \"5s\", \"stock_size\": 20, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\", \"2h\"], \"hands\": {\"0\": [\"6s\", \"Ts\", \"5c\", \"7c\", \"Qc\", \"3d\", \"7d\", \"8d\", \"9d\", \"Qh\"], \"1\": []}, \"deadwood\": {\"0\": 51, \"1\": null}, \"repeated_move\": 0}",
+      "{\"phase\": \"Discard\", \"current_player\": 0, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"5s\", \"upcard\": null, \"stock_size\": 20, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\", \"2h\"], \"hands\": {\"0\": [\"5s\", \"6s\", \"Ts\", \"5c\", \"7c\", \"Qc\", \"3d\", \"7d\", \"8d\", \"9d\", \"Qh\"], \"1\": []}, \"deadwood\": {\"0\": 46, \"1\": null}, \"repeated_move\": 0}",
+      "{\"phase\": \"Draw\", \"current_player\": 1, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"5s\", \"upcard\": \"5s\", \"stock_size\": 20, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\", \"2h\"], \"hands\": {\"0\": [\"6s\", \"Ts\", \"5c\", \"7c\", \"Qc\", \"3d\", \"7d\", \"8d\", \"9d\", \"Qh\"], \"1\": []}, \"deadwood\": {\"0\": 51, \"1\": null}, \"repeated_move\": 1}",
+      "{\"phase\": \"Deal\", \"current_player\": -1, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"5s\", \"upcard\": null, \"stock_size\": 20, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\", \"2h\", \"5s\"], \"hands\": {\"0\": [\"6s\", \"Ts\", \"5c\", \"7c\", \"Qc\", \"3d\", \"7d\", \"8d\", \"9d\", \"Qh\"], \"1\": []}, \"deadwood\": {\"0\": 51, \"1\": null}, \"repeated_move\": 1}",
+      "{\"phase\": \"Discard\", \"current_player\": 1, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"5s\", \"upcard\": null, \"stock_size\": 19, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\", \"2h\", \"5s\"], \"hands\": {\"0\": [\"6s\", \"Ts\", \"5c\", \"7c\", \"Qc\", \"3d\", \"7d\", \"8d\", \"9d\", \"Qh\"], \"1\": []}, \"deadwood\": {\"0\": 51, \"1\": null}, \"repeated_move\": 1}",
+      "{\"phase\": \"Draw\", \"current_player\": 0, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"5s\", \"upcard\": \"7s\", \"stock_size\": 19, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\", \"2h\", \"5s\"], \"hands\": {\"0\": [\"6s\", \"Ts\", \"5c\", \"7c\", \"Qc\", \"3d\", \"7d\", \"8d\", \"9d\", \"Qh\"], \"1\": []}, \"deadwood\": {\"0\": 51, \"1\": null}, \"repeated_move\": 0}",
+      "{\"phase\": \"Discard\", \"current_player\": 0, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"7s\", \"upcard\": null, \"stock_size\": 19, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\", \"2h\", \"5s\"], \"hands\": {\"0\": [\"6s\", \"7s\", \"Ts\", \"5c\", \"7c\", \"Qc\", \"3d\", \"7d\", \"8d\", \"9d\", \"Qh\"], \"1\": []}, \"deadwood\": {\"0\": 48, \"1\": null}, \"repeated_move\": 0}",
+      "{\"phase\": \"Draw\", \"current_player\": 1, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"7s\", \"upcard\": \"7c\", \"stock_size\": 19, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\", \"2h\", \"5s\"], \"hands\": {\"0\": [\"6s\", \"7s\", \"Ts\", \"5c\", \"Qc\", \"3d\", \"7d\", \"8d\", \"9d\", \"Qh\"], \"1\": []}, \"deadwood\": {\"0\": 51, \"1\": null}, \"repeated_move\": 0}",
+      "{\"phase\": \"Deal\", \"current_player\": -1, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"7c\", \"upcard\": null, \"stock_size\": 19, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\", \"2h\", \"5s\", \"7c\"], \"hands\": {\"0\": [\"6s\", \"7s\", \"Ts\", \"5c\", \"Qc\", \"3d\", \"7d\", \"8d\", \"9d\", \"Qh\"], \"1\": []}, \"deadwood\": {\"0\": 51, \"1\": null}, \"repeated_move\": 0}",
+      "{\"phase\": \"Discard\", \"current_player\": 1, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"7c\", \"upcard\": null, \"stock_size\": 18, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\", \"2h\", \"5s\", \"7c\"], \"hands\": {\"0\": [\"6s\", \"7s\", \"Ts\", \"5c\", \"Qc\", \"3d\", \"7d\", \"8d\", \"9d\", \"Qh\"], \"1\": []}, \"deadwood\": {\"0\": 51, \"1\": null}, \"repeated_move\": 0}",
+      "{\"phase\": \"Draw\", \"current_player\": 0, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"7c\", \"upcard\": \"Td\", \"stock_size\": 18, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\", \"2h\", \"5s\", \"7c\"], \"hands\": {\"0\": [\"6s\", \"7s\", \"Ts\", \"5c\", \"Qc\", \"3d\", \"7d\", \"8d\", \"9d\", \"Qh\"], \"1\": []}, \"deadwood\": {\"0\": 51, \"1\": null}, \"repeated_move\": 0}",
+      "{\"phase\": \"Deal\", \"current_player\": -1, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"Td\", \"upcard\": null, \"stock_size\": 18, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\", \"2h\", \"5s\", \"7c\", \"Td\"], \"hands\": {\"0\": [\"6s\", \"7s\", \"Ts\", \"5c\", \"Qc\", \"3d\", \"7d\", \"8d\", \"9d\", \"Qh\"], \"1\": []}, \"deadwood\": {\"0\": 51, \"1\": null}, \"repeated_move\": 0}",
+      "{\"phase\": \"Discard\", \"current_player\": 0, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"Td\", \"upcard\": null, \"stock_size\": 17, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\", \"2h\", \"5s\", \"7c\", \"Td\"], \"hands\": {\"0\": [\"6s\", \"7s\", \"Ts\", \"5c\", \"Qc\", \"Ad\", \"3d\", \"7d\", \"8d\", \"9d\", \"Qh\"], \"1\": []}, \"deadwood\": {\"0\": 42, \"1\": null}, \"repeated_move\": 0}",
+      "{\"phase\": \"Draw\", \"current_player\": 1, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"Td\", \"upcard\": \"8d\", \"stock_size\": 17, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\", \"2h\", \"5s\", \"7c\", \"Td\"], \"hands\": {\"0\": [\"6s\", \"7s\", \"Ts\", \"5c\", \"Qc\", \"Ad\", \"3d\", \"7d\", \"9d\", \"Qh\"], \"1\": []}, \"deadwood\": {\"0\": 68, \"1\": null}, \"repeated_move\": 0}",
+      "{\"phase\": \"Deal\", \"current_player\": -1, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"8d\", \"upcard\": null, \"stock_size\": 17, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\", \"2h\", \"5s\", \"7c\", \"Td\", \"8d\"], \"hands\": {\"0\": [\"6s\", \"7s\", \"Ts\", \"5c\", \"Qc\", \"Ad\", \"3d\", \"7d\", \"9d\", \"Qh\"], \"1\": []}, \"deadwood\": {\"0\": 68, \"1\": null}, \"repeated_move\": 0}",
+      "{\"phase\": \"Discard\", \"current_player\": 1, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"8d\", \"upcard\": null, \"stock_size\": 16, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\", \"2h\", \"5s\", \"7c\", \"Td\", \"8d\"], \"hands\": {\"0\": [\"6s\", \"7s\", \"Ts\", \"5c\", \"Qc\", \"Ad\", \"3d\", \"7d\", \"9d\", \"Qh\"], \"1\": []}, \"deadwood\": {\"0\": 68, \"1\": null}, \"repeated_move\": 0}",
+      "{\"phase\": \"Draw\", \"current_player\": 0, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"8d\", \"upcard\": \"9s\", \"stock_size\": 16, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\", \"2h\", \"5s\", \"7c\", \"Td\", \"8d\"], \"hands\": {\"0\": [\"6s\", \"7s\", \"Ts\", \"5c\", \"Qc\", \"Ad\", \"3d\", \"7d\", \"9d\", \"Qh\"], \"1\": []}, \"deadwood\": {\"0\": 68, \"1\": null}, \"repeated_move\": 0}",
+      "{\"phase\": \"Discard\", \"current_player\": 0, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"9s\", \"upcard\": null, \"stock_size\": 16, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\", \"2h\", \"5s\", \"7c\", \"Td\", \"8d\"], \"hands\": {\"0\": [\"6s\", \"7s\", \"9s\", \"Ts\", \"5c\", \"Qc\", \"Ad\", \"3d\", \"7d\", \"9d\", \"Qh\"], \"1\": []}, \"deadwood\": {\"0\": 67, \"1\": null}, \"repeated_move\": 0}",
+      "{\"phase\": \"Draw\", \"current_player\": 1, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"9s\", \"upcard\": \"7d\", \"stock_size\": 16, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\", \"2h\", \"5s\", \"7c\", \"Td\", \"8d\"], \"hands\": {\"0\": [\"6s\", \"7s\", \"9s\", \"Ts\", \"5c\", \"Qc\", \"Ad\", \"3d\", \"9d\", \"Qh\"], \"1\": []}, \"deadwood\": {\"0\": 70, \"1\": null}, \"repeated_move\": 0}",
+      "{\"phase\": \"Discard\", \"current_player\": 1, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"7d\", \"upcard\": null, \"stock_size\": 16, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\", \"2h\", \"5s\", \"7c\", \"Td\", \"8d\"], \"hands\": {\"0\": [\"6s\", \"7s\", \"9s\", \"Ts\", \"5c\", \"Qc\", \"Ad\", \"3d\", \"9d\", \"Qh\"], \"1\": []}, \"deadwood\": {\"0\": 70, \"1\": null}, \"repeated_move\": 0}",
+      "{\"phase\": \"Draw\", \"current_player\": 0, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"7d\", \"upcard\": \"Tc\", \"stock_size\": 16, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\", \"2h\", \"5s\", \"7c\", \"Td\", \"8d\"], \"hands\": {\"0\": [\"6s\", \"7s\", \"9s\", \"Ts\", \"5c\", \"Qc\", \"Ad\", \"3d\", \"9d\", \"Qh\"], \"1\": []}, \"deadwood\": {\"0\": 70, \"1\": null}, \"repeated_move\": 0}",
+      "{\"phase\": \"Discard\", \"current_player\": 0, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"Tc\", \"upcard\": null, \"stock_size\": 16, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\", \"2h\", \"5s\", \"7c\", \"Td\", \"8d\"], \"hands\": {\"0\": [\"6s\", \"7s\", \"9s\", \"Ts\", \"5c\", \"Tc\", \"Qc\", \"Ad\", \"3d\", \"9d\", \"Qh\"], \"1\": []}, \"deadwood\": {\"0\": 70, \"1\": null}, \"repeated_move\": 0}",
+      "{\"phase\": \"Draw\", \"current_player\": 1, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"Tc\", \"upcard\": \"Qc\", \"stock_size\": 16, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\", \"2h\", \"5s\", \"7c\", \"Td\", \"8d\"], \"hands\": {\"0\": [\"6s\", \"7s\", \"9s\", \"Ts\", \"5c\", \"Tc\", \"Ad\", \"3d\", \"9d\", \"Qh\"], \"1\": []}, \"deadwood\": {\"0\": 70, \"1\": null}, \"repeated_move\": 0}",
+      "{\"phase\": \"Deal\", \"current_player\": -1, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"Qc\", \"upcard\": null, \"stock_size\": 16, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\", \"2h\", \"5s\", \"7c\", \"Td\", \"8d\", \"Qc\"], \"hands\": {\"0\": [\"6s\", \"7s\", \"9s\", \"Ts\", \"5c\", \"Tc\", \"Ad\", \"3d\", \"9d\", \"Qh\"], \"1\": []}, \"deadwood\": {\"0\": 70, \"1\": null}, \"repeated_move\": 0}",
+      "{\"phase\": \"Discard\", \"current_player\": 1, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"Qc\", \"upcard\": null, \"stock_size\": 15, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\", \"2h\", \"5s\", \"7c\", \"Td\", \"8d\", \"Qc\"], \"hands\": {\"0\": [\"6s\", \"7s\", \"9s\", \"Ts\", \"5c\", \"Tc\", \"Ad\", \"3d\", \"9d\", \"Qh\"], \"1\": []}, \"deadwood\": {\"0\": 70, \"1\": null}, \"repeated_move\": 0}",
+      "{\"phase\": \"Draw\", \"current_player\": 0, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"Qc\", \"upcard\": \"2s\", \"stock_size\": 15, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\", \"2h\", \"5s\", \"7c\", \"Td\", \"8d\", \"Qc\"], \"hands\": {\"0\": [\"6s\", \"7s\", \"9s\", \"Ts\", \"5c\", \"Tc\", \"Ad\", \"3d\", \"9d\", \"Qh\"], \"1\": []}, \"deadwood\": {\"0\": 70, \"1\": null}, \"repeated_move\": 0}",
+      "{\"phase\": \"Discard\", \"current_player\": 0, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"2s\", \"upcard\": null, \"stock_size\": 15, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\", \"2h\", \"5s\", \"7c\", \"Td\", \"8d\", \"Qc\"], \"hands\": {\"0\": [\"2s\", \"6s\", \"7s\", \"9s\", \"Ts\", \"5c\", \"Tc\", \"Ad\", \"3d\", \"9d\", \"Qh\"], \"1\": []}, \"deadwood\": {\"0\": 62, \"1\": null}, \"repeated_move\": 0}",
+      "{\"phase\": \"Draw\", \"current_player\": 1, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"2s\", \"upcard\": \"9s\", \"stock_size\": 15, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\", \"2h\", \"5s\", \"7c\", \"Td\", \"8d\", \"Qc\"], \"hands\": {\"0\": [\"2s\", \"6s\", \"7s\", \"Ts\", \"5c\", \"Tc\", \"Ad\", \"3d\", \"9d\", \"Qh\"], \"1\": []}, \"deadwood\": {\"0\": 63, \"1\": null}, \"repeated_move\": 0}",
+      "{\"phase\": \"Deal\", \"current_player\": -1, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"9s\", \"upcard\": null, \"stock_size\": 15, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\", \"2h\", \"5s\", \"7c\", \"Td\", \"8d\", \"Qc\", \"9s\"], \"hands\": {\"0\": [\"2s\", \"6s\", \"7s\", \"Ts\", \"5c\", \"Tc\", \"Ad\", \"3d\", \"9d\", \"Qh\"], \"1\": []}, \"deadwood\": {\"0\": 63, \"1\": null}, \"repeated_move\": 0}",
+      "{\"phase\": \"Discard\", \"current_player\": 1, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"9s\", \"upcard\": null, \"stock_size\": 14, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\", \"2h\", \"5s\", \"7c\", \"Td\", \"8d\", \"Qc\", \"9s\"], \"hands\": {\"0\": [\"2s\", \"6s\", \"7s\", \"Ts\", \"5c\", \"Tc\", \"Ad\", \"3d\", \"9d\", \"Qh\"], \"1\": []}, \"deadwood\": {\"0\": 63, \"1\": null}, \"repeated_move\": 0}",
+      "{\"phase\": \"Draw\", \"current_player\": 0, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"9s\", \"upcard\": \"Kd\", \"stock_size\": 14, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\", \"2h\", \"5s\", \"7c\", \"Td\", \"8d\", \"Qc\", \"9s\"], \"hands\": {\"0\": [\"2s\", \"6s\", \"7s\", \"Ts\", \"5c\", \"Tc\", \"Ad\", \"3d\", \"9d\", \"Qh\"], \"1\": []}, \"deadwood\": {\"0\": 63, \"1\": null}, \"repeated_move\": 0}",
+      "{\"phase\": \"Deal\", \"current_player\": -1, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"Kd\", \"upcard\": null, \"stock_size\": 14, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\", \"2h\", \"5s\", \"7c\", \"Td\", \"8d\", \"Qc\", \"9s\", \"Kd\"], \"hands\": {\"0\": [\"2s\", \"6s\", \"7s\", \"Ts\", \"5c\", \"Tc\", \"Ad\", \"3d\", \"9d\", \"Qh\"], \"1\": []}, \"deadwood\": {\"0\": 63, \"1\": null}, \"repeated_move\": 0}",
+      "{\"phase\": \"Discard\", \"current_player\": 0, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"Kd\", \"upcard\": null, \"stock_size\": 13, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\", \"2h\", \"5s\", \"7c\", \"Td\", \"8d\", \"Qc\", \"9s\", \"Kd\"], \"hands\": {\"0\": [\"2s\", \"6s\", \"7s\", \"Ts\", \"5c\", \"Tc\", \"Jc\", \"Ad\", \"3d\", \"9d\", \"Qh\"], \"1\": []}, \"deadwood\": {\"0\": 63, \"1\": null}, \"repeated_move\": 0}",
+      "{\"phase\": \"Draw\", \"current_player\": 1, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"Kd\", \"upcard\": \"6s\", \"stock_size\": 13, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\", \"2h\", \"5s\", \"7c\", \"Td\", \"8d\", \"Qc\", \"9s\", \"Kd\"], \"hands\": {\"0\": [\"2s\", \"7s\", \"Ts\", \"5c\", \"Tc\", \"Jc\", \"Ad\", \"3d\", \"9d\", \"Qh\"], \"1\": []}, \"deadwood\": {\"0\": 67, \"1\": null}, \"repeated_move\": 0}",
+      "{\"phase\": \"Deal\", \"current_player\": -1, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"6s\", \"upcard\": null, \"stock_size\": 13, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\", \"2h\", \"5s\", \"7c\", \"Td\", \"8d\", \"Qc\", \"9s\", \"Kd\", \"6s\"], \"hands\": {\"0\": [\"2s\", \"7s\", \"Ts\", \"5c\", \"Tc\", \"Jc\", \"Ad\", \"3d\", \"9d\", \"Qh\"], \"1\": []}, \"deadwood\": {\"0\": 67, \"1\": null}, \"repeated_move\": 0}",
+      "{\"phase\": \"Discard\", \"current_player\": 1, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"6s\", \"upcard\": null, \"stock_size\": 12, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\", \"2h\", \"5s\", \"7c\", \"Td\", \"8d\", \"Qc\", \"9s\", \"Kd\", \"6s\"], \"hands\": {\"0\": [\"2s\", \"7s\", \"Ts\", \"5c\", \"Tc\", \"Jc\", \"Ad\", \"3d\", \"9d\", \"Qh\"], \"1\": []}, \"deadwood\": {\"0\": 67, \"1\": null}, \"repeated_move\": 0}",
+      "{\"phase\": \"Draw\", \"current_player\": 0, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"6s\", \"upcard\": \"4h\", \"stock_size\": 12, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\", \"2h\", \"5s\", \"7c\", \"Td\", \"8d\", \"Qc\", \"9s\", \"Kd\", \"6s\"], \"hands\": {\"0\": [\"2s\", \"7s\", \"Ts\", \"5c\", \"Tc\", \"Jc\", \"Ad\", \"3d\", \"9d\", \"Qh\"], \"1\": []}, \"deadwood\": {\"0\": 67, \"1\": null}, \"repeated_move\": 0}",
+      "{\"phase\": \"Discard\", \"current_player\": 0, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"4h\", \"upcard\": null, \"stock_size\": 12, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\", \"2h\", \"5s\", \"7c\", \"Td\", \"8d\", \"Qc\", \"9s\", \"Kd\", \"6s\"], \"hands\": {\"0\": [\"2s\", \"7s\", \"Ts\", \"5c\", \"Tc\", \"Jc\", \"Ad\", \"3d\", \"9d\", \"4h\", \"Qh\"], \"1\": []}, \"deadwood\": {\"0\": 61, \"1\": null}, \"repeated_move\": 0}",
+      "{\"phase\": \"Draw\", \"current_player\": 1, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"4h\", \"upcard\": \"2s\", \"stock_size\": 12, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\", \"2h\", \"5s\", \"7c\", \"Td\", \"8d\", \"Qc\", \"9s\", \"Kd\", \"6s\"], \"hands\": {\"0\": [\"7s\", \"Ts\", \"5c\", \"Tc\", \"Jc\", \"Ad\", \"3d\", \"9d\", \"4h\", \"Qh\"], \"1\": []}, \"deadwood\": {\"0\": 69, \"1\": null}, \"repeated_move\": 0}",
+      "{\"phase\": \"Discard\", \"current_player\": 1, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"2s\", \"upcard\": null, \"stock_size\": 12, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\", \"2h\", \"5s\", \"7c\", \"Td\", \"8d\", \"Qc\", \"9s\", \"Kd\", \"6s\"], \"hands\": {\"0\": [\"7s\", \"Ts\", \"5c\", \"Tc\", \"Jc\", \"Ad\", \"3d\", \"9d\", \"4h\", \"Qh\"], \"1\": []}, \"deadwood\": {\"0\": 69, \"1\": null}, \"repeated_move\": 0}",
+      "{\"phase\": \"Draw\", \"current_player\": 0, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"2s\", \"upcard\": \"9h\", \"stock_size\": 12, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\", \"2h\", \"5s\", \"7c\", \"Td\", \"8d\", \"Qc\", \"9s\", \"Kd\", \"6s\"], \"hands\": {\"0\": [\"7s\", \"Ts\", \"5c\", \"Tc\", \"Jc\", \"Ad\", \"3d\", \"9d\", \"4h\", \"Qh\"], \"1\": []}, \"deadwood\": {\"0\": 69, \"1\": null}, \"repeated_move\": 0}",
+      "{\"phase\": \"Discard\", \"current_player\": 0, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"9h\", \"upcard\": null, \"stock_size\": 12, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\", \"2h\", \"5s\", \"7c\", \"Td\", \"8d\", \"Qc\", \"9s\", \"Kd\", \"6s\"], \"hands\": {\"0\": [\"7s\", \"Ts\", \"5c\", \"Tc\", \"Jc\", \"Ad\", \"3d\", \"9d\", \"4h\", \"9h\", \"Qh\"], \"1\": []}, \"deadwood\": {\"0\": 68, \"1\": null}, \"repeated_move\": 0}",
+      "{\"phase\": \"Draw\", \"current_player\": 1, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"9h\", \"upcard\": \"Ad\", \"stock_size\": 12, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\", \"2h\", \"5s\", \"7c\", \"Td\", \"8d\", \"Qc\", \"9s\", \"Kd\", \"6s\"], \"hands\": {\"0\": [\"7s\", \"Ts\", \"5c\", \"Tc\", \"Jc\", \"3d\", \"9d\", \"4h\", \"9h\", \"Qh\"], \"1\": []}, \"deadwood\": {\"0\": 77, \"1\": null}, \"repeated_move\": 0}",
+      "{\"phase\": \"Deal\", \"current_player\": -1, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"Ad\", \"upcard\": null, \"stock_size\": 12, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\", \"2h\", \"5s\", \"7c\", \"Td\", \"8d\", \"Qc\", \"9s\", \"Kd\", \"6s\", \"Ad\"], \"hands\": {\"0\": [\"7s\", \"Ts\", \"5c\", \"Tc\", \"Jc\", \"3d\", \"9d\", \"4h\", \"9h\", \"Qh\"], \"1\": []}, \"deadwood\": {\"0\": 77, \"1\": null}, \"repeated_move\": 0}",
+      "{\"phase\": \"Discard\", \"current_player\": 1, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"Ad\", \"upcard\": null, \"stock_size\": 11, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\", \"2h\", \"5s\", \"7c\", \"Td\", \"8d\", \"Qc\", \"9s\", \"Kd\", \"6s\", \"Ad\"], \"hands\": {\"0\": [\"7s\", \"Ts\", \"5c\", \"Tc\", \"Jc\", \"3d\", \"9d\", \"4h\", \"9h\", \"Qh\"], \"1\": []}, \"deadwood\": {\"0\": 77, \"1\": null}, \"repeated_move\": 0}",
+      "{\"phase\": \"Draw\", \"current_player\": 0, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"Ad\", \"upcard\": \"2c\", \"stock_size\": 11, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\", \"2h\", \"5s\", \"7c\", \"Td\", \"8d\", \"Qc\", \"9s\", \"Kd\", \"6s\", \"Ad\"], \"hands\": {\"0\": [\"7s\", \"Ts\", \"5c\", \"Tc\", \"Jc\", \"3d\", \"9d\", \"4h\", \"9h\", \"Qh\"], \"1\": []}, \"deadwood\": {\"0\": 77, \"1\": null}, \"repeated_move\": 0}",
+      "{\"phase\": \"Discard\", \"current_player\": 0, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"2c\", \"upcard\": null, \"stock_size\": 11, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\", \"2h\", \"5s\", \"7c\", \"Td\", \"8d\", \"Qc\", \"9s\", \"Kd\", \"6s\", \"Ad\"], \"hands\": {\"0\": [\"7s\", \"Ts\", \"2c\", \"5c\", \"Tc\", \"Jc\", \"3d\", \"9d\", \"4h\", \"9h\", \"Qh\"], \"1\": []}, \"deadwood\": {\"0\": 69, \"1\": null}, \"repeated_move\": 0}",
+      "{\"phase\": \"Draw\", \"current_player\": 1, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"2c\", \"upcard\": \"7s\", \"stock_size\": 11, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\", \"2h\", \"5s\", \"7c\", \"Td\", \"8d\", \"Qc\", \"9s\", \"Kd\", \"6s\", \"Ad\"], \"hands\": {\"0\": [\"Ts\", \"2c\", \"5c\", \"Tc\", \"Jc\", \"3d\", \"9d\", \"4h\", \"9h\", \"Qh\"], \"1\": []}, \"deadwood\": {\"0\": 72, \"1\": null}, \"repeated_move\": 0}",
+      "{\"phase\": \"Deal\", \"current_player\": -1, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"7s\", \"upcard\": null, \"stock_size\": 11, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\", \"2h\", \"5s\", \"7c\", \"Td\", \"8d\", \"Qc\", \"9s\", \"Kd\", \"6s\", \"Ad\", \"7s\"], \"hands\": {\"0\": [\"Ts\", \"2c\", \"5c\", \"Tc\", \"Jc\", \"3d\", \"9d\", \"4h\", \"9h\", \"Qh\"], \"1\": []}, \"deadwood\": {\"0\": 72, \"1\": null}, \"repeated_move\": 0}",
+      "{\"phase\": \"Discard\", \"current_player\": 1, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"7s\", \"upcard\": null, \"stock_size\": 10, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\", \"2h\", \"5s\", \"7c\", \"Td\", \"8d\", \"Qc\", \"9s\", \"Kd\", \"6s\", \"Ad\", \"7s\"], \"hands\": {\"0\": [\"Ts\", \"2c\", \"5c\", \"Tc\", \"Jc\", \"3d\", \"9d\", \"4h\", \"9h\", \"Qh\"], \"1\": []}, \"deadwood\": {\"0\": 72, \"1\": null}, \"repeated_move\": 0}",
+      "{\"phase\": \"Draw\", \"current_player\": 0, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"7s\", \"upcard\": \"4c\", \"stock_size\": 10, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\", \"2h\", \"5s\", \"7c\", \"Td\", \"8d\", \"Qc\", \"9s\", \"Kd\", \"6s\", \"Ad\", \"7s\"], \"hands\": {\"0\": [\"Ts\", \"2c\", \"5c\", \"Tc\", \"Jc\", \"3d\", \"9d\", \"4h\", \"9h\", \"Qh\"], \"1\": []}, \"deadwood\": {\"0\": 72, \"1\": null}, \"repeated_move\": 0}",
+      "{\"phase\": \"Discard\", \"current_player\": 0, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"4c\", \"upcard\": null, \"stock_size\": 10, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\", \"2h\", \"5s\", \"7c\", \"Td\", \"8d\", \"Qc\", \"9s\", \"Kd\", \"6s\", \"Ad\", \"7s\"], \"hands\": {\"0\": [\"Ts\", \"2c\", \"4c\", \"5c\", \"Tc\", \"Jc\", \"3d\", \"9d\", \"4h\", \"9h\", \"Qh\"], \"1\": []}, \"deadwood\": {\"0\": 66, \"1\": null}, \"repeated_move\": 0}",
+      "{\"phase\": \"Draw\", \"current_player\": 1, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"4c\", \"upcard\": \"4h\", \"stock_size\": 10, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\", \"2h\", \"5s\", \"7c\", \"Td\", \"8d\", \"Qc\", \"9s\", \"Kd\", \"6s\", \"Ad\", \"7s\"], \"hands\": {\"0\": [\"Ts\", \"2c\", \"4c\", \"5c\", \"Tc\", \"Jc\", \"3d\", \"9d\", \"9h\", \"Qh\"], \"1\": []}, \"deadwood\": {\"0\": 72, \"1\": null}, \"repeated_move\": 0}",
+      "{\"phase\": \"Deal\", \"current_player\": -1, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"4h\", \"upcard\": null, \"stock_size\": 10, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\", \"2h\", \"5s\", \"7c\", \"Td\", \"8d\", \"Qc\", \"9s\", \"Kd\", \"6s\", \"Ad\", \"7s\", \"4h\"], \"hands\": {\"0\": [\"Ts\", \"2c\", \"4c\", \"5c\", \"Tc\", \"Jc\", \"3d\", \"9d\", \"9h\", \"Qh\"], \"1\": []}, \"deadwood\": {\"0\": 72, \"1\": null}, \"repeated_move\": 0}",
+      "{\"phase\": \"Discard\", \"current_player\": 1, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"4h\", \"upcard\": null, \"stock_size\": 9, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\", \"2h\", \"5s\", \"7c\", \"Td\", \"8d\", \"Qc\", \"9s\", \"Kd\", \"6s\", \"Ad\", \"7s\", \"4h\"], \"hands\": {\"0\": [\"Ts\", \"2c\", \"4c\", \"5c\", \"Tc\", \"Jc\", \"3d\", \"9d\", \"9h\", \"Qh\"], \"1\": []}, \"deadwood\": {\"0\": 72, \"1\": null}, \"repeated_move\": 0}",
+      "{\"phase\": \"Draw\", \"current_player\": 0, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"4h\", \"upcard\": \"4d\", \"stock_size\": 9, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\", \"2h\", \"5s\", \"7c\", \"Td\", \"8d\", \"Qc\", \"9s\", \"Kd\", \"6s\", \"Ad\", \"7s\", \"4h\"], \"hands\": {\"0\": [\"Ts\", \"2c\", \"4c\", \"5c\", \"Tc\", \"Jc\", \"3d\", \"9d\", \"9h\", \"Qh\"], \"1\": []}, \"deadwood\": {\"0\": 72, \"1\": null}, \"repeated_move\": 0}",
+      "{\"phase\": \"Deal\", \"current_player\": -1, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"4d\", \"upcard\": null, \"stock_size\": 9, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\", \"2h\", \"5s\", \"7c\", \"Td\", \"8d\", \"Qc\", \"9s\", \"Kd\", \"6s\", \"Ad\", \"7s\", \"4h\", \"4d\"], \"hands\": {\"0\": [\"Ts\", \"2c\", \"4c\", \"5c\", \"Tc\", \"Jc\", \"3d\", \"9d\", \"9h\", \"Qh\"], \"1\": []}, \"deadwood\": {\"0\": 72, \"1\": null}, \"repeated_move\": 0}",
+      "{\"phase\": \"Discard\", \"current_player\": 0, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"4d\", \"upcard\": null, \"stock_size\": 8, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\", \"2h\", \"5s\", \"7c\", \"Td\", \"8d\", \"Qc\", \"9s\", \"Kd\", \"6s\", \"Ad\", \"7s\", \"4h\", \"4d\"], \"hands\": {\"0\": [\"Ts\", \"2c\", \"4c\", \"5c\", \"Tc\", \"Jc\", \"3d\", \"9d\", \"6h\", \"9h\", \"Qh\"], \"1\": []}, \"deadwood\": {\"0\": 68, \"1\": null}, \"repeated_move\": 0}",
+      "{\"phase\": \"Draw\", \"current_player\": 1, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"4d\", \"upcard\": \"Qh\", \"stock_size\": 8, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\", \"2h\", \"5s\", \"7c\", \"Td\", \"8d\", \"Qc\", \"9s\", \"Kd\", \"6s\", \"Ad\", \"7s\", \"4h\", \"4d\"], \"hands\": {\"0\": [\"Ts\", \"2c\", \"4c\", \"5c\", \"Tc\", \"Jc\", \"3d\", \"9d\", \"6h\", \"9h\"], \"1\": []}, \"deadwood\": {\"0\": 68, \"1\": null}, \"repeated_move\": 0}",
+      "{\"phase\": \"Discard\", \"current_player\": 1, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"Qh\", \"upcard\": null, \"stock_size\": 8, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\", \"2h\", \"5s\", \"7c\", \"Td\", \"8d\", \"Qc\", \"9s\", \"Kd\", \"6s\", \"Ad\", \"7s\", \"4h\", \"4d\"], \"hands\": {\"0\": [\"Ts\", \"2c\", \"4c\", \"5c\", \"Tc\", \"Jc\", \"3d\", \"9d\", \"6h\", \"9h\"], \"1\": []}, \"deadwood\": {\"0\": 68, \"1\": null}, \"repeated_move\": 0}",
+      "{\"phase\": \"Draw\", \"current_player\": 0, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"Qh\", \"upcard\": \"7d\", \"stock_size\": 8, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\", \"2h\", \"5s\", \"7c\", \"Td\", \"8d\", \"Qc\", \"9s\", \"Kd\", \"6s\", \"Ad\", \"7s\", \"4h\", \"4d\"], \"hands\": {\"0\": [\"Ts\", \"2c\", \"4c\", \"5c\", \"Tc\", \"Jc\", \"3d\", \"9d\", \"6h\", \"9h\"], \"1\": []}, \"deadwood\": {\"0\": 68, \"1\": null}, \"repeated_move\": 0}",
+      "{\"phase\": \"Discard\", \"current_player\": 0, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"7d\", \"upcard\": null, \"stock_size\": 8, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\", \"2h\", \"5s\", \"7c\", \"Td\", \"8d\", \"Qc\", \"9s\", \"Kd\", \"6s\", \"Ad\", \"7s\", \"4h\", \"4d\"], \"hands\": {\"0\": [\"Ts\", \"2c\", \"4c\", \"5c\", \"Tc\", \"Jc\", \"3d\", \"7d\", \"9d\", \"6h\", \"9h\"], \"1\": []}, \"deadwood\": {\"0\": 65, \"1\": null}, \"repeated_move\": 0}",
+      "{\"phase\": \"Draw\", \"current_player\": 1, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"7d\", \"upcard\": \"7d\", \"stock_size\": 8, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\", \"2h\", \"5s\", \"7c\", \"Td\", \"8d\", \"Qc\", \"9s\", \"Kd\", \"6s\", \"Ad\", \"7s\", \"4h\", \"4d\"], \"hands\": {\"0\": [\"Ts\", \"2c\", \"4c\", \"5c\", \"Tc\", \"Jc\", \"3d\", \"9d\", \"6h\", \"9h\"], \"1\": []}, \"deadwood\": {\"0\": 68, \"1\": null}, \"repeated_move\": 1}",
+      "{\"phase\": \"Discard\", \"current_player\": 1, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"7d\", \"upcard\": null, \"stock_size\": 8, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\", \"2h\", \"5s\", \"7c\", \"Td\", \"8d\", \"Qc\", \"9s\", \"Kd\", \"6s\", \"Ad\", \"7s\", \"4h\", \"4d\"], \"hands\": {\"0\": [\"Ts\", \"2c\", \"4c\", \"5c\", \"Tc\", \"Jc\", \"3d\", \"9d\", \"6h\", \"9h\"], \"1\": []}, \"deadwood\": {\"0\": 68, \"1\": null}, \"repeated_move\": 1}",
+      "{\"phase\": \"Draw\", \"current_player\": 0, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"7d\", \"upcard\": \"8h\", \"stock_size\": 8, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\", \"2h\", \"5s\", \"7c\", \"Td\", \"8d\", \"Qc\", \"9s\", \"Kd\", \"6s\", \"Ad\", \"7s\", \"4h\", \"4d\"], \"hands\": {\"0\": [\"Ts\", \"2c\", \"4c\", \"5c\", \"Tc\", \"Jc\", \"3d\", \"9d\", \"6h\", \"9h\"], \"1\": []}, \"deadwood\": {\"0\": 68, \"1\": null}, \"repeated_move\": 0}",
+      "{\"phase\": \"Deal\", \"current_player\": -1, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"8h\", \"upcard\": null, \"stock_size\": 8, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\", \"2h\", \"5s\", \"7c\", \"Td\", \"8d\", \"Qc\", \"9s\", \"Kd\", \"6s\", \"Ad\", \"7s\", \"4h\", \"4d\", \"8h\"], \"hands\": {\"0\": [\"Ts\", \"2c\", \"4c\", \"5c\", \"Tc\", \"Jc\", \"3d\", \"9d\", \"6h\", \"9h\"], \"1\": []}, \"deadwood\": {\"0\": 68, \"1\": null}, \"repeated_move\": 0}",
+      "{\"phase\": \"Discard\", \"current_player\": 0, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"8h\", \"upcard\": null, \"stock_size\": 7, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\", \"2h\", \"5s\", \"7c\", \"Td\", \"8d\", \"Qc\", \"9s\", \"Kd\", \"6s\", \"Ad\", \"7s\", \"4h\", \"4d\", \"8h\"], \"hands\": {\"0\": [\"Ts\", \"2c\", \"4c\", \"5c\", \"Tc\", \"Jc\", \"3d\", \"9d\", \"Jd\", \"6h\", \"9h\"], \"1\": []}, \"deadwood\": {\"0\": 68, \"1\": null}, \"repeated_move\": 0}",
+      "{\"phase\": \"Draw\", \"current_player\": 1, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"8h\", \"upcard\": \"4c\", \"stock_size\": 7, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\", \"2h\", \"5s\", \"7c\", \"Td\", \"8d\", \"Qc\", \"9s\", \"Kd\", \"6s\", \"Ad\", \"7s\", \"4h\", \"4d\", \"8h\"], \"hands\": {\"0\": [\"Ts\", \"2c\", \"5c\", \"Tc\", \"Jc\", \"3d\", \"9d\", \"Jd\", \"6h\", \"9h\"], \"1\": []}, \"deadwood\": {\"0\": 74, \"1\": null}, \"repeated_move\": 0}",
+      "{\"phase\": \"Discard\", \"current_player\": 1, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"4c\", \"upcard\": null, \"stock_size\": 7, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\", \"2h\", \"5s\", \"7c\", \"Td\", \"8d\", \"Qc\", \"9s\", \"Kd\", \"6s\", \"Ad\", \"7s\", \"4h\", \"4d\", \"8h\"], \"hands\": {\"0\": [\"Ts\", \"2c\", \"5c\", \"Tc\", \"Jc\", \"3d\", \"9d\", \"Jd\", \"6h\", \"9h\"], \"1\": []}, \"deadwood\": {\"0\": 74, \"1\": null}, \"repeated_move\": 0}",
+      "{\"phase\": \"Draw\", \"current_player\": 0, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"4c\", \"upcard\": \"Kh\", \"stock_size\": 7, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\", \"2h\", \"5s\", \"7c\", \"Td\", \"8d\", \"Qc\", \"9s\", \"Kd\", \"6s\", \"Ad\", \"7s\", \"4h\", \"4d\", \"8h\"], \"hands\": {\"0\": [\"Ts\", \"2c\", \"5c\", \"Tc\", \"Jc\", \"3d\", \"9d\", \"Jd\", \"6h\", \"9h\"], \"1\": []}, \"deadwood\": {\"0\": 74, \"1\": null}, \"repeated_move\": 0}",
+      "{\"phase\": \"Deal\", \"current_player\": -1, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"Kh\", \"upcard\": null, \"stock_size\": 7, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\", \"2h\", \"5s\", \"7c\", \"Td\", \"8d\", \"Qc\", \"9s\", \"Kd\", \"6s\", \"Ad\", \"7s\", \"4h\", \"4d\", \"8h\", \"Kh\"], \"hands\": {\"0\": [\"Ts\", \"2c\", \"5c\", \"Tc\", \"Jc\", \"3d\", \"9d\", \"Jd\", \"6h\", \"9h\"], \"1\": []}, \"deadwood\": {\"0\": 74, \"1\": null}, \"repeated_move\": 0}",
+      "{\"phase\": \"Discard\", \"current_player\": 0, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"Kh\", \"upcard\": null, \"stock_size\": 6, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\", \"2h\", \"5s\", \"7c\", \"Td\", \"8d\", \"Qc\", \"9s\", \"Kd\", \"6s\", \"Ad\", \"7s\", \"4h\", \"4d\", \"8h\", \"Kh\"], \"hands\": {\"0\": [\"Ts\", \"Js\", \"2c\", \"5c\", \"Tc\", \"Jc\", \"3d\", \"9d\", \"Jd\", \"6h\", \"9h\"], \"1\": []}, \"deadwood\": {\"0\": 44, \"1\": null}, \"repeated_move\": 0}",
+      "{\"phase\": \"Draw\", \"current_player\": 1, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"Kh\", \"upcard\": \"Jd\", \"stock_size\": 6, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\", \"2h\", \"5s\", \"7c\", \"Td\", \"8d\", \"Qc\", \"9s\", \"Kd\", \"6s\", \"Ad\", \"7s\", \"4h\", \"4d\", \"8h\", \"Kh\"], \"hands\": {\"0\": [\"Ts\", \"Js\", \"2c\", \"5c\", \"Tc\", \"Jc\", \"3d\", \"9d\", \"6h\", \"9h\"], \"1\": []}, \"deadwood\": {\"0\": 74, \"1\": null}, \"repeated_move\": 0}",
+      "{\"phase\": \"Discard\", \"current_player\": 1, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"Jd\", \"upcard\": null, \"stock_size\": 6, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\", \"2h\", \"5s\", \"7c\", \"Td\", \"8d\", \"Qc\", \"9s\", \"Kd\", \"6s\", \"Ad\", \"7s\", \"4h\", \"4d\", \"8h\", \"Kh\"], \"hands\": {\"0\": [\"Ts\", \"Js\", \"2c\", \"5c\", \"Tc\", \"Jc\", \"3d\", \"9d\", \"6h\", \"9h\"], \"1\": []}, \"deadwood\": {\"0\": 74, \"1\": null}, \"repeated_move\": 0}",
+      "{\"phase\": \"Draw\", \"current_player\": 0, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"Jd\", \"upcard\": \"Qs\", \"stock_size\": 6, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\", \"2h\", \"5s\", \"7c\", \"Td\", \"8d\", \"Qc\", \"9s\", \"Kd\", \"6s\", \"Ad\", \"7s\", \"4h\", \"4d\", \"8h\", \"Kh\"], \"hands\": {\"0\": [\"Ts\", \"Js\", \"2c\", \"5c\", \"Tc\", \"Jc\", \"3d\", \"9d\", \"6h\", \"9h\"], \"1\": []}, \"deadwood\": {\"0\": 74, \"1\": null}, \"repeated_move\": 0}",
+      "{\"phase\": \"Discard\", \"current_player\": 0, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"Qs\", \"upcard\": null, \"stock_size\": 6, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\", \"2h\", \"5s\", \"7c\", \"Td\", \"8d\", \"Qc\", \"9s\", \"Kd\", \"6s\", \"Ad\", \"7s\", \"4h\", \"4d\", \"8h\", \"Kh\"], \"hands\": {\"0\": [\"Ts\", \"Js\", \"Qs\", \"2c\", \"5c\", \"Tc\", \"Jc\", \"3d\", \"9d\", \"6h\", \"9h\"], \"1\": []}, \"deadwood\": {\"0\": 44, \"1\": null}, \"repeated_move\": 0}",
+      "{\"phase\": \"Draw\", \"current_player\": 1, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"Qs\", \"upcard\": \"9h\", \"stock_size\": 6, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\", \"2h\", \"5s\", \"7c\", \"Td\", \"8d\", \"Qc\", \"9s\", \"Kd\", \"6s\", \"Ad\", \"7s\", \"4h\", \"4d\", \"8h\", \"Kh\"], \"hands\": {\"0\": [\"Ts\", \"Js\", \"Qs\", \"2c\", \"5c\", \"Tc\", \"Jc\", \"3d\", \"9d\", \"6h\"], \"1\": []}, \"deadwood\": {\"0\": 45, \"1\": null}, \"repeated_move\": 0}",
+      "{\"phase\": \"Deal\", \"current_player\": -1, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"9h\", \"upcard\": null, \"stock_size\": 6, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\", \"2h\", \"5s\", \"7c\", \"Td\", \"8d\", \"Qc\", \"9s\", \"Kd\", \"6s\", \"Ad\", \"7s\", \"4h\", \"4d\", \"8h\", \"Kh\", \"9h\"], \"hands\": {\"0\": [\"Ts\", \"Js\", \"Qs\", \"2c\", \"5c\", \"Tc\", \"Jc\", \"3d\", \"9d\", \"6h\"], \"1\": []}, \"deadwood\": {\"0\": 45, \"1\": null}, \"repeated_move\": 0}",
+      "{\"phase\": \"Discard\", \"current_player\": 1, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"9h\", \"upcard\": null, \"stock_size\": 5, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\", \"2h\", \"5s\", \"7c\", \"Td\", \"8d\", \"Qc\", \"9s\", \"Kd\", \"6s\", \"Ad\", \"7s\", \"4h\", \"4d\", \"8h\", \"Kh\", \"9h\"], \"hands\": {\"0\": [\"Ts\", \"Js\", \"Qs\", \"2c\", \"5c\", \"Tc\", \"Jc\", \"3d\", \"9d\", \"6h\"], \"1\": []}, \"deadwood\": {\"0\": 45, \"1\": null}, \"repeated_move\": 0}",
+      "{\"phase\": \"Draw\", \"current_player\": 0, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"9h\", \"upcard\": \"4c\", \"stock_size\": 5, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\", \"2h\", \"5s\", \"7c\", \"Td\", \"8d\", \"Qc\", \"9s\", \"Kd\", \"6s\", \"Ad\", \"7s\", \"4h\", \"4d\", \"8h\", \"Kh\", \"9h\"], \"hands\": {\"0\": [\"Ts\", \"Js\", \"Qs\", \"2c\", \"5c\", \"Tc\", \"Jc\", \"3d\", \"9d\", \"6h\"], \"1\": []}, \"deadwood\": {\"0\": 45, \"1\": null}, \"repeated_move\": 0}",
+      "{\"phase\": \"Discard\", \"current_player\": 0, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"4c\", \"upcard\": null, \"stock_size\": 5, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\", \"2h\", \"5s\", \"7c\", \"Td\", \"8d\", \"Qc\", \"9s\", \"Kd\", \"6s\", \"Ad\", \"7s\", \"4h\", \"4d\", \"8h\", \"Kh\", \"9h\"], \"hands\": {\"0\": [\"Ts\", \"Js\", \"Qs\", \"2c\", \"4c\", \"5c\", \"Tc\", \"Jc\", \"3d\", \"9d\", \"6h\"], \"1\": []}, \"deadwood\": {\"0\": 39, \"1\": null}, \"repeated_move\": 0}",
+      "{\"phase\": \"Draw\", \"current_player\": 1, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"4c\", \"upcard\": \"Js\", \"stock_size\": 5, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\", \"2h\", \"5s\", \"7c\", \"Td\", \"8d\", \"Qc\", \"9s\", \"Kd\", \"6s\", \"Ad\", \"7s\", \"4h\", \"4d\", \"8h\", \"Kh\", \"9h\"], \"hands\": {\"0\": [\"Ts\", \"Qs\", \"2c\", \"4c\", \"5c\", \"Tc\", \"Jc\", \"3d\", \"9d\", \"6h\"], \"1\": []}, \"deadwood\": {\"0\": 69, \"1\": null}, \"repeated_move\": 0}",
+      "{\"phase\": \"Deal\", \"current_player\": -1, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"Js\", \"upcard\": null, \"stock_size\": 5, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\", \"2h\", \"5s\", \"7c\", \"Td\", \"8d\", \"Qc\", \"9s\", \"Kd\", \"6s\", \"Ad\", \"7s\", \"4h\", \"4d\", \"8h\", \"Kh\", \"9h\", \"Js\"], \"hands\": {\"0\": [\"Ts\", \"Qs\", \"2c\", \"4c\", \"5c\", \"Tc\", \"Jc\", \"3d\", \"9d\", \"6h\"], \"1\": []}, \"deadwood\": {\"0\": 69, \"1\": null}, \"repeated_move\": 0}",
+      "{\"phase\": \"Discard\", \"current_player\": 1, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"Js\", \"upcard\": null, \"stock_size\": 4, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\", \"2h\", \"5s\", \"7c\", \"Td\", \"8d\", \"Qc\", \"9s\", \"Kd\", \"6s\", \"Ad\", \"7s\", \"4h\", \"4d\", \"8h\", \"Kh\", \"9h\", \"Js\"], \"hands\": {\"0\": [\"Ts\", \"Qs\", \"2c\", \"4c\", \"5c\", \"Tc\", \"Jc\", \"3d\", \"9d\", \"6h\"], \"1\": []}, \"deadwood\": {\"0\": 69, \"1\": null}, \"repeated_move\": 0}",
+      "{\"phase\": \"Draw\", \"current_player\": 0, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"Js\", \"upcard\": \"3s\", \"stock_size\": 4, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\", \"2h\", \"5s\", \"7c\", \"Td\", \"8d\", \"Qc\", \"9s\", \"Kd\", \"6s\", \"Ad\", \"7s\", \"4h\", \"4d\", \"8h\", \"Kh\", \"9h\", \"Js\"], \"hands\": {\"0\": [\"Ts\", \"Qs\", \"2c\", \"4c\", \"5c\", \"Tc\", \"Jc\", \"3d\", \"9d\", \"6h\"], \"1\": []}, \"deadwood\": {\"0\": 69, \"1\": null}, \"repeated_move\": 0}",
+      "{\"phase\": \"Deal\", \"current_player\": -1, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"3s\", \"upcard\": null, \"stock_size\": 4, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\", \"2h\", \"5s\", \"7c\", \"Td\", \"8d\", \"Qc\", \"9s\", \"Kd\", \"6s\", \"Ad\", \"7s\", \"4h\", \"4d\", \"8h\", \"Kh\", \"9h\", \"Js\", \"3s\"], \"hands\": {\"0\": [\"Ts\", \"Qs\", \"2c\", \"4c\", \"5c\", \"Tc\", \"Jc\", \"3d\", \"9d\", \"6h\"], \"1\": []}, \"deadwood\": {\"0\": 69, \"1\": null}, \"repeated_move\": 0}",
+      "{\"phase\": \"Discard\", \"current_player\": 0, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"3s\", \"upcard\": null, \"stock_size\": 3, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\", \"2h\", \"5s\", \"7c\", \"Td\", \"8d\", \"Qc\", \"9s\", \"Kd\", \"6s\", \"Ad\", \"7s\", \"4h\", \"4d\", \"8h\", \"Kh\", \"9h\", \"Js\", \"3s\"], \"hands\": {\"0\": [\"As\", \"Ts\", \"Qs\", \"2c\", \"4c\", \"5c\", \"Tc\", \"Jc\", \"3d\", \"9d\", \"6h\"], \"1\": []}, \"deadwood\": {\"0\": 60, \"1\": null}, \"repeated_move\": 0}",
+      "{\"phase\": \"Draw\", \"current_player\": 1, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"3s\", \"upcard\": \"6h\", \"stock_size\": 3, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\", \"2h\", \"5s\", \"7c\", \"Td\", \"8d\", \"Qc\", \"9s\", \"Kd\", \"6s\", \"Ad\", \"7s\", \"4h\", \"4d\", \"8h\", \"Kh\", \"9h\", \"Js\", \"3s\"], \"hands\": {\"0\": [\"As\", \"Ts\", \"Qs\", \"2c\", \"4c\", \"5c\", \"Tc\", \"Jc\", \"3d\", \"9d\"], \"1\": []}, \"deadwood\": {\"0\": 64, \"1\": null}, \"repeated_move\": 0}",
+      "{\"phase\": \"Deal\", \"current_player\": -1, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"6h\", \"upcard\": null, \"stock_size\": 3, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\", \"2h\", \"5s\", \"7c\", \"Td\", \"8d\", \"Qc\", \"9s\", \"Kd\", \"6s\", \"Ad\", \"7s\", \"4h\", \"4d\", \"8h\", \"Kh\", \"9h\", \"Js\", \"3s\", \"6h\"], \"hands\": {\"0\": [\"As\", \"Ts\", \"Qs\", \"2c\", \"4c\", \"5c\", \"Tc\", \"Jc\", \"3d\", \"9d\"], \"1\": []}, \"deadwood\": {\"0\": 64, \"1\": null}, \"repeated_move\": 0}",
+      "{\"phase\": \"Discard\", \"current_player\": 1, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"6h\", \"upcard\": null, \"stock_size\": 2, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\", \"2h\", \"5s\", \"7c\", \"Td\", \"8d\", \"Qc\", \"9s\", \"Kd\", \"6s\", \"Ad\", \"7s\", \"4h\", \"4d\", \"8h\", \"Kh\", \"9h\", \"Js\", \"3s\", \"6h\"], \"hands\": {\"0\": [\"As\", \"Ts\", \"Qs\", \"2c\", \"4c\", \"5c\", \"Tc\", \"Jc\", \"3d\", \"9d\"], \"1\": []}, \"deadwood\": {\"0\": 64, \"1\": null}, \"repeated_move\": 0}",
+      "{\"phase\": \"Wall\", \"current_player\": 0, \"is_terminal\": false, \"winner\": null, \"returns\": [], \"knock_card\": 10, \"prev_upcard\": \"6h\", \"upcard\": \"Jd\", \"stock_size\": 2, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\", \"2h\", \"5s\", \"7c\", \"Td\", \"8d\", \"Qc\", \"9s\", \"Kd\", \"6s\", \"Ad\", \"7s\", \"4h\", \"4d\", \"8h\", \"Kh\", \"9h\", \"Js\", \"3s\", \"6h\"], \"hands\": {\"0\": [\"As\", \"Ts\", \"Qs\", \"2c\", \"4c\", \"5c\", \"Tc\", \"Jc\", \"3d\", \"9d\"], \"1\": []}, \"deadwood\": {\"0\": 64, \"1\": null}, \"repeated_move\": 0}",
+      "{\"phase\": \"GameOver\", \"current_player\": -4, \"is_terminal\": true, \"winner\": \"draw\", \"returns\": [0.0, 0.0], \"knock_card\": 10, \"prev_upcard\": \"6h\", \"upcard\": \"Jd\", \"stock_size\": 2, \"discard_pile\": [\"Ac\", \"4s\", \"Jh\", \"5h\", \"6d\", \"6c\", \"8s\", \"3c\", \"9c\", \"5d\", \"2h\", \"5s\", \"7c\", \"Td\", \"8d\", \"Qc\", \"9s\", \"Kd\", \"6s\", \"Ad\", \"7s\", \"4h\", \"4d\", \"8h\", \"Kh\", \"9h\", \"Js\", \"3s\", \"6h\"], \"hands\": {\"0\": [\"As\", \"Ts\", \"Qs\", \"2c\", \"4c\", \"5c\", \"Tc\", \"Jc\", \"3d\", \"9d\"], \"1\": []}, \"deadwood\": {\"0\": 64, \"1\": null}, \"repeated_move\": 0}"
+    ],
+    "actionHistory": [
+      "43",
+      "7",
+      "5",
+      "31",
+      "28",
+      "13",
+      "49",
+      "18",
+      "47",
+      "50",
+      "3",
+      "51",
+      "21",
+      "6",
+      "38",
+      "11",
+      "48",
+      "25",
+      "32",
+      "4",
+      "14",
+      "52",
+      "49",
+      "52",
+      "6",
+      "52",
+      "14",
+      "52",
+      "32",
+      "52",
+      "47",
+      "52",
+      "48",
+      "52",
+      "13",
+      "53",
+      "19",
+      "3",
+      "53",
+      "34",
+      "48",
+      "52",
+      "49",
+      "53",
+      "24",
+      "6",
+      "52",
+      "47",
+      "52",
+      "43",
+      "52",
+      "43",
+      "53",
+      "33",
+      "31",
+      "53",
+      "37",
+      "37",
+      "52",
+      "18",
+      "52",
+      "18",
+      "53",
+      "30",
+      "7",
+      "53",
+      "15",
+      "15",
+      "53",
+      "17",
+      "37",
+      "52",
+      "21",
+      "53",
+      "40",
+      "30",
+      "53",
+      "9",
+      "19",
+      "52",
+      "40",
+      "53",
+      "29",
+      "9",
+      "52",
+      "47",
+      "52",
+      "4",
+      "52",
+      "4",
+      "53",
+      "35",
+      "6",
+      "52",
+      "19",
+      "53",
+      "8",
+      "35",
+      "53",
+      "26",
+      "33",
+      "53",
+      "22",
+      "8",
+      "52",
+      "32",
+      "52",
+      "22",
+      "52",
+      "24",
+      "53",
+      "1",
+      "1",
+      "52",
+      "8",
+      "53",
+      "46",
+      "38",
+      "53",
+      "23",
+      "5",
+      "53",
+      "42",
+      "42",
+      "52",
+      "1",
+      "52",
+      "47",
+      "52",
+      "26",
+      "53",
+      "16",
+      "14",
+      "52",
+      "6",
+      "53",
+      "45",
+      "16",
+      "52",
+      "42",
+      "53",
+      "2",
+      "29",
+      "53",
+      "44",
+      "50",
+      "52",
+      "32",
+      "52",
+      "32",
+      "52",
+      "46",
+      "53",
+      "36",
+      "16",
+      "52",
+      "51",
+      "53",
+      "10",
+      "36",
+      "52",
+      "11",
+      "52",
+      "47",
+      "53",
+      "27",
+      "16",
+      "52",
+      "10",
+      "53",
+      "39",
+      "2",
+      "53",
+      "0",
+      "44",
+      "53",
+      "41",
+      "36",
+      "54"
+    ],
+    "moveDurations": [
+      0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+      0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+      0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+      0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+      0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+      0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+      0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+      0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+      0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0
+    ]
+  }
+}

--- a/kaggle_environments/envs/open_spiel_env/games/gin_rummy/visualizer/default/src/main.ts
+++ b/kaggle_environments/envs/open_spiel_env/games/gin_rummy/visualizer/default/src/main.ts
@@ -1,0 +1,27 @@
+import { createReplayVisualizer, ReplayAdapter } from '@kaggle-environments/core';
+import { renderer } from './renderer';
+import { ginRummyTransformer } from './transformers/ginRummyTransformer';
+import './style.css';
+
+const app = document.getElementById('app');
+if (!app) {
+  throw new Error('Could not find app element');
+}
+
+if (import.meta.env?.DEV && import.meta.hot) {
+  import.meta.hot.accept();
+}
+
+createReplayVisualizer(
+  app,
+  new ReplayAdapter({
+    gameName: 'open_spiel_gin_rummy',
+    renderer: renderer as any,
+    ui: 'side-panel',
+    transformer: (replay) => ({
+      ...replay,
+      steps: ginRummyTransformer(replay),
+      isTransformed: true,
+    }),
+  })
+);

--- a/kaggle_environments/envs/open_spiel_env/games/gin_rummy/visualizer/default/src/renderer.ts
+++ b/kaggle_environments/envs/open_spiel_env/games/gin_rummy/visualizer/default/src/renderer.ts
@@ -1,0 +1,432 @@
+import type { RendererOptions } from '@kaggle-environments/core';
+import type { GinRummyStep } from './transformers/ginRummyTransformer';
+
+interface GinRummyObservation {
+  phase: string | null;
+  current_player: number;
+  is_terminal: boolean;
+  winner: number | string | null;
+  returns: number[];
+  knock_card: number | null;
+  prev_upcard: string | null;
+  upcard: string | null;
+  stock_size: number;
+  discard_pile: string[];
+  hands: { '0': string[]; '1': string[] };
+  deadwood: { '0': number | null; '1': number | null };
+  repeated_move: number;
+}
+
+const PLAYER_0_COLOR = '#1f77b4';
+const PLAYER_1_COLOR = '#d62728';
+const SUIT_GLYPH: Record<string, string> = { s: '\u2660', c: '\u2663', d: '\u2666', h: '\u2665' };
+const SUIT_COLOR: Record<string, 'red' | 'black'> = { s: 'black', c: 'black', d: 'red', h: 'red' };
+const RANK_DISPLAY: Record<string, string> = {
+  A: 'A',
+  T: '10',
+  J: 'J',
+  Q: 'Q',
+  K: 'K',
+};
+
+function rankOf(card: string): string {
+  const r = card[0];
+  return RANK_DISPLAY[r] ?? r;
+}
+
+function suitOf(card: string): string {
+  return card[1];
+}
+
+const RANK_ORDER: Record<string, number> = {
+  A: 1,
+  '2': 2,
+  '3': 3,
+  '4': 4,
+  '5': 5,
+  '6': 6,
+  '7': 7,
+  '8': 8,
+  '9': 9,
+  T: 10,
+  J: 11,
+  Q: 12,
+  K: 13,
+};
+const SUIT_ORDER: Record<string, number> = { s: 0, h: 1, d: 2, c: 3 };
+
+function sortHand(hand: string[]): string[] {
+  return [...hand].sort((a, b) => {
+    const sa = SUIT_ORDER[suitOf(a)] ?? 9;
+    const sb = SUIT_ORDER[suitOf(b)] ?? 9;
+    if (sa !== sb) return sa - sb;
+    return (RANK_ORDER[a[0]] ?? 99) - (RANK_ORDER[b[0]] ?? 99);
+  });
+}
+
+function parseObservation(step: any, playerIdx: number): GinRummyObservation | null {
+  const raw = step?.[playerIdx]?.observation?.observationString;
+  if (!raw) return null;
+  try {
+    return JSON.parse(raw);
+  } catch {
+    return null;
+  }
+}
+
+function mergedObservation(step: any): GinRummyObservation | null {
+  // Player 0's observation has player 0's hand visible; player 1's observation
+  // has player 1's hand visible. Merge so the spectator view shows both.
+  const o0 = parseObservation(step, 0);
+  const o1 = parseObservation(step, 1);
+  const base = o0 ?? o1;
+  if (!base) return null;
+  const merged: GinRummyObservation = JSON.parse(JSON.stringify(base));
+  if (o0 && o0.hands?.['0']?.length) {
+    merged.hands['0'] = o0.hands['0'];
+    merged.deadwood['0'] = o0.deadwood['0'];
+  }
+  if (o1 && o1.hands?.['1']?.length) {
+    merged.hands['1'] = o1.hands['1'];
+    merged.deadwood['1'] = o1.deadwood['1'];
+  }
+  return merged;
+}
+
+function getPlayerName(replay: any, idx: number): string {
+  const info = replay?.info?.TeamNames?.[idx];
+  if (info) return info;
+  const fromAgent = replay?.agents?.[idx]?.name;
+  if (fromAgent) return fromAgent;
+  return idx === 0 ? 'Player 1' : 'Player 2';
+}
+
+function buildCard(
+  card: string | null,
+  options: { compact?: boolean; faceDown?: boolean; highlight?: boolean; dim?: boolean } = {}
+): HTMLDivElement {
+  const el = document.createElement('div');
+  const classes = ['card'];
+  if (options.compact) classes.push('compact');
+  if (options.faceDown || !card) {
+    classes.push('face-down');
+  } else {
+    const suit = suitOf(card);
+    classes.push(SUIT_COLOR[suit]);
+  }
+  if (options.highlight) classes.push('highlight');
+  if (options.dim) classes.push('dim');
+  el.className = classes.join(' ');
+  if (!options.faceDown && card) {
+    const rank = rankOf(card);
+    const glyph = SUIT_GLYPH[suitOf(card)] ?? '?';
+    el.innerHTML = `
+      <div class="corner top">
+        <span>${rank}</span>
+        <span class="suit">${glyph}</span>
+      </div>
+      <div class="corner bottom">
+        <span>${rank}</span>
+        <span class="suit">${glyph}</span>
+      </div>
+    `;
+  }
+  return el;
+}
+
+function actionLabel(submission: number, hand: string[] | null): string {
+  if (submission === 52) return 'Draw upcard';
+  if (submission === 53) return 'Draw stock';
+  if (submission === 54) return 'Pass';
+  if (submission === 55) return 'Knock';
+  if (submission >= 0 && submission < 52) {
+    // Single card action: drawn-card index 0..51 maps to a specific card.
+    // We don't know the exact card from the action alone in all phases;
+    // best effort: derive card string from action index using OpenSpiel's
+    // canonical ordering: rank-major within suit (s, c, d, h).
+    const ranks = ['A', '2', '3', '4', '5', '6', '7', '8', '9', 'T', 'J', 'Q', 'K'];
+    const suits = ['s', 'c', 'd', 'h'];
+    const suit = suits[Math.floor(submission / 13)];
+    const rank = ranks[submission % 13];
+    const card = `${rank}${suit}`;
+    if (hand && hand.includes(card)) return `Discard ${rank}${SUIT_GLYPH[suit]}`;
+    return `${rank}${SUIT_GLYPH[suit]}`;
+  }
+  if (submission >= 56) return `Meld (action ${submission})`;
+  return `Action ${submission}`;
+}
+
+function findLastAction(step: any): { actor: number; submission: number } | null {
+  if (!Array.isArray(step)) return null;
+  for (let i = 0; i < step.length; i++) {
+    const sub = step[i]?.action?.submission;
+    if (typeof sub === 'number' && sub >= 0) return { actor: i, submission: sub };
+  }
+  return null;
+}
+
+function phaseLabel(phase: string | null): string {
+  if (!phase) return '';
+  // Make camel-case phases more readable.
+  return phase.replace(/([a-z])([A-Z])/g, '$1 $2');
+}
+
+function renderPlayerRow(
+  container: HTMLDivElement,
+  name: string,
+  hand: string[],
+  deadwood: number | null,
+  isActive: boolean,
+  isWinner: boolean,
+  color: string,
+  showFaceDown: boolean,
+  highlightCard: string | null
+) {
+  container.innerHTML = '';
+
+  const meta = document.createElement('div');
+  meta.className = 'player-meta';
+  meta.innerHTML = `
+    <span class="sketched-border" style="padding:2px 10px;background:white;color:${color};font-weight:700;">
+      ${name}${isActive ? ' \u25b6' : ''}${isWinner ? ' \u2605' : ''}
+    </span>
+    <span class="deadwood sketched-border">Deadwood: ${deadwood ?? '?'}</span>
+    <span class="deadwood sketched-border">Cards: ${hand.length}</span>
+  `;
+  container.appendChild(meta);
+
+  const handEl = document.createElement('div');
+  handEl.className = 'hand';
+  const sorted = showFaceDown ? hand : sortHand(hand);
+  // If hand empty and showFaceDown, render placeholder face-down cards.
+  const cardsToRender = sorted.length ? sorted : showFaceDown ? new Array(10).fill('XX') : [];
+  for (const card of cardsToRender) {
+    const isHighlight = !!highlightCard && card === highlightCard && !showFaceDown;
+    handEl.appendChild(
+      buildCard(card === 'XX' ? null : card, {
+        faceDown: showFaceDown,
+        highlight: isHighlight,
+      })
+    );
+  }
+  container.appendChild(handEl);
+}
+
+export function renderer(options: RendererOptions<GinRummyStep[]>) {
+  const { parent, replay, step } = options;
+  const steps = (replay?.steps ?? []) as GinRummyStep[];
+  if (!steps.length) return;
+
+  parent.innerHTML = `
+    <div class="renderer-container">
+      <div class="header"></div>
+      <div class="table">
+        <div class="player-row top-row"></div>
+        <div class="center-row"></div>
+        <div class="player-row bottom-row"></div>
+      </div>
+      <div class="status-container sketched-border"></div>
+    </div>
+  `;
+  const header = parent.querySelector('.header') as HTMLDivElement;
+  const topRow = parent.querySelector('.top-row') as HTMLDivElement;
+  const centerRow = parent.querySelector('.center-row') as HTMLDivElement;
+  const bottomRow = parent.querySelector('.bottom-row') as HTMLDivElement;
+  const statusContainer = parent.querySelector('.status-container') as HTMLDivElement;
+
+  const currentStep = steps[step]?.rawStep;
+  const observation = mergedObservation(currentStep);
+  if (!observation) {
+    statusContainer.textContent = 'Waiting for first observation...';
+    return;
+  }
+
+  const playerNames = [getPlayerName(replay, 0), getPlayerName(replay, 1)];
+  const isTerminal = observation.is_terminal;
+  const activeIdx = isTerminal ? -1 : observation.current_player;
+  const winnerIdx = typeof observation.winner === 'number' ? observation.winner : -1;
+
+  // Header
+  header.innerHTML = `
+    <span class="player sketched-border ${activeIdx === 0 ? 'active' : ''}" style="color: ${PLAYER_0_COLOR};">
+      ${playerNames[0]}
+    </span>
+    <span class="vs">vs</span>
+    <span class="player sketched-border ${activeIdx === 1 ? 'active' : ''}" style="color: ${PLAYER_1_COLOR};">
+      ${playerNames[1]}
+    </span>
+  `;
+
+  // Detect the action that produced this state (if any).
+  const lastAction = findLastAction(currentStep);
+  let highlightDiscard: string | null = null;
+  let highlightTakenUpcard = false;
+  let highlightDrawStock = false;
+  let highlightCardP0: string | null = null;
+  let highlightCardP1: string | null = null;
+  if (lastAction) {
+    const { actor, submission } = lastAction;
+    if (submission === 52) highlightTakenUpcard = true;
+    else if (submission === 53) highlightDrawStock = true;
+    else if (submission >= 0 && submission < 52) {
+      // Single-card action: top card of discard pile is the just-discarded card
+      // (in Discard / Knock phases). Highlight it as the move.
+      const discard = observation.discard_pile;
+      if (discard.length) highlightDiscard = discard[discard.length - 1];
+      // If knock, highlight that card in the actor's hand as well.
+      if (actor === 0) highlightCardP0 = discard.length ? discard[discard.length - 1] : null;
+      if (actor === 1) highlightCardP1 = discard.length ? discard[discard.length - 1] : null;
+    }
+  }
+
+  // Top: player 1
+  renderPlayerRow(
+    topRow,
+    playerNames[1],
+    observation.hands['1'] ?? [],
+    observation.deadwood['1'],
+    activeIdx === 1,
+    winnerIdx === 1,
+    PLAYER_1_COLOR,
+    false,
+    highlightCardP1
+  );
+
+  // Center: stock | discard | (recent action info)
+  centerRow.innerHTML = '';
+
+  // Stock pile (face-down stack)
+  const stockPile = document.createElement('div');
+  stockPile.className = 'pile';
+  const stockStack = document.createElement('div');
+  stockStack.className = 'pile-stack';
+  const stockCardCount = Math.min(observation.stock_size, 3);
+  if (stockCardCount === 0) {
+    const empty = document.createElement('div');
+    empty.className = 'pile-empty';
+    empty.textContent = 'empty';
+    stockPile.appendChild(empty);
+  } else {
+    for (let i = 0; i < stockCardCount; i++) {
+      stockStack.appendChild(
+        buildCard(null, { faceDown: true, highlight: i === stockCardCount - 1 && highlightDrawStock })
+      );
+    }
+    stockPile.appendChild(stockStack);
+  }
+  const stockLabel = document.createElement('div');
+  stockLabel.textContent = `Stock (${observation.stock_size})`;
+  stockPile.appendChild(stockLabel);
+  centerRow.appendChild(stockPile);
+
+  // Upcard / discard top -- in OpenSpiel gin_rummy, the upcard is the visible
+  // top of the discard pile during draw phases; once drawn or after a discard,
+  // the discard pile's last card is the visible top. We render the upcard slot
+  // separately when present (Draw phase) and the rest of the pile beneath.
+  const upcardPile = document.createElement('div');
+  upcardPile.className = 'pile';
+  if (observation.upcard) {
+    upcardPile.appendChild(
+      buildCard(observation.upcard, {
+        highlight: highlightTakenUpcard || (highlightDiscard !== null && highlightDiscard === observation.upcard),
+      })
+    );
+    const lbl = document.createElement('div');
+    lbl.textContent = 'Upcard';
+    upcardPile.appendChild(lbl);
+  } else {
+    const empty = document.createElement('div');
+    empty.className = 'pile-empty';
+    empty.textContent = 'no upcard';
+    upcardPile.appendChild(empty);
+    const lbl = document.createElement('div');
+    lbl.textContent = 'Upcard';
+    upcardPile.appendChild(lbl);
+  }
+  centerRow.appendChild(upcardPile);
+
+  // Discard pile beneath the upcard slot. The OpenSpiel discard_pile and
+  // upcard are disjoint (the upcard is reported on its own line and is not
+  // included in the discard pile).
+  const discardPile = document.createElement('div');
+  discardPile.className = 'pile';
+  const discardStack = document.createElement('div');
+  discardStack.className = 'pile-stack';
+  const dp = observation.discard_pile;
+  const visible = dp.slice(-3);
+  if (visible.length === 0) {
+    const empty = document.createElement('div');
+    empty.className = 'pile-empty';
+    empty.textContent = 'empty';
+    discardPile.appendChild(empty);
+  } else {
+    visible.forEach((card, i) => {
+      const isTop = i === visible.length - 1;
+      discardStack.appendChild(
+        buildCard(card, {
+          highlight: isTop && highlightDiscard !== null && card === highlightDiscard,
+        })
+      );
+    });
+    discardPile.appendChild(discardStack);
+  }
+  const dpLabel = document.createElement('div');
+  dpLabel.textContent = `Discard (${dp.length})`;
+  discardPile.appendChild(dpLabel);
+  centerRow.appendChild(discardPile);
+
+  // Bottom: player 0
+  renderPlayerRow(
+    bottomRow,
+    playerNames[0],
+    observation.hands['0'] ?? [],
+    observation.deadwood['0'],
+    activeIdx === 0,
+    winnerIdx === 0,
+    PLAYER_0_COLOR,
+    false,
+    highlightCardP0
+  );
+
+  // Status: phase, last action, terminal result
+  const parts: string[] = [];
+  if (observation.phase) {
+    parts.push(`<span class="phase-pill">${phaseLabel(observation.phase)}</span>`);
+  }
+  if (observation.knock_card !== null) {
+    parts.push(`<span class="annotation">knock card: ${observation.knock_card}</span>`);
+  }
+  if (lastAction) {
+    const { actor, submission } = lastAction;
+    const moverColor = actor === 0 ? PLAYER_0_COLOR : PLAYER_1_COLOR;
+    const moverHand = observation.hands[String(actor) as '0' | '1'] ?? [];
+    const lbl = actionLabel(submission, moverHand);
+    parts.push(
+      `<span class="annotation">last move:</span> <span style="color:${moverColor};font-weight:700;">${playerNames[actor]} \u2192 ${lbl}</span>`
+    );
+  } else if (!isTerminal) {
+    const turnColor = activeIdx === 0 ? PLAYER_0_COLOR : PLAYER_1_COLOR;
+    const turnName = activeIdx >= 0 ? playerNames[activeIdx] : '';
+    if (turnName) {
+      parts.push(`<span>Turn: <span style="color:${turnColor};font-weight:700;">${turnName}</span></span>`);
+    }
+  }
+
+  if (isTerminal) {
+    let resultHTML = '';
+    if (winnerIdx === 0) {
+      resultHTML = `<span style="color:${PLAYER_0_COLOR};font-weight:700;">${playerNames[0]} wins</span>`;
+    } else if (winnerIdx === 1) {
+      resultHTML = `<span style="color:${PLAYER_1_COLOR};font-weight:700;">${playerNames[1]} wins</span>`;
+    } else {
+      resultHTML = `<span>Game over: ${observation.winner ?? 'draw'}</span>`;
+    }
+    const ret = observation.returns;
+    if (ret && ret.length === 2) {
+      resultHTML += ` <span class="annotation">(score ${ret[0]} : ${ret[1]})</span>`;
+    }
+    parts.push(resultHTML);
+  }
+
+  statusContainer.innerHTML = parts.join(' ');
+}

--- a/kaggle_environments/envs/open_spiel_env/games/gin_rummy/visualizer/default/src/style.css
+++ b/kaggle_environments/envs/open_spiel_env/games/gin_rummy/visualizer/default/src/style.css
@@ -1,0 +1,325 @@
+@import url('https://fonts.googleapis.com/css2?family=Inter:ital,opsz,wght@0,14..32,100..900;1,14..32,100..900&display=swap');
+
+html,
+body,
+#app {
+  width: 100%;
+  height: 100%;
+  margin: 0;
+  padding: 0;
+  overflow: hidden;
+}
+
+.renderer-container {
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  width: 100%;
+  height: 100%;
+  min-height: 0;
+  background-color: #f5f1e2;
+  overflow: hidden;
+  font-family: 'Inter', sans-serif;
+  color: #050001;
+  container-type: inline-size;
+  box-sizing: border-box;
+  padding: 8px 12px 12px;
+}
+
+.sketched-border {
+  border: 1px dashed #3c3b37;
+}
+
+.header {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 16px;
+  padding: 6px 0;
+  font-size: 1.05rem;
+  font-weight: 600;
+  flex-shrink: 0;
+}
+
+.header .player {
+  display: inline-flex;
+  flex-direction: row;
+  align-items: center;
+  width: auto;
+  height: auto;
+  padding: 4px 12px;
+  background-color: white;
+  background: white;
+  transition: scale 300ms, background-color 300ms;
+  white-space: nowrap;
+}
+
+.header .player.active {
+  background-color: #bdeeff;
+  scale: 1.1;
+}
+
+.header .vs {
+  color: #444343;
+  font-weight: 500;
+}
+
+.table {
+  display: grid;
+  grid-template-rows: 1fr auto 1fr;
+  flex: 1 1 0;
+  min-height: 0;
+  width: 100%;
+  gap: 6px;
+  padding: 6px 0;
+  align-items: stretch;
+}
+
+.player-row {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 4px;
+  min-height: 0;
+}
+
+.player-row .player-meta {
+  display: flex;
+  gap: 12px;
+  align-items: center;
+  font-size: 0.85rem;
+  color: #444343;
+  font-weight: 600;
+}
+
+.player-row .player-meta .deadwood {
+  background-color: white;
+  padding: 2px 10px;
+}
+
+.hand {
+  display: flex;
+  flex-direction: row;
+  flex-wrap: nowrap;
+  align-items: center;
+  justify-content: center;
+  gap: 0;
+  flex: 0 1 auto;
+  min-height: 0;
+  padding: 4px;
+}
+
+.center-row {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: center;
+  gap: 18px;
+  flex-shrink: 0;
+  padding: 6px 0;
+}
+
+.pile {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
+  font-size: 0.78rem;
+  font-weight: 600;
+  color: #444343;
+}
+
+.pile-stack {
+  position: relative;
+  width: 64px;
+  height: 90px;
+}
+
+.card {
+  position: relative;
+  display: inline-flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: space-between;
+  width: 56px;
+  height: 80px;
+  border: 1px dashed #3c3b37;
+  border-radius: 6px;
+  background-color: white;
+  padding: 4px 6px;
+  margin-left: -16px;
+  box-sizing: border-box;
+  font-family: 'Inter', sans-serif;
+  font-weight: 700;
+  color: #050001;
+  transition: transform 200ms, margin-left 200ms;
+  flex-shrink: 0;
+  user-select: none;
+}
+
+.card:first-child {
+  margin-left: 0;
+}
+
+.card.compact {
+  width: 44px;
+  height: 64px;
+  padding: 3px 4px;
+  margin-left: -12px;
+  font-size: 0.78rem;
+}
+
+.card.compact:first-child {
+  margin-left: 0;
+}
+
+.card .corner {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  font-size: 1.05rem;
+  line-height: 1;
+}
+
+.card.compact .corner {
+  font-size: 0.85rem;
+}
+
+.card .corner.bottom {
+  align-items: flex-end;
+  transform: rotate(180deg);
+}
+
+.card .suit {
+  font-size: 1rem;
+  line-height: 1;
+}
+
+.card.compact .suit {
+  font-size: 0.78rem;
+}
+
+.card.face-down {
+  background-color: #fbf7e8;
+  background-image:
+    repeating-linear-gradient(
+      45deg,
+      #d9d3bf 0,
+      #d9d3bf 2px,
+      transparent 2px,
+      transparent 6px
+    );
+}
+
+.card.face-down .corner,
+.card.face-down .center {
+  display: none;
+}
+
+.card.red {
+  color: #c0392b;
+}
+
+.card.black {
+  color: #1a1a1a;
+}
+
+.card.highlight {
+  outline: 2.5px solid #f5b400;
+  outline-offset: 2px;
+  z-index: 2;
+  transform: translateY(-6px);
+}
+
+.card.dim {
+  opacity: 0.55;
+}
+
+.pile-stack .card {
+  position: absolute;
+  margin-left: 0;
+  top: 0;
+  left: 4px;
+}
+
+.pile-stack .card:nth-child(1) {
+  left: 0;
+  top: 6px;
+}
+.pile-stack .card:nth-child(2) {
+  left: 4px;
+  top: 3px;
+}
+.pile-stack .card:nth-child(3) {
+  left: 8px;
+  top: 0;
+}
+
+.pile-empty {
+  width: 56px;
+  height: 80px;
+  border: 1px dashed #9a9684;
+  border-radius: 6px;
+  background-color: transparent;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.7rem;
+  color: #9a9684;
+  font-style: italic;
+}
+
+.status-container {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-wrap: wrap;
+  gap: 8px 14px;
+  padding: 5px 16px;
+  background-color: white;
+  font-size: 0.88rem;
+  font-weight: 600;
+  min-height: 18px;
+  min-width: 240px;
+  margin: 4px auto 0;
+  flex-shrink: 0;
+  text-align: center;
+}
+
+.status-container .annotation {
+  font-family: 'Mynerve', cursive;
+  font-weight: 400;
+  color: #444343;
+}
+
+.status-container .phase-pill {
+  background-color: #bdeeff;
+  border: 1px dashed #3c3b37;
+  padding: 2px 10px;
+  border-radius: 999px;
+  font-weight: 700;
+}
+
+@container (max-width: 520px) {
+  .card {
+    width: 44px;
+    height: 64px;
+    margin-left: -12px;
+    font-size: 0.78rem;
+  }
+  .card .corner {
+    font-size: 0.85rem;
+  }
+  .card .suit {
+    font-size: 0.78rem;
+  }
+  .pile-stack {
+    width: 52px;
+    height: 72px;
+  }
+  .pile-empty {
+    width: 44px;
+    height: 64px;
+  }
+}

--- a/kaggle_environments/envs/open_spiel_env/games/gin_rummy/visualizer/default/src/transformers/ginRummyTransformer.ts
+++ b/kaggle_environments/envs/open_spiel_env/games/gin_rummy/visualizer/default/src/transformers/ginRummyTransformer.ts
@@ -1,0 +1,105 @@
+// Gin Rummy replay transformer.
+//
+// Builds the per-step `players` array the side-panel UI needs so the right-hand
+// Game Log can render each agent's action label and thoughts. The renderer
+// itself still consumes the raw step data via `mergedObservation()`.
+
+interface GinRummyAction {
+  submission?: number;
+  actionString?: string | null;
+  thoughts?: string | null;
+  status?: string | null;
+  generate_returns?: string[] | null;
+}
+
+interface GinRummyReplayPlayer {
+  action?: GinRummyAction;
+  reward: number;
+  observation?: { observationString?: string; isTerminal?: boolean };
+  status?: string;
+}
+
+interface GinRummyPlayer {
+  id: number;
+  name: string;
+  thumbnail: string;
+  isTurn: boolean;
+  actionDisplayText: string;
+  thoughts: string;
+  reward: number;
+  generateReturns: string[] | null;
+}
+
+export interface GinRummyStep {
+  step: number;
+  players: GinRummyPlayer[];
+  isTerminal: boolean;
+  rawStep: GinRummyReplayPlayer[];
+}
+
+const SUIT_GLYPH: Record<string, string> = { s: '\u2660', c: '\u2663', d: '\u2666', h: '\u2665' };
+
+function actionLabel(submission: number | undefined): string {
+  if (submission === undefined || submission < 0) return '';
+  if (submission === 52) return 'Draw upcard';
+  if (submission === 53) return 'Draw stock';
+  if (submission === 54) return 'Pass';
+  if (submission === 55) return 'Knock';
+  if (submission >= 56) return `Meld (action ${submission})`;
+  // Single-card action 0-51: derive the card from OpenSpiel's canonical
+  // ordering (rank-major within suit s, c, d, h).
+  const ranks = ['A', '2', '3', '4', '5', '6', '7', '8', '9', 'T', 'J', 'Q', 'K'];
+  const suits = ['s', 'c', 'd', 'h'];
+  const suit = suits[Math.floor(submission / 13)];
+  const rank = ranks[submission % 13];
+  return `${rank}${SUIT_GLYPH[suit] ?? suit}`;
+}
+
+function parseThoughts(action?: GinRummyAction): string {
+  // Prefer the Go-harness ``main_response_and_thoughts`` payload when
+  // generate_returns is populated; fall through to ``action.thoughts``.
+  if (action?.generate_returns?.[0]) {
+    try {
+      const parsed = JSON.parse(action.generate_returns[0]);
+      if (parsed.main_response_and_thoughts) {
+        return parsed.main_response_and_thoughts;
+      }
+    } catch {
+      // fall through
+    }
+  }
+  return action?.thoughts ?? '';
+}
+
+export const ginRummyTransformer = (environment: any): GinRummyStep[] => {
+  const teamNames: string[] = environment?.info?.TeamNames ?? ['Player 1', 'Player 2'];
+  const rawSteps: GinRummyReplayPlayer[][] = environment?.steps ?? [];
+  const out: GinRummyStep[] = [];
+
+  rawSteps.forEach((step, index) => {
+    const players: GinRummyPlayer[] = step.map((p, i): GinRummyPlayer => {
+      const submission = p.action?.submission;
+      const isTurn = submission !== undefined && submission !== -1;
+      return {
+        id: i,
+        name: teamNames[i] ?? (i === 0 ? 'Player 1' : 'Player 2'),
+        thumbnail: '',
+        isTurn,
+        actionDisplayText: p.action?.actionString ?? actionLabel(submission),
+        thoughts: parseThoughts(p.action),
+        reward: p.reward ?? 0,
+        generateReturns: p.action?.generate_returns ?? null,
+      };
+    });
+
+    const isTerminal = !!step[0]?.observation?.isTerminal;
+    out.push({
+      step: index,
+      players,
+      isTerminal,
+      rawStep: step,
+    });
+  });
+
+  return out;
+};

--- a/kaggle_environments/envs/open_spiel_env/games/gin_rummy/visualizer/default/tsconfig.json
+++ b/kaggle_environments/envs/open_spiel_env/games/gin_rummy/visualizer/default/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../../../../../../web/tsconfig.base.json",
+  "include": ["src"],
+  "compilerOptions": {
+    "allowJs": true
+  }
+}

--- a/kaggle_environments/envs/open_spiel_env/games/gin_rummy/visualizer/default/vite.config.ts
+++ b/kaggle_environments/envs/open_spiel_env/games/gin_rummy/visualizer/default/vite.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig, mergeConfig } from 'vite';
+import baseConfig from '../../../../../../../web/vite.config.base';
+
+export default mergeConfig(
+  baseConfig,
+  defineConfig({
+    publicDir: 'replays',
+  })
+);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -151,6 +151,22 @@ importers:
         specifier: ^5.0.0
         version: 5.4.21(@types/node@25.2.1)
 
+  kaggle_environments/envs/crawl/visualizer/default:
+    dependencies:
+      '@kaggle-environments/core':
+        specifier: workspace:*
+        version: link:../../../../../web/core
+    devDependencies:
+      cross-env:
+        specifier: ^10.1.0
+        version: 10.1.0
+      typescript:
+        specifier: ^5.0.0
+        version: 5.9.3
+      vite:
+        specifier: ^5.0.0
+        version: 5.4.21(@types/node@25.2.1)
+
   kaggle_environments/envs/halite/visualizer/default:
     dependencies:
       '@kaggle-environments/core':
@@ -350,6 +366,22 @@ importers:
         version: 5.4.21(@types/node@25.2.1)
 
   kaggle_environments/envs/open_spiel_env/games/dark_hex/visualizer/default:
+    dependencies:
+      '@kaggle-environments/core':
+        specifier: workspace:*
+        version: link:../../../../../../../web/core
+    devDependencies:
+      cross-env:
+        specifier: ^10.1.0
+        version: 10.1.0
+      typescript:
+        specifier: ^5.0.0
+        version: 5.9.3
+      vite:
+        specifier: ^5.0.0
+        version: 5.4.21(@types/node@25.2.1)
+
+  kaggle_environments/envs/open_spiel_env/games/gin_rummy/visualizer/default:
     dependencies:
       '@kaggle-environments/core':
         specifier: workspace:*

--- a/tests/envs/open_spiel_env/test_open_spiel_env.py
+++ b/tests/envs/open_spiel_env/test_open_spiel_env.py
@@ -81,6 +81,68 @@ class OpenSpielEnvTest(absltest.TestCase):
             ],
         )
 
+    def test_gin_rummy_agent_playthrough(self):
+        env = make(
+            "open_spiel_gin_rummy",
+            configuration={"includeLegalActions": True},
+            debug=True,
+        )
+        env.run(["random", "random"])
+        playthrough = env.toJSON()
+        self.assertEqual(playthrough["name"], "open_spiel_gin_rummy")
+        self.assertTrue(all(status == "DONE" for status in playthrough["statuses"]))
+
+    def test_gin_rummy_observation_is_json(self):
+        env = make(
+            "open_spiel_gin_rummy",
+            configuration={"includeLegalActions": True},
+            debug=True,
+        )
+        env.reset()
+        env.step([{"submission": -1}, {"submission": -1}])  # Initial setup step.
+        # After dealing, it is player 0's turn (FirstUpcard phase).
+        obs_p0 = json.loads(env.state[0]["observation"]["observationString"])
+        self.assertEqual(obs_p0["phase"], "FirstUpcard")
+        self.assertEqual(obs_p0["current_player"], 0)
+        self.assertFalse(obs_p0["is_terminal"])
+        self.assertEqual(obs_p0["knock_card"], 10)
+        self.assertEqual(obs_p0["stock_size"], 31)
+        self.assertIsNotNone(obs_p0["upcard"])
+        # Player 0 sees their own 10-card hand; opponent's hand is hidden.
+        self.assertEqual(len(obs_p0["hands"]["0"]), 10)
+        self.assertEqual(obs_p0["hands"]["1"], [])
+        self.assertIsNotNone(obs_p0["deadwood"]["0"])
+        self.assertIsNone(obs_p0["deadwood"]["1"])
+
+    def test_gin_rummy_observation_hides_opponent(self):
+        env = make("open_spiel_gin_rummy", debug=True)
+        env.reset()
+        env.step([{"submission": -1}, {"submission": -1}])  # Initial setup step.
+        # Each player should only see their own hand in their observation.
+        obs_p0 = json.loads(env.state[0]["observation"]["observationString"])
+        obs_p1 = json.loads(env.state[1]["observation"]["observationString"])
+        self.assertEqual(len(obs_p0["hands"]["0"]), 10)
+        self.assertEqual(obs_p0["hands"]["1"], [])
+        self.assertEqual(obs_p1["hands"]["0"], [])
+        self.assertEqual(len(obs_p1["hands"]["1"]), 10)
+
+    def test_gin_rummy_invalid_action(self):
+        env = make("open_spiel_gin_rummy", debug=True)
+        env.reset()
+        env.step([{"submission": -1}, {"submission": -1}])  # Initial setup step.
+        # In FirstUpcard phase only actions 52 (Draw upcard) and 54 (Pass)
+        # are legal, so 0 (the As card) is an invalid action.
+        env.step([{"submission": 0}, {"submission": -1}])
+        self.assertTrue(env.done)
+        playthrough = env.toJSON()
+        self.assertEqual(
+            playthrough["rewards"],
+            [
+                open_spiel_env.DEFAULT_INVALID_ACTION_REWARD,
+                -open_spiel_env.DEFAULT_INVALID_ACTION_REWARD,
+            ],
+        )
+
     def test_tic_tac_toe_agent_playthrough(self):
         env = make("open_spiel_tic_tac_toe", debug=True)
         env.run(["random", "random"])


### PR DESCRIPTION
Adds gin_rummy to the OpenSpiel game list with a JSON-emitting proxy that parses OpenSpiel's ASCII observation_string into structured fields (phase, hands, deadwood, upcard, discard pile, knock card). Each player only sees their own hand, preserving the imperfect-information property.

Includes a side-panel visualizer that renders both hands face-up for spectators, the stock/upcard/discard piles in the center, and surfaces each agent's action label and thoughts in the right-hand Game Log via a transformer mirroring the amazons pattern.