### PR TITLE
Crawl: tune unit carry capacity and fix randomSeed schema

### DIFF
--- a/kaggle_environments/envs/crawl/README.md
+++ b/kaggle_environments/envs/crawl/README.md
@@ -13,9 +13,9 @@ The maze has **east/west symmetry**: the left half mirrors the right half, with 
 | Type | Cost | Max Energy | Move Period | Vision | Special Abilities |
 |------|------|------------|-------------|--------|-------------------|
 | **Factory** | — | unlimited | 2 turns | 4 | BUILD, JUMP (20-turn CD), indestructible |
-| **Scout** | 50 | 50 | 1 turn | 5 | Fast explorer |
-| **Worker** | 200 | 200 | 2 turns | 3 | BUILD_DIR / REMOVE_DIR walls (100 energy) |
-| **Miner** | 300 | 300 | 2 turns | 3 | TRANSFORM into energy mine (requires mining node) |
+| **Scout** | 50 | 100 | 1 turn | 5 | Fast explorer |
+| **Worker** | 200 | 300 | 2 turns | 3 | BUILD_DIR / REMOVE_DIR walls (100 energy) |
+| **Miner** | 300 | 500 | 2 turns | 3 | TRANSFORM into energy mine (requires mining node) |
 
 All robots consume 1 energy per turn. Robots with 0 energy are forced idle.
 
@@ -179,9 +179,12 @@ env.render(mode="ipython", width=800, height=800)
 | `width` | 20 | Maze width |
 | `height` | 20 | Visible window height |
 | `factoryEnergy` | 1000 | Starting factory energy |
-| `scoutCost` | 50 | Energy to build scout |
-| `workerCost` | 200 | Energy to build worker |
-| `minerCost` | 300 | Energy to build miner |
+| `scoutCost` | 50 | Energy to build scout (also the energy a freshly-built scout spawns with) |
+| `workerCost` | 200 | Energy to build worker (also the energy a freshly-built worker spawns with) |
+| `minerCost` | 300 | Energy to build miner (also the energy a freshly-built miner spawns with) |
+| `scoutMaxEnergy` | 100 | Max energy a scout can carry |
+| `workerMaxEnergy` | 300 | Max energy a worker can carry |
+| `minerMaxEnergy` | 500 | Max energy a miner can carry |
 | `wallBuildCost` | 100 | Energy per worker BUILD_DIR (charged even on no-op) |
 | `wallRemoveCost` | 100 | Energy per worker REMOVE_DIR (charged even on no-op) |
 | `transformCost` | 100 | Energy for miner transform |

--- a/kaggle_environments/envs/crawl/crawl.json
+++ b/kaggle_environments/envs/crawl/crawl.json
@@ -24,8 +24,8 @@
       "minimum": 10
     },
     "randomSeed": {
-      "description": "Optional input seed for deterministic maze generation. The interpreter clears this from configuration after reading and stores the resolved seed on env.info['seed'] so it stays out of agent observations but is still recorded in the replay.",
-      "type": "integer",
+      "description": "Optional input seed for deterministic maze generation. The interpreter clears this from configuration after reading and stores the resolved seed on env.info['seed'] so it stays out of agent observations but is still recorded in the replay. Type allows null because the interpreter scrubs the value to null after reading, and the agent server re-validates the (scrubbed) configuration on every act() call.",
+      "type": ["integer", "null"],
       "default": null
     },
     "factoryEnergy": {
@@ -55,19 +55,19 @@
     "scoutMaxEnergy": {
       "description": "Maximum energy a scout can carry.",
       "type": "integer",
-      "default": 50,
+      "default": 100,
       "minimum": 1
     },
     "workerMaxEnergy": {
       "description": "Maximum energy a worker can carry.",
       "type": "integer",
-      "default": 200,
+      "default": 300,
       "minimum": 1
     },
     "minerMaxEnergy": {
       "description": "Maximum energy a miner can carry.",
       "type": "integer",
-      "default": 300,
+      "default": 500,
       "minimum": 1
     },
     "wallBuildCost": {

--- a/kaggle_environments/envs/crawl/crawl.py
+++ b/kaggle_environments/envs/crawl/crawl.py
@@ -689,15 +689,15 @@ def interpreter(state, env):
         if action == "BUILD_SCOUT":
             cost = config.scoutCost
             new_type = SCOUT
-            new_energy = config.scoutMaxEnergy
+            new_energy = config.scoutCost
         elif action == "BUILD_WORKER":
             cost = config.workerCost
             new_type = WORKER
-            new_energy = config.workerMaxEnergy
+            new_energy = config.workerCost
         elif action == "BUILD_MINER":
             cost = config.minerCost
             new_type = MINER
-            new_energy = config.minerMaxEnergy
+            new_energy = config.minerCost
         else:
             continue
 


### PR DESCRIPTION
- Raise max-energy caps so units have headroom to absorb crystals when near full (scout 50→100, worker 200→300, miner 300→500).
- Spawn freshly-built units at their build cost rather than max, so the extra capacity is room to grow into rather than free starting energy.
- Allow null in randomSeed schema so the agent server's re-validation of the scrubbed config doesn't fail on each act() call (mirrors the fix applied to orbit_wars in #1024).