### PR TITLE
Open Spiel: strict mode preserves natural ERROR/TIMEOUT statuses

### DIFF
--- a/kaggle_environments/envs/open_spiel_env/open_spiel_env.py
+++ b/kaggle_environments/envs/open_spiel_env/open_spiel_env.py
@@ -151,9 +151,12 @@ CONFIGURATION_SPEC_TEMPLATE = {
         "description": (
             "If true, agents must return only {'submission': int} (no extra fields"
             " like 'thoughts'), and per-agent TIMEOUT/ERROR/INVALID counts as a"
-            " loss for the offending agent only — other agents win. If false"
-            " (default), any agent error halts and voids the entire episode,"
-            " matching the lenient research-mode behavior."
+            " loss for the offending agent only — other agents are marked DONE"
+            " with a winning reward. The offender keeps its natural ERROR or"
+            " TIMEOUT status (matching how every other Kaggle competition"
+            " reports per-player failures). If false (default), any agent error"
+            " halts and voids the entire episode, matching the lenient"
+            " research-mode behavior."
         ),
         "type": "boolean",
         "default": False,
@@ -568,15 +571,16 @@ def interpreter(
     for player_id, agent_state in enumerate(kaggle_state):
         reward = None
         if agent_error and strict_mode:
-            # Per-player scoping mirrors the INVALID path: offender DONE+loss,
-            # others DONE+win. Final status must be DONE (not ERROR/TIMEOUT) so
-            # that core.py preserves the reward and the C# scoring carveout for
-            # open_spiel does not skip the episode.
+            # Per-player scoping like every other competition: offender keeps
+            # its natural ERROR / TIMEOUT status (core.py will null its reward),
+            # others get DONE + winning reward. The kaggleazure open_spiel
+            # carveout is gated on UseModelProxy / EnableInternet so non-DONE
+            # statuses no longer void the episode in strict-mode competitions.
             if agent_state["status"] in ("TIMEOUT", "ERROR"):
-                reward = DEFAULT_INVALID_ACTION_REWARD
+                status = agent_state["status"]
             else:
                 reward = -DEFAULT_INVALID_ACTION_REWARD
-            status = "DONE"
+                status = "DONE"
         elif agent_error:
             # Set all agent statuses to ERROR in order not to score episode. Preserve
             # TIMEOUT which has the same effect.

--- a/kaggle_environments/envs/open_spiel_env/open_spiel_env.py
+++ b/kaggle_environments/envs/open_spiel_env/open_spiel_env.py
@@ -473,6 +473,10 @@ def interpreter(
                 action_applied = action_submitted
                 env.info["actionHistory"].append(str(action_applied))
                 env.info["stateHistory"].append(str(os_state))
+                # Visualizers (e.g. goTransformer) read actionString off the
+                # action dict to render moves. The LLM harness populates this
+                # itself; for code-submission agents we populate it here.
+                kaggle_state[acting_agent]["action"]["actionString"] = action_submitted_to_string
             elif action_submitted == AGENT_ERROR_ACTION:
                 kaggle_state[acting_agent]["status"] = "ERROR"
             else:
@@ -524,6 +528,9 @@ def interpreter(
             os_state.apply_actions(actions_for_apply)
             for pid in range(num_players):
                 simul_actions_applied[pid] = simul_actions_submitted[pid]
+                # See note above: surface actionString for visualizers.
+                if simul_actions_submitted_to_string[pid] is not None:
+                    kaggle_state[pid]["action"]["actionString"] = simul_actions_submitted_to_string[pid]
             env.info["actionHistory"].append(str(actions_for_apply))
             env.info["stateHistory"].append(str(os_state))
 

--- a/tests/envs/open_spiel_env/test_open_spiel_env.py
+++ b/tests/envs/open_spiel_env/test_open_spiel_env.py
@@ -81,6 +81,48 @@ class OpenSpielEnvTest(absltest.TestCase):
             ],
         )
 
+    def test_strict_mode_agent_error_keeps_per_player_status(self):
+        env = make(
+            "open_spiel_dark_hex",
+            configuration={"strictMode": True},
+            debug=True,
+        )
+        env.reset()
+        env.step([{"submission": -1}, {"submission": -1}])  # Initial setup step.
+        # Player 0 signals an internal error; player 1 plays normally.
+        env.step([{"submission": open_spiel_env.AGENT_ERROR_ACTION}, {"submission": -1}])
+        self.assertTrue(env.done)
+        playthrough = env.toJSON()
+        # Offender keeps its natural ERROR status; the other agent gets DONE+win.
+        self.assertEqual(playthrough["statuses"], ["ERROR", "DONE"])
+        # Offender's reward is nulled by core.py because status is ERROR;
+        # the other agent receives the winning reward.
+        self.assertIsNone(playthrough["rewards"][0])
+        self.assertEqual(playthrough["rewards"][1], -open_spiel_env.DEFAULT_INVALID_ACTION_REWARD)
+
+    def test_strict_mode_extra_action_field_is_invalid(self):
+        env = make(
+            "open_spiel_dark_hex",
+            configuration={"strictMode": True},
+            debug=True,
+        )
+        env.reset()
+        env.step([{"submission": -1}, {"submission": -1}])  # Initial setup step.
+        # Extra "thoughts" key violates the strict-mode action schema.
+        env.step([{"submission": 0, "thoughts": "..."}, {"submission": -1}])
+        self.assertTrue(env.done)
+        playthrough = env.toJSON()
+        # INVALID still maps to DONE (matches lenient behavior; kaggleazure
+        # already accepts INVALID statuses through the open_spiel carveout).
+        self.assertEqual(playthrough["statuses"], ["DONE", "DONE"])
+        self.assertEqual(
+            playthrough["rewards"],
+            [
+                open_spiel_env.DEFAULT_INVALID_ACTION_REWARD,
+                -open_spiel_env.DEFAULT_INVALID_ACTION_REWARD,
+            ],
+        )
+
     def test_gin_rummy_agent_playthrough(self):
         env = make(
             "open_spiel_gin_rummy",

--- a/tests/envs/open_spiel_env/test_open_spiel_env.py
+++ b/tests/envs/open_spiel_env/test_open_spiel_env.py
@@ -123,6 +123,19 @@ class OpenSpielEnvTest(absltest.TestCase):
             ],
         )
 
+    def test_action_string_populated_for_visualizer(self):
+        # Visualizers (e.g. goTransformer) read actionString off each player's
+        # action dict to render moves. The env must surface it even when the
+        # agent only submits {"submission": int}.
+        env = make("open_spiel_dark_hex", debug=True)
+        env.reset()
+        env.step([{"submission": -1}, {"submission": -1}])  # Initial setup.
+        env.step([{"submission": 0}, {"submission": -1}])
+        steps = env.toJSON()["steps"]
+        played_action = steps[2][0]["action"]
+        self.assertIn("actionString", played_action)
+        self.assertTrue(played_action["actionString"])
+
     def test_gin_rummy_agent_playthrough(self):
         env = make(
             "open_spiel_gin_rummy",


### PR DESCRIPTION
Previously strict mode forced `agent_state.status` to `DONE` on agent error so the kaggleazure open_spiel scoring carveout (which voids any episode with a non-DONE/INVALID status) wouldn't drop the episode. The downside is that DONE+reward in self-play validation looks like a successful match — the validation handler's All(DidComplete) check then promotes a broken submission to active.

Make strict mode behave like every other Kaggle competition: the offending agent keeps its natural ERROR or TIMEOUT status (with reward nulled by core.py), the other agent gets DONE+win. Validation episodes now correctly fail when an agent errors against itself. The kaggleazure carveout is being gated on `UseModelProxy`/`EnableInternet` in a separate PR so that strict-mode competitions are scored normally.