### PR TITLE
Orbit Wars: check planet collision before OOB (#1017)

### DIFF
--- a/kaggle_environments/envs/orbit_wars/orbit_wars.py
+++ b/kaggle_environments/envs/orbit_wars/orbit_wars.py
@@ -582,23 +582,24 @@ def interpreter(state, env):
         fleet[3] += math.sin(angle) * speed
         new_pos = (fleet[2], fleet[3])
 
-        # Check if fleet went out of bounds
-        if not (0 <= fleet[2] <= BOARD_SIZE and 0 <= fleet[3] <= BOARD_SIZE):
-            fleets_to_remove.append(fleet)
-            continue
-
         # Check if fleet path crossed the sun
         if point_to_segment_distance((CENTER, CENTER), old_pos, new_pos) < SUN_RADIUS:
             fleets_to_remove.append(fleet)
             continue
 
-        # Check if fleet path intersected any planet (continuous collision)
+        # Check if fleet path intersected any planet (continuous collision).
+        # Runs before the OOB check so a fleet that passes through a planet
+        # near the board edge gets captured instead of destroyed.
         for planet in obs0.planets:
             planet_pos = (planet[2], planet[3])
             if point_to_segment_distance(planet_pos, old_pos, new_pos) < planet[4]:
                 combat_lists[planet[0]].append(fleet)
                 fleets_to_remove.append(fleet)
                 break
+        else:
+            # No planet hit — check if fleet went out of bounds
+            if not (0 <= fleet[2] <= BOARD_SIZE and 0 <= fleet[3] <= BOARD_SIZE):
+                fleets_to_remove.append(fleet)
 
     # 3. Planet Movement & Sweep
     angular_velocity = obs0.angular_velocity


### PR DESCRIPTION
The OOB check at line 586 runs before the continuous collision check at line 598. A fast fleet near the board edge can overshoot a planet and land out of bounds — the OOB check destroys it before the collision check (point_to_segment_distance) can detect the hit.

Fix: run the planet collision loop first. Use for...else so OOB only triggers when no planet captured the fleet. Sun check stays first since crossing the sun is always fatal.

Reproduction: seed 62, send ~1000 ships from planet 8 at planet 0 (0.42 units from the top board edge). The fleet passes through planet 0's radius but gets destroyed by OOB.