### PR TITLE
Web core: drop .viewer canvas absolute-position rule

### DIFF
--- a/kaggle_environments/envs/open_spiel_env/games/amazons/visualizer/default/src/renderer.ts
+++ b/kaggle_environments/envs/open_spiel_env/games/amazons/visualizer/default/src/renderer.ts
@@ -242,10 +242,7 @@ export function renderer(options: RendererOptions<AmazonsStep[]>) {
     ${makePlayerCard(oName, 'o', oActive)}
   `;
 
-  // Size canvas to its container. We compute pixel CSS sizes and write them
-  // as inline styles so that the host's `.viewer canvas { position: absolute;
-  // width: 100%; height: 100%; }` (from web/core) cannot override us. Inline
-  // styles win over external CSS regardless of selector specificity.
+  // Size canvas to its container.
   canvas.style.width = '0';
   canvas.style.height = '0';
   const containerRect = (canvas.parentElement ?? canvas).getBoundingClientRect();

--- a/kaggle_environments/envs/open_spiel_env/games/amazons/visualizer/default/src/style.css
+++ b/kaggle_environments/envs/open_spiel_env/games/amazons/visualizer/default/src/style.css
@@ -25,10 +25,6 @@ html, body, #app {
 }
 
 .renderer-container canvas {
-  /* Override .viewer canvas { position: absolute; ... } from web/core which
-     would otherwise pull the canvas out of the column flex layout and stretch
-     it to fill the entire .viewer (hiding header/status). */
-  position: relative;
   display: block;
   flex: 1 1 0;
   width: 100%;

--- a/kaggle_environments/envs/open_spiel_env/games/connect_four/visualizer/default/src/style.css
+++ b/kaggle_environments/envs/open_spiel_env/games/connect_four/visualizer/default/src/style.css
@@ -17,8 +17,6 @@ html, body, #app {
 }
 
 .renderer-container canvas {
-  /* Override web/core's .viewer canvas absolute positioning */
-  position: relative;
   flex-grow: 1;
   width: 100%;
   min-height: 0; /* Critical for flex items to shrink properly */

--- a/kaggle_environments/envs/open_spiel_env/games/dark_hex/visualizer/default/src/style.css
+++ b/kaggle_environments/envs/open_spiel_env/games/dark_hex/visualizer/default/src/style.css
@@ -96,8 +96,6 @@ body,
 }
 
 .board-card canvas {
-  /* Override .viewer canvas { position: absolute; ... } from web/core. */
-  position: relative;
   display: block;
   max-width: 100%;
   max-height: 100%;

--- a/kaggle_environments/envs/open_spiel_env/games/go/visualizer/v2/src/App.css
+++ b/kaggle_environments/envs/open_spiel_env/games/go/visualizer/v2/src/App.css
@@ -57,8 +57,7 @@
 }
 
 .viewer canvas {
-  position: relative !important;
-  width: 100% !important;
-  height: auto !important;
+  width: 100%;
+  height: auto;
   max-width: 512px;
 }

--- a/kaggle_environments/envs/open_spiel_env/games/y/visualizer/default/src/style.css
+++ b/kaggle_environments/envs/open_spiel_env/games/y/visualizer/default/src/style.css
@@ -70,8 +70,6 @@ body,
 }
 
 .board-wrap canvas {
-  /* Override .viewer canvas { position: absolute; ... } from web/core. */
-  position: relative;
   display: block;
   max-width: 100%;
   max-height: 100%;

--- a/web/core/src/player/style.css
+++ b/web/core/src/player/style.css
@@ -34,14 +34,6 @@ body,
   position: relative;
 }
 
-.viewer canvas {
-  position: absolute;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-}
-
 .controls {
   display: flex;
   align-items: center;


### PR DESCRIPTION
The base layer was making a layout decision (canvas fills .viewer absolutely) that belongs to each renderer. Every game-specific visualizer ended up overriding it (amazons, y, dark_hex, connect_four, go v2 — the last with !important).

Drop the rule from web/core and clean up the now-redundant overrides. Renderers that want fill-the-viewer behavior can opt in with their own CSS.