### PR TITLE
Crawl: speed up default visualizer playback to 5x (440ms/step)

### DIFF
--- a/kaggle_environments/envs/crawl/visualizer/default/src/main.ts
+++ b/kaggle_environments/envs/crawl/visualizer/default/src/main.ts
@@ -1,5 +1,6 @@
 import { createReplayVisualizer, ReplayAdapter } from '@kaggle-environments/core';
 import { renderer } from './renderer';
+import { getCrawlStepRenderTime } from './timing';
 import './style.css';
 
 const app = document.getElementById('app');
@@ -17,5 +18,6 @@ createReplayVisualizer(
     gameName: 'crawl',
     renderer: renderer as any,
     ui: 'inline',
+    getStepRenderTime: (step, replayMode, speedModifier) => getCrawlStepRenderTime(step, replayMode, speedModifier),
   })
 );

--- a/kaggle_environments/envs/crawl/visualizer/default/src/timing.ts
+++ b/kaggle_environments/envs/crawl/visualizer/default/src/timing.ts
@@ -1,0 +1,12 @@
+import { defaultGetStepRenderTime } from '@kaggle-environments/core';
+import type { BaseGameStep, ReplayMode } from '@kaggle-environments/core';
+
+const CRAWL_STEP_DURATION = 440; // 2200 / 5 — RTS plays best at 5x default speed
+
+export const getCrawlStepRenderTime = (
+  gameStep: BaseGameStep,
+  replayMode: ReplayMode,
+  speedModifier: number
+): number => {
+  return defaultGetStepRenderTime(gameStep, replayMode, speedModifier, CRAWL_STEP_DURATION);
+};


### PR DESCRIPTION
Mirrors orbit_wars: RTS-style games play best at 5x default speed. Adds timing.ts with CRAWL_STEP_DURATION=440 and wires getStepRenderTime into the ReplayAdapter.