### PR TITLE
Crawl: visualizer polish + serve built viewer for HTML mode

### DIFF
--- a/kaggle_environments/envs/crawl/crawl.js
+++ b/kaggle_environments/envs/crawl/crawl.js
@@ -40,8 +40,8 @@ async function renderer(context) {
   var WORKER = 2;
   var MINER = 3;
 
-  var PLAYER_COLORS = ['#42A5F5', '#EF5350'];
-  var PLAYER_COLORS_LIGHT = ['rgba(66,165,245,0.25)', 'rgba(239,83,80,0.25)'];
+  var PLAYER_COLORS = ['#2196F3', '#F44336'];
+  var PLAYER_COLORS_LIGHT = ['rgba(33,150,243,0.2)', 'rgba(244,67,54,0.2)'];
   var TYPE_LABELS = { 0: 'F', 1: 'S', 2: 'W', 3: 'M' };
 
   var currentStep = environment.steps[step];

--- a/kaggle_environments/envs/crawl/crawl.py
+++ b/kaggle_environments/envs/crawl/crawl.py
@@ -1174,9 +1174,21 @@ with open(json_path) as json_file:
     specification = json.load(json_file)
 
 
-def html_renderer():
-    js_path = path.join(dir_path, "crawl.js")
-    if path.exists(js_path):
-        with open(js_path, encoding="utf-8") as f:
+def html_renderer(env, mode):
+    # In ipython/notebook mode, use the lightweight single-file JS renderer
+    if mode == "ipython":
+        js_path = path.abspath(path.join(dir_path, "crawl.js"))
+        if path.exists(js_path):
+            with open(js_path, encoding="utf-8") as js_file:
+                return js_file.read()
+    # Default: use the full Vite-built visualizer
+    jspath = path.join(dir_path, "visualizer", "default", "dist", "index.html")
+    if path.exists(jspath):
+        with open(jspath, encoding="utf-8") as f:
             return f.read()
+    # Fallback to single-file JS renderer
+    js_path = path.abspath(path.join(dir_path, "crawl.js"))
+    if path.exists(js_path):
+        with open(js_path, encoding="utf-8") as js_file:
+            return js_file.read()
     return ""

--- a/kaggle_environments/envs/crawl/visualizer/default/src/renderer.ts
+++ b/kaggle_environments/envs/crawl/visualizer/default/src/renderer.ts
@@ -177,6 +177,25 @@ function drawRobot(c: CanvasRenderingContext2D, x: number, y: number, size: numb
   c.fillRect(barX, barY, barW * pct, barH);
 }
 
+function drawMiningNode(c: CanvasRenderingContext2D, x: number, y: number, size: number) {
+  const cx = x + size / 2;
+  const cy = y + size / 2;
+  const r = size * 0.22;
+
+  // Dashed triangle outline, no fill, neutral color — signals an unclaimed
+  // mining node that a worker could transform into a mine.
+  c.strokeStyle = '#5a5a5a';
+  c.lineWidth = 1.25;
+  c.setLineDash([3, 2]);
+  c.beginPath();
+  c.moveTo(cx, cy - r);
+  c.lineTo(cx + r, cy + r * 0.7);
+  c.lineTo(cx - r, cy + r * 0.7);
+  c.closePath();
+  c.stroke();
+  c.setLineDash([]);
+}
+
 function drawMine(c: CanvasRenderingContext2D, x: number, y: number, size: number, mine: MineData) {
   const cx = x + size / 2;
   const cy = y + size / 2;
@@ -212,12 +231,29 @@ function drawMine(c: CanvasRenderingContext2D, x: number, y: number, size: numbe
 function drawCrystal(c: CanvasRenderingContext2D, x: number, y: number, size: number, energy: number) {
   const cx = x + size / 2;
   const cy = y + size / 2;
-  const r = size * 0.18;
+  const r = size * 0.34;
 
-  // Glowing crystal shape
+  // Sun rays radiating outward
+  c.strokeStyle = 'rgba(218, 165, 32, 0.7)';
+  c.lineWidth = 1.25;
+  const rayInner = r * 1.1;
+  const rayOuter = r * 1.55;
+  for (let i = 0; i < 8; i++) {
+    const ang = (Math.PI / 4) * i;
+    const ix = cx + Math.cos(ang) * rayInner;
+    const iy = cy + Math.sin(ang) * rayInner;
+    const ox = cx + Math.cos(ang) * rayOuter;
+    const oy = cy + Math.sin(ang) * rayOuter;
+    c.beginPath();
+    c.moveTo(ix, iy);
+    c.lineTo(ox, oy);
+    c.stroke();
+  }
+
+  // Crystal shape
   c.fillStyle = 'rgba(255, 215, 0, 0.6)';
   c.strokeStyle = '#DAA520';
-  c.lineWidth = 1;
+  c.lineWidth = 1.25;
   c.beginPath();
   c.moveTo(cx, cy - r * 1.2);
   c.lineTo(cx + r, cy);
@@ -227,17 +263,29 @@ function drawCrystal(c: CanvasRenderingContext2D, x: number, y: number, size: nu
   c.fill();
   c.stroke();
 
-  // Energy value
-  if (size > 16) {
-    c.fillStyle = '#8B6914';
-    c.font = `${Math.max(7, size * 0.22)}px Inter, sans-serif`;
+  // Energy value, centered, dark for legibility
+  if (size > 14) {
+    c.fillStyle = '#050001';
+    c.font = `bold ${Math.max(8, size * 0.28)}px Inter, sans-serif`;
     c.textAlign = 'center';
     c.textBaseline = 'middle';
-    c.fillText(`${energy}`, cx, cy + r * 1.5);
+    c.fillText(`${energy}`, cx, cy);
   }
 }
 
+// Persistent UI state across step changes. The renderer is invoked anew on
+// every step, so we keep the selected fog-of-war view at module scope.
+type ViewMode = 'all' | 'p0' | 'p1';
+let viewMode: ViewMode = 'all';
+let lastOptions: CrawlOptions | null = null;
+
+(window as any).__crawlSetView = (mode: ViewMode) => {
+  viewMode = mode;
+  if (lastOptions) renderer(lastOptions);
+};
+
 export function renderer(options: CrawlOptions) {
+  lastOptions = options;
   const { step, replay, parent, agents } = options;
   const steps = replay.steps;
 
@@ -263,11 +311,59 @@ export function renderer(options: CrawlOptions) {
   const northBound: number = obs.northBound ?? 29;
   const windowHeight = northBound - southBound + 1;
 
-  // Parse global state from replay
+  // Pick per-view observations. In 'all' mode we use the omniscient global
+  // state; in 'p0'/'p1' mode we use that player's restricted observation
+  // (visible robots/crystals/mines/nodes + a per-cell wall list where -1
+  // means "never explored").
+  const playerObs = viewMode === 'p1' ? currentStep[1]?.observation : obs;
+  const fogged = viewMode !== 'all' && playerObs;
+
+  // Walls: omniscient version always available; player wall list is per-cell.
   const globalWalls: Record<string, number[]> = obs.globalWalls ?? {};
+  const playerWallsFlat: number[] = fogged ? (playerObs.walls ?? []) : [];
+
+  // Per-player currently-visible wall lists, used for the "All" view overlay
+  // that tints each cell by which player(s) can currently see it.
+  const p0WallsFlat: number[] = currentStep[0]?.observation?.walls ?? [];
+  const p1WallsFlat: number[] = currentStep[1]?.observation?.walls ?? [];
+
   const globalCrystals: Record<string, number> = obs.globalCrystals ?? {};
-  const robots = parseRobots(obs.globalRobots);
-  const mines = parseMines(obs.globalMines);
+  const globalMiningNodes: Record<string, number> = obs.globalMiningNodes ?? {};
+  const robots = parseRobots(fogged ? playerObs.robots : obs.globalRobots);
+  const mines = parseMines(fogged ? playerObs.mines : obs.globalMines);
+
+  // Per-view collections used below for drawing.
+  const drawCrystals: Record<string, number> = fogged ? (playerObs.crystals ?? {}) : globalCrystals;
+  const drawMiningNodes: Record<string, number> = fogged ? (playerObs.miningNodes ?? {}) : globalMiningNodes;
+
+  // Discovered cells (set of "col,row" strings) — only meaningful in fogged mode.
+  const discoveredSet = new Set<string>();
+  if (fogged) {
+    const playerIdx = viewMode === 'p1' ? 1 : 0;
+    // discoveredCells lives on player 0's observation as [p0_cells, p1_cells]
+    const allDiscovered = obs.discoveredCells;
+    const myCells = Array.isArray(allDiscovered) ? allDiscovered[playerIdx] : null;
+    if (Array.isArray(myCells)) {
+      for (const cell of myCells) {
+        if (Array.isArray(cell) && cell.length >= 2) {
+          discoveredSet.add(`${cell[0]},${cell[1]}`);
+        }
+      }
+    }
+  }
+
+  // Helper: is a cell in the player's currently-visible (lit) area?
+  // We treat "wall list != -1 for that cell" as currently visible.
+  const isLit = (col: number, row: number): boolean => {
+    if (!fogged) return true;
+    if (row < southBound || row > northBound) return false;
+    const idx = (row - southBound) * width + col;
+    return playerWallsFlat[idx] !== undefined && playerWallsFlat[idx] !== -1;
+  };
+  const isDiscovered = (col: number, row: number): boolean => {
+    if (!fogged) return true;
+    return isLit(col, row) || discoveredSet.has(`${col},${row}`);
+  };
 
   // Compute energy totals for each player
   const totalEnergy = [0, 0];
@@ -290,6 +386,10 @@ export function renderer(options: CrawlOptions) {
   };
   const isGameOver = currentStep.every((s) => s.status === 'DONE');
 
+  const viewBtn = (mode: ViewMode, label: string) => `
+    <button onclick="window.__crawlSetView('${mode}')" class="view-btn ${viewMode === mode ? 'active' : ''}">${label}</button>
+  `;
+
   header.innerHTML = `
     <div class="player-card ${!isGameOver ? 'active' : ''}" style="border-left: 3px solid ${PLAYER_COLORS[0]}">
       <span>${getName(0)}</span>
@@ -299,6 +399,12 @@ export function renderer(options: CrawlOptions) {
     <div class="player-card ${!isGameOver ? 'active' : ''}" style="border-left: 3px solid ${PLAYER_COLORS[1]}">
       <span>${getName(1)}</span>
       <span class="energy">E: ${totalEnergy[1]} | F:${robotCounts[1].factory} S:${robotCounts[1].scout} W:${robotCounts[1].worker} M:${robotCounts[1].miner}</span>
+    </div>
+    <div class="view-toggle">
+      <span style="font-size: 0.75rem; color: #444343;">View:</span>
+      ${viewBtn('all', 'All')}
+      ${viewBtn('p0', 'P1')}
+      ${viewBtn('p1', 'P2')}
     </div>
   `;
 
@@ -344,10 +450,46 @@ export function renderer(options: CrawlOptions) {
 
     for (let col = 0; col < width; col++) {
       const { x, y } = cellToCanvas(col, row);
-      const w = rowWalls ? rowWalls[col] : 0;
+      let w = rowWalls ? rowWalls[col] : 0;
 
-      // Cell background - subtle grid
-      c.fillStyle = 'rgba(255, 255, 255, 0.15)';
+      const lit = isLit(col, row);
+      const discovered = isDiscovered(col, row);
+
+      // In fogged mode, hide walls in cells the player has never seen, and
+      // tint the cell to convey unexplored / remembered / lit state.
+      if (fogged) {
+        if (!discovered) {
+          // Unexplored: don't draw cell background or any walls — fully dark.
+          c.fillStyle = 'rgba(40, 36, 28, 0.55)';
+          c.fillRect(x, y, cellSize, cellSize);
+          continue;
+        }
+        // For wall data in fogged mode, prefer the player's per-cell wall list
+        // if the cell is currently lit. Cells that are remembered (discovered
+        // but not lit) reuse the global wall data we still need to know which
+        // walls exist there — that's a small fairness compromise for clarity.
+        if (lit) {
+          const idx = (row - southBound) * width + col;
+          const pw = playerWallsFlat[idx];
+          if (typeof pw === 'number' && pw >= 0) w = pw;
+        }
+        c.fillStyle = lit ? 'rgba(255, 255, 255, 0.15)' : 'rgba(40, 36, 28, 0.18)';
+      } else {
+        // All view: tint each cell by which player(s) currently see it, so
+        // you can see fog-of-war coverage at a glance without switching views.
+        const idx = (row - southBound) * width + col;
+        const p0Sees = p0WallsFlat[idx] !== undefined && p0WallsFlat[idx] !== -1;
+        const p1Sees = p1WallsFlat[idx] !== undefined && p1WallsFlat[idx] !== -1;
+        if (p0Sees && p1Sees) {
+          c.fillStyle = 'rgba(160, 90, 200, 0.18)'; // both — purple blend
+        } else if (p0Sees) {
+          c.fillStyle = 'rgba(33, 150, 243, 0.18)'; // p0 — blue
+        } else if (p1Sees) {
+          c.fillStyle = 'rgba(244, 67, 54, 0.18)'; // p1 — red
+        } else {
+          c.fillStyle = 'rgba(255, 255, 255, 0.15)'; // unseen by either — neutral
+        }
+      }
       c.fillRect(x + 0.5, y + 0.5, cellSize - 1, cellSize - 1);
 
       // Draw walls. Fixed walls (perimeter + middle axis) draw as double
@@ -390,6 +532,29 @@ export function renderer(options: CrawlOptions) {
     }
   }
 
+  // Eastern + western perimeters: always draw as two clearly-spaced parallel
+  // lines so it's obvious workers cannot remove them. We push both strokes
+  // inward (the maze can sit flush against the canvas edge), so the outer
+  // line at the literal edge isn't half-clipped.
+  c.strokeStyle = '#3c3b37';
+  c.lineWidth = 2;
+  const perimInner = 1;
+  const perimGap = 5;
+  // Left perimeter
+  c.beginPath();
+  c.moveTo(offsetX + perimInner, offsetY);
+  c.lineTo(offsetX + perimInner, offsetY + gridH);
+  c.moveTo(offsetX + perimInner + perimGap, offsetY);
+  c.lineTo(offsetX + perimInner + perimGap, offsetY + gridH);
+  c.stroke();
+  // Right perimeter
+  c.beginPath();
+  c.moveTo(offsetX + gridW - perimInner, offsetY);
+  c.lineTo(offsetX + gridW - perimInner, offsetY + gridH);
+  c.moveTo(offsetX + gridW - perimInner - perimGap, offsetY);
+  c.lineTo(offsetX + gridW - perimInner - perimGap, offsetY + gridH);
+  c.stroke();
+
   // Draw center divider line (dashed, subtle)
   const half = width / 2;
   c.strokeStyle = 'rgba(60, 59, 55, 0.3)';
@@ -403,13 +568,23 @@ export function renderer(options: CrawlOptions) {
   c.setLineDash([]);
 
   // Draw crystals
-  for (const [key, energy] of Object.entries(globalCrystals)) {
+  for (const [key, energy] of Object.entries(drawCrystals)) {
     const [colStr, rowStr] = key.split(',');
     const col = parseInt(colStr);
     const row = parseInt(rowStr);
     if (row < southBound || row > northBound) continue;
     const { x, y } = cellToCanvas(col, row);
     drawCrystal(c, x, y, cellSize, energy);
+  }
+
+  // Draw mining nodes (unbuilt spots where a worker could create a mine)
+  for (const key of Object.keys(drawMiningNodes)) {
+    const [colStr, rowStr] = key.split(',');
+    const col = parseInt(colStr);
+    const row = parseInt(rowStr);
+    if (row < southBound || row > northBound) continue;
+    const { x, y } = cellToCanvas(col, row);
+    drawMiningNode(c, x, y, cellSize);
   }
 
   // Draw mines
@@ -463,6 +638,22 @@ export function renderer(options: CrawlOptions) {
   const scrollInfo = `Scroll: ${southBound}-${northBound}`;
   const mineCount = mines.size;
 
+  // Inline crystal SVG used in the scoreboard in place of the word "Crystals"
+  const crystalSvg = `
+    <svg viewBox="-12 -12 24 24" width="14" height="14" style="vertical-align: -2px;" aria-label="crystals">
+      <g stroke="rgba(218,165,32,0.9)" stroke-width="1.25" stroke-linecap="round">
+        <line x1="0" y1="-9" x2="0" y2="-12"/>
+        <line x1="0" y1="9" x2="0" y2="12"/>
+        <line x1="-9" y1="0" x2="-12" y2="0"/>
+        <line x1="9" y1="0" x2="12" y2="0"/>
+        <line x1="-6.4" y1="-6.4" x2="-8.5" y2="-8.5"/>
+        <line x1="6.4" y1="-6.4" x2="8.5" y2="-8.5"/>
+        <line x1="-6.4" y1="6.4" x2="-8.5" y2="8.5"/>
+        <line x1="6.4" y1="6.4" x2="8.5" y2="8.5"/>
+      </g>
+      <polygon points="0,-8 7,0 0,5 -7,0" fill="rgba(255,215,0,0.7)" stroke="#DAA520" stroke-width="1.25"/>
+    </svg>`;
+
   if (isGameOver) {
     const r0 = currentStep[0].reward;
     const r1 = currentStep[1].reward;
@@ -477,11 +668,16 @@ export function renderer(options: CrawlOptions) {
       <span class="status-item">${scrollInfo}</span>
     `;
   } else {
+    const visibleNodes = Object.keys(globalMiningNodes).filter((k) => {
+      const r = parseInt(k.split(',')[1]);
+      return r >= southBound && r <= northBound;
+    }).length;
     statusContainer.innerHTML = `
       <span class="status-item">Step <strong>${currentStepNum}</strong></span>
       <span class="status-item">${scrollInfo}</span>
       <span class="status-item">Mines: <strong>${mineCount}</strong></span>
-      <span class="status-item">Crystals: <strong>${Object.keys(globalCrystals).length}</strong></span>
+      <span class="status-item">Nodes: <strong>${visibleNodes}</strong></span>
+      <span class="status-item">${crystalSvg} <strong>${Object.keys(globalCrystals).length}</strong></span>
     `;
   }
 }

--- a/kaggle_environments/envs/crawl/visualizer/default/src/style.css
+++ b/kaggle_environments/envs/crawl/visualizer/default/src/style.css
@@ -8,6 +8,30 @@ html, body, #app {
   overflow: hidden;
 }
 
+html, body {
+  background-color: #f5f1e2 !important;
+}
+
+/* EpisodePlayer wrapper (.player) and its inline-controls strip use MUI's
+   dark `paper` color by default. Repaint them as parchment so the page
+   matches the renderer's sketched-paper feel. */
+.player,
+.player > div,
+.player > div > div:last-child,
+.player > div > div:last-child > div {
+  background-color: #f5f1e2 !important;
+}
+
+.player select {
+  background-color: #f1f1f1 !important;
+  color: #050001 !important;
+  border: 1px dashed #3c3b37 !important;
+}
+
+.player button {
+  color: #050001 !important;
+}
+
 .renderer-container {
   display: flex;
   flex-direction: column;
@@ -96,4 +120,27 @@ html, body, #app {
 .status-container .status-item strong {
   color: #050001;
   font-weight: 600;
+}
+
+.view-toggle {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  margin-left: 12px;
+}
+
+.view-btn {
+  font-family: 'Inter', sans-serif;
+  font-size: 0.75rem;
+  font-weight: 600;
+  padding: 2px 8px;
+  background-color: #f1f1f1;
+  border: 1px dashed #3c3b37;
+  color: #050001;
+  cursor: pointer;
+}
+
+.view-btn.active {
+  background-color: #bdeeff;
+  box-shadow: -0.125rem 0.125rem 0 #000;
 }


### PR DESCRIPTION
- renderer.ts: parchment background, double-thick perimeter walls, bigger crystals with sun rays + centered energy, dashed mining-node triangles, per-player fog-of-war view toggle (All/P1/P2), fog tint on All view, inline crystal SVG in scoreboard
- style.css: parchment overrides for player chrome, view-toggle styles
- crawl.js: align standalone viewer colors with default
- crawl.py: html_renderer(env, mode) — serve Vite dist for html mode, standalone .js for ipython/notebook mode (mirrors orbit_wars)