### PR TITLE
Orbit Wars: allow null seed in schema so scrubbed config re-validates

### DIFF
--- a/kaggle_environments/envs/orbit_wars/orbit_wars.json
+++ b/kaggle_environments/envs/orbit_wars/orbit_wars.json
@@ -24,8 +24,8 @@
       "default": 4.0
     },
     "seed": {
-      "description": "Optional input seed for deterministic planet/comet generation. The interpreter clears this from configuration after reading and stores the resolved seed on env.info['seed'] so it stays out of agent observations but is still recorded in the replay.",
-      "type": "integer",
+      "description": "Optional input seed for deterministic planet/comet generation. The interpreter clears this from configuration after reading and stores the resolved seed on env.info['seed'] so it stays out of agent observations but is still recorded in the replay. Type allows null because the interpreter scrubs the value to null after reading, and the agent server re-validates the (scrubbed) configuration on every act() call.",
+      "type": ["integer", "null"],
       "default": null
     }
   },

--- a/kaggle_environments/envs/orbit_wars/test_orbit_wars.py
+++ b/kaggle_environments/envs/orbit_wars/test_orbit_wars.py
@@ -718,6 +718,22 @@ class TestOrbitWars(unittest.TestCase):
             self.assertIsNone(s, msg=f"agent saw generated seed={s}")
         self.assertIsNotNone(env.info.get("seed"))
 
+    def test_scrubbed_config_passes_remote_agent_make(self):
+        # On the agent server, action_act re-invokes make() with the config
+        # the local env sent over. After scrub that config has seed=null, so
+        # the schema must allow null — otherwise make() raises InvalidArgument
+        # and the agent server returns an error response with no "action" key,
+        # surfacing as KeyError: 'action' in the local UrlAgent wrapper.
+        from kaggle_environments import make
+
+        # Simulate a config that has already been scrubbed by the interpreter.
+        env = make(
+            "orbit_wars",
+            configuration={"seed": None, "episodeSteps": 60},
+            debug=True,
+        )
+        self.assertIsNone(env.configuration.get("seed"))
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
After PR #1020 the interpreter sets `configuration.seed = None` to hide the seed from agents. But the remote agent server calls `make()` on every `act()`, which re-validates configuration against the schema. The schema required `type=integer`, so the scrubbed null failed validation and the agent server returned an error response with no `"action"` key, surfacing locally as `KeyError: 'action'` in `UrlAgent`.