### PR TITLE
Connect Four: declare winner when loser's response is cut off

### DIFF
--- a/kaggle_environments/envs/open_spiel_env/games/connect_four/visualizer/default/src/renderer.ts
+++ b/kaggle_environments/envs/open_spiel_env/games/connect_four/visualizer/default/src/renderer.ts
@@ -392,6 +392,7 @@ export function renderer({ parent, step, replay }: ConnectFourOptions) {
     // Open Spiel format: winner info is in finalStep.winner or finalStep.boardState.winner
     const boardWinner = finalStep.boardState?.winner; // 'x', 'o', or undefined/null for draw
     const winnerText = finalStep.winner; // e.g., "O (Player Name) Wins!" or "Draw"
+    const forfeitReason = finalStep.forfeitReason; // Set when loser failed to submit valid action
 
     if (boardWinner === 'x') {
       tokenUrl = getTokenAsDataURL(1);
@@ -403,6 +404,9 @@ export function renderer({ parent, step, replay }: ConnectFourOptions) {
       message = winnerText || 'Draw';
     }
 
-    statusBar.innerHTML = `${tokenUrl ? `<img src="${tokenUrl}" class="token" />` : ''}<span>${message}</span>`;
+    const escapeHtml = (s: string) =>
+      s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
+    const forfeitHtml = forfeitReason ? `<div class="forfeit-reason">${escapeHtml(forfeitReason)}</div>` : '';
+    statusBar.innerHTML = `<div class="status-line">${tokenUrl ? `<img src="${tokenUrl}" class="token" />` : ''}<span>${escapeHtml(message)}</span></div>${forfeitHtml}`;
   }
 }

--- a/kaggle_environments/envs/open_spiel_env/games/connect_four/visualizer/default/src/style.css
+++ b/kaggle_environments/envs/open_spiel_env/games/connect_four/visualizer/default/src/style.css
@@ -26,6 +26,7 @@ html, body, #app {
 
 .status-bar {
   display: flex;
+  flex-direction: column;
   align-items: center;
   justify-content: center;
   padding: 8px;
@@ -35,12 +36,28 @@ html, body, #app {
   font-weight: 500;
   min-height: 18px;
   flex-shrink: 0;
+  gap: 4px;
+}
+
+.status-bar .status-line {
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
 
 .status-bar .token {
   width: 20px;
   height: 20px;
   margin-right: 8px;
+}
+
+.status-bar .forfeit-reason {
+  font-weight: 400;
+  font-size: 12px;
+  opacity: 0.8;
+  font-style: italic;
+  text-align: center;
+  max-width: 600px;
 }
 
 .player-legend {

--- a/kaggle_environments/envs/open_spiel_env/games/connect_four/visualizer/default/src/transformers/connectFourReplayTypes.ts
+++ b/kaggle_environments/envs/open_spiel_env/games/connect_four/visualizer/default/src/transformers/connectFourReplayTypes.ts
@@ -20,6 +20,8 @@ export interface ConnectFourStep extends Omit<BaseGameStep, 'players'> {
   boardState: ConnectFourBoardState;
   isTerminal: boolean;
   winner: string | null;
+  /** Set when the loser failed to produce a valid action (e.g. response cut off). */
+  forfeitReason?: string | null;
 }
 
 /**

--- a/kaggle_environments/envs/open_spiel_env/games/connect_four/visualizer/default/src/transformers/connectFourTransformer.ts
+++ b/kaggle_environments/envs/open_spiel_env/games/connect_four/visualizer/default/src/transformers/connectFourTransformer.ts
@@ -46,17 +46,20 @@ export function getConnectFourStepDescription(step: ConnectFourStep) {
   return step.players.find((player) => player.isTurn)?.thoughts ?? '';
 }
 
-export function deriveWinnerFromRewards(players: ConnectFourPlayer[], teamNames: string[]) {
-  if (players.length < 2) return '';
+export function deriveWinnerFromRewards(rewards: (number | null | undefined)[], teamNames: string[]) {
+  if (rewards.length < 2) return '';
 
-  const player0Reward = players[0].reward;
-  const player1Reward = players[1].reward;
+  const player0Reward = rewards[0] ?? null;
+  const player1Reward = rewards[1] ?? null;
 
   if (player0Reward === player1Reward) {
     return 'Draw';
   }
 
-  const winnerPlayerIndex = player0Reward === 1 ? 0 : 1;
+  // Higher reward wins (handles null vs -1, 1 vs -1, etc.)
+  const r0 = player0Reward ?? -Infinity;
+  const r1 = player1Reward ?? -Infinity;
+  const winnerPlayerIndex = r0 > r1 ? 0 : 1;
   const piece = winnerPlayerIndex === 0 ? 'X' : 'O';
   const name = teamNames[winnerPlayerIndex] || `Player ${winnerPlayerIndex + 1}`;
 
@@ -77,6 +80,7 @@ export const connectFourTransformer = (environment: any) => {
     boardState: parseBoardState(stateHistory[0]), // Initial empty board
     isTerminal: false,
     winner: null,
+    forfeitReason: null,
   });
 
   // Track actual moves to properly index into stateHistory
@@ -117,16 +121,53 @@ export const connectFourTransformer = (environment: any) => {
       boardState,
       isTerminal: false,
       winner: null,
+      forfeitReason: null,
     });
   });
+
+  // The original replay's last step holds the terminal rewards (e.g. [1, -1])
+  // even when the losing agent's response was cut off and never produced a
+  // valid move. Using these instead of the last in-game step's rewards
+  // (which are typically null mid-play) ensures we still declare a winner
+  // when an agent errors out instead of falling back to "Draw".
+  const lastReplayStep = connectFourReplay.steps[connectFourReplay.steps.length - 1] ?? [];
+  const terminalRewards = lastReplayStep.map((p) => p.reward);
+  const finalBoardState = { ...connectFourSteps[moveCount].boardState };
+  if (!finalBoardState.winner && terminalRewards.length >= 2) {
+    const r0 = terminalRewards[0] ?? null;
+    const r1 = terminalRewards[1] ?? null;
+    if (r0 !== r1) {
+      finalBoardState.winner = (r0 ?? -Infinity) > (r1 ?? -Infinity) ? 'x' : 'o';
+    }
+  }
+
+  // If rewards indicate a winner but the on-board game state never reached
+  // a real "in-a-row" win, the loser must have forfeited (e.g. response cut
+  // off / unparsable submission). Surface that explicitly so the UI doesn't
+  // imply a normal win.
+  let forfeitReason: string | null = null;
+  if (terminalRewards.length >= 2) {
+    const r0 = terminalRewards[0] ?? null;
+    const r1 = terminalRewards[1] ?? null;
+    const gameWonOnBoard =
+      connectFourSteps[moveCount].boardState.winner === 'x' || connectFourSteps[moveCount].boardState.winner === 'o';
+    if (r0 !== r1 && !gameWonOnBoard) {
+      const loserIndex = (r0 ?? -Infinity) < (r1 ?? -Infinity) ? 0 : 1;
+      const winnerIndex = 1 - loserIndex;
+      const loserName = agents[loserIndex] || `Player ${loserIndex + 1}`;
+      const winnerName = agents[winnerIndex] || `Player ${winnerIndex + 1}`;
+      forfeitReason = `${loserName} failed to produce valid input. ${winnerName} wins by default.`;
+    }
+  }
 
   // Artificially insert a step at the end to emphasize the win state
   connectFourSteps.push({
     step: moveCount,
     players: [],
-    boardState: connectFourSteps[moveCount].boardState,
+    boardState: finalBoardState,
     isTerminal: true,
-    winner: deriveWinnerFromRewards(connectFourSteps[moveCount].players, agents),
+    winner: deriveWinnerFromRewards(terminalRewards, agents),
+    forfeitReason,
   });
 
   return connectFourSteps;


### PR DESCRIPTION
## Summary
- When a model's response is truncated and produces no parsable move, the OpenSpiel Connect Four visualizer was reading rewards from the last in-game step (where rewards are still `null` mid-play) and falling back to "Draw" — even though the surviving agent clearly won.
- Read the terminal rewards from the actual final replay step instead, so the winning agent is declared correctly.
- Add a forfeit note in the status bar (e.g. *"Claude Sonnet 4.6 failed to produce valid input. Claude Opus 4.7 wins by default."*) so the result reads as decided-by-error rather than a normal in-a-row win. The note only appears when rewards diverge but no on-board win was reached.

## Test plan
- [ ] Load an episode where one agent's response gets cut off (e.g. Kaggle episode 75229979) — status bar shows the winner with the forfeit note instead of "Draw".
- [ ] Load a normally-finished game — status bar shows the winner with no forfeit note.
- [ ] Load an actual draw — status bar shows "Draw" with no forfeit note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)