### PR TITLE
Orbit Wars: 4-fold rotational symmetry for fair 4p starts

### DIFF
--- a/kaggle_environments/envs/orbit_wars/orbit_wars.py
+++ b/kaggle_environments/envs/orbit_wars/orbit_wars.py
@@ -23,7 +23,7 @@ COMET_PRODUCTION = 1
 PLANET_CLEARANCE = 7
 MIN_PLANET_GROUPS = 5
 MAX_PLANET_GROUPS = 10
-MIN_STATIC_GROUPS = 2  # plus 1 guaranteed static-diagonal group from Phase 0
+MIN_STATIC_GROUPS = 3
 COMET_SPAWN_STEPS = [50, 150, 250, 350, 450]
 
 
@@ -43,51 +43,6 @@ def point_to_segment_distance(p, v, w):
     return distance(p, projection)
 
 
-def _place_diagonal_group(rng, planets, id_counter, orbital_range, attempts=1000):
-    """Try to place a symmetric group of 4 planets on the y=x diagonal.
-
-    orbital_range(r) returns (min_orbital, max_orbital) for radius r.
-    Validation matches Phase 2: standard distance check, plus a cross-check
-    that one rotating + one static planet don't collide as the rotating one
-    sweeps around. Returns the placed planets, or None on failure.
-    """
-    for _ in range(attempts):
-        prod = rng.randint(1, 5)
-        r = 1 + math.log(prod)
-        min_orbital, max_orbital = orbital_range(r)
-        if min_orbital >= max_orbital:
-            continue
-        orbital_r = rng.uniform(min_orbital, max_orbital)
-        x = CENTER + orbital_r * math.cos(math.pi / 4)
-        y = CENTER + orbital_r * math.sin(math.pi / 4)
-        ships = min(rng.randint(5, 99), rng.randint(5, 99))
-        temp_planets = [
-            [id_counter, -1, x, y, r, ships, prod],
-            [id_counter + 1, -1, BOARD_SIZE - x, y, r, ships, prod],
-            [id_counter + 2, -1, x, BOARD_SIZE - y, r, ships, prod],
-            [id_counter + 3, -1, BOARD_SIZE - x, BOARD_SIZE - y, r, ships, prod],
-        ]
-        tp_is_rotating = orbital_r + r < ROTATION_RADIUS_LIMIT
-        valid = True
-        for tp in temp_planets:
-            tp_orbital = distance((tp[2], tp[3]), (CENTER, CENTER))
-            for p in planets:
-                if distance((p[2], p[3]), (tp[2], tp[3])) < p[4] + tp[4] + PLANET_CLEARANCE:
-                    valid = False
-                    break
-                p_orbital = distance((p[2], p[3]), (CENTER, CENTER))
-                p_is_rotating = p_orbital + p[4] < ROTATION_RADIUS_LIMIT
-                if tp_is_rotating != p_is_rotating:
-                    if abs(tp_orbital - p_orbital) < tp[4] + p[4] + PLANET_CLEARANCE:
-                        valid = False
-                        break
-            if not valid:
-                break
-        if valid:
-            return temp_planets
-    return None
-
-
 def generate_planets(rng=None):
     if rng is None:
         rng = random
@@ -95,36 +50,7 @@ def generate_planets(rng=None):
     num_q1 = rng.randint(MIN_PLANET_GROUPS, MAX_PLANET_GROUPS)
     id_counter = 0
 
-    # Phase 0: Place the two guaranteed y=x diagonal groups (one static, one
-    # orbiting) FIRST. In 4p, only y=x diagonal starts are fair: orbiting
-    # copies stay evenly spaced under rotation, and static copies mirror
-    # across both axes. Placing these before the random Phase 1 static groups
-    # keeps the diagonal slot reserved — Phase 1's random angles route around
-    # them rather than blocking the diagonal.
-    static_diag = _place_diagonal_group(
-        rng,
-        planets,
-        id_counter,
-        lambda r: (
-            max(ROTATION_RADIUS_LIMIT - r, (r + 5) * math.sqrt(2)),
-            (BOARD_SIZE - CENTER - r) * math.sqrt(2),
-        ),
-    )
-    if static_diag is not None:
-        planets.extend(static_diag)
-        id_counter += 4
-
-    orbiting_diag = _place_diagonal_group(
-        rng,
-        planets,
-        id_counter,
-        lambda r: (SUN_RADIUS + r + 10, ROTATION_RADIUS_LIMIT - r),
-    )
-    if orbiting_diag is not None:
-        planets.extend(orbiting_diag)
-        id_counter += 4
-
-    # Phase 1: Generate 3 guaranteed static planet groups using polar coordinates.
+    # Phase 1: Generate guaranteed static planet groups using polar coordinates.
     # Sample within the circular region where orbital_radius + r >= ROTATION_RADIUS_LIMIT.
     static_groups = 0
     for _ in range(5000):
@@ -153,10 +79,10 @@ def generate_planets(rng=None):
 
         ships = min(rng.randint(5, 99), rng.randint(5, 99))
         temp_planets = [
-            [id_counter, -1, x, y, r, ships, prod],
+            [id_counter, -1, y, x, r, ships, prod],
             [id_counter + 1, -1, BOARD_SIZE - x, y, r, ships, prod],
             [id_counter + 2, -1, x, BOARD_SIZE - y, r, ships, prod],
-            [id_counter + 3, -1, BOARD_SIZE - x, BOARD_SIZE - y, r, ships, prod],
+            [id_counter + 3, -1, BOARD_SIZE - y, BOARD_SIZE - x, r, ships, prod],
         ]
 
         # Check overlap with existing planets
@@ -203,10 +129,10 @@ def generate_planets(rng=None):
         valid = True
         ships = rng.randint(5, 30)
         temp_planets = [
-            [id_counter, -1, x, y, r, ships, prod],
+            [id_counter, -1, y, x, r, ships, prod],
             [id_counter + 1, -1, BOARD_SIZE - x, y, r, ships, prod],
             [id_counter + 2, -1, x, BOARD_SIZE - y, r, ships, prod],
-            [id_counter + 3, -1, BOARD_SIZE - x, BOARD_SIZE - y, r, ships, prod],
+            [id_counter + 3, -1, BOARD_SIZE - y, BOARD_SIZE - x, r, ships, prod],
         ]
 
         for tp in temp_planets:
@@ -311,12 +237,15 @@ def generate_comet_paths(
         if not (5 <= len(visible) <= 40):
             continue
 
-        # Build 4 symmetric paths
+        # Build 4 rotationally symmetric paths (4-fold rotation about center).
+        # Q1 and Q3 copies are reflected across the y=x diagonal so all 4
+        # copies are 90° rotations of each other — every player sees the
+        # same game state rotated by their quadrant.
         paths = [
-            [[x, y] for x, y in visible],
+            [[y, x] for x, y in visible],
             [[BOARD_SIZE - x, y] for x, y in visible],
             [[x, BOARD_SIZE - y] for x, y in visible],
-            [[BOARD_SIZE - x, BOARD_SIZE - y] for x, y in visible],
+            [[BOARD_SIZE - y, BOARD_SIZE - x] for x, y in visible],
         ]
 
         # Separate planets into static and orbiting (exclude other comets)
@@ -341,10 +270,10 @@ def generate_comet_paths(
 
             # Check all 4 symmetric positions against static planets
             sym_pts = [
-                (cx, cy),
+                (cy, cx),
                 (BOARD_SIZE - cx, cy),
                 (cx, BOARD_SIZE - cy),
-                (BOARD_SIZE - cx, BOARD_SIZE - cy),
+                (BOARD_SIZE - cy, BOARD_SIZE - cx),
             ]
             for planet in static_planets:
                 for sp in sym_pts:
@@ -411,31 +340,12 @@ def interpreter(state, env):
         obs0.comets = []
         obs0.comet_planet_ids = []
 
-        # Assign home planets — pick a random symmetric group of 4
+        # Assign home planets — pick a random symmetric group of 4. Under
+        # 4-fold rotational symmetry, every group's 4 copies are 90°
+        # rotations of each other, so any group is fair for both 2p and 4p.
         num_groups = len(obs0.planets) // 4
         if num_groups > 0:
-            if num_agents == 4:
-                # In 4p, both orbiting and static starts are only fair when
-                # the 4 copies sit symmetrically. The y=x diagonal guarantees
-                # this for both (orbiting copies stay evenly spaced under
-                # rotation; static copies mirror across both axes). Collect
-                # all y=x diagonal groups (orbiting + static) and pick one
-                # using init_rng so the choice is reproducible from seed.
-                diagonal_groups = [
-                    g
-                    for g in range(num_groups)
-                    if abs(
-                        (obs0.planets[g * 4][2] - CENTER)
-                        - (obs0.planets[g * 4][3] - CENTER)
-                    )
-                    < 0.01
-                ]
-                assert diagonal_groups, "4p requires at least one y=x diagonal group"
-                home_group = diagonal_groups[
-                    init_rng.randint(0, len(diagonal_groups) - 1)
-                ]
-            else:
-                home_group = init_rng.randint(0, num_groups - 1)
+            home_group = init_rng.randint(0, num_groups - 1)
             base = home_group * 4
 
             if num_agents == 2:

--- a/kaggle_environments/envs/orbit_wars/test_orbit_wars.py
+++ b/kaggle_environments/envs/orbit_wars/test_orbit_wars.py
@@ -200,44 +200,13 @@ class TestOrbitWars(unittest.TestCase):
             self.assertEqual(obs0.comet_planet_ids, other_obs.comet_planet_ids)
             self.assertEqual(obs0.initial_planets, other_obs.initial_planets)
 
-    def test_generate_planets_has_diagonal_orbiting_group(self):
-        # The y=x diagonal orbiting group should always be generated
+    def test_4p_home_planets_rotationally_symmetric(self):
+        # In 4p, the 4 home planets must be a 4-fold rotationally symmetric
+        # set about the board center: rotating any home position by 90° CCW
+        # must land on another home position. This guarantees every player's
+        # view is identical (just rotated), so all are equidistant from
+        # the planet rotationally ahead and behind.
         for _ in range(50):
-            planets = generate_planets()
-            num_groups = len(planets) // 4
-            found_diagonal = False
-            for g in range(num_groups):
-                p = planets[g * 4]  # Q1 planet
-                orb_r = distance((p[2], p[3]), (CENTER, CENTER))
-                is_orbiting = orb_r + p[4] < ROTATION_RADIUS_LIMIT
-                on_diagonal = abs((p[2] - CENTER) - (p[3] - CENTER)) < 0.01
-                if is_orbiting and on_diagonal:
-                    found_diagonal = True
-                    break
-            self.assertTrue(found_diagonal, "No y=x diagonal orbiting group found")
-
-    def test_generate_planets_has_diagonal_static_group(self):
-        # The y=x diagonal static group should always be generated
-        for _ in range(50):
-            planets = generate_planets()
-            num_groups = len(planets) // 4
-            found_diagonal = False
-            for g in range(num_groups):
-                p = planets[g * 4]  # Q1 planet
-                orb_r = distance((p[2], p[3]), (CENTER, CENTER))
-                is_static = orb_r + p[4] >= ROTATION_RADIUS_LIMIT
-                on_diagonal = abs((p[2] - CENTER) - (p[3] - CENTER)) < 0.01
-                if is_static and on_diagonal:
-                    found_diagonal = True
-                    break
-            self.assertTrue(found_diagonal, "No y=x diagonal static group found")
-
-    def test_4p_start_always_on_diagonal(self):
-        # In 4p, starting planets (orbiting OR static) must be on the y=x
-        # diagonal so the 4 player copies sit symmetrically.
-        saw_static = False
-        saw_orbiting = False
-        for _ in range(100):
             state = [
                 SimpleNamespace(
                     observation=SimpleNamespace(step=0),
@@ -259,25 +228,22 @@ class TestOrbitWars(unittest.TestCase):
                 done=False,
             )
             new_state = interpreter(state, env)
-            obs = new_state[0].observation
-            owned = [p for p in obs.planets if p[1] != -1]
+            owned = [p for p in new_state[0].observation.planets if p[1] != -1]
             self.assertEqual(len(owned), 4)
-
-            q1 = owned[0]  # Player 0's planet (Q1)
-            orb_r = distance((q1[2], q1[3]), (CENTER, CENTER))
-            is_orbiting = orb_r + q1[4] < ROTATION_RADIUS_LIMIT
-            self.assertAlmostEqual(
-                q1[2] - CENTER, q1[3] - CENTER, places=2,
-                msg="4p start not on y=x diagonal"
-            )
-            if is_orbiting:
-                saw_orbiting = True
-            else:
-                saw_static = True
-
-        # Across 100 episodes both start types should appear (random pick).
-        self.assertTrue(saw_static, "4p never picked a static-diagonal start")
-        self.assertTrue(saw_orbiting, "4p never picked an orbiting-diagonal start")
+            positions = [(p[2], p[3]) for p in owned]
+            # Rotate each position 90° CCW about CENTER and verify it lands on
+            # another home position.
+            for x, y in positions:
+                rx = CENTER - (y - CENTER)
+                ry = CENTER + (x - CENTER)
+                self.assertTrue(
+                    any(
+                        math.isclose(rx, px, abs_tol=1e-5)
+                        and math.isclose(ry, py, abs_tol=1e-5)
+                        for px, py in positions
+                    ),
+                    msg=f"home set not 4-fold rotational: {positions}",
+                )
 
     def _make_state(self, planets, fleets, step=1):
         """Helper to build a minimal 2-player state for testing."""

--- a/scripts/preview_orbit_wars_starts.py
+++ b/scripts/preview_orbit_wars_starts.py
@@ -1,0 +1,105 @@
+"""Render a grid of orbit_wars starting positions for visual review.
+
+Usage:
+    python3 scripts/preview_orbit_wars_starts.py [num_seeds] [start_seed]
+
+Defaults to 16 seeds starting at 0. Saves to orbit_wars_starts.png.
+"""
+import math
+import random
+import sys
+
+import matplotlib.pyplot as plt
+from matplotlib.patches import Circle
+
+from kaggle_environments.envs.orbit_wars.orbit_wars import (
+    BOARD_SIZE,
+    CENTER,
+    ROTATION_RADIUS_LIMIT,
+    SUN_RADIUS,
+    generate_planets,
+)
+
+PLAYER_COLORS = ["#e74c3c", "#3498db", "#2ecc71", "#f1c40f"]
+
+
+def pick_home_group(planets, num_agents, rng):
+    num_groups = len(planets) // 4
+    if num_groups == 0:
+        return None
+    return rng.randint(0, num_groups - 1)
+
+
+def render(ax, seed, num_agents=4):
+    rng = random.Random(seed)
+    # Match interpreter: angular_velocity drawn first, then planets.
+    rng.uniform(0.025, 0.05)
+    planets = generate_planets(rng)
+    home_group = pick_home_group(planets, num_agents, rng)
+
+    ax.set_xlim(0, BOARD_SIZE)
+    ax.set_ylim(0, BOARD_SIZE)
+    ax.set_aspect("equal")
+    ax.set_facecolor("#0b1020")
+    ax.set_title(f"seed={seed}", fontsize=8)
+    ax.set_xticks([])
+    ax.set_yticks([])
+
+    # Rotation radius boundary
+    ax.add_patch(Circle((CENTER, CENTER), ROTATION_RADIUS_LIMIT,
+                        fill=False, edgecolor="#333", linestyle="--", linewidth=0.5))
+    # Sun
+    ax.add_patch(Circle((CENTER, CENTER), SUN_RADIUS, color="#f39c12"))
+
+    home_ids = set()
+    if home_group is not None:
+        base = home_group * 4
+        if num_agents == 2:
+            home_ids = {base, base + 3}
+        elif num_agents == 4:
+            home_ids = {base + j for j in range(4)}
+
+    for i, p in enumerate(planets):
+        pid, _, x, y, r, _, _ = p
+        orbital = math.hypot(x - CENTER, y - CENTER)
+        is_orbiting = orbital + r < ROTATION_RADIUS_LIMIT
+        if pid in home_ids:
+            if num_agents == 4:
+                base = (home_group or 0) * 4
+                player = pid - base
+            else:
+                player = 0 if pid == (home_group or 0) * 4 else 1
+            color = PLAYER_COLORS[player]
+            edge = "white"
+        else:
+            color = "#7f8c8d" if is_orbiting else "#bdc3c7"
+            edge = None
+        ax.add_patch(Circle((x, y), max(r, 0.8), color=color,
+                            ec=edge, linewidth=0.8 if edge else 0))
+
+
+def main():
+    num_seeds = int(sys.argv[1]) if len(sys.argv) > 1 else 16
+    start_seed = int(sys.argv[2]) if len(sys.argv) > 2 else 0
+
+    cols = int(math.ceil(math.sqrt(num_seeds)))
+    rows = int(math.ceil(num_seeds / cols))
+    fig, axes = plt.subplots(rows, cols, figsize=(cols * 2.2, rows * 2.2))
+    axes = axes.flatten() if num_seeds > 1 else [axes]
+
+    for i, ax in enumerate(axes):
+        if i < num_seeds:
+            render(ax, start_seed + i, num_agents=4)
+        else:
+            ax.axis("off")
+
+    fig.suptitle(f"orbit_wars starts (4p, seeds {start_seed}..{start_seed + num_seeds - 1})",
+                 color="black")
+    fig.tight_layout()
+    out = "orbit_wars_starts.png"
+    fig.savefig(out, dpi=120, facecolor="white")
+    print(f"wrote {out}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Previously the 4 symmetric copies of each planet/comet group were mirrored across both axes (rectangle layout). In 4p this meant players were equidistant from "their own" copy but not from the copies rotationally ahead and behind, so the four player views weren't equivalent under rotation.

Reflect Q1 and Q3 copies across the y=x diagonal so all 4 copies are 90° rotations of each other. Now every player's view is the others' rotated by 90°.

With true rotational symmetry, any group is fair for both 2p and 4p, so drop the y=x diagonal restriction and the dedicated Phase 0 diagonal placements. Bump MIN_STATIC_GROUPS from 2 to 3 to keep the same number of guaranteed static groups; total planet count range (20-40) is unchanged.

Also add scripts/preview_orbit_wars_starts.py to render a grid of starting positions for visual review.