### PR TITLE
Rename make_prompt to generate_prompt in docstring

### DIFF
--- a/kaggle_environments/core_harness.py
+++ b/kaggle_environments/core_harness.py
@@ -9,7 +9,7 @@ Game-specific harnesses implement the ``GameHarness`` protocol by providing
 three methods:
 
 - ``get_legal_moves(observation)``
-- ``make_prompt(observation, move_history, previous_response?, previous_action?)``
+- ``generate_prompt(observation, move_history, previous_response?, previous_action?)``
 - ``parse_response(response, legal_action_strings)``
 
 Use ``create_agent_fn(game_harness)`` to produce a Kaggle-compatible

--- a/kaggle_environments/core_harness.py
+++ b/kaggle_environments/core_harness.py
@@ -12,6 +12,9 @@ three methods:
 - ``generate_prompt(observation, move_history, previous_response?, previous_action?)``
 - ``parse_response(response, legal_action_strings)``
 
+Note that the provided harness requires a ``generate_prompt`` while this uses
+``make_prompt`` internally. (The static submission maps between these two)
+
 Use ``create_agent_fn(game_harness)`` to produce a Kaggle-compatible
 ``agent_fn(obs, config) -> {"submission": int, ...}`` callable.
 """


### PR DESCRIPTION
`generate_prompt` is consistent across the core_harness, created harnesses, and static submission file