### PR TITLE
Add savePrompt config to persist LLM prompts in replays

### DIFF
--- a/kaggle_environments/core_harness.py
+++ b/kaggle_environments/core_harness.py
@@ -273,6 +273,8 @@ def create_agent_fn(
             )
             setup_done = True
 
+        save_prompt = bool(config.get("savePrompt", False)) if config else False
+
         observation = obs if isinstance(obs, dict) else vars(obs)
 
         # -- inactive-call guard --
@@ -354,12 +356,15 @@ def create_agent_fn(
                         "legal_action": result.legal_action,
                     },
                 )
-                return {
+                action: dict[str, Any] = {
                     "submission": legal_actions[idx],
                     "actionString": result.legal_action,
                     "thoughts": last_content,
                     "status": "OK",
                 }
+                if save_prompt:
+                    action["prompt"] = prompt
+                return action
 
             # -- parse failed → prepare rethink --
             _TELEMETRY(

--- a/kaggle_environments/envs/open_spiel_env/open_spiel_env.py
+++ b/kaggle_environments/envs/open_spiel_env/open_spiel_env.py
@@ -158,6 +158,16 @@ CONFIGURATION_SPEC_TEMPLATE = {
         "type": "boolean",
         "default": False,
     },
+    "savePrompt": {
+        "description": (
+            "If true, the LLM prompt produced by the harness is included as a"
+            " 'prompt' field on the action returned by core_harness, which causes"
+            " it to be persisted in the episode replay. Defaults to false to keep"
+            " replays small."
+        ),
+        "type": "boolean",
+        "default": False,
+    },
 }
 
 OBSERVATION_SPEC_TEMPLATE = {

--- a/tests/core_harness_test.py
+++ b/tests/core_harness_test.py
@@ -188,6 +188,31 @@ class CoreHarnessTest(absltest.TestCase):
         self.assertIn("calling_llm", kinds)
         self.assertIn("action_is_legal", kinds)
 
+    def test_save_prompt_includes_prompt_in_action(self):
+        harness = _SimpleHarness()
+        agent = create_agent_fn(harness)
+        with patch.dict("os.environ", _ENV, clear=False), patch.object(
+            core_harness.litellm,
+            "completion",
+            return_value=_fake_completion("move_1"),
+        ):
+            result = agent({}, {"savePrompt": True})
+
+        self.assertEqual(result["submission"], 1)
+        self.assertEqual(result["prompt"], harness.prompts[-1])
+
+    def test_save_prompt_omitted_by_default(self):
+        harness = _SimpleHarness()
+        agent = create_agent_fn(harness)
+        with patch.dict("os.environ", _ENV, clear=False), patch.object(
+            core_harness.litellm,
+            "completion",
+            return_value=_fake_completion("move_1"),
+        ):
+            result = agent({}, {})
+
+        self.assertNotIn("prompt", result)
+
     def test_move_history_accumulates_across_calls(self):
         harness = _SimpleHarness()
         agent = create_agent_fn(harness)


### PR DESCRIPTION
When `savePrompt` is true on the env configuration, `core_harness` includes the prompt as a "prompt" field on the returned action so it ends up in the episode replay. Defaults to false to keep replays small. This allows for better debugging for Game Arena games.