### PR TITLE
Chess: declare winner when loser exceeds budget or errors out

### DIFF
--- a/kaggle_environments/envs/open_spiel_env/games/chess/visualizer/default/replays/test-replay-forfeit.json
+++ b/kaggle_environments/envs/open_spiel_env/games/chess/visualizer/default/replays/test-replay-forfeit.json
@@ -1,0 +1,1098 @@
+{
+  "configuration": {
+    "actTimeout": 3600,
+    "episodeSteps": 17795,
+    "metadata": {},
+    "openSpielGameName": "chess",
+    "openSpielGameParameters": {
+      "chess960": false
+    },
+    "openSpielGameString": "chess()",
+    "runTimeout": 172800,
+    "seed": 1398552928
+  },
+  "description": "Kaggle environment wrapper for OpenSpiel games.\nFor game implementation details see:\nhttps://github.com/google-deepmind/open_spiel/tree/master/open_spiel/games",
+  "id": "fd1f9084-793a-11f0-aca2-0242ac130202",
+  "info": {
+    "EpisodeId": 73000130,
+    "LiveVideoPath": null,
+    "TeamNames": ["GPT 4.1", "o3"],
+    "actionHistory": [
+      "2426",
+      "1258",
+      "3572",
+      "656",
+      "1842",
+      "1431",
+      "3132",
+      "3572",
+      "656",
+      "2426",
+      "2037",
+      "89",
+      "943",
+      "2974",
+      "216",
+      "674",
+      "1456",
+      "3134",
+      "1798",
+      "3593",
+      "3751",
+      "1842",
+      "2612",
+      "1213",
+      "2101",
+      "2366",
+      "1550",
+      "31",
+      "1212",
+      "920",
+      "701",
+      "1769",
+      "4672",
+      "1917",
+      "1768",
+      "1188",
+      "1846",
+      "2964",
+      "2277",
+      "4113",
+      "2144",
+      "2536",
+      "377",
+      "819",
+      "2550",
+      "892",
+      "2111",
+      "1006",
+      "1379",
+      "1189",
+      "1184",
+      "3666",
+      "143",
+      "3739",
+      "4177",
+      "2571",
+      "1384",
+      "4178",
+      "4250",
+      "3812",
+      "2624",
+      "3634",
+      "3722",
+      "3109",
+      "2976",
+      "2466",
+      "4115",
+      "1955",
+      "2355",
+      "1444",
+      "2655",
+      "905",
+      "1257",
+      "3010",
+      "909",
+      "308",
+      "3237"
+    ],
+    "moveDurations": [
+      9.701, 8.783, 16.793, 7.933, 12.022, 9.231, 15.645, 11.233, 133.187,
+      14.42, 37.564, 21.113, 72.547, 15.581, 175.324, 17.605, 187.625, 25.964,
+      285.149, 17.086, 175.493, 18.577, 166.499, 25.355, 122.101, 14.178,
+      89.772, 10.111, 255.745, 9.302, 396.231, 16.902, 338.167, 17.504, 103.405,
+      9.602, 357.176, 32.032, 402.203, 11.831, 229.274, 14.759, 190.808, 18.089,
+      459.089, 24.123, 334.334, 19.275, 111.796, 11.921, 31.435, 23.902,
+      223.511, 14.651, 175.514, 12.758, 65.267, 29.628, 222.015, 14.309, 30.706,
+      20.816, 85.731, 16.321, 304.163, 26.945, 442.873, 16.672, 168.228, 12.959,
+      569.712, 30.798, 212.031, 20.714, 134.647, 22.429, 58.774
+    ],
+    "stateHistory": [
+      "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1",
+      "rnbqkbnr/pppppppp/8/8/4P3/8/PPPP1PPP/RNBQKBNR b KQkq - 0 1",
+      "rnbqkbnr/pp1ppppp/8/2p5/4P3/8/PPPP1PPP/RNBQKBNR w KQkq - 0 2",
+      "rnbqkbnr/pp1ppppp/8/2p5/4P3/5N2/PPPP1PPP/RNBQKB1R b KQkq - 1 2",
+      "r1bqkbnr/pp1ppppp/2n5/2p5/4P3/5N2/PPPP1PPP/RNBQKB1R w KQkq - 2 3",
+      "r1bqkbnr/pp1ppppp/2n5/2p5/3PP3/5N2/PPP2PPP/RNBQKB1R b KQkq - 0 3",
+      "r1bqkbnr/pp1ppppp/2n5/8/3pP3/5N2/PPP2PPP/RNBQKB1R w KQkq - 0 4",
+      "r1bqkbnr/pp1ppppp/2n5/8/3NP3/8/PPP2PPP/RNBQKB1R b KQkq - 0 4",
+      "r1bqkb1r/pp1ppppp/2n2n2/8/3NP3/8/PPP2PPP/RNBQKB1R w KQkq - 1 5",
+      "r1bqkb1r/pp1ppppp/2n2n2/8/3NP3/2N5/PPP2PPP/R1BQKB1R b KQkq - 2 5",
+      "r1bqkb1r/pp1p1ppp/2n2n2/4p3/3NP3/2N5/PPP2PPP/R1BQKB1R w KQkq - 0 6",
+      "r1bqkb1r/pp1p1ppp/2n2n2/1N2p3/4P3/2N5/PPP2PPP/R1BQKB1R b KQkq - 1 6",
+      "r1bqkb1r/1p1p1ppp/p1n2n2/1N2p3/4P3/2N5/PPP2PPP/R1BQKB1R w KQkq - 0 7",
+      "r1bqkb1r/1p1p1ppp/p1n2n2/4p3/4P3/N1N5/PPP2PPP/R1BQKB1R b KQkq - 1 7",
+      "r1bqk2r/1p1p1ppp/p1n2n2/4p3/1b2P3/N1N5/PPP2PPP/R1BQKB1R w KQkq - 2 8",
+      "r1bqk2r/1p1p1ppp/p1n2n2/4p3/1bN1P3/2N5/PPP2PPP/R1BQKB1R b KQkq - 3 8",
+      "r1bqk2r/3p1ppp/p1n2n2/1p2p3/1bN1P3/2N5/PPP2PPP/R1BQKB1R w KQkq - 0 9",
+      "r1bqk2r/3p1ppp/p1n2n2/1p2p3/1b2P3/2N1N3/PPP2PPP/R1BQKB1R b KQkq - 1 9",
+      "r1bqk2r/3p1ppp/p1n5/1p2p3/1b2n3/2N1N3/PPP2PPP/R1BQKB1R w KQkq - 0 10",
+      "r1bqk2r/3p1ppp/p1n5/1p2p3/1b2n1Q1/2N1N3/PPP2PPP/R1B1KB1R b KQkq - 1 10",
+      "r1bqk2r/3p1p1p/p1n3p1/1p2p3/1b2n1Q1/2N1N3/PPP2PPP/R1B1KB1R w KQkq - 0 11",
+      "r1bqk2r/3p1p1p/p1n3p1/1p2p3/1b2Q3/2N1N3/PPP2PPP/R1B1KB1R b KQkq - 0 11",
+      "r1bqk2r/5p1p/p1n3p1/1p1pp3/1b2Q3/2N1N3/PPP2PPP/R1B1KB1R w KQkq - 0 12",
+      "r1bqk2r/5p1p/p1n3p1/1p1Qp3/1b6/2N1N3/PPP2PPP/R1B1KB1R b KQkq - 0 12",
+      "r2qk2r/5p1p/p1n1b1p1/1p1Qp3/1b6/2N1N3/PPP2PPP/R1B1KB1R w KQkq - 1 13",
+      "r2qk2r/5p1p/p1Q1b1p1/1p2p3/1b6/2N1N3/PPP2PPP/R1B1KB1R b KQkq - 0 13",
+      "r2q1k1r/5p1p/p1Q1b1p1/1p2p3/1b6/2N1N3/PPP2PPP/R1B1KB1R w KQ - 1 14",
+      "r1Qq1k1r/5p1p/p3b1p1/1p2p3/1b6/2N1N3/PPP2PPP/R1B1KB1R b KQ - 2 14",
+      "2rq1k1r/5p1p/p3b1p1/1p2p3/1b6/2N1N3/PPP2PPP/R1B1KB1R w KQ - 0 15",
+      "2rq1k1r/5p1p/p3b1p1/1p2p3/1b6/2N1N3/PPPB1PPP/R3KB1R b KQ - 1 15",
+      "2rq1k1r/5p1p/p3b1p1/1p2p3/8/2b1N3/PPPB1PPP/R3KB1R w KQ - 0 16",
+      "2rq1k1r/5p1p/p3b1p1/1p2p3/8/2P1N3/P1PB1PPP/R3KB1R b KQ - 0 16",
+      "2r2k1r/5p1p/p2qb1p1/1p2p3/8/2P1N3/P1PB1PPP/R3KB1R w KQ - 1 17",
+      "2r2k1r/5p1p/p2qb1p1/1p2p3/8/2P1N3/P1PB1PPP/2KR1B1R b - - 2 17",
+      "2r2k1r/5p1p/p3b1p1/1p2p3/8/2P1N3/P1Pq1PPP/2KR1B1R w - - 0 18",
+      "2r2k1r/5p1p/p3b1p1/1p2p3/8/2P1N3/P1PR1PPP/2K2B1R b - - 0 18",
+      "5k1r/5p1p/p3b1p1/1p2p3/8/2r1N3/P1PR1PPP/2K2B1R w - - 0 19",
+      "3R1k1r/5p1p/p3b1p1/1p2p3/8/2r1N3/P1P2PPP/2K2B1R b - - 1 19",
+      "3R3r/5pkp/p3b1p1/1p2p3/8/2r1N3/P1P2PPP/2K2B1R w - - 2 20",
+      "7r/5pkp/p2Rb1p1/1p2p3/8/2r1N3/P1P2PPP/2K2B1R b - - 3 20",
+      "2r5/5pkp/p2Rb1p1/1p2p3/8/2r1N3/P1P2PPP/2K2B1R w - - 4 21",
+      "2r5/5pkp/R3b1p1/1p2p3/8/2r1N3/P1P2PPP/2K2B1R b - - 0 21",
+      "2r5/5pkp/R5p1/1p2p3/8/2r1N3/b1P2PPP/2K2B1R w - - 0 22",
+      "2r5/5pkp/6p1/1p2p3/8/2r1N3/R1P2PPP/2K2B1R b - - 0 22",
+      "2r5/5pkp/6p1/4p3/1p6/2r1N3/R1P2PPP/2K2B1R w - - 0 23",
+      "2r5/5pkp/6p1/3Np3/1p6/2r5/R1P2PPP/2K2B1R b - - 1 23",
+      "2r5/5pkp/6p1/3Np3/8/1pr5/R1P2PPP/2K2B1R w - - 0 24",
+      "2r5/5pkp/6p1/4p3/8/1pN5/R1P2PPP/2K2B1R b - - 0 24",
+      "2r5/5pkp/6p1/4p3/8/2N5/p1P2PPP/2K2B1R w - - 0 25",
+      "2r5/5pkp/6p1/4p3/8/8/N1P2PPP/2K2B1R b - - 0 25",
+      "8/5pkp/6p1/4p3/8/8/N1r2PPP/2K2B1R w - - 0 26",
+      "8/5pkp/6p1/4p3/8/8/N1K2PPP/5B1R b - - 0 26",
+      "8/5pkp/8/4p1p1/8/8/N1K2PPP/5B1R w - - 0 27",
+      "8/5pkp/8/4p1p1/8/2N5/2K2PPP/5B1R b - - 1 27",
+      "8/5pkp/8/4p3/6p1/2N5/2K2PPP/5B1R w - - 0 28",
+      "8/5pkp/8/4p3/6p1/2N4P/2K2PP1/5B1R b - - 0 28",
+      "8/5pkp/8/8/4p1p1/2N4P/2K2PP1/5B1R w - - 0 29",
+      "8/5pkp/8/8/4N1p1/7P/2K2PP1/5B1R b - - 0 29",
+      "8/5pk1/8/7p/4N1p1/7P/2K2PP1/5B1R w - - 0 30",
+      "8/5pk1/8/7p/4N1pP/8/2K2PP1/5B1R b - - 0 30",
+      "8/5pk1/8/7p/4N2P/6p1/2K2PP1/5B1R w - - 0 31",
+      "8/5pk1/8/7p/7P/6N1/2K2PP1/5B1R b - - 0 31",
+      "8/5p2/5k2/7p/7P/6N1/2K2PP1/5B1R w - - 1 32",
+      "8/5p2/5k2/7N/7P/8/2K2PP1/5B1R b - - 0 32",
+      "8/4kp2/8/7N/7P/8/2K2PP1/5B1R w - - 1 33",
+      "8/4kp2/8/7N/7P/3B4/2K2PP1/7R b - - 2 33",
+      "8/5p2/3k4/7N/7P/3B4/2K2PP1/7R w - - 3 34",
+      "8/5p2/3k4/7N/7P/3B4/2K2PP1/4R3 b - - 4 34",
+      "8/5p2/8/2k4N/7P/3B4/2K2PP1/4R3 w - - 5 35",
+      "8/5p2/8/2k1R2N/7P/3B4/2K2PP1/8 b - - 6 35",
+      "8/5p2/8/4R2N/1k5P/3B4/2K2PP1/8 w - - 7 36",
+      "8/5p2/8/1R5N/1k5P/3B4/2K2PP1/8 b - - 8 36",
+      "8/5p2/8/1R5N/k6P/3B4/2K2PP1/8 w - - 9 37",
+      "8/5p2/8/1R5N/k6P/2KB4/5PP1/8 b - - 10 37",
+      "8/8/8/1R3p1N/k6P/2KB4/5PP1/8 w - - 0 38",
+      "8/8/8/5R1N/k6P/2KB4/5PP1/8 b - - 0 38",
+      "8/8/8/5R1N/7P/k1KB4/5PP1/8 w - - 1 39",
+      "8/8/8/R6N/7P/k1KB4/5PP1/8 b - - 2 39"
+    ]
+  },
+  "name": "open_spiel_chess",
+  "rewards": [1.0, -1.0],
+  "schema_version": 1,
+  "specification": {
+    "action": {
+      "default": {
+        "submission": -1
+      },
+      "description": "Action object MUST contain a field `submission`, and MAY contain arbitrary additional information.",
+      "type": "object"
+    },
+    "agents": [2],
+    "configuration": {
+      "actTimeout": {
+        "default": 3600,
+        "description": "Maximum runtime (seconds) to obtain an action from an agent.",
+        "minimum": 0,
+        "type": "number"
+      },
+      "episodeSteps": {
+        "default": 17795,
+        "description": "Maximum number of steps in the episode.",
+        "minimum": 1,
+        "type": "integer"
+      },
+      "metadata": {
+        "default": {},
+        "description": "Arbitrary metadata.",
+        "properties": {},
+        "type": "object"
+      },
+      "openSpielGameName": {
+        "default": "chess",
+        "description": "The short_name of the OpenSpiel game to load.",
+        "type": "string"
+      },
+      "openSpielGameParameters": {
+        "default": {
+          "chess960": false
+        },
+        "description": "Game parameters for Open Spiel game.",
+        "properties": {},
+        "type": "object"
+      },
+      "openSpielGameString": {
+        "default": "chess()",
+        "description": "The full game string including parameters.",
+        "type": "string"
+      },
+      "runTimeout": {
+        "default": 172800,
+        "description": "Maximum runtime (seconds) of an episode (not necessarily DONE).",
+        "minimum": 0,
+        "type": "number"
+      }
+    },
+    "info": {},
+    "observation": {
+      "default": {},
+      "properties": {
+        "currentPlayer": {
+          "description": "ID of player whose turn it is.",
+          "type": "integer"
+        },
+        "isTerminal": {
+          "description": "Boolean indicating game end.",
+          "type": "boolean"
+        },
+        "legalActionStrings": {
+          "description": "List of OpenSpiel legal actions strings.",
+          "type": "array"
+        },
+        "legalActions": {
+          "description": "List of OpenSpiel legal action integers.",
+          "type": "array"
+        },
+        "observationString": {
+          "description": "String representation of state.",
+          "type": "string"
+        },
+        "openSpielGameName": {
+          "default": "chess",
+          "description": "Short name of the OpenSpiel game.",
+          "type": "string"
+        },
+        "openSpielGameString": {
+          "default": "chess()",
+          "description": "Full game string including parameters.",
+          "type": "string"
+        },
+        "playerId": {
+          "description": "ID of the agent receiving this observation.",
+          "type": "integer"
+        },
+        "remainingOverageTime": 60,
+        "serializedGameAndState": {
+          "description": "Enables reconstructing the Game and State objects.",
+          "type": "string"
+        },
+        "step": 0
+      },
+      "remainingOverageTime": {
+        "default": 12,
+        "description": "Total remaining banked time (seconds) that can be used in excess of per-step actTimeouts -- agent is disqualified with TIMEOUT status when this drops below 0.",
+        "minimum": 0,
+        "shared": false,
+        "type": "number"
+      },
+      "step": {
+        "default": 0,
+        "description": "Current step within the episode.",
+        "minimum": 0,
+        "shared": true,
+        "type": "integer"
+      }
+    },
+    "reward": {
+      "default": 0.0,
+      "type": ["number", "null"]
+    }
+  },
+  "statuses": ["DONE", "DONE"],
+  "steps": [
+    [
+      {
+        "action": {
+          "submission": -1
+        },
+        "info": {},
+        "observation": {
+          "remainingOverageTime": 12,
+          "step": 0
+        },
+        "reward": 0.0,
+        "status": "ACTIVE"
+      },
+      {
+        "action": {
+          "submission": -1
+        },
+        "info": {},
+        "observation": {
+          "remainingOverageTime": 12
+        },
+        "reward": 0.0,
+        "status": "ACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "actionString": null,
+          "generate_returns": [],
+          "status": "OK; Setup step; model not called.",
+          "submission": -1,
+          "thoughts": null
+        },
+        "info": {},
+        "observation": {
+          "currentPlayer": 1,
+          "isTerminal": false,
+          "legalActionStrings": [],
+          "legalActions": [],
+          "observationString": "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1",
+          "playerId": 0,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess()\n[State]\nFEN: rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1\n\n\n",
+          "step": 1
+        },
+        "reward": null,
+        "status": "INACTIVE"
+      },
+      {
+        "action": {
+          "actionString": null,
+          "generate_returns": [],
+          "status": "OK; Setup step; model not called.",
+          "submission": -1,
+          "thoughts": null
+        },
+        "info": {
+          "actionApplied": null,
+          "actionSubmitted": null,
+          "actionSubmittedToString": null,
+          "agentSelfReportedStatus": "OK; Setup step; model not called.",
+          "timeTaken": null
+        },
+        "observation": {
+          "currentPlayer": 1,
+          "isTerminal": false,
+          "legalActionStrings": [
+            "a3",
+            "a4",
+            "Na3",
+            "Nc3",
+            "b3",
+            "b4",
+            "c3",
+            "c4",
+            "d3",
+            "d4",
+            "e3",
+            "e4",
+            "f3",
+            "f4",
+            "Nf3",
+            "Nh3",
+            "g3",
+            "g4",
+            "h3",
+            "h4"
+          ],
+          "legalActions": [
+            89, 90, 652, 656, 673, 674, 1257, 1258, 1841, 1842, 2425, 2426,
+            3009, 3010, 3572, 3576, 3593, 3594, 4177, 4178
+          ],
+          "observationString": "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1",
+          "playerId": 1,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess()\n[State]\nFEN: rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1\n\n\n"
+        },
+        "reward": null,
+        "status": "ACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "submission": -1
+        },
+        "info": {},
+        "observation": {
+          "currentPlayer": 0,
+          "isTerminal": false,
+          "legalActionStrings": [
+            "a6",
+            "a5",
+            "Na6",
+            "Nc6",
+            "b6",
+            "b5",
+            "c6",
+            "c5",
+            "d6",
+            "d5",
+            "e6",
+            "e5",
+            "f6",
+            "f5",
+            "Nf6",
+            "Nh6",
+            "g6",
+            "g5",
+            "h6",
+            "h5"
+          ],
+          "legalActions": [
+            89, 90, 652, 656, 673, 674, 1257, 1258, 1841, 1842, 2425, 2426,
+            3009, 3010, 3572, 3576, 3593, 3594, 4177, 4178
+          ],
+          "observationString": "rnbqkbnr/pppppppp/8/8/4P3/8/PPPP1PPP/RNBQKBNR b KQkq - 0 1",
+          "playerId": 0,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess()\n[State]\nFEN: rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1\n2426\n\n",
+          "step": 2
+        },
+        "reward": null,
+        "status": "ACTIVE"
+      },
+      {
+        "action": {
+          "actionString": "e4",
+          "generate_returns": [
+            "{\n  \"main_response\": \"To choose White\\u2019s first move I consider the usual opening principles:  \\n\\u2022 Occupy or control the centre.  \\n\\u2022 Develop pieces quickly.  \\n\\u2022 Keep options open for king safety (castling).\\n\\nCandidate moves from the starting position:  \\n1. e4 \\u2013 immediately claims the centre, opens lines for the queen and king\\u2019s bishop.  \\n2. d4 \\u2013 also takes the centre, but keeps the king\\u2019s bishop shut for now.  \\n3. Nf3 \\u2013 develops a knight and attacks e5, but does not occupy the centre with a pawn.  \\n4. c4 \\u2013 aims for a strong central presence (English Opening), but slightly slower.\\n\\nAmong these, 1.e4 is the most forcing, scores well in databases, and leads to many reputable open\\u2010game lines. It is fully consistent with opening principles and is of equal or better theoretical value than any alternative.\\n\\nLegality check:  \\n\\u2022 Square e2 is occupied by a White pawn.  \\n\\u2022 Square e4 is empty.  \\n\\u2022 Moving two squares forward from the starting rank on the first move is legal.  \\nTherefore 1.e4 is legal.\\n\\nI will therefore play 1.e4.\\n\\nFinal Answer: e4\",\n  \"main_response_and_thoughts\": \"\",\n  \"request_for_logging\": {\n    \"model\": \"o3-2025-04-16\",\n    \"messages\": [\n      {\n        \"role\": \"user\",\n        \"content\": [\n          {\n            \"type\": \"text\",\n            \"text\": \"Let's play chess. The current game state in Forsyth-Edwards Notation (FEN) notation is:\\nrnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1\\nThe moves played so far are:\\n1.\\nYou are playing as player White.\\nIt is now your turn. Play your strongest move. The move MUST be legal. Reason step by step to come up with your move, then output your final answer in the format \\\"Final Answer: X\\\" where X is your chosen move in standard algebraic notation (SAN).\\n\"\n          }\n        ]\n      }\n    ],\n    \"config\": {\n      \"temperature\": \"NOT_GIVEN\",\n      \"top_p\": \"NOT_GIVEN\",\n      \"max_tokens\": \"NOT_GIVEN\",\n      \"reasoning_effort\": \"NOT_GIVEN\"\n    }\n  },\n  \"response_for_logging\": {\n    \"id\": \"chatcmpl-C4WoNpfAFRneVPtNiobzX1oTCrwCI\",\n    \"choices\": [\n      {\n        \"finish_reason\": \"stop\",\n        \"index\": 0,\n        \"message\": {\n          \"content\": \"To choose White\\u2019s first move I consider the usual opening principles:  \\n\\u2022 Occupy or control the centre.  \\n\\u2022 Develop pieces quickly.  \\n\\u2022 Keep options open for king safety (castling).\\n\\nCandidate moves from the starting position:  \\n1. e4 \\u2013 immediately claims the centre, opens lines for the queen and king\\u2019s bishop.  \\n2. d4 \\u2013 also takes the centre, but keeps the king\\u2019s bishop shut for now.  \\n3. Nf3 \\u2013 develops a knight and attacks e5, but does not occupy the centre with a pawn.  \\n4. c4 \\u2013 aims for a strong central presence (English Opening), but slightly slower.\\n\\nAmong these, 1.e4 is the most forcing, scores well in databases, and leads to many reputable open\\u2010game lines. It is fully consistent with opening principles and is of equal or better theoretical value than any alternative.\\n\\nLegality check:  \\n\\u2022 Square e2 is occupied by a White pawn.  \\n\\u2022 Square e4 is empty.  \\n\\u2022 Moving two squares forward from the starting rank on the first move is legal.  \\nTherefore 1.e4 is legal.\\n\\nI will therefore play 1.e4.\\n\\nFinal Answer: e4\",\n          \"refusal\": null,\n          \"role\": \"assistant\",\n          \"annotations\": []\n        }\n      }\n    ],\n    \"created\": 1755195475,\n    \"model\": \"o3-2025-04-16\",\n    \"object\": \"chat.completion\",\n    \"service_tier\": \"default\",\n    \"system_fingerprint\": null,\n    \"usage\": {\n      \"completion_tokens\": 454,\n      \"prompt_tokens\": 142,\n      \"total_tokens\": 596,\n      \"completion_tokens_details\": {\n        \"accepted_prediction_tokens\": 0,\n        \"audio_tokens\": 0,\n        \"reasoning_tokens\": 192,\n        \"rejected_prediction_tokens\": 0\n      },\n      \"prompt_tokens_details\": {\n        \"audio_tokens\": 0,\n        \"cached_tokens\": 0\n      }\n    }\n  },\n  \"generation_tokens\": 454,\n  \"prompt_tokens\": 142,\n  \"reasoning_tokens\": 192,\n  \"duration_success_only_secs\": 9.670661960997677\n}"
+          ],
+          "status": "OK",
+          "submission": 2426,
+          "thoughts": "To choose White\u2019s first move I consider the usual opening principles:  \n\u2022 Occupy or control the centre.  \n\u2022 Develop pieces quickly.  \n\u2022 Keep options open for king safety (castling).\n\nCandidate moves from the starting position:  \n1. e4 \u2013 immediately claims the centre, opens lines for the queen and king\u2019s bishop.  \n2. d4 \u2013 also takes the centre, but keeps the king\u2019s bishop shut for now.  \n3. Nf3 \u2013 develops a knight and attacks e5, but does not occupy the centre with a pawn.  \n4. c4 \u2013 aims for a strong central presence (English Opening), but slightly slower.\n\nAmong these, 1.e4 is the most forcing, scores well in databases, and leads to many reputable open\u2010game lines. It is fully consistent with opening principles and is of equal or better theoretical value than any alternative.\n\nLegality check:  \n\u2022 Square e2 is occupied by a White pawn.  \n\u2022 Square e4 is empty.  \n\u2022 Moving two squares forward from the starting rank on the first move is legal.  \nTherefore 1.e4 is legal.\n\nI will therefore play 1.e4.\n\nFinal Answer: e4"
+        },
+        "info": {
+          "actionApplied": 2426,
+          "actionSubmitted": 2426,
+          "actionSubmittedToString": "e4",
+          "agentSelfReportedStatus": "OK",
+          "timeTaken": 9.701
+        },
+        "observation": {
+          "currentPlayer": 0,
+          "isTerminal": false,
+          "legalActionStrings": [],
+          "legalActions": [],
+          "observationString": "rnbqkbnr/pppppppp/8/8/4P3/8/PPPP1PPP/RNBQKBNR b KQkq - 0 1",
+          "playerId": 1,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess()\n[State]\nFEN: rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1\n2426\n\n"
+        },
+        "reward": null,
+        "status": "INACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "actionString": "c5",
+          "generate_returns": [
+            "{\n  \"main_response\": \"Let's analyze the position after 1.e4.\\n\\n**FEN:**  \\nrnbqkbnr/pppppppp/8/8/4P3/8/PPPP1PPP/RNBQKBNR b KQkq - 0 1\\n\\nIt is Black's turn.\\n\\n### Step-by-step Reasoning\\n\\n1. **Common replies to 1.e4:**  \\n   The most common responses are:\\n   - 1...c5 (Sicilian Defense)\\n   - 1...e5 (Open Game, Double King's Pawn)\\n   - 1...e6 (French Defense)\\n   - 1...c6 (Caro-Kann Defense)\\n   - 1...d6 (Pirc/Modern)\\n   - 1...g6 (Robatsch/Modern Defense)\\n   - 1...d5 (Center Counter/Scandinavian)\\n\\n2. **Evaluating Choices**:  \\n   - **1...e5:** Classical, symmetrical, leads to Open Games.\\n   - **1...c5:** Leads to asymmetrical positions, fights for the center, very challenging, and arguably the most popular at high level (Sicilian).\\n   - **1...e6:** French, solid but can be passive for Black.\\n   - **1...c6:** Caro-Kann, also solid with less immediate pressure.\\n   - **1...d5:** Immediately challenges e4, but White can gain some initiative after exd5 Qxd5 Nc3.\\n\\n3. **Strength of Each Move:**\\n   - The **Sicilian Defense (1...c5)** is statistically the strongest reply at every level, as it prevents White from consolidating a big center, creates tough counterplay, and has been played by world champions for generations.\\n\\n### Final Decision\\n\\nBased on the above, the strongest move for Black is **1...c5** (the Sicilian Defense).\\n\\n**Final Answer: c5**\",\n  \"main_response_and_thoughts\": \"\",\n  \"request_for_logging\": {\n    \"model\": \"gpt-4.1-2025-04-14\",\n    \"messages\": [\n      {\n        \"role\": \"user\",\n        \"content\": [\n          {\n            \"type\": \"text\",\n            \"text\": \"Let's play chess. The current game state in Forsyth-Edwards Notation (FEN) notation is:\\nrnbqkbnr/pppppppp/8/8/4P3/8/PPPP1PPP/RNBQKBNR b KQkq - 0 1\\nThe moves played so far are:\\n1. e4\\nYou are playing as player Black.\\nIt is now your turn. Play your strongest move. The move MUST be legal. Reason step by step to come up with your move, then output your final answer in the format \\\"Final Answer: X\\\" where X is your chosen move in standard algebraic notation (SAN).\\n\"\n          }\n        ]\n      }\n    ],\n    \"config\": {\n      \"temperature\": \"NOT_GIVEN\",\n      \"top_p\": \"NOT_GIVEN\",\n      \"max_tokens\": \"NOT_GIVEN\",\n      \"reasoning_effort\": \"NOT_GIVEN\"\n    }\n  },\n  \"response_for_logging\": {\n    \"id\": \"chatcmpl-C4WoXpuqbAnesSGTYlfMMfW7k6G0R\",\n    \"choices\": [\n      {\n        \"finish_reason\": \"stop\",\n        \"index\": 0,\n        \"logprobs\": null,\n        \"message\": {\n          \"content\": \"Let's analyze the position after 1.e4.\\n\\n**FEN:**  \\nrnbqkbnr/pppppppp/8/8/4P3/8/PPPP1PPP/RNBQKBNR b KQkq - 0 1\\n\\nIt is Black's turn.\\n\\n### Step-by-step Reasoning\\n\\n1. **Common replies to 1.e4:**  \\n   The most common responses are:\\n   - 1...c5 (Sicilian Defense)\\n   - 1...e5 (Open Game, Double King's Pawn)\\n   - 1...e6 (French Defense)\\n   - 1...c6 (Caro-Kann Defense)\\n   - 1...d6 (Pirc/Modern)\\n   - 1...g6 (Robatsch/Modern Defense)\\n   - 1...d5 (Center Counter/Scandinavian)\\n\\n2. **Evaluating Choices**:  \\n   - **1...e5:** Classical, symmetrical, leads to Open Games.\\n   - **1...c5:** Leads to asymmetrical positions, fights for the center, very challenging, and arguably the most popular at high level (Sicilian).\\n   - **1...e6:** French, solid but can be passive for Black.\\n   - **1...c6:** Caro-Kann, also solid with less immediate pressure.\\n   - **1...d5:** Immediately challenges e4, but White can gain some initiative after exd5 Qxd5 Nc3.\\n\\n3. **Strength of Each Move:**\\n   - The **Sicilian Defense (1...c5)** is statistically the strongest reply at every level, as it prevents White from consolidating a big center, creates tough counterplay, and has been played by world champions for generations.\\n\\n### Final Decision\\n\\nBased on the above, the strongest move for Black is **1...c5** (the Sicilian Defense).\\n\\n**Final Answer: c5**\",\n          \"refusal\": null,\n          \"role\": \"assistant\",\n          \"annotations\": []\n        }\n      }\n    ],\n    \"created\": 1755195485,\n    \"model\": \"gpt-4.1-2025-04-14\",\n    \"object\": \"chat.completion\",\n    \"service_tier\": \"default\",\n    \"system_fingerprint\": \"fp_7d949b30bb\",\n    \"usage\": {\n      \"completion_tokens\": 405,\n      \"prompt_tokens\": 148,\n      \"total_tokens\": 553,\n      \"completion_tokens_details\": {\n        \"accepted_prediction_tokens\": 0,\n        \"audio_tokens\": 0,\n        \"reasoning_tokens\": 0,\n        \"rejected_prediction_tokens\": 0\n      },\n      \"prompt_tokens_details\": {\n        \"audio_tokens\": 0,\n        \"cached_tokens\": 0\n      }\n    }\n  },\n  \"generation_tokens\": 405,\n  \"prompt_tokens\": 148,\n  \"reasoning_tokens\": 0,\n  \"duration_success_only_secs\": 8.752019104998908\n}"
+          ],
+          "status": "OK",
+          "submission": 1258,
+          "thoughts": "Let's analyze the position after 1.e4.\n\n**FEN:**  \nrnbqkbnr/pppppppp/8/8/4P3/8/PPPP1PPP/RNBQKBNR b KQkq - 0 1\n\nIt is Black's turn.\n\n### Step-by-step Reasoning\n\n1. **Common replies to 1.e4:**  \n   The most common responses are:\n   - 1...c5 (Sicilian Defense)\n   - 1...e5 (Open Game, Double King's Pawn)\n   - 1...e6 (French Defense)\n   - 1...c6 (Caro-Kann Defense)\n   - 1...d6 (Pirc/Modern)\n   - 1...g6 (Robatsch/Modern Defense)\n   - 1...d5 (Center Counter/Scandinavian)\n\n2. **Evaluating Choices**:  \n   - **1...e5:** Classical, symmetrical, leads to Open Games.\n   - **1...c5:** Leads to asymmetrical positions, fights for the center, very challenging, and arguably the most popular at high level (Sicilian).\n   - **1...e6:** French, solid but can be passive for Black.\n   - **1...c6:** Caro-Kann, also solid with less immediate pressure.\n   - **1...d5:** Immediately challenges e4, but White can gain some initiative after exd5 Qxd5 Nc3.\n\n3. **Strength of Each Move:**\n   - The **Sicilian Defense (1...c5)** is statistically the strongest reply at every level, as it prevents White from consolidating a big center, creates tough counterplay, and has been played by world champions for generations.\n\n### Final Decision\n\nBased on the above, the strongest move for Black is **1...c5** (the Sicilian Defense).\n\n**Final Answer: c5**"
+        },
+        "info": {
+          "actionApplied": 1258,
+          "actionSubmitted": 1258,
+          "actionSubmittedToString": "c5",
+          "agentSelfReportedStatus": "OK",
+          "timeTaken": 8.783
+        },
+        "observation": {
+          "currentPlayer": 1,
+          "isTerminal": false,
+          "legalActionStrings": [],
+          "legalActions": [],
+          "observationString": "rnbqkbnr/pp1ppppp/8/2p5/4P3/8/PPPP1PPP/RNBQKBNR w KQkq - 0 2",
+          "playerId": 0,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess()\n[State]\nFEN: rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1\n2426\n1258\n\n",
+          "step": 3
+        },
+        "reward": null,
+        "status": "INACTIVE"
+      },
+      {
+        "action": {
+          "submission": -1
+        },
+        "info": {},
+        "observation": {
+          "currentPlayer": 1,
+          "isTerminal": false,
+          "legalActionStrings": [
+            "a3",
+            "a4",
+            "Na3",
+            "Nc3",
+            "b3",
+            "b4",
+            "c3",
+            "c4",
+            "Qe2",
+            "Qf3",
+            "Qg4",
+            "Qh5",
+            "d3",
+            "d4",
+            "Ke2",
+            "e5",
+            "Ba6",
+            "Bb5",
+            "Bc4",
+            "Bd3",
+            "Be2",
+            "f3",
+            "f4",
+            "Ne2",
+            "Nf3",
+            "Nh3",
+            "g3",
+            "g4",
+            "h3",
+            "h4"
+          ],
+          "legalActions": [
+            89, 90, 652, 656, 673, 674, 1257, 1258, 1796, 1797, 1798, 1799,
+            1841, 1842, 2352, 2571, 2973, 2974, 2975, 2976, 2977, 3009, 3010,
+            3570, 3572, 3576, 3593, 3594, 4177, 4178
+          ],
+          "observationString": "rnbqkbnr/pp1ppppp/8/2p5/4P3/8/PPPP1PPP/RNBQKBNR w KQkq - 0 2",
+          "playerId": 1,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess()\n[State]\nFEN: rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1\n2426\n1258\n\n"
+        },
+        "reward": null,
+        "status": "ACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "submission": -1
+        },
+        "info": {},
+        "observation": {
+          "currentPlayer": 0,
+          "isTerminal": false,
+          "legalActionStrings": [
+            "a6",
+            "a5",
+            "Na6",
+            "Nc6",
+            "b6",
+            "b5",
+            "c4",
+            "Qa5",
+            "Qb6",
+            "Qc7",
+            "d6",
+            "d5",
+            "e6",
+            "e5",
+            "f6",
+            "f5",
+            "Nf6",
+            "Nh6",
+            "g6",
+            "g5",
+            "h6",
+            "h5"
+          ],
+          "legalActions": [
+            89, 90, 652, 656, 673, 674, 1403, 1807, 1808, 1809, 1841, 1842,
+            2425, 2426, 3009, 3010, 3572, 3576, 3593, 3594, 4177, 4178
+          ],
+          "observationString": "rnbqkbnr/pp1ppppp/8/2p5/4P3/5N2/PPPP1PPP/RNBQKB1R b KQkq - 1 2",
+          "playerId": 0,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess()\n[State]\nFEN: rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1\n2426\n1258\n3572\n\n",
+          "step": 4
+        },
+        "reward": null,
+        "status": "ACTIVE"
+      },
+      {
+        "action": {
+          "actionString": "Nf3",
+          "generate_returns": [
+            "{\n  \"main_response\": \"We are in the mainline Sicilian Defence after 1.e4 c5.\\n\\n1. Identify candidate moves for White\\u2019s second move:\\n   \\u2022 2.Nf3 \\u2013 develops a knight toward the center, controls d4 and e5, prepares 3.d4 to challenge Black\\u2019s c-pawn, and keeps castling options open.\\n   \\u2022 2.d4 \\u2013 the Smith-Morra Gambit, sacrificing a pawn for rapid development.\\n   \\u2022 2.Nc3 \\u2013 the Closed Sicilian setup.\\n   \\u2022 2.c3 \\u2013 the Alapin Variation, aiming for d4 without pawn loss.\\n\\n2. Compare the candidates:\\n   \\u2022 2.Nf3 is the most flexible and universally accepted mainline move. It develops a piece, attacks the e5 square, and puts immediate pressure on d4.  \\n   \\u2022 2.d4 offers sharp play but gives up a pawn.  \\n   \\u2022 2.Nc3 keeps options but blocks the c-pawn and concedes Black easy equality if White later goes d4.  \\n   \\u2022 2.c3 is solid but less ambitious.\\n\\n3. Verify legality of 2.Nf3:\\n   \\u2022 The knight on g1 moves in an L-shape to f3.  \\n   \\u2022 Square f3 is empty.  \\n   \\u2022 No rules are violated.\\n\\n4. Confirm there are no checks or captures; hence SAN is simply \\u201cNf3\\u201d.\\n\\nTherefore, the strongest and most conventional move is 2.Nf3.\\n\\nFinal Answer: Nf3\",\n  \"main_response_and_thoughts\": \"\",\n  \"request_for_logging\": {\n    \"model\": \"o3-2025-04-16\",\n    \"messages\": [\n      {\n        \"role\": \"user\",\n        \"content\": [\n          {\n            \"type\": \"text\",\n            \"text\": \"Let's play chess. The current game state in Forsyth-Edwards Notation (FEN) notation is:\\nrnbqkbnr/pp1ppppp/8/2p5/4P3/8/PPPP1PPP/RNBQKBNR w KQkq - 0 2\\nThe moves played so far are:\\n1. e4 c5 2.\\nYou are playing as player White.\\nIt is now your turn. Play your strongest move. The move MUST be legal. Reason step by step to come up with your move, then output your final answer in the format \\\"Final Answer: X\\\" where X is your chosen move in standard algebraic notation (SAN).\\n\"\n          }\n        ]\n      }\n    ],\n    \"config\": {\n      \"temperature\": \"NOT_GIVEN\",\n      \"top_p\": \"NOT_GIVEN\",\n      \"max_tokens\": \"NOT_GIVEN\",\n      \"reasoning_effort\": \"NOT_GIVEN\"\n    }\n  },\n  \"response_for_logging\": {\n    \"id\": \"chatcmpl-C4Wofb5JbgUHviRPWHnvkwO424PZ4\",\n    \"choices\": [\n      {\n        \"finish_reason\": \"stop\",\n        \"index\": 0,\n        \"message\": {\n          \"content\": \"We are in the mainline Sicilian Defence after 1.e4 c5.\\n\\n1. Identify candidate moves for White\\u2019s second move:\\n   \\u2022 2.Nf3 \\u2013 develops a knight toward the center, controls d4 and e5, prepares 3.d4 to challenge Black\\u2019s c-pawn, and keeps castling options open.\\n   \\u2022 2.d4 \\u2013 the Smith-Morra Gambit, sacrificing a pawn for rapid development.\\n   \\u2022 2.Nc3 \\u2013 the Closed Sicilian setup.\\n   \\u2022 2.c3 \\u2013 the Alapin Variation, aiming for d4 without pawn loss.\\n\\n2. Compare the candidates:\\n   \\u2022 2.Nf3 is the most flexible and universally accepted mainline move. It develops a piece, attacks the e5 square, and puts immediate pressure on d4.  \\n   \\u2022 2.d4 offers sharp play but gives up a pawn.  \\n   \\u2022 2.Nc3 keeps options but blocks the c-pawn and concedes Black easy equality if White later goes d4.  \\n   \\u2022 2.c3 is solid but less ambitious.\\n\\n3. Verify legality of 2.Nf3:\\n   \\u2022 The knight on g1 moves in an L-shape to f3.  \\n   \\u2022 Square f3 is empty.  \\n   \\u2022 No rules are violated.\\n\\n4. Confirm there are no checks or captures; hence SAN is simply \\u201cNf3\\u201d.\\n\\nTherefore, the strongest and most conventional move is 2.Nf3.\\n\\nFinal Answer: Nf3\",\n          \"refusal\": null,\n          \"role\": \"assistant\",\n          \"annotations\": []\n        }\n      }\n    ],\n    \"created\": 1755195493,\n    \"model\": \"o3-2025-04-16\",\n    \"object\": \"chat.completion\",\n    \"service_tier\": \"default\",\n    \"system_fingerprint\": null,\n    \"usage\": {\n      \"completion_tokens\": 714,\n      \"prompt_tokens\": 154,\n      \"total_tokens\": 868,\n      \"completion_tokens_details\": {\n        \"accepted_prediction_tokens\": 0,\n        \"audio_tokens\": 0,\n        \"reasoning_tokens\": 384,\n        \"rejected_prediction_tokens\": 0\n      },\n      \"prompt_tokens_details\": {\n        \"audio_tokens\": 0,\n        \"cached_tokens\": 0\n      }\n    }\n  },\n  \"generation_tokens\": 714,\n  \"prompt_tokens\": 154,\n  \"reasoning_tokens\": 384,\n  \"duration_success_only_secs\": 16.764486129002762\n}"
+          ],
+          "status": "OK",
+          "submission": 3572,
+          "thoughts": "We are in the mainline Sicilian Defence after 1.e4 c5.\n\n1. Identify candidate moves for White\u2019s second move:\n   \u2022 2.Nf3 \u2013 develops a knight toward the center, controls d4 and e5, prepares 3.d4 to challenge Black\u2019s c-pawn, and keeps castling options open.\n   \u2022 2.d4 \u2013 the Smith-Morra Gambit, sacrificing a pawn for rapid development.\n   \u2022 2.Nc3 \u2013 the Closed Sicilian setup.\n   \u2022 2.c3 \u2013 the Alapin Variation, aiming for d4 without pawn loss.\n\n2. Compare the candidates:\n   \u2022 2.Nf3 is the most flexible and universally accepted mainline move. It develops a piece, attacks the e5 square, and puts immediate pressure on d4.  \n   \u2022 2.d4 offers sharp play but gives up a pawn.  \n   \u2022 2.Nc3 keeps options but blocks the c-pawn and concedes Black easy equality if White later goes d4.  \n   \u2022 2.c3 is solid but less ambitious.\n\n3. Verify legality of 2.Nf3:\n   \u2022 The knight on g1 moves in an L-shape to f3.  \n   \u2022 Square f3 is empty.  \n   \u2022 No rules are violated.\n\n4. Confirm there are no checks or captures; hence SAN is simply \u201cNf3\u201d.\n\nTherefore, the strongest and most conventional move is 2.Nf3.\n\nFinal Answer: Nf3"
+        },
+        "info": {
+          "actionApplied": 3572,
+          "actionSubmitted": 3572,
+          "actionSubmittedToString": "Nf3",
+          "agentSelfReportedStatus": "OK",
+          "timeTaken": 16.793
+        },
+        "observation": {
+          "currentPlayer": 0,
+          "isTerminal": false,
+          "legalActionStrings": [],
+          "legalActions": [],
+          "observationString": "rnbqkbnr/pp1ppppp/8/2p5/4P3/5N2/PPPP1PPP/RNBQKB1R b KQkq - 1 2",
+          "playerId": 1,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess()\n[State]\nFEN: rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1\n2426\n1258\n3572\n\n"
+        },
+        "reward": null,
+        "status": "INACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "actionString": "Nc6",
+          "generate_returns": [
+            "{\n  \"main_response\": \"Let\\u2019s reason through the position after 1. e4 c5 2. Nf3:\\n\\n**Position summary (after 2. Nf3, Black to move):**\\n- White has played 1. e4 (occupying the center) and 2. Nf3, attacking Black\\u2019s e5 square and preparing to support d4.\\n- Black played 1...c5 (Sicilian Defense), countering White's center.\\n- It's now Black's second move.\\n\\nLet me consider standard plans in this position:\\n- The most common continuations for Black here are: d6, Nc6, e6, g6, and sometimes a6.\\n- The move d6 supports the c5 pawn, prepares to develop the knight to c6 without worrying about Nb5, and prepares Nf6.\\n- Nc6 is also a natural development move controlling the center and preparing e6 or d6.\\n\\nLet\\u2019s think step by step:\\n1. **Nc6**: Develops a piece and contests the center. Most common.\\n2. **d6**: Solid, but slightly less flexible than Nc6 immediately, though it prevents e5 and supports c5.\\n3. **e6**: Retreats to a French structure, less flexible and blocks the c8 bishop.\\n4. **g6**: Hypermodern, preparing to fianchetto, but more committal.\\n5. **a6**: Prevents Nb5 but not usually urgent here.\\n6. **Nf6**: Developing, attacks e4, but can be met with e5, kicking the knight.\\n\\nConsulting mainline Sicilian theory, after 2. Nf3, the principal move is 2...Nc6 leading to the Open Sicilian. This continues developing pieces and puts immediate pressure on the e4 pawn.\\n\\n**Legality check:**\\n- After 2...Nc6, all rules are satisfied and there is no tactical refutation.\\n\\nTherefore, the strongest move here is:\\n\\n**Final Answer: Nc6**\",\n  \"main_response_and_thoughts\": \"\",\n  \"request_for_logging\": {\n    \"model\": \"gpt-4.1-2025-04-14\",\n    \"messages\": [\n      {\n        \"role\": \"user\",\n        \"content\": [\n          {\n            \"type\": \"text\",\n            \"text\": \"Let's play chess. The current game state in Forsyth-Edwards Notation (FEN) notation is:\\nrnbqkbnr/pp1ppppp/8/2p5/4P3/5N2/PPPP1PPP/RNBQKB1R b KQkq - 1 2\\nThe moves played so far are:\\n1. e4 c5 2. Nf3\\nYou are playing as player Black.\\nIt is now your turn. Play your strongest move. The move MUST be legal. Reason step by step to come up with your move, then output your final answer in the format \\\"Final Answer: X\\\" where X is your chosen move in standard algebraic notation (SAN).\\n\"\n          }\n        ]\n      }\n    ],\n    \"config\": {\n      \"temperature\": \"NOT_GIVEN\",\n      \"top_p\": \"NOT_GIVEN\",\n      \"max_tokens\": \"NOT_GIVEN\",\n      \"reasoning_effort\": \"NOT_GIVEN\"\n    }\n  },\n  \"response_for_logging\": {\n    \"id\": \"chatcmpl-C4WowWgnFm2Qt1O7j0QkWUA3jqTq3\",\n    \"choices\": [\n      {\n        \"finish_reason\": \"stop\",\n        \"index\": 0,\n        \"logprobs\": null,\n        \"message\": {\n          \"content\": \"Let\\u2019s reason through the position after 1. e4 c5 2. Nf3:\\n\\n**Position summary (after 2. Nf3, Black to move):**\\n- White has played 1. e4 (occupying the center) and 2. Nf3, attacking Black\\u2019s e5 square and preparing to support d4.\\n- Black played 1...c5 (Sicilian Defense), countering White's center.\\n- It's now Black's second move.\\n\\nLet me consider standard plans in this position:\\n- The most common continuations for Black here are: d6, Nc6, e6, g6, and sometimes a6.\\n- The move d6 supports the c5 pawn, prepares to develop the knight to c6 without worrying about Nb5, and prepares Nf6.\\n- Nc6 is also a natural development move controlling the center and preparing e6 or d6.\\n\\nLet\\u2019s think step by step:\\n1. **Nc6**: Develops a piece and contests the center. Most common.\\n2. **d6**: Solid, but slightly less flexible than Nc6 immediately, though it prevents e5 and supports c5.\\n3. **e6**: Retreats to a French structure, less flexible and blocks the c8 bishop.\\n4. **g6**: Hypermodern, preparing to fianchetto, but more committal.\\n5. **a6**: Prevents Nb5 but not usually urgent here.\\n6. **Nf6**: Developing, attacks e4, but can be met with e5, kicking the knight.\\n\\nConsulting mainline Sicilian theory, after 2. Nf3, the principal move is 2...Nc6 leading to the Open Sicilian. This continues developing pieces and puts immediate pressure on the e4 pawn.\\n\\n**Legality check:**\\n- After 2...Nc6, all rules are satisfied and there is no tactical refutation.\\n\\nTherefore, the strongest move here is:\\n\\n**Final Answer: Nc6**\",\n          \"refusal\": null,\n          \"role\": \"assistant\",\n          \"annotations\": []\n        }\n      }\n    ],\n    \"created\": 1755195510,\n    \"model\": \"gpt-4.1-2025-04-14\",\n    \"object\": \"chat.completion\",\n    \"service_tier\": \"default\",\n    \"system_fingerprint\": \"fp_7d949b30bb\",\n    \"usage\": {\n      \"completion_tokens\": 420,\n      \"prompt_tokens\": 161,\n      \"total_tokens\": 581,\n      \"completion_tokens_details\": {\n        \"accepted_prediction_tokens\": 0,\n        \"audio_tokens\": 0,\n        \"reasoning_tokens\": 0,\n        \"rejected_prediction_tokens\": 0\n      },\n      \"prompt_tokens_details\": {\n        \"audio_tokens\": 0,\n        \"cached_tokens\": 0\n      }\n    }\n  },\n  \"generation_tokens\": 420,\n  \"prompt_tokens\": 161,\n  \"reasoning_tokens\": 0,\n  \"duration_success_only_secs\": 7.904948307004815\n}"
+          ],
+          "status": "OK",
+          "submission": 656,
+          "thoughts": "Let\u2019s reason through the position after 1. e4 c5 2. Nf3:\n\n**Position summary (after 2. Nf3, Black to move):**\n- White has played 1. e4 (occupying the center) and 2. Nf3, attacking Black\u2019s e5 square and preparing to support d4.\n- Black played 1...c5 (Sicilian Defense), countering White's center.\n- It's now Black's second move.\n\nLet me consider standard plans in this position:\n- The most common continuations for Black here are: d6, Nc6, e6, g6, and sometimes a6.\n- The move d6 supports the c5 pawn, prepares to develop the knight to c6 without worrying about Nb5, and prepares Nf6.\n- Nc6 is also a natural development move controlling the center and preparing e6 or d6.\n\nLet\u2019s think step by step:\n1. **Nc6**: Develops a piece and contests the center. Most common.\n2. **d6**: Solid, but slightly less flexible than Nc6 immediately, though it prevents e5 and supports c5.\n3. **e6**: Retreats to a French structure, less flexible and blocks the c8 bishop.\n4. **g6**: Hypermodern, preparing to fianchetto, but more committal.\n5. **a6**: Prevents Nb5 but not usually urgent here.\n6. **Nf6**: Developing, attacks e4, but can be met with e5, kicking the knight.\n\nConsulting mainline Sicilian theory, after 2. Nf3, the principal move is 2...Nc6 leading to the Open Sicilian. This continues developing pieces and puts immediate pressure on the e4 pawn.\n\n**Legality check:**\n- After 2...Nc6, all rules are satisfied and there is no tactical refutation.\n\nTherefore, the strongest move here is:\n\n**Final Answer: Nc6**"
+        },
+        "info": {
+          "actionApplied": 656,
+          "actionSubmitted": 656,
+          "actionSubmittedToString": "Nc6",
+          "agentSelfReportedStatus": "OK",
+          "timeTaken": 7.933
+        },
+        "observation": {
+          "currentPlayer": 1,
+          "isTerminal": false,
+          "legalActionStrings": [],
+          "legalActions": [],
+          "observationString": "r1bqkbnr/pp1ppppp/2n5/2p5/4P3/5N2/PPPP1PPP/RNBQKB1R w KQkq - 2 3",
+          "playerId": 0,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess()\n[State]\nFEN: rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1\n2426\n1258\n3572\n656\n\n",
+          "step": 5
+        },
+        "reward": null,
+        "status": "INACTIVE"
+      },
+      {
+        "action": {
+          "submission": -1
+        },
+        "info": {},
+        "observation": {
+          "currentPlayer": 1,
+          "isTerminal": false,
+          "legalActionStrings": [
+            "a3",
+            "a4",
+            "Na3",
+            "Nc3",
+            "b3",
+            "b4",
+            "c3",
+            "c4",
+            "Qe2",
+            "d3",
+            "d4",
+            "Ke2",
+            "e5",
+            "Ba6",
+            "Bb5",
+            "Bc4",
+            "Bd3",
+            "Be2",
+            "Nd4",
+            "Ne5",
+            "Nh4",
+            "Ng1",
+            "Ng5",
+            "g3",
+            "g4",
+            "Rg1",
+            "h3",
+            "h4"
+          ],
+          "legalActions": [
+            89, 90, 652, 656, 673, 674, 1257, 1258, 1796, 1841, 1842, 2352,
+            2571, 2973, 2974, 2975, 2976, 2977, 3132, 3134, 3136, 3137, 3138,
+            3593, 3594, 4117, 4177, 4178
+          ],
+          "observationString": "r1bqkbnr/pp1ppppp/2n5/2p5/4P3/5N2/PPPP1PPP/RNBQKB1R w KQkq - 2 3",
+          "playerId": 1,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess()\n[State]\nFEN: rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1\n2426\n1258\n3572\n656\n\n"
+        },
+        "reward": null,
+        "status": "ACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "submission": -1
+        },
+        "info": {},
+        "observation": {
+          "currentPlayer": 0,
+          "isTerminal": false,
+          "legalActionStrings": [
+            "Rb8",
+            "a6",
+            "a5",
+            "b6",
+            "b5",
+            "Na5",
+            "Nb8",
+            "Nb4",
+            "Ne5",
+            "Nxd4",
+            "c4",
+            "cxd4",
+            "Qa5+",
+            "Qb6",
+            "Qc7",
+            "d6",
+            "d5",
+            "e6",
+            "e5",
+            "f6",
+            "f5",
+            "Nf6",
+            "Nh6",
+            "g6",
+            "g5",
+            "h6",
+            "h5"
+          ],
+          "legalActions": [
+            30, 89, 90, 673, 674, 1380, 1381, 1382, 1384, 1386, 1403, 1431,
+            1807, 1808, 1809, 1841, 1842, 2425, 2426, 3009, 3010, 3572, 3576,
+            3593, 3594, 4177, 4178
+          ],
+          "observationString": "r1bqkbnr/pp1ppppp/2n5/2p5/3PP3/5N2/PPP2PPP/RNBQKB1R b KQkq - 0 3",
+          "playerId": 0,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess()\n[State]\nFEN: rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1\n2426\n1258\n3572\n656\n1842\n\n",
+          "step": 6
+        },
+        "reward": null,
+        "status": "ACTIVE"
+      },
+      {
+        "action": {
+          "actionString": "d4",
+          "generate_returns": [
+            "{\n  \"main_response\": \"To select the best move, first examine the position and standard plans in the Sicilian after 1 e4 c5 2 Nf3 Nc6.\\n\\n1. Opening principles  \\n   \\u2022 White usually aims for quick central occupation.  \\n   \\u2022 In the Sicilian, the main theoretical branch is the \\u201cOpen Sicilian,\\u201d reached by d2\\u2013d4, immediately challenging Black\\u2019s c-pawn.\\n\\n2. Candidate moves  \\n   a) 3.d4 \\u2013 the most popular and theoretically critical, opening the center.  \\n   b) 3.Bb5 \\u2013 the Rossolimo, also reputable but less forcing.  \\n   c) 3.Nc3 \\u2013 a Closed Sicilian setup, more restrained.  \\n\\n3. Evaluation  \\n   \\u2022 3.d4 strikes at the center right away, maximizes piece activity, and is endorsed by opening theory as White\\u2019s main line.  \\n   \\u2022 3.Bb5 is sound but allows Black more structural choices.  \\n   \\u2022 3.Nc3 is solid but less ambitious.\\n\\nGiven the objective of playing the strongest, most principled continuation, 3.d4 is the optimal choice.\\n\\nFinal Answer: d4\",\n  \"main_response_and_thoughts\": \"\",\n  \"request_for_logging\": {\n    \"model\": \"o3-2025-04-16\",\n    \"messages\": [\n      {\n        \"role\": \"user\",\n        \"content\": [\n          {\n            \"type\": \"text\",\n            \"text\": \"Let's play chess. The current game state in Forsyth-Edwards Notation (FEN) notation is:\\nr1bqkbnr/pp1ppppp/2n5/2p5/4P3/5N2/PPPP1PPP/RNBQKB1R w KQkq - 2 3\\nThe moves played so far are:\\n1. e4 c5 2. Nf3 Nc6 3.\\nYou are playing as player White.\\nIt is now your turn. Play your strongest move. The move MUST be legal. Reason step by step to come up with your move, then output your final answer in the format \\\"Final Answer: X\\\" where X is your chosen move in standard algebraic notation (SAN).\\n\"\n          }\n        ]\n      }\n    ],\n    \"config\": {\n      \"temperature\": \"NOT_GIVEN\",\n      \"top_p\": \"NOT_GIVEN\",\n      \"max_tokens\": \"NOT_GIVEN\",\n      \"reasoning_effort\": \"NOT_GIVEN\"\n    }\n  },\n  \"response_for_logging\": {\n    \"id\": \"chatcmpl-C4Wp40JfCEtlyCTMSwC7QnnF6bbRn\",\n    \"choices\": [\n      {\n        \"finish_reason\": \"stop\",\n        \"index\": 0,\n        \"message\": {\n          \"content\": \"To select the best move, first examine the position and standard plans in the Sicilian after 1 e4 c5 2 Nf3 Nc6.\\n\\n1. Opening principles  \\n   \\u2022 White usually aims for quick central occupation.  \\n   \\u2022 In the Sicilian, the main theoretical branch is the \\u201cOpen Sicilian,\\u201d reached by d2\\u2013d4, immediately challenging Black\\u2019s c-pawn.\\n\\n2. Candidate moves  \\n   a) 3.d4 \\u2013 the most popular and theoretically critical, opening the center.  \\n   b) 3.Bb5 \\u2013 the Rossolimo, also reputable but less forcing.  \\n   c) 3.Nc3 \\u2013 a Closed Sicilian setup, more restrained.  \\n\\n3. Evaluation  \\n   \\u2022 3.d4 strikes at the center right away, maximizes piece activity, and is endorsed by opening theory as White\\u2019s main line.  \\n   \\u2022 3.Bb5 is sound but allows Black more structural choices.  \\n   \\u2022 3.Nc3 is solid but less ambitious.\\n\\nGiven the objective of playing the strongest, most principled continuation, 3.d4 is the optimal choice.\\n\\nFinal Answer: d4\",\n          \"refusal\": null,\n          \"role\": \"assistant\",\n          \"annotations\": []\n        }\n      }\n    ],\n    \"created\": 1755195518,\n    \"model\": \"o3-2025-04-16\",\n    \"object\": \"chat.completion\",\n    \"service_tier\": \"default\",\n    \"system_fingerprint\": null,\n    \"usage\": {\n      \"completion_tokens\": 837,\n      \"prompt_tokens\": 167,\n      \"total_tokens\": 1004,\n      \"completion_tokens_details\": {\n        \"accepted_prediction_tokens\": 0,\n        \"audio_tokens\": 0,\n        \"reasoning_tokens\": 576,\n        \"rejected_prediction_tokens\": 0\n      },\n      \"prompt_tokens_details\": {\n        \"audio_tokens\": 0,\n        \"cached_tokens\": 0\n      }\n    }\n  },\n  \"generation_tokens\": 837,\n  \"prompt_tokens\": 167,\n  \"reasoning_tokens\": 576,\n  \"duration_success_only_secs\": 11.991624780996062\n}"
+          ],
+          "status": "OK",
+          "submission": 1842,
+          "thoughts": "To select the best move, first examine the position and standard plans in the Sicilian after 1 e4 c5 2 Nf3 Nc6.\n\n1. Opening principles  \n   \u2022 White usually aims for quick central occupation.  \n   \u2022 In the Sicilian, the main theoretical branch is the \u201cOpen Sicilian,\u201d reached by d2\u2013d4, immediately challenging Black\u2019s c-pawn.\n\n2. Candidate moves  \n   a) 3.d4 \u2013 the most popular and theoretically critical, opening the center.  \n   b) 3.Bb5 \u2013 the Rossolimo, also reputable but less forcing.  \n   c) 3.Nc3 \u2013 a Closed Sicilian setup, more restrained.  \n\n3. Evaluation  \n   \u2022 3.d4 strikes at the center right away, maximizes piece activity, and is endorsed by opening theory as White\u2019s main line.  \n   \u2022 3.Bb5 is sound but allows Black more structural choices.  \n   \u2022 3.Nc3 is solid but less ambitious.\n\nGiven the objective of playing the strongest, most principled continuation, 3.d4 is the optimal choice.\n\nFinal Answer: d4"
+        },
+        "info": {
+          "actionApplied": 1842,
+          "actionSubmitted": 1842,
+          "actionSubmittedToString": "d4",
+          "agentSelfReportedStatus": "OK",
+          "timeTaken": 12.022
+        },
+        "observation": {
+          "currentPlayer": 0,
+          "isTerminal": false,
+          "legalActionStrings": [],
+          "legalActions": [],
+          "observationString": "r1bqkbnr/pp1ppppp/2n5/2p5/3PP3/5N2/PPP2PPP/RNBQKB1R b KQkq - 0 3",
+          "playerId": 1,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess()\n[State]\nFEN: rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1\n2426\n1258\n3572\n656\n1842\n\n"
+        },
+        "reward": null,
+        "status": "INACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "actionString": "cxd4",
+          "generate_returns": [
+            "{\n  \"main_response\": \"Let's analyze the position after 1. e4 c5 2. Nf3 Nc6 3. d4:\\n\\n**FEN**: r1bqkbnr/pp1ppppp/2n5/2p5/3PP3/5N2/PPP2PPP/RNBQKB1R b KQkq - 0 3\\n\\n**Board:**\\n```\\n8 r  .  b  q  k  b  n  r\\n7 p  p  .  p  p  p  p  p\\n6 .  .  n  .  .  .  .  .\\n5 .  .  p  .  .  .  .  .\\n4 .  .  .  P  P  .  .  .\\n3 .  .  .  .  .  N  .  .\\n2 P  P  P  .  .  P  P  P\\n1 R  N  B  Q  K  B  .  R\\n  a  b  c  d  e  f  g  h\\n```\\n\\n**White's last move:** 3. d4  \\nNow, it\\u2019s Black\\u2019s turn.\\n\\n---\\n\\n**Step-by-Step Reasoning:**\\n\\n1. **White threatens:** The pawn on d4 attacks Black's pawn on c5. If Black does nothing, White can play dxc5, winning a pawn.  \\n2. **Options for Black:**\\n   - **cxd4**: Exchange pawns in the center, the most popular and theoretically sound move.\\n   - **Nf6**: Developing a piece, but allows d5 by White, gaining space.\\n   - **e6**: Prepares to develop the dark-square bishop, but White still can play d5.\\n   - **Qa5+**: A check, but easily blocked by Nc3 or Bd2.\\n   - **g6, d6**: Typical Sicilian moves, but less immediate than taking on d4.\\n3. **Best Practice in Open Sicilian:** After 3. d4, standard play is to exchange on d4: 3... cxd4 4. Nxd4, entering the Open Sicilian.\\n\\n4. **Check legality:**  \\n   - cxd4 captures White\\u2019s pawn on d4.\\n   - The c-pawn is on c5 and d4 has a white pawn; the capture is legal.\\n\\n5. **Evaluation:**  \\n   - cxd4 is the main line.\\n   - It maintains balance, doesn\\u2019t allow White to seize a central advantage, opens lines for Black, and is entirely safe and standard.\\n\\n---\\n\\n**Conclusion:** The strongest, most principled move is **cxd4**.\\n\\n---\\n\\nFinal Answer: cxd4\",\n  \"main_response_and_thoughts\": \"\",\n  \"request_for_logging\": {\n    \"model\": \"gpt-4.1-2025-04-14\",\n    \"messages\": [\n      {\n        \"role\": \"user\",\n        \"content\": [\n          {\n            \"type\": \"text\",\n            \"text\": \"Let's play chess. The current game state in Forsyth-Edwards Notation (FEN) notation is:\\nr1bqkbnr/pp1ppppp/2n5/2p5/3PP3/5N2/PPP2PPP/RNBQKB1R b KQkq - 0 3\\nThe moves played so far are:\\n1. e4 c5 2. Nf3 Nc6 3. d4\\nYou are playing as player Black.\\nIt is now your turn. Play your strongest move. The move MUST be legal. Reason step by step to come up with your move, then output your final answer in the format \\\"Final Answer: X\\\" where X is your chosen move in standard algebraic notation (SAN).\\n\"\n          }\n        ]\n      }\n    ],\n    \"config\": {\n      \"temperature\": \"NOT_GIVEN\",\n      \"top_p\": \"NOT_GIVEN\",\n      \"max_tokens\": \"NOT_GIVEN\",\n      \"reasoning_effort\": \"NOT_GIVEN\"\n    }\n  },\n  \"response_for_logging\": {\n    \"id\": \"chatcmpl-C4WpGJ0TePQuASmKrGMy1qV1s7iHT\",\n    \"choices\": [\n      {\n        \"finish_reason\": \"stop\",\n        \"index\": 0,\n        \"logprobs\": null,\n        \"message\": {\n          \"content\": \"Let's analyze the position after 1. e4 c5 2. Nf3 Nc6 3. d4:\\n\\n**FEN**: r1bqkbnr/pp1ppppp/2n5/2p5/3PP3/5N2/PPP2PPP/RNBQKB1R b KQkq - 0 3\\n\\n**Board:**\\n```\\n8 r  .  b  q  k  b  n  r\\n7 p  p  .  p  p  p  p  p\\n6 .  .  n  .  .  .  .  .\\n5 .  .  p  .  .  .  .  .\\n4 .  .  .  P  P  .  .  .\\n3 .  .  .  .  .  N  .  .\\n2 P  P  P  .  .  P  P  P\\n1 R  N  B  Q  K  B  .  R\\n  a  b  c  d  e  f  g  h\\n```\\n\\n**White's last move:** 3. d4  \\nNow, it\\u2019s Black\\u2019s turn.\\n\\n---\\n\\n**Step-by-Step Reasoning:**\\n\\n1. **White threatens:** The pawn on d4 attacks Black's pawn on c5. If Black does nothing, White can play dxc5, winning a pawn.  \\n2. **Options for Black:**\\n   - **cxd4**: Exchange pawns in the center, the most popular and theoretically sound move.\\n   - **Nf6**: Developing a piece, but allows d5 by White, gaining space.\\n   - **e6**: Prepares to develop the dark-square bishop, but White still can play d5.\\n   - **Qa5+**: A check, but easily blocked by Nc3 or Bd2.\\n   - **g6, d6**: Typical Sicilian moves, but less immediate than taking on d4.\\n3. **Best Practice in Open Sicilian:** After 3. d4, standard play is to exchange on d4: 3... cxd4 4. Nxd4, entering the Open Sicilian.\\n\\n4. **Check legality:**  \\n   - cxd4 captures White\\u2019s pawn on d4.\\n   - The c-pawn is on c5 and d4 has a white pawn; the capture is legal.\\n\\n5. **Evaluation:**  \\n   - cxd4 is the main line.\\n   - It maintains balance, doesn\\u2019t allow White to seize a central advantage, opens lines for Black, and is entirely safe and standard.\\n\\n---\\n\\n**Conclusion:** The strongest, most principled move is **cxd4**.\\n\\n---\\n\\nFinal Answer: cxd4\",\n          \"refusal\": null,\n          \"role\": \"assistant\",\n          \"annotations\": []\n        }\n      }\n    ],\n    \"created\": 1755195530,\n    \"model\": \"gpt-4.1-2025-04-14\",\n    \"object\": \"chat.completion\",\n    \"service_tier\": \"default\",\n    \"system_fingerprint\": \"fp_7d949b30bb\",\n    \"usage\": {\n      \"completion_tokens\": 582,\n      \"prompt_tokens\": 170,\n      \"total_tokens\": 752,\n      \"completion_tokens_details\": {\n        \"accepted_prediction_tokens\": 0,\n        \"audio_tokens\": 0,\n        \"reasoning_tokens\": 0,\n        \"rejected_prediction_tokens\": 0\n      },\n      \"prompt_tokens_details\": {\n        \"audio_tokens\": 0,\n        \"cached_tokens\": 0\n      }\n    }\n  },\n  \"generation_tokens\": 582,\n  \"prompt_tokens\": 170,\n  \"reasoning_tokens\": 0,\n  \"duration_success_only_secs\": 9.20247976900282\n}"
+          ],
+          "status": "OK",
+          "submission": 1431,
+          "thoughts": "Let's analyze the position after 1. e4 c5 2. Nf3 Nc6 3. d4:\n\n**FEN**: r1bqkbnr/pp1ppppp/2n5/2p5/3PP3/5N2/PPP2PPP/RNBQKB1R b KQkq - 0 3\n\n**Board:**\n```\n8 r  .  b  q  k  b  n  r\n7 p  p  .  p  p  p  p  p\n6 .  .  n  .  .  .  .  .\n5 .  .  p  .  .  .  .  .\n4 .  .  .  P  P  .  .  .\n3 .  .  .  .  .  N  .  .\n2 P  P  P  .  .  P  P  P\n1 R  N  B  Q  K  B  .  R\n  a  b  c  d  e  f  g  h\n```\n\n**White's last move:** 3. d4  \nNow, it\u2019s Black\u2019s turn.\n\n---\n\n**Step-by-Step Reasoning:**\n\n1. **White threatens:** The pawn on d4 attacks Black's pawn on c5. If Black does nothing, White can play dxc5, winning a pawn.  \n2. **Options for Black:**\n   - **cxd4**: Exchange pawns in the center, the most popular and theoretically sound move.\n   - **Nf6**: Developing a piece, but allows d5 by White, gaining space.\n   - **e6**: Prepares to develop the dark-square bishop, but White still can play d5.\n   - **Qa5+**: A check, but easily blocked by Nc3 or Bd2.\n   - **g6, d6**: Typical Sicilian moves, but less immediate than taking on d4.\n3. **Best Practice in Open Sicilian:** After 3. d4, standard play is to exchange on d4: 3... cxd4 4. Nxd4, entering the Open Sicilian.\n\n4. **Check legality:**  \n   - cxd4 captures White\u2019s pawn on d4.\n   - The c-pawn is on c5 and d4 has a white pawn; the capture is legal.\n\n5. **Evaluation:**  \n   - cxd4 is the main line.\n   - It maintains balance, doesn\u2019t allow White to seize a central advantage, opens lines for Black, and is entirely safe and standard.\n\n---\n\n**Conclusion:** The strongest, most principled move is **cxd4**.\n\n---\n\nFinal Answer: cxd4"
+        },
+        "info": {
+          "actionApplied": 1431,
+          "actionSubmitted": 1431,
+          "actionSubmittedToString": "cxd4",
+          "agentSelfReportedStatus": "OK",
+          "timeTaken": 9.231
+        },
+        "observation": {
+          "currentPlayer": 1,
+          "isTerminal": false,
+          "legalActionStrings": [],
+          "legalActions": [],
+          "observationString": "r1bqkbnr/pp1ppppp/2n5/8/3pP3/5N2/PPP2PPP/RNBQKB1R w KQkq - 0 4",
+          "playerId": 0,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess()\n[State]\nFEN: rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1\n2426\n1258\n3572\n656\n1842\n1431\n\n",
+          "step": 7
+        },
+        "reward": null,
+        "status": "INACTIVE"
+      },
+      {
+        "action": {
+          "submission": -1
+        },
+        "info": {},
+        "observation": {
+          "currentPlayer": 1,
+          "isTerminal": false,
+          "legalActionStrings": [
+            "a3",
+            "a4",
+            "Na3",
+            "Nbd2",
+            "Nc3",
+            "b3",
+            "b4",
+            "Bd2",
+            "Be3",
+            "Bf4",
+            "Bg5",
+            "Bh6",
+            "c3",
+            "c4",
+            "Qd2",
+            "Qd3",
+            "Qxd4",
+            "Qe2",
+            "Ke2",
+            "Kd2",
+            "e5",
+            "Ba6",
+            "Bb5",
+            "Bc4",
+            "Bd3",
+            "Be2",
+            "Nfd2",
+            "Nxd4",
+            "Ne5",
+            "Nh4",
+            "Ng1",
+            "Ng5",
+            "g3",
+            "g4",
+            "Rg1",
+            "h3",
+            "h4"
+          ],
+          "legalActions": [
+            89, 90, 652, 654, 656, 673, 674, 1212, 1213, 1214, 1215, 1216, 1257,
+            1258, 1768, 1769, 1770, 1796, 2352, 2393, 2571, 2973, 2974, 2975,
+            2976, 2977, 3131, 3132, 3134, 3136, 3137, 3138, 3593, 3594, 4117,
+            4177, 4178
+          ],
+          "observationString": "r1bqkbnr/pp1ppppp/2n5/8/3pP3/5N2/PPP2PPP/RNBQKB1R w KQkq - 0 4",
+          "playerId": 1,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess()\n[State]\nFEN: rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1\n2426\n1258\n3572\n656\n1842\n1431\n\n"
+        },
+        "reward": null,
+        "status": "ACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "submission": -1
+        },
+        "info": {},
+        "observation": {
+          "currentPlayer": 0,
+          "isTerminal": false,
+          "legalActionStrings": [
+            "Rb8",
+            "a6",
+            "a5",
+            "b6",
+            "b5",
+            "Na5",
+            "Nb8",
+            "Nb4",
+            "Ne5",
+            "Nxd4",
+            "Qa5+",
+            "Qb6",
+            "Qc7",
+            "d6",
+            "d5",
+            "e6",
+            "e5",
+            "f6",
+            "f5",
+            "Nf6",
+            "Nh6",
+            "g6",
+            "g5",
+            "h6",
+            "h5"
+          ],
+          "legalActions": [
+            30, 89, 90, 673, 674, 1380, 1381, 1382, 1384, 1386, 1807, 1808,
+            1809, 1841, 1842, 2425, 2426, 3009, 3010, 3572, 3576, 3593, 3594,
+            4177, 4178
+          ],
+          "observationString": "r1bqkbnr/pp1ppppp/2n5/8/3NP3/8/PPP2PPP/RNBQKB1R b KQkq - 0 4",
+          "playerId": 0,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess()\n[State]\nFEN: rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1\n2426\n1258\n3572\n656\n1842\n1431\n3132\n\n",
+          "step": 8
+        },
+        "reward": null,
+        "status": "ACTIVE"
+      },
+      {
+        "action": {
+          "actionString": "Nxd4",
+          "generate_returns": [
+            "{\n  \"main_response\": \"First, identify what is happening on the board.\\n\\n\\u2022 Black\\u2019s pawn from c5 has just captured on d4, so a black pawn now sits on d4.  \\n\\u2022 White\\u2019s knight stands on f3. A knight moves in an \\u201cL\\u201d: two squares in one direction and one perpendicular. From f3 a legal knight jump is to d4 (two files left, one rank up), exactly the square occupied by the black pawn.  \\n\\u2022 Capturing that pawn both regains the material and places a well-centralised knight on d4, the standard reply in the Open Sicilian.  \\n\\u2022 No other White piece can currently recapture the pawn, and not recapturing would leave Black a healthy extra pawn in the centre. Hence the recapture is clearly the strongest move.  \\n\\u2022 The move is legal, does not leave White in check, and is the main theoretical continuation.\\n\\nTherefore White should play:\\n\\nFinal Answer: Nxd4\",\n  \"main_response_and_thoughts\": \"\",\n  \"request_for_logging\": {\n    \"model\": \"o3-2025-04-16\",\n    \"messages\": [\n      {\n        \"role\": \"user\",\n        \"content\": [\n          {\n            \"type\": \"text\",\n            \"text\": \"Let's play chess. The current game state in Forsyth-Edwards Notation (FEN) notation is:\\nr1bqkbnr/pp1ppppp/2n5/8/3pP3/5N2/PPP2PPP/RNBQKB1R w KQkq - 0 4\\nThe moves played so far are:\\n1. e4 c5 2. Nf3 Nc6 3. d4 cxd4 4.\\nYou are playing as player White.\\nIt is now your turn. Play your strongest move. The move MUST be legal. Reason step by step to come up with your move, then output your final answer in the format \\\"Final Answer: X\\\" where X is your chosen move in standard algebraic notation (SAN).\\n\"\n          }\n        ]\n      }\n    ],\n    \"config\": {\n      \"temperature\": \"NOT_GIVEN\",\n      \"top_p\": \"NOT_GIVEN\",\n      \"max_tokens\": \"NOT_GIVEN\",\n      \"reasoning_effort\": \"NOT_GIVEN\"\n    }\n  },\n  \"response_for_logging\": {\n    \"id\": \"chatcmpl-C4WpPhHt9f0c11Eg4219Vk0LcIBLP\",\n    \"choices\": [\n      {\n        \"finish_reason\": \"stop\",\n        \"index\": 0,\n        \"message\": {\n          \"content\": \"First, identify what is happening on the board.\\n\\n\\u2022 Black\\u2019s pawn from c5 has just captured on d4, so a black pawn now sits on d4.  \\n\\u2022 White\\u2019s knight stands on f3. A knight moves in an \\u201cL\\u201d: two squares in one direction and one perpendicular. From f3 a legal knight jump is to d4 (two files left, one rank up), exactly the square occupied by the black pawn.  \\n\\u2022 Capturing that pawn both regains the material and places a well-centralised knight on d4, the standard reply in the Open Sicilian.  \\n\\u2022 No other White piece can currently recapture the pawn, and not recapturing would leave Black a healthy extra pawn in the centre. Hence the recapture is clearly the strongest move.  \\n\\u2022 The move is legal, does not leave White in check, and is the main theoretical continuation.\\n\\nTherefore White should play:\\n\\nFinal Answer: Nxd4\",\n          \"refusal\": null,\n          \"role\": \"assistant\",\n          \"annotations\": []\n        }\n      }\n    ],\n    \"created\": 1755195539,\n    \"model\": \"o3-2025-04-16\",\n    \"object\": \"chat.completion\",\n    \"service_tier\": \"default\",\n    \"system_fingerprint\": null,\n    \"usage\": {\n      \"completion_tokens\": 1235,\n      \"prompt_tokens\": 173,\n      \"total_tokens\": 1408,\n      \"completion_tokens_details\": {\n        \"accepted_prediction_tokens\": 0,\n        \"audio_tokens\": 0,\n        \"reasoning_tokens\": 1024,\n        \"rejected_prediction_tokens\": 0\n      },\n      \"prompt_tokens_details\": {\n        \"audio_tokens\": 0,\n        \"cached_tokens\": 0\n      }\n    }\n  },\n  \"generation_tokens\": 1235,\n  \"prompt_tokens\": 173,\n  \"reasoning_tokens\": 1024,\n  \"duration_success_only_secs\": 15.61725274699711\n}"
+          ],
+          "status": "OK",
+          "submission": 3132,
+          "thoughts": "First, identify what is happening on the board.\n\n\u2022 Black\u2019s pawn from c5 has just captured on d4, so a black pawn now sits on d4.  \n\u2022 White\u2019s knight stands on f3. A knight moves in an \u201cL\u201d: two squares in one direction and one perpendicular. From f3 a legal knight jump is to d4 (two files left, one rank up), exactly the square occupied by the black pawn.  \n\u2022 Capturing that pawn both regains the material and places a well-centralised knight on d4, the standard reply in the Open Sicilian.  \n\u2022 No other White piece can currently recapture the pawn, and not recapturing would leave Black a healthy extra pawn in the centre. Hence the recapture is clearly the strongest move.  \n\u2022 The move is legal, does not leave White in check, and is the main theoretical continuation.\n\nTherefore White should play:\n\nFinal Answer: Nxd4"
+        },
+        "info": {
+          "actionApplied": 3132,
+          "actionSubmitted": 3132,
+          "actionSubmittedToString": "Nxd4",
+          "agentSelfReportedStatus": "OK",
+          "timeTaken": 15.645
+        },
+        "observation": {
+          "currentPlayer": 0,
+          "isTerminal": false,
+          "legalActionStrings": [],
+          "legalActions": [],
+          "observationString": "r1bqkbnr/pp1ppppp/2n5/8/3NP3/8/PPP2PPP/RNBQKB1R b KQkq - 0 4",
+          "playerId": 1,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess()\n[State]\nFEN: rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1\n2426\n1258\n3572\n656\n1842\n1431\n3132\n\n"
+        },
+        "reward": null,
+        "status": "INACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "actionString": "Nf6",
+          "generate_returns": [
+            "{\n  \"main_response\": \"Let's break down the current position.\\n\\n### FEN\\n```\\nr1bqkbnr/pp1ppppp/2n5/8/3NP3/8/PPP2PPP/RNBQKB1R b KQkq - 0 4\\n```\\n\\n### Move History\\n1. e4 c5\\n2. Nf3 Nc6\\n3. d4 cxd4\\n4. Nxd4\\n\\nWhite has just played Nxd4, regaining the pawn.\\n\\n### Board layout:\\n\\n- Black to move\\n- Pieces developed: Both knights (Nc6 Nd4)\\n- Center: White has a strong knight on d4.\\n- It's standard open Sicilian (Open Sicilian, after 4. Nxd4)\\n\\n### Candidate Moves\\n\\nLet me consider common and best responses for Black in this position:\\n\\n1. **...Nf6**  \\n   Attacks e4 and develops a piece. This is the most common move, putting pressure on White's center and preparing for ...e6 or ...d6.\\n\\n2. **...e6**  \\n   Prepares to develop the dark bishop and solidifies the center. However, it doesn't challenge White's center immediately.\\n\\n3. **...g6**  \\n   Prepares to fianchetto, common in the Dragon (accelerated or normal). After 5. Nc3 Bg7, it\\u2019s a standard setup.\\n\\n4. **...Qc7 or ...a6**  \\n   These are also common moves (Paulsen, Kan, or Taimanov systems), but generally played after ...e6.\\n\\n### What is most principled?\\n\\nThe most direct and principled is **...Nf6**. It immediately attacks the e4 pawn, continues development, and keeps all options open. After 5. Nc3, Black can still choose among a number of Sicilian lines (Classical, Scheveningen, Dragon, etc.).\\n\\n**Is ...Nf6 legal?**\\n\\nLet's make sure:\\n- The knight moves from g8 to f6. No piece is blocking.\\n- e4 is attacked.\\n\\nYes, this is legal.\\n\\n### Justification\\n\\n- Develops a piece (knight)\\n- Increases central pressure\\n- Prepares ...e6 or ...g6 or even ...d6 next\\n\\nHence, the strongest and most flexible move in this position is:\\n\\n**Final Answer: Nf6**\",\n  \"main_response_and_thoughts\": \"\",\n  \"request_for_logging\": {\n    \"model\": \"gpt-4.1-2025-04-14\",\n    \"messages\": [\n      {\n        \"role\": \"user\",\n        \"content\": [\n          {\n            \"type\": \"text\",\n            \"text\": \"Let's play chess. The current game state in Forsyth-Edwards Notation (FEN) notation is:\\nr1bqkbnr/pp1ppppp/2n5/8/3NP3/8/PPP2PPP/RNBQKB1R b KQkq - 0 4\\nThe moves played so far are:\\n1. e4 c5 2. Nf3 Nc6 3. d4 cxd4 4. Nxd4\\nYou are playing as player Black.\\nIt is now your turn. Play your strongest move. The move MUST be legal. Reason step by step to come up with your move, then output your final answer in the format \\\"Final Answer: X\\\" where X is your chosen move in standard algebraic notation (SAN).\\n\"\n          }\n        ]\n      }\n    ],\n    \"config\": {\n      \"temperature\": \"NOT_GIVEN\",\n      \"top_p\": \"NOT_GIVEN\",\n      \"max_tokens\": \"NOT_GIVEN\",\n      \"reasoning_effort\": \"NOT_GIVEN\"\n    }\n  },\n  \"response_for_logging\": {\n    \"id\": \"chatcmpl-C4WpfZWtczkAzPrhGI4BX36oqefNc\",\n    \"choices\": [\n      {\n        \"finish_reason\": \"stop\",\n        \"index\": 0,\n        \"logprobs\": null,\n        \"message\": {\n          \"content\": \"Let's break down the current position.\\n\\n### FEN\\n```\\nr1bqkbnr/pp1ppppp/2n5/8/3NP3/8/PPP2PPP/RNBQKB1R b KQkq - 0 4\\n```\\n\\n### Move History\\n1. e4 c5\\n2. Nf3 Nc6\\n3. d4 cxd4\\n4. Nxd4\\n\\nWhite has just played Nxd4, regaining the pawn.\\n\\n### Board layout:\\n\\n- Black to move\\n- Pieces developed: Both knights (Nc6 Nd4)\\n- Center: White has a strong knight on d4.\\n- It's standard open Sicilian (Open Sicilian, after 4. Nxd4)\\n\\n### Candidate Moves\\n\\nLet me consider common and best responses for Black in this position:\\n\\n1. **...Nf6**  \\n   Attacks e4 and develops a piece. This is the most common move, putting pressure on White's center and preparing for ...e6 or ...d6.\\n\\n2. **...e6**  \\n   Prepares to develop the dark bishop and solidifies the center. However, it doesn't challenge White's center immediately.\\n\\n3. **...g6**  \\n   Prepares to fianchetto, common in the Dragon (accelerated or normal). After 5. Nc3 Bg7, it\\u2019s a standard setup.\\n\\n4. **...Qc7 or ...a6**  \\n   These are also common moves (Paulsen, Kan, or Taimanov systems), but generally played after ...e6.\\n\\n### What is most principled?\\n\\nThe most direct and principled is **...Nf6**. It immediately attacks the e4 pawn, continues development, and keeps all options open. After 5. Nc3, Black can still choose among a number of Sicilian lines (Classical, Scheveningen, Dragon, etc.).\\n\\n**Is ...Nf6 legal?**\\n\\nLet's make sure:\\n- The knight moves from g8 to f6. No piece is blocking.\\n- e4 is attacked.\\n\\nYes, this is legal.\\n\\n### Justification\\n\\n- Develops a piece (knight)\\n- Increases central pressure\\n- Prepares ...e6 or ...g6 or even ...d6 next\\n\\nHence, the strongest and most flexible move in this position is:\\n\\n**Final Answer: Nf6**\",\n          \"refusal\": null,\n          \"role\": \"assistant\",\n          \"annotations\": []\n        }\n      }\n    ],\n    \"created\": 1755195555,\n    \"model\": \"gpt-4.1-2025-04-14\",\n    \"object\": \"chat.completion\",\n    \"service_tier\": \"default\",\n    \"system_fingerprint\": \"fp_7d949b30bb\",\n    \"usage\": {\n      \"completion_tokens\": 497,\n      \"prompt_tokens\": 175,\n      \"total_tokens\": 672,\n      \"completion_tokens_details\": {\n        \"accepted_prediction_tokens\": 0,\n        \"audio_tokens\": 0,\n        \"reasoning_tokens\": 0,\n        \"rejected_prediction_tokens\": 0\n      },\n      \"prompt_tokens_details\": {\n        \"audio_tokens\": 0,\n        \"cached_tokens\": 0\n      }\n    }\n  },\n  \"generation_tokens\": 497,\n  \"prompt_tokens\": 175,\n  \"reasoning_tokens\": 0,\n  \"duration_success_only_secs\": 11.201628533002804\n}"
+          ],
+          "status": "OK",
+          "submission": 3572,
+          "thoughts": "Let's break down the current position.\n\n### FEN\n```\nr1bqkbnr/pp1ppppp/2n5/8/3NP3/8/PPP2PPP/RNBQKB1R b KQkq - 0 4\n```\n\n### Move History\n1. e4 c5\n2. Nf3 Nc6\n3. d4 cxd4\n4. Nxd4\n\nWhite has just played Nxd4, regaining the pawn.\n\n### Board layout:\n\n- Black to move\n- Pieces developed: Both knights (Nc6 Nd4)\n- Center: White has a strong knight on d4.\n- It's standard open Sicilian (Open Sicilian, after 4. Nxd4)\n\n### Candidate Moves\n\nLet me consider common and best responses for Black in this position:\n\n1. **...Nf6**  \n   Attacks e4 and develops a piece. This is the most common move, putting pressure on White's center and preparing for ...e6 or ...d6.\n\n2. **...e6**  \n   Prepares to develop the dark bishop and solidifies the center. However, it doesn't challenge White's center immediately.\n\n3. **...g6**  \n   Prepares to fianchetto, common in the Dragon (accelerated or normal). After 5. Nc3 Bg7, it\u2019s a standard setup.\n\n4. **...Qc7 or ...a6**  \n   These are also common moves (Paulsen, Kan, or Taimanov systems), but generally played after ...e6.\n\n### What is most principled?\n\nThe most direct and principled is **...Nf6**. It immediately attacks the e4 pawn, continues development, and keeps all options open. After 5. Nc3, Black can still choose among a number of Sicilian lines (Classical, Scheveningen, Dragon, etc.).\n\n**Is ...Nf6 legal?**\n\nLet's make sure:\n- The knight moves from g8 to f6. No piece is blocking.\n- e4 is attacked.\n\nYes, this is legal.\n\n### Justification\n\n- Develops a piece (knight)\n- Increases central pressure\n- Prepares ...e6 or ...g6 or even ...d6 next\n\nHence, the strongest and most flexible move in this position is:\n\n**Final Answer: Nf6**"
+        },
+        "info": {
+          "actionApplied": 3572,
+          "actionSubmitted": 3572,
+          "actionSubmittedToString": "Nf6",
+          "agentSelfReportedStatus": "OK",
+          "timeTaken": 11.233
+        },
+        "observation": {
+          "currentPlayer": 1,
+          "isTerminal": false,
+          "legalActionStrings": [],
+          "legalActions": [],
+          "observationString": "r1bqkb1r/pp1ppppp/2n2n2/8/3NP3/8/PPP2PPP/RNBQKB1R w KQkq - 1 5",
+          "playerId": 0,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess()\n[State]\nFEN: rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1\n2426\n1258\n3572\n656\n1842\n1431\n3132\n3572\n\n",
+          "step": 9
+        },
+        "reward": 1.0,
+        "status": "DONE"
+      },
+      {
+        "action": {
+          "submission": -1
+        },
+        "info": {},
+        "observation": {
+          "currentPlayer": 1,
+          "isTerminal": false,
+          "legalActionStrings": [
+            "a3",
+            "a4",
+            "Na3",
+            "Nd2",
+            "Nc3",
+            "b3",
+            "b4",
+            "Bd2",
+            "Be3",
+            "Bf4",
+            "Bg5",
+            "Bh6",
+            "c3",
+            "c4",
+            "Qd2",
+            "Qd3",
+            "Qe2",
+            "Qf3",
+            "Qg4",
+            "Qh5",
+            "Nb3",
+            "Nb5",
+            "Nxc6",
+            "Nf3",
+            "Nf5",
+            "Ne2",
+            "Ne6",
+            "Ke2",
+            "Kd2",
+            "e5",
+            "Ba6",
+            "Bb5",
+            "Bc4",
+            "Bd3",
+            "Be2",
+            "f3",
+            "f4",
+            "g3",
+            "g4",
+            "Rg1",
+            "h3",
+            "h4"
+          ],
+          "legalActions": [
+            89, 90, 652, 654, 656, 673, 674, 1212, 1213, 1214, 1215, 1216, 1257,
+            1258, 1768, 1769, 1796, 1797, 1798, 1799, 2036, 2037, 2039, 2040,
+            2041, 2042, 2043, 2352, 2393, 2571, 2973, 2974, 2975, 2976, 2977,
+            3009, 3010, 3593, 3594, 4117, 4177, 4178
+          ],
+          "observationString": "r1bqkb1r/pp1ppppp/2n2n2/8/3NP3/8/PPP2PPP/RNBQKB1R w KQkq - 1 5",
+          "playerId": 1,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess()\n[State]\nFEN: rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1\n2426\n1258\n3572\n656\n1842\n1431\n3132\n3572\n\n"
+        },
+        "reward": -1.0,
+        "status": "TIMEOUT"
+      }
+    ]
+  ],
+  "title": "Open Spiel: chess",
+  "version": "0.1.0"
+}

--- a/kaggle_environments/envs/open_spiel_env/games/chess/visualizer/default/src/chess_renderer.ts
+++ b/kaggle_environments/envs/open_spiel_env/games/chess/visualizer/default/src/chess_renderer.ts
@@ -265,12 +265,17 @@ export function renderer(options: RendererOptions<ChessStep[]>) {
     currentStatusTextElement.innerHTML = '';
     currentWinnerTextElement.innerHTML = '';
     if (chessStep.isTerminal) {
+      const escapeHtml = (s: string) =>
+        s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
+      const forfeitHtml = chessStep.forfeitReason
+        ? `<div style="font-size: ${isMobile ? '0.75rem' : '0.85rem'}; font-weight: 400; font-style: italic; color: #666; margin-top: 4px; max-width: 600px;">${escapeHtml(chessStep.forfeitReason)}</div>`
+        : '';
       if (isMobile) {
         currentStatusTextElement.innerHTML = `<div style="font-size: 0.9rem; color: #666;">Winner</div>`;
-        currentWinnerTextElement.innerHTML = `<div style="font-size: 1.1rem; font-weight: bold;">${chessStep.winner}</div>`;
+        currentWinnerTextElement.innerHTML = `<div style="font-size: 1.1rem; font-weight: bold;">${chessStep.winner}</div>${forfeitHtml}`;
       } else {
         currentStatusTextElement.textContent = '';
-        currentWinnerTextElement.innerHTML = `<span style="font-weight: bold; color: black;">${chessStep.winner}</span>`;
+        currentWinnerTextElement.innerHTML = `<span style="font-weight: bold; color: black;">${chessStep.winner}</span>${forfeitHtml}`;
       }
     } else {
       const currentPlayer = chessStep.players.find((player) => player.isTurn);

--- a/kaggle_environments/envs/open_spiel_env/games/chess/visualizer/default/src/transformers/chessReplayTypes.ts
+++ b/kaggle_environments/envs/open_spiel_env/games/chess/visualizer/default/src/transformers/chessReplayTypes.ts
@@ -24,6 +24,8 @@ export interface ChessStep extends Omit<BaseGameStep, 'players'> {
   fenState: FenState;
   isTerminal: boolean;
   winner: string | null;
+  /** Set when the loser failed to produce a valid action (e.g. ran out of overage time, errored, or submitted an illegal move). */
+  forfeitReason?: string | null;
 }
 
 /**
@@ -86,5 +88,5 @@ interface ChessReplayStep {
     step: number;
   };
   reward: number | null;
-  status: 'ACTIVE' | 'INACTIVE' | 'DONE';
+  status: 'ACTIVE' | 'INACTIVE' | 'DONE' | 'TIMEOUT' | 'ERROR' | 'INVALID';
 }

--- a/kaggle_environments/envs/open_spiel_env/games/chess/visualizer/default/src/transformers/chessTransformer.ts
+++ b/kaggle_environments/envs/open_spiel_env/games/chess/visualizer/default/src/transformers/chessTransformer.ts
@@ -56,7 +56,8 @@ export function getChessStepLabel(step: ChessStep) {
 
 export function getChessStepDescription(step: ChessStep) {
   if (step.isTerminal) {
-    return step.winner ?? '';
+    const winner = step.winner ?? '';
+    return step.forfeitReason ? `${winner}\n${step.forfeitReason}` : winner;
   }
 
   return step.players.find((player) => player.isTurn)?.thoughts ?? '';
@@ -76,6 +77,27 @@ export function deriveWinnerFromRewards(players: ChessPlayer[]) {
   const color = winnerPlayerIndex === 0 ? 'Black' : 'White';
 
   return `🎉 ${color} (${players[winnerPlayerIndex].name}) Wins!`;
+}
+
+/**
+ * Statuses set by open_spiel_env when an agent fails to produce a valid action:
+ *   TIMEOUT — exceeded the per-move / overage time budget
+ *   ERROR   — agent crashed or response was unparsable / cut off
+ *   INVALID — submitted an illegal move
+ * In all three cases the opponent wins by default.
+ */
+const FORFEIT_STATUSES = new Set(['TIMEOUT', 'ERROR', 'INVALID']);
+
+function describeForfeit(status: string): string {
+  switch (status) {
+    case 'TIMEOUT':
+      return 'ran out of time';
+    case 'INVALID':
+      return 'submitted an illegal move';
+    case 'ERROR':
+    default:
+      return 'failed to produce valid input';
+  }
 }
 
 export const chessTransformer = (environment: any) => {
@@ -114,6 +136,21 @@ export const chessTransformer = (environment: any) => {
   const lastStep = chessSteps[chessSteps.length - 1];
   const winDescription = deriveWinnerFromRewards(lastStep.players);
 
+  // If the loser exceeded their time budget / errored / submitted an illegal
+  // move, open_spiel_env marks their final status as TIMEOUT/ERROR/INVALID
+  // and gives the opponent the win. Surface this so the UI doesn't imply a
+  // normal checkmate/draw outcome.
+  let forfeitReason: string | null = null;
+  const rawLastStep = chessReplay.steps[chessReplay.steps.length - 1] ?? [];
+  const loserIndex = rawLastStep.findIndex((player) => FORFEIT_STATUSES.has(player.status));
+  if (loserIndex !== -1 && rawLastStep.length >= 2) {
+    const winnerIndex = 1 - loserIndex;
+    const loserName = agents[loserIndex] || `Player ${loserIndex + 1}`;
+    const winnerName = agents[winnerIndex] || `Player ${winnerIndex + 1}`;
+    const reason = describeForfeit(rawLastStep[loserIndex].status);
+    forfeitReason = `${loserName} ${reason}. ${winnerName} wins by default.`;
+  }
+
   // Artificially insert a step at the end to emphasize the win state
   chessSteps.push({
     players: [
@@ -131,6 +168,7 @@ export const chessTransformer = (environment: any) => {
     fenState: lastStep.fenState,
     step: lastStep.step + 1,
     winner: winDescription,
+    forfeitReason,
   });
 
   return chessSteps;


### PR DESCRIPTION
## Summary

When an agent in an open_spiel chess game runs out of overage time, crashes, or submits an illegal move, `open_spiel_env` marks its terminal status as `TIMEOUT`/`ERROR`/`INVALID` and awards the win to the opponent. The visualizer previously only showed the winner banner, leaving no indication that the game ended by forfeit rather than checkmate.

This PR detects the forfeit status on the final replay step and surfaces a human-readable reason as italic subtext below the winner banner on the terminal step. Mirrors the connect-four forfeit treatment from cf52ac28d.

Example forfeit message: *"o3 ran out of time. GPT 4.1 wins by default."*

Targeted at the `open_spiel_chess/default` visualizer because that's what's actually loaded on `kaggle.com/game-arena` today (verified via DevTools — the iframe loads `episode-visualizers/open_spiel_chess/default/...`). The `v2` visualizer lives on the `chess-v2/main` branch and would need a separate port.

## Changes

- `transformers/chessReplayTypes.ts` — add `forfeitReason?: string | null` to `ChessStep`; expand status union with `TIMEOUT | ERROR | INVALID`.
- `transformers/chessTransformer.ts` — detect forfeit by inspecting the loser's terminal status; emit a human-readable reason; include it in `getChessStepDescription` for side-panel use.
- `chess_renderer.ts` — render the forfeit reason as italic subtext under the winner banner on the terminal step.
- `replays/test-replay-forfeit.json` — synthetic replay with `TIMEOUT` status on Black for manual verification.

<img width="473" height="153" alt="Screenshot 2026-04-29 at 11 45 57 AM" src="https://github.com/user-attachments/assets/606da4a5-25d8-4d3c-a079-8bcd0786d425" />

