### PR TITLE
core_harness: ship telemetry to Model Proxy /telemetry/logs by default

### DIFF
--- a/kaggle_environments/core_harness.py
+++ b/kaggle_environments/core_harness.py
@@ -56,7 +56,9 @@ def _model_proxy_send(module: str, **kwargs: Any) -> None:
     url = os.environ.get("MODEL_PROXY_URL")
     if not token or not url or url == "dummy_url":
         return
-    endpoint = f"https://{urllib.parse.urlparse(url).netloc}/telemetry/logs"
+    parsed = urllib.parse.urlparse(url)
+    host = parsed.netloc or parsed.path.split("/", 1)[0]
+    endpoint = f"https://{host}/telemetry/logs"
     payload = json.dumps({module: kwargs}).encode("utf-8")
     req = urllib.request.Request(
         endpoint,

--- a/kaggle_environments/core_harness.py
+++ b/kaggle_environments/core_harness.py
@@ -55,6 +55,7 @@ def _model_proxy_send(module: str, **kwargs: Any) -> None:
     token = os.environ.get("MODEL_PROXY_KEY")
     url = os.environ.get("MODEL_PROXY_URL")
     if not token or not url or url == "dummy_url":
+        _log.info("[telemetry] %s %s", module, json.dumps(kwargs, default=str))
         return
     parsed = urllib.parse.urlparse(url)
     host = parsed.netloc or parsed.path.split("/", 1)[0]

--- a/kaggle_environments/core_harness.py
+++ b/kaggle_environments/core_harness.py
@@ -17,10 +17,13 @@ Use ``create_agent_fn(game_harness)`` to produce a Kaggle-compatible
 """
 
 import dataclasses
+import json
 import logging
 import os
 import sys
 import time
+import urllib.parse
+import urllib.request
 from typing import Any, Callable, Mapping, Protocol, Sequence
 
 import litellm
@@ -47,7 +50,30 @@ class TelemetrySendFn(Protocol):
     def __call__(self, module: str, **kwargs: Any) -> None: ...
 
 
-_SEND: TelemetrySendFn = lambda module, **kwargs: None  # noqa: E731
+def _model_proxy_send(module: str, **kwargs: Any) -> None:
+    """Default exporter that POSTs to the Kaggle Model Proxy /telemetry/logs."""
+    token = os.environ.get("MODEL_PROXY_KEY")
+    url = os.environ.get("MODEL_PROXY_URL")
+    if not token or not url or url == "dummy_url":
+        return
+    endpoint = f"https://{urllib.parse.urlparse(url).netloc}/telemetry/logs"
+    payload = json.dumps({module: kwargs}).encode("utf-8")
+    req = urllib.request.Request(
+        endpoint,
+        data=payload,
+        headers={
+            "Authorization": f"Bearer {token}",
+            "Content-Type": "application/json",
+        },
+        method="POST",
+    )
+    try:
+        urllib.request.urlopen(req, timeout=5).close()
+    except Exception as exc:  # noqa: BLE001 - never let telemetry break play
+        _log.warning("Failed to post telemetry to Kaggle Model Proxy: %s", exc)
+
+
+_SEND: TelemetrySendFn = _model_proxy_send
 
 
 def get_telemetry_logger(module: str) -> Callable[..., None]:


### PR DESCRIPTION
Mirrors the game_arena submission's `model_proxy_telemetry.send` so harnesses mounted via `StaticHarnessAgentScript` emit to the same BigQuery sink that chess-text and iterated-prisoners-dilemma already use. The default exporter is a no-op when MODEL_PROXY_URL / MODEL_PROXY_KEY are unset, so dev and tests are unaffected.