### PR TITLE
Orbit Wars playable: mobile / touch support

### DIFF
--- a/kaggle_environments/envs/orbit_wars/visualizer/playable/src/style.css
+++ b/kaggle_environments/envs/orbit_wars/visualizer/playable/src/style.css
@@ -59,6 +59,9 @@ input, select {
   width: min(100vh, calc(100vw - 280px));
   height: min(100vh, calc(100vw - 280px));
   cursor: crosshair;
+  touch-action: none;
+  user-select: none;
+  -webkit-user-select: none;
 }
 .hud {
   background: #14141e;
@@ -125,3 +128,79 @@ input, select {
   text-align: center;
 }
 .modal h2 { margin: 0 0 12px; }
+
+/* Floating step button (mobile only). */
+.fab-step {
+  display: none;
+  position: fixed;
+  right: 16px;
+  bottom: 16px;
+  width: 64px;
+  height: 64px;
+  border-radius: 50%;
+  background: #4a8fff;
+  color: white;
+  border: none;
+  font-size: 26px;
+  font-weight: bold;
+  align-items: center;
+  justify-content: center;
+  z-index: 50;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.6);
+  padding: 0;
+}
+.fab-step:hover { background: #5a9fff; }
+.fab-step:disabled { opacity: 0.4; }
+
+/* Mobile / portrait layout. */
+@media (max-width: 700px) {
+  .game {
+    grid-template-columns: 1fr;
+    grid-template-rows: auto 1fr;
+    height: 100dvh;
+  }
+  .game-canvas-wrap {
+    flex-direction: column;
+    justify-content: flex-start;
+  }
+  .game-canvas-wrap canvas {
+    width: min(100vw, calc(100dvh - 220px));
+    height: min(100vw, calc(100dvh - 220px));
+    flex-shrink: 0;
+    margin: 0 auto;
+  }
+  .hud {
+    border-left: none;
+    border-bottom: 1px solid #2a2a40;
+    padding: 6px 10px;
+    flex-direction: row;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 6px 10px;
+    overflow: visible;
+  }
+  .hud h2 { margin: 0; font-size: 13px; }
+  .hud .scores { flex-direction: row; flex-wrap: wrap; gap: 4px; }
+  .hud .score-row { padding: 2px 6px; font-size: 12px; }
+  .hud .pending { font-size: 11px; }
+  .hud-mobile-hide { display: none !important; }
+  .fleet-menu {
+    position: static !important;
+    left: auto !important;
+    top: auto !important;
+    width: 100%;
+    min-width: 0;
+    border-radius: 0;
+    border-left: none;
+    border-right: none;
+    border-bottom: none;
+    padding: 8px 10px;
+    box-shadow: none;
+  }
+  .fleet-menu h3 { font-size: 12px; margin: 0 0 4px; }
+  .fleet-menu .row { margin: 4px 0; }
+  .fleet-menu .row label { width: auto; }
+  .fleet-menu .actions button { padding: 8px 14px; }
+  .fleet-menu .mobile-hint { display: none; }
+  .fab-step { display: flex; }
+}

--- a/kaggle_environments/envs/orbit_wars/visualizer/playable/src/ui/FleetMenu.tsx
+++ b/kaggle_environments/envs/orbit_wars/visualizer/playable/src/ui/FleetMenu.tsx
@@ -62,7 +62,7 @@ export function FleetMenu({ planet, anchor, aimAngle, ships, alreadyQueued, onSh
         <button onClick={send}>Send</button>
         <button onClick={onCancel}>Cancel</button>
       </div>
-      <div style={{ marginTop: 6, color: '#aaaab0', fontSize: 11 }}>
+      <div className="mobile-hint" style={{ marginTop: 6, color: '#aaaab0', fontSize: 11 }}>
         Aim with the mouse. Right-click or Esc to cancel.
       </div>
     </div>

--- a/kaggle_environments/envs/orbit_wars/visualizer/playable/src/ui/GameCanvas.tsx
+++ b/kaggle_environments/envs/orbit_wars/visualizer/playable/src/ui/GameCanvas.tsx
@@ -18,9 +18,9 @@ interface Props {
   dragging: boolean;
   pendingActions: Action[];
   humanPlayerId: number;
-  onMouseDown(planet: Planet | null, boardX: number, boardY: number): void;
-  onMouseMove(boardX: number, boardY: number): void;
-  onMouseUp(boardX: number, boardY: number): void;
+  onPointerDown(planet: Planet | null, boardX: number, boardY: number, pointerType: string): void;
+  onPointerMove(boardX: number, boardY: number): void;
+  onPointerUp(boardX: number, boardY: number): void;
   onContextMenu(): void;
 }
 
@@ -34,9 +34,9 @@ export function GameCanvas({
   dragging,
   pendingActions,
   humanPlayerId,
-  onMouseDown,
-  onMouseMove,
-  onMouseUp,
+  onPointerDown,
+  onPointerMove,
+  onPointerUp,
   onContextMenu,
 }: Props) {
   const canvasRef = useRef<HTMLCanvasElement | null>(null);
@@ -134,25 +134,31 @@ export function GameCanvas({
     <canvas
       ref={canvasRef}
       style={cursor ? { cursor } : undefined}
-      onMouseDown={(e) => {
+      onPointerDown={(e) => {
         const c = canvasRef.current;
         if (!c) return;
-        const { x, y } = screenToBoard(c, e);
-        onMouseDown(planetAt(state, x, y), x, y);
-      }}
-      onMouseMove={(e) => {
-        const c = canvasRef.current;
-        if (!c) return;
-        const { x, y } = screenToBoard(c, e);
+        c.setPointerCapture(e.pointerId);
+        const { x, y } = screenToBoard(c, e.nativeEvent);
         setMouseBoard({ x, y });
-        onMouseMove(x, y);
+        onPointerDown(planetAt(state, x, y), x, y, e.pointerType);
       }}
-      onMouseLeave={() => setMouseBoard(null)}
-      onMouseUp={(e) => {
+      onPointerMove={(e) => {
         const c = canvasRef.current;
         if (!c) return;
-        const { x, y } = screenToBoard(c, e);
-        onMouseUp(x, y);
+        const { x, y } = screenToBoard(c, e.nativeEvent);
+        setMouseBoard({ x, y });
+        onPointerMove(x, y);
+      }}
+      onPointerUp={(e) => {
+        const c = canvasRef.current;
+        if (!c) return;
+        const { x, y } = screenToBoard(c, e.nativeEvent);
+        onPointerUp(x, y);
+        // Touch has no hover; clear cursor-position highlight on release.
+        if (e.pointerType !== 'mouse') setMouseBoard(null);
+      }}
+      onPointerLeave={(e) => {
+        if (e.pointerType === 'mouse') setMouseBoard(null);
       }}
       onContextMenu={(e) => {
         e.preventDefault();

--- a/kaggle_environments/envs/orbit_wars/visualizer/playable/src/ui/GameScreen.tsx
+++ b/kaggle_environments/envs/orbit_wars/visualizer/playable/src/ui/GameScreen.tsx
@@ -68,9 +68,10 @@ export function GameScreen({ setup, onExit }: Props) {
   if (error) return <div style={{ padding: 20, color: '#ff6666' }}>Worker error: {error}</div>;
   if (!state) return <div style={{ padding: 20 }}>Loading…</div>;
 
-  // Compute the screen-space anchor for the fleet menu.
+  // Compute the screen-space anchor for the fleet menu (desktop only).
   // While the user is still picking an aim direction (target not placed yet),
   // park the menu in the top-right corner so it can't sit under the cursor.
+  // On mobile the CSS overrides this anchor and pins the menu to the bottom.
   let menuAnchor: { left: number; top: number } | null = null;
   if (selected && wrapRef.current) {
     const rect = wrapRef.current.getBoundingClientRect();
@@ -104,17 +105,33 @@ export function GameScreen({ setup, onExit }: Props) {
           dragging={draggingTarget}
           pendingActions={pendingActions}
           humanPlayerId={HUMAN_PLAYER_ID}
-          onMouseDown={(planet, bx, by) => {
+          onPointerDown={(planet, bx, by, pointerType) => {
+            const isTouch = pointerType !== 'mouse';
             if (!selected) {
               if (planet && planet.owner === HUMAN_PLAYER_ID) {
                 const queued = pendingActions.filter(([pid]) => pid === planet.id).reduce((acc, [, , s]) => acc + s, 0);
                 const available = Math.max(0, Math.floor(planet.ships) - queued);
                 setSelectedId(planet.id);
                 setAimShips(available);
-                setAimTarget({ x: bx, y: by });
-                setAimAngle(Math.atan2(by - planet.y, bx - planet.x));
-                setAimPlaced(false);
-                setDraggingTarget(false);
+                if (isTouch) {
+                  // Auto-place a target a few units past the planet, pointed at the sun,
+                  // so the player can immediately see the trajectory and drag to refine.
+                  const dx = BOARD_SIZE / 2 - planet.x;
+                  const dy = BOARD_SIZE / 2 - planet.y;
+                  const dist = Math.hypot(dx, dy) || 1;
+                  const off = planet.radius + 5;
+                  const tx = planet.x + (dx / dist) * off;
+                  const ty = planet.y + (dy / dist) * off;
+                  setAimTarget({ x: tx, y: ty });
+                  setAimAngle(Math.atan2(ty - planet.y, tx - planet.x));
+                  setAimPlaced(true);
+                  setDraggingTarget(false);
+                } else {
+                  setAimTarget({ x: bx, y: by });
+                  setAimAngle(Math.atan2(by - planet.y, bx - planet.x));
+                  setAimPlaced(false);
+                  setDraggingTarget(false);
+                }
               }
               return;
             }
@@ -126,26 +143,28 @@ export function GameScreen({ setup, onExit }: Props) {
               setDraggingTarget(true); // allow press+drag to fine-tune in one motion
               return;
             }
-            // Target already placed: drag if click lands on it, else deselect.
+            // Target already placed: drag if press lands on it, else deselect.
+            // Touch gets a larger hit slop since fingers are imprecise.
             if (aimTarget) {
               const dx = bx - aimTarget.x;
               const dy = by - aimTarget.y;
-              if (dx * dx + dy * dy <= TARGET_HIT_RADIUS * TARGET_HIT_RADIUS) {
+              const slop = isTouch ? TARGET_HIT_RADIUS * 2 : TARGET_HIT_RADIUS;
+              if (dx * dx + dy * dy <= slop * slop) {
                 setDraggingTarget(true);
                 return;
               }
             }
             closeMenu();
           }}
-          onMouseMove={(bx, by) => {
+          onPointerMove={(bx, by) => {
             if (!selected) return;
-            // Follow mouse while previewing (target not yet placed) or while dragging it.
+            // Follow pointer while previewing (target not yet placed) or while dragging it.
             if (!aimPlaced || draggingTarget) {
               setAimTarget({ x: bx, y: by });
               setAimAngle(Math.atan2(by - selected.y, bx - selected.x));
             }
           }}
-          onMouseUp={() => {
+          onPointerUp={() => {
             setDraggingTarget(false);
           }}
           onContextMenu={closeMenu}
@@ -202,6 +221,17 @@ export function GameScreen({ setup, onExit }: Props) {
         }}
         onExit={onExit}
       />
+      {!state.done && (
+        <button
+          className="fab-step"
+          onClick={handleStep}
+          disabled={busy}
+          aria-label="Advance one turn"
+          title="Advance one turn"
+        >
+          »
+        </button>
+      )}
     </div>
   );
 }

--- a/kaggle_environments/envs/orbit_wars/visualizer/playable/src/ui/HUD.tsx
+++ b/kaggle_environments/envs/orbit_wars/visualizer/playable/src/ui/HUD.tsx
@@ -33,15 +33,15 @@ export function HUD({ state, slots, pendingCount, busy, onStep, onReset, onExit 
 
       <div className="pending">Queued orders: {pendingCount}</div>
 
-      <button onClick={onStep} disabled={busy || state.done}>
+      <button className="hud-mobile-hide" onClick={onStep} disabled={busy || state.done}>
         {busy ? 'Working…' : 'Step (Space)'}
       </button>
       <button onClick={onReset} disabled={busy}>
-        Reset (same setup)
+        Reset
       </button>
       <button onClick={onExit}>New Game</button>
 
-      <div style={{ fontSize: 12, color: '#aaaab0', marginTop: 12 }}>
+      <div className="hud-mobile-hide" style={{ fontSize: 12, color: '#aaaab0', marginTop: 12 }}>
         <p>Click an owned planet to open its fleet menu.</p>
         <p>Drag from the planet to aim a fleet, set the count, then Send.</p>
         <p>Press Space (or click Step) to advance one turn.</p>


### PR DESCRIPTION
- GameCanvas: switch from mouse to pointer events with setPointerCapture for unified mouse + touch + pen input; touch-action: none and user-select: none on the canvas so touch drags don't scroll/select.
- GameScreen: on touch tap of an owned planet, auto-place the aim target ~radius+5 units past the planet pointed at the sun and mark it placed, so the player immediately sees the trajectory and can drag to refine. Touch also gets a 2x hit-slop on the target reticle.
- Floating "»" FAB in the bottom-right replaces the keyboard Step shortcut on mobile. Spacebar handler stays for desktop.
- HUD collapses to a single horizontal top bar on small screens; the canvas wrap stacks column-wise so the FleetMenu sits below the canvas (not on top of it) keeping the target reticle visible while dragging.
- @media (max-width: 700px) drives all the layout changes; no JS viewport detection.