### PR TITLE
Orbit Wars: hide seed from agents while keeping it in the replay

### DIFF
--- a/kaggle_environments/envs/orbit_wars/orbit_wars.json
+++ b/kaggle_environments/envs/orbit_wars/orbit_wars.json
@@ -24,7 +24,7 @@
       "default": 4.0
     },
     "seed": {
-      "description": "Seed used to deterministically generate planets and comets. If unset, one is chosen at random and recorded back into the configuration so the episode can be reproduced.",
+      "description": "Optional input seed for deterministic planet/comet generation. The interpreter clears this from configuration after reading and stores the resolved seed on env.info['seed'] so it stays out of agent observations but is still recorded in the replay.",
       "type": "integer",
       "default": null
     }

--- a/kaggle_environments/envs/orbit_wars/orbit_wars.py
+++ b/kaggle_environments/envs/orbit_wars/orbit_wars.py
@@ -315,20 +315,31 @@ def interpreter(state, env):
     num_agents = len(state)
     obs0 = state[0].observation
 
-    if env.done:
-        return state
-
-    # Initialize game state if not already done
+    # Initialize game state if not already done. Run this BEFORE the
+    # `env.done` early-return so initialization happens during env.reset()
+    # (when all agents are temporarily INACTIVE / "done"). That guarantees
+    # the seed is scrubbed from configuration before the first agent.act()
+    # call — otherwise agents would see the seed on turn 0.
     if not hasattr(obs0, "planets") or not obs0.planets:
-        # Resolve / record episode seed so planet & comet generation are
-        # reproducible from the replay configuration.
-        seed = get(configuration, "seed", None)
+        # Resolve episode seed and stash it on env.info so it persists into
+        # the replay but stays out of `configuration`, which is visible to
+        # agents. Agents must not be able to reconstruct the comet schedule.
+        if not hasattr(env, "info") or env.info is None:
+            env.info = {}
+        # Reuse the previously-resolved seed if env.reset() runs twice
+        # (e.g. make() + run() both trigger reset). Otherwise read from
+        # configuration, then fall back to a random one.
+        seed = env.info.get("seed")
+        if seed is None:
+            seed = get(configuration, "seed", None)
         if seed is None:
             seed = random.randrange(2**31)
-            try:
-                configuration.seed = seed
-            except (AttributeError, TypeError):
-                configuration["seed"] = seed
+        # Scrub seed from configuration so agents can't read it.
+        try:
+            configuration.seed = None
+        except (AttributeError, TypeError):
+            configuration["seed"] = None
+        env.info["seed"] = seed
         init_rng = random.Random(seed)
 
         angular_velocity = init_rng.uniform(0.025, 0.05)
@@ -371,6 +382,9 @@ def interpreter(state, env):
 
         return state
 
+    if env.done:
+        return state
+
     # Remove expired comets before fleet launch so agents can't act on them
     expired_comet_pids = []
     for group in obs0.comets:
@@ -398,8 +412,10 @@ def interpreter(state, env):
     comet_speed = configuration.cometSpeed
     if (step + 1) in COMET_SPAWN_STEPS:
         # Derive a per-spawn RNG from the episode seed so comet shape and
-        # ship counts are reproducible from the replay configuration.
-        episode_seed = get(configuration, "seed", 0) or 0
+        # ship counts are reproducible. Seed lives on env.info to keep it
+        # hidden from agents (see init block above).
+        env_info = getattr(env, "info", None) or {}
+        episode_seed = env_info.get("seed", 0) or 0
         comet_rng = random.Random(f"orbit_wars-comet-{episode_seed}-{step + 1}")
         comet_paths = generate_comet_paths(
             obs0.initial_planets,

--- a/kaggle_environments/envs/orbit_wars/test_orbit_wars.py
+++ b/kaggle_environments/envs/orbit_wars/test_orbit_wars.py
@@ -622,5 +622,60 @@ class TestOrbitWars(unittest.TestCase):
         self.assertEqual(p[5], 25)  # 35 - 10 = 25
 
 
+    def test_seed_hidden_from_agents_but_in_replay(self):
+        # The seed drives planet placement and the comet schedule (which is
+        # supposed to be hidden info). Agents must NOT see the seed via the
+        # configuration they're handed, but the replay/env must still record
+        # it for reproducibility.
+        from kaggle_environments import make
+
+        seen_seeds = []
+        seen_configs = []
+
+        def spy_agent(observation, configuration):
+            seen_seeds.append(configuration.get("seed"))
+            seen_configs.append(dict(configuration))
+            return []
+
+        chosen_seed = 1234567
+        env = make(
+            "orbit_wars",
+            configuration={"seed": chosen_seed, "episodeSteps": 60},
+            debug=True,
+        )
+        env.run([spy_agent, spy_agent])
+
+        self.assertTrue(seen_seeds, "spy agent never received configuration")
+        for s, cfg in zip(seen_seeds, seen_configs):
+            self.assertIsNone(
+                s, msg=f"agent saw seed={s} in configuration: {cfg}"
+            )
+
+        # Seed must still be persisted on the env / replay for reproducibility.
+        self.assertEqual(env.info.get("seed"), chosen_seed)
+        replay = env.toJSON()
+        self.assertEqual(replay["info"].get("seed"), chosen_seed)
+        self.assertIsNone(replay["configuration"].get("seed"))
+
+    def test_seed_hidden_when_unset_by_user(self):
+        # When the user doesn't supply a seed, the interpreter generates one.
+        # That generated seed must also stay out of the agent's configuration
+        # view but be recorded in env.info.
+        from kaggle_environments import make
+
+        seen_seeds = []
+
+        def spy_agent(observation, configuration):
+            seen_seeds.append(configuration.get("seed"))
+            return []
+
+        env = make("orbit_wars", configuration={"episodeSteps": 60}, debug=True)
+        env.run([spy_agent, spy_agent])
+
+        for s in seen_seeds:
+            self.assertIsNone(s, msg=f"agent saw generated seed={s}")
+        self.assertIsNotNone(env.info.get("seed"))
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
The episode seed deterministically generates the comet schedule, which is supposed to be hidden info. Previously the interpreter wrote the resolved seed back into `configuration`, which agents see, letting them reconstruct the schedule.

Now the seed is stored on `env.info` (persisted into the replay via `toJSON`) and scrubbed from `configuration`. Initialization runs during `env.reset()` so the scrub happens before the first `agent.act()` call.