### PR TITLE
Orbit Wars: check planet collision before bounds/sun for fleets

### DIFF
--- a/kaggle_environments/envs/orbit_wars/orbit_wars.py
+++ b/kaggle_environments/envs/orbit_wars/orbit_wars.py
@@ -492,6 +492,20 @@ def interpreter(state, env):
         fleet[3] += math.sin(angle) * speed
         new_pos = (fleet[2], fleet[3])
 
+        # Check if fleet path intersected any planet (continuous collision).
+        # Check planets first so fast fleets that would overshoot the bounds
+        # or sun still get credit for hitting a planet along the way.
+        hit_planet = False
+        for planet in obs0.planets:
+            planet_pos = (planet[2], planet[3])
+            if point_to_segment_distance(planet_pos, old_pos, new_pos) < planet[4]:
+                combat_lists[planet[0]].append(fleet)
+                fleets_to_remove.append(fleet)
+                hit_planet = True
+                break
+        if hit_planet:
+            continue
+
         # Check if fleet went out of bounds
         if not (0 <= fleet[2] <= BOARD_SIZE and 0 <= fleet[3] <= BOARD_SIZE):
             fleets_to_remove.append(fleet)
@@ -501,14 +515,6 @@ def interpreter(state, env):
         if point_to_segment_distance((CENTER, CENTER), old_pos, new_pos) < SUN_RADIUS:
             fleets_to_remove.append(fleet)
             continue
-
-        # Check if fleet path intersected any planet (continuous collision)
-        for planet in obs0.planets:
-            planet_pos = (planet[2], planet[3])
-            if point_to_segment_distance(planet_pos, old_pos, new_pos) < planet[4]:
-                combat_lists[planet[0]].append(fleet)
-                fleets_to_remove.append(fleet)
-                break
 
     # 3. Planet Movement & Sweep
     angular_velocity = obs0.angular_velocity

--- a/kaggle_environments/envs/orbit_wars/test_orbit_wars.py
+++ b/kaggle_environments/envs/orbit_wars/test_orbit_wars.py
@@ -470,6 +470,48 @@ class TestOrbitWars(unittest.TestCase):
         remaining = new_state[0].observation.fleets
         self.assertEqual(len(remaining), 1)
 
+    def test_fast_fleet_hits_planet_before_leaving_board(self):
+        # A fast fleet whose move ends out-of-bounds should still resolve
+        # combat at any planet its segment crosses on the way out.
+        # Planet at (98, 50) radius 2 sits beyond r=50 from center so it
+        # does not rotate (r + radius = 50, not < ROTATION_RADIUS_LIMIT).
+        # Fleet has 1000 ships -> max speed 6. It moves from x=95 to x=101
+        # (out of bounds) but its segment passes through the planet.
+        planets = [[0, 1, 98.0, 50.0, 2.0, 50, 1]]
+        fleets = [[0, 0, 95.0, 50.0, 0.0, 99, 1000]]
+        state = self._make_state(planets, fleets)
+        env = SimpleNamespace(
+            configuration=SimpleNamespace(shipSpeed=6, episodeSteps=500, cometSpeed=4),
+            done=False,
+        )
+
+        new_state = interpreter(state, env)
+        p = new_state[0].observation.planets[0]
+        # Combat should have resolved: attacker (1000) vs garrison (50+1 prod = 51)
+        self.assertEqual(p[1], 0)
+        self.assertEqual(p[5], 1000 - 51)
+        self.assertEqual(len(new_state[0].observation.fleets), 0)
+
+    def test_fast_fleet_hits_planet_before_sun(self):
+        # A fast fleet whose segment crosses both a planet and the sun
+        # should resolve combat at the planet rather than be silently
+        # consumed by the sun.
+        planets = [[0, 1, 62.0, 50.0, 2.0, 50, 1]]
+        fleets = [[0, 0, 65.0, 50.0, math.pi, 99, 1000]]
+        state = self._make_state(planets, fleets)
+        # Disable rotation to keep the planet fixed for this geometry test.
+        state[0].observation.angular_velocity = 0.0
+        env = SimpleNamespace(
+            configuration=SimpleNamespace(shipSpeed=6, episodeSteps=500, cometSpeed=4),
+            done=False,
+        )
+
+        new_state = interpreter(state, env)
+        p = new_state[0].observation.planets[0]
+        self.assertEqual(p[1], 0)
+        self.assertEqual(p[5], 1000 - 51)
+        self.assertEqual(len(new_state[0].observation.fleets), 0)
+
     def test_combat_simple_capture(self):
         # Fleet of 30 attacks neutral planet with 10 ships
         # Attacker wins with 30-10=20 ships remaining, captures planet


### PR DESCRIPTION
Fast fleets can move far enough in one step to overshoot the board edge or cross the sun while their segment also passes through a planet. Previously the bounds and sun checks ran first, so the fleet was silently removed without resolving combat at the planet. Reorder the checks so planet collision is tested first.