### PR TITLE
Onboard OpenSpiel Crazyhouse chess variant

### DIFF
--- a/kaggle_environments/envs/open_spiel_env/games/crazyhouse/crazyhouse_proxy.py
+++ b/kaggle_environments/envs/open_spiel_env/games/crazyhouse/crazyhouse_proxy.py
@@ -1,0 +1,132 @@
+"""Structured JSON observations for Crazyhouse.
+
+OpenSpiel's default observation for Crazyhouse is a Crazyhouse-FEN string,
+e.g. ``rnbqkbnr/.../RNBQKBNR[Pn] w KQkq - 0 2``. Pieces are encoded as
+single letters (uppercase = White, lowercase = Black) and the bracketed
+section after the placement field lists each player's pocket. This proxy
+parses that into a structured dict for agents.
+
+Note: in OpenSpiel's Crazyhouse, ``current_player()`` returns ``0`` for
+Black and ``1`` for White (see ``ColorToPlayer`` in crazyhouse.h).
+"""
+
+import json
+from typing import Any
+
+import pyspiel
+
+from ... import proxy
+
+
+_PLAYER_BLACK = 0
+_PLAYER_WHITE = 1
+
+
+def _parse_fen(fen: str) -> dict[str, Any]:
+    """Parse a Crazyhouse FEN into structured fields."""
+    placement_with_pockets, side, castling, en_passant, halfmove, fullmove = fen.split()
+
+    if "[" in placement_with_pockets:
+        placement, pocket_str = placement_with_pockets.split("[", 1)
+        pocket_str = pocket_str.rstrip("]")
+    else:
+        placement, pocket_str = placement_with_pockets, ""
+
+    # Board: rank 8 first (matches FEN order), each row is a list of 8 chars.
+    board: list[list[str]] = []
+    for rank in placement.split("/"):
+        row: list[str] = []
+        for ch in rank:
+            if ch.isdigit():
+                row.extend(["."] * int(ch))
+            else:
+                row.append(ch)
+        board.append(row)
+
+    white_pocket: dict[str, int] = {}
+    black_pocket: dict[str, int] = {}
+    for ch in pocket_str:
+        if ch.isupper():
+            white_pocket[ch] = white_pocket.get(ch, 0) + 1
+        else:
+            key = ch.upper()
+            black_pocket[key] = black_pocket.get(key, 0) + 1
+
+    return {
+        "board": board,
+        "side_to_move": side,
+        "castling_rights": castling,
+        "en_passant": en_passant,
+        "halfmove_clock": int(halfmove),
+        "fullmove_number": int(fullmove),
+        "pockets": {"white": white_pocket, "black": black_pocket},
+    }
+
+
+class CrazyhouseState(proxy.State):
+    """Wraps OpenSpiel Crazyhouse state with JSON observations."""
+
+    def state_dict(self, player: int | None = None) -> dict[str, Any]:
+        del player
+        fen = self.__wrapped__.observation_string(0)
+        parsed = _parse_fen(fen)
+
+        winner: str | None = None
+        if self.is_terminal():
+            returns = self.returns()
+            if returns[_PLAYER_WHITE] > returns[_PLAYER_BLACK]:
+                winner = "white"
+            elif returns[_PLAYER_BLACK] > returns[_PLAYER_WHITE]:
+                winner = "black"
+            else:
+                winner = "draw"
+
+        current = self.current_player()
+        if current == _PLAYER_WHITE:
+            current_label: Any = "white"
+        elif current == _PLAYER_BLACK:
+            current_label = "black"
+        else:
+            current_label = current
+
+        return {
+            "fen": fen,
+            "board": parsed["board"],
+            "side_to_move": parsed["side_to_move"],
+            "castling_rights": parsed["castling_rights"],
+            "en_passant": parsed["en_passant"],
+            "halfmove_clock": parsed["halfmove_clock"],
+            "fullmove_number": parsed["fullmove_number"],
+            "pockets": parsed["pockets"],
+            "current_player": current_label,
+            "is_terminal": self.is_terminal(),
+            "winner": winner,
+        }
+
+    def to_json(self, player: int | None = None) -> str:
+        return json.dumps(self.state_dict(player))
+
+    def observation_string(self, player: int) -> str:
+        return self.to_json(player)
+
+    def __str__(self) -> str:
+        return self.to_json()
+
+
+class CrazyhouseGame(proxy.Game):
+    """Crazyhouse game proxy."""
+
+    def __init__(self, params: Any | None = None):
+        params = params or {}
+        wrapped = pyspiel.load_game("crazyhouse", params)
+        super().__init__(
+            wrapped,
+            short_name="crazyhouse_proxy",
+            long_name="Crazyhouse (proxy)",
+        )
+
+    def new_initial_state(self, *args) -> CrazyhouseState:
+        return CrazyhouseState(self.__wrapped__.new_initial_state(*args), game=self)
+
+
+pyspiel.register_game(CrazyhouseGame().get_type(), CrazyhouseGame)

--- a/kaggle_environments/envs/open_spiel_env/games/crazyhouse/harness.py
+++ b/kaggle_environments/envs/open_spiel_env/games/crazyhouse/harness.py
@@ -1,0 +1,300 @@
+"""LLM harness for OpenSpiel Crazyhouse.
+
+Drop the body of this file into the notebook attached to the competition via
+HarnessKernelId. The auto-generated ``main.py`` calls these three module-level
+functions: ``get_legal_moves``, ``generate_prompt``, ``parse_response``.
+
+Crazyhouse is a chess variant: captured pieces switch colour and enter the
+captor's *pocket*, from which they can later be *dropped* onto any empty
+square (pawns may not drop on the 1st or 8th rank). OpenSpiel exposes moves
+in Standard Algebraic Notation, e.g. ``e4``, ``Nf3``, ``Bxd5``, ``O-O``, and
+drops as ``P@e4`` / ``N@d5`` (uppercase piece, ``@``, target square).
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from typing import Any, Mapping, Sequence
+
+import pyspiel
+
+from kaggle_environments.core_harness import ParseResult
+
+try:
+    from kaggle_environments.envs.open_spiel_env.games.crazyhouse import (  # noqa: F401
+        crazyhouse_proxy,
+    )
+except Exception:
+    pass
+
+
+_JSON_BLOCK_RE = re.compile(r"```json\s*(\{.*?\})\s*```", re.DOTALL)
+_BARE_JSON_RE = re.compile(r"\{[^{}]*\"move\"\s*:\s*\"([^\"]+)\"[^{}]*\}", re.DOTALL)
+
+# A SAN-or-drop token. Conservative: piece letter (PNBRQK) or pawn file (a-h),
+# optional disambiguation, optional capture x, target square, optional
+# promotion (=Q etc.), optional check/mate marker. Castling and drops are
+# handled separately.
+_SAN_TOKEN_RE = re.compile(
+    r"\b("
+    r"O-O-O[+#]?|O-O[+#]?"                               # castling
+    r"|[PNBRQK]@[a-h][1-8]"                              # drop
+    r"|[NBRQK][a-h]?[1-8]?x?[a-h][1-8][+#]?"             # piece move
+    r"|[a-h]x?[a-h][1-8](?:=[NBRQ])?[+#]?"               # pawn capture / push (file form)
+    r"|[a-h][1-8](?:=[NBRQ])?[+#]?"                      # pawn push (target only)
+    r")"
+)
+
+
+# --- Prompt -----------------------------------------------------------------
+
+
+CRAZYHOUSE_PROMPT_TEMPLATE = """Let's play Crazyhouse.
+
+Rules: Crazyhouse is chess with one twist — when you capture an opponent's
+piece, it switches colour and enters your *pocket*. Instead of a normal move
+you may *drop* any piece from your pocket onto any empty square, with these
+restrictions:
+- Pawns cannot be dropped on the 1st or 8th rank.
+- Promoted pieces revert to pawns when captured.
+- A drop that gives checkmate IS legal (no rule against drop-mate here).
+All other rules are standard chess: castling, en passant, promotion, and
+the king cannot remain in check after your move.
+
+Move notation (Standard Algebraic Notation):
+- Pawn push: ``e4``, ``d5``. Pawn capture: ``exd5``. Promotion: ``e8=Q``.
+- Piece move: ``Nf3``, ``Bxc4``, ``Qd1``. Disambiguation when needed:
+  ``Nbd2`` (file) or ``R1e2`` (rank).
+- Castling: ``O-O`` (kingside), ``O-O-O`` (queenside).
+- Drop: ``P@e4``, ``N@d5``, ``B@h6``, ``R@e1``, ``Q@d4`` (uppercase piece,
+  ``@``, target square). Drops use uppercase regardless of which side
+  you play.
+Suffixes ``+`` (check) and ``#`` (mate) may appear in legal moves; copy
+them exactly when present.
+
+Current game state (JSON; ``pockets`` lists piece counts available to drop,
+both sides shown with uppercase letters):
+{state_str}
+
+The moves played so far are:
+{move_history}
+
+Your pocket: {my_pocket}
+Opponent pocket: {opp_pocket}
+
+You are playing as {player_name} ({player_code}). It is now your turn.
+Pick your strongest move from the legal list. The move MUST appear
+verbatim (including any ``+``/``#`` suffix and the exact letter case) in
+the legal moves list — there are too many legal moves to enumerate them
+all here, so consult the position above.
+
+Respond with your reasoning followed by your final move in a JSON block:
+
+```json
+{{
+  "move": "<move>"
+}}
+```
+
+Failure to output your final answer in the specified format, or selecting
+a move that is not legal, will result in a loss.
+Begin!
+"""
+
+
+RETHINK_SUFFIX = """
+
+Your previous response was:
+{previous_response}
+
+You suggested move "{previous_action}" but this is not in the legal moves
+list. Reconsider the position and play a legal move. Remember that drops
+use uppercase piece letters with ``@`` (e.g. ``P@e4``) and that check/mate
+suffixes (``+``/``#``) must match the legal move string exactly.
+"""
+
+
+# --- Helpers ----------------------------------------------------------------
+
+
+def _parse_state_payload(observation: Mapping[str, Any]) -> dict[str, Any]:
+    """Pull the structured crazyhouse state dict out of the observation."""
+    raw = observation.get("observationString", "") or ""
+    if raw:
+        try:
+            parsed = json.loads(raw)
+            if isinstance(parsed, dict):
+                return parsed
+        except json.JSONDecodeError:
+            pass
+    serialized = observation.get("serializedGameAndState", "")
+    if serialized:
+        try:
+            _, state = pyspiel.deserialize_game_and_state(serialized)
+            return json.loads(state.observation_string(0))
+        except (json.JSONDecodeError, RuntimeError):
+            pass
+    return {}
+
+
+def _format_pocket(pocket: Mapping[str, int] | None) -> str:
+    """Render a pocket like ``{"P": 2, "N": 1}`` as ``2xP, 1xN`` (or empty)."""
+    if not pocket:
+        return "(empty)"
+    return ", ".join(f"{count}x{piece}" for piece, count in sorted(pocket.items()))
+
+
+def _normalize_san(token: str) -> str:
+    """Normalize an SAN token for tolerant matching.
+
+    Strips trailing ``+``/``#`` markers and lower-cases pawn-only moves so
+    ``E4`` and ``e4`` are treated the same. Piece moves keep their leading
+    uppercase letter so ``Nf3`` doesn't collide with a hypothetical ``nf3``.
+    """
+    t = token.strip().rstrip("+#")
+    if not t:
+        return t
+    if "@" in t:
+        # Drop: P@e4 — uppercase piece letter, lowercase square.
+        head, _, tail = t.partition("@")
+        return head.upper() + "@" + tail.lower()
+    if t.startswith(("O-O", "0-0")):
+        return t.replace("0", "O")
+    first = t[0]
+    if first in "PNBRQK":
+        return first + t[1:].lower()
+    return t.lower()
+
+
+def _build_legal_index(legal_moves: Sequence[str]) -> dict[str, str]:
+    """Map normalised SAN -> the exact legal string the engine expects."""
+    index: dict[str, str] = {}
+    for legal in legal_moves:
+        index.setdefault(_normalize_san(legal), legal)
+    return index
+
+
+def _match_move_to_legal(
+    move: str,
+    legal_moves: Sequence[str],
+) -> str | None:
+    """Match a candidate move string to one of the legal action strings."""
+    if not move:
+        return None
+    candidate = _normalize_san(move)
+    index = _build_legal_index(legal_moves)
+    if candidate in index:
+        return index[candidate]
+    # Try with the check/mate suffix the model may have omitted: a unique
+    # legal move whose stripped form matches counts as a hit.
+    stripped_hits = [legal for legal in legal_moves if _normalize_san(legal) == candidate]
+    if len(stripped_hits) == 1:
+        return stripped_hits[0]
+    return None
+
+
+def _extract_move_from_json(response: str) -> str | None:
+    """Pull the move string from a ```json``` block or a bare JSON object."""
+    match = _JSON_BLOCK_RE.search(response)
+    if match:
+        try:
+            data = json.loads(match.group(1))
+            move = str(data.get("move", "")).strip()
+            if move:
+                return move
+        except json.JSONDecodeError:
+            pass
+
+    bare = _BARE_JSON_RE.search(response)
+    if bare:
+        return bare.group(1).strip()
+
+    return None
+
+
+# --- Public functions (called by main.py) -----------------------------------
+
+
+def get_legal_moves(observation: Mapping[str, Any]) -> dict[int, str]:
+    """Return ``{action_id: action_string}`` for the current state."""
+    legal_actions = observation.get("legalActions")
+    legal_action_strings = observation.get("legalActionStrings")
+    if legal_actions and legal_action_strings:
+        return dict(zip(legal_actions, legal_action_strings))
+
+    serialized = observation.get("serializedGameAndState", "")
+    if not serialized:
+        return {}
+    _, state = pyspiel.deserialize_game_and_state(serialized)
+    player_id = state.current_player()
+    if player_id < 0:
+        return {}
+    actions = state.legal_actions(player_id)
+    return {a: state.action_to_string(player_id, a) for a in actions}
+
+
+def generate_prompt(
+    observation: Mapping[str, Any],
+    move_history: list[str],
+    previous_response: str | None = None,
+    previous_action: str | None = None,
+) -> str:
+    """Build the LLM prompt for the current crazyhouse state."""
+    state = _parse_state_payload(observation)
+    # Crazyhouse uses player 1 = White, 0 = Black (see crazyhouse_proxy.py).
+    player_id = observation.get("playerId", 1)
+    player_name = "White" if player_id == 1 else "Black"
+    player_code = "W" if player_id == 1 else "B"
+
+    pockets = state.get("pockets") or {}
+    my_pocket = pockets.get(player_name.lower(), {})
+    opp_pocket = pockets.get("black" if player_id == 1 else "white", {})
+
+    move_history_str = " ".join(move_history) if move_history else "None"
+
+    prompt = CRAZYHOUSE_PROMPT_TEMPLATE.format(
+        state_str=observation.get("observationString", "") or json.dumps(state),
+        move_history=move_history_str,
+        my_pocket=_format_pocket(my_pocket),
+        opp_pocket=_format_pocket(opp_pocket),
+        player_name=player_name,
+        player_code=player_code,
+    )
+
+    if previous_response is not None:
+        prompt += RETHINK_SUFFIX.format(
+            previous_response=previous_response[:500],
+            previous_action=previous_action or "(could not parse)",
+        )
+
+    return prompt
+
+
+def parse_response(
+    response: str, legal_action_strings: Sequence[str],
+) -> ParseResult:
+    """Extract a legal crazyhouse move from the LLM response.
+
+    Tries a ```json``` block first, then a bare ``{"move": "..."}``, then
+    scans the response text for any token that matches a legal SAN move.
+    """
+    raw = _extract_move_from_json(response)
+    if raw is not None:
+        matched = _match_move_to_legal(raw, legal_action_strings)
+        if matched is not None:
+            return ParseResult(legal_action=matched, raw_action=raw)
+
+    # Fallback: scan response for any legal SAN/drop token. Iterate in the
+    # order the model wrote them so the first plausible move wins.
+    legal_index = _build_legal_index(legal_action_strings)
+    for match in _SAN_TOKEN_RE.finditer(response):
+        token = match.group(1)
+        canonical = _normalize_san(token)
+        if canonical in legal_index:
+            return ParseResult(
+                legal_action=legal_index[canonical],
+                raw_action=raw or token,
+            )
+
+    return ParseResult(legal_action=None, raw_action=raw)

--- a/kaggle_environments/envs/open_spiel_env/games/crazyhouse/harness.py
+++ b/kaggle_environments/envs/open_spiel_env/games/crazyhouse/harness.py
@@ -32,11 +32,11 @@ except Exception:
 _JSON_BLOCK_RE = re.compile(r"```json\s*(\{.*?\})\s*```", re.DOTALL)
 _BARE_JSON_RE = re.compile(r"\{[^{}]*\"move\"\s*:\s*\"([^\"]+)\"[^{}]*\}", re.DOTALL)
 
-# A SAN-or-drop token. Conservative: piece letter (PNBRQK) or pawn file (a-h),
-# optional disambiguation, optional capture x, target square, optional
-# promotion (=Q etc.), optional check/mate marker. Castling and drops are
-# handled separately.
-_SAN_TOKEN_RE = re.compile(
+# Crazyhouse move token: standard SAN (pawn pushes, piece moves with optional
+# disambiguation, captures, promotions, check/mate markers, castling) plus the
+# crazyhouse-specific drop form ``P@e4``. Drops are not part of SAN proper but
+# OpenSpiel emits them as legal action strings in the same list.
+_MOVE_TOKEN_RE = re.compile(
     r"\b("
     r"O-O-O[+#]?|O-O[+#]?"                               # castling
     r"|[PNBRQK]@[a-h][1-8]"                              # drop
@@ -145,12 +145,13 @@ def _format_pocket(pocket: Mapping[str, int] | None) -> str:
     return ", ".join(f"{count}x{piece}" for piece, count in sorted(pocket.items()))
 
 
-def _normalize_san(token: str) -> str:
-    """Normalize an SAN token for tolerant matching.
+def _normalize_move(token: str) -> str:
+    """Normalize a crazyhouse move token (SAN or drop) for tolerant matching.
 
     Strips trailing ``+``/``#`` markers and lower-cases pawn-only moves so
     ``E4`` and ``e4`` are treated the same. Piece moves keep their leading
     uppercase letter so ``Nf3`` doesn't collide with a hypothetical ``nf3``.
+    Drops (``P@e4``) are normalised to uppercase piece, lowercase square.
     """
     t = token.strip().rstrip("+#")
     if not t:
@@ -168,10 +169,10 @@ def _normalize_san(token: str) -> str:
 
 
 def _build_legal_index(legal_moves: Sequence[str]) -> dict[str, str]:
-    """Map normalised SAN -> the exact legal string the engine expects."""
+    """Map normalised move -> the exact legal string the engine expects."""
     index: dict[str, str] = {}
     for legal in legal_moves:
-        index.setdefault(_normalize_san(legal), legal)
+        index.setdefault(_normalize_move(legal), legal)
     return index
 
 
@@ -182,13 +183,13 @@ def _match_move_to_legal(
     """Match a candidate move string to one of the legal action strings."""
     if not move:
         return None
-    candidate = _normalize_san(move)
+    candidate = _normalize_move(move)
     index = _build_legal_index(legal_moves)
     if candidate in index:
         return index[candidate]
     # Try with the check/mate suffix the model may have omitted: a unique
     # legal move whose stripped form matches counts as a hit.
-    stripped_hits = [legal for legal in legal_moves if _normalize_san(legal) == candidate]
+    stripped_hits = [legal for legal in legal_moves if _normalize_move(legal) == candidate]
     if len(stripped_hits) == 1:
         return stripped_hits[0]
     return None
@@ -277,7 +278,7 @@ def parse_response(
     """Extract a legal crazyhouse move from the LLM response.
 
     Tries a ```json``` block first, then a bare ``{"move": "..."}``, then
-    scans the response text for any token that matches a legal SAN move.
+    scans the response text for any token that matches a legal move.
     """
     raw = _extract_move_from_json(response)
     if raw is not None:
@@ -285,12 +286,12 @@ def parse_response(
         if matched is not None:
             return ParseResult(legal_action=matched, raw_action=raw)
 
-    # Fallback: scan response for any legal SAN/drop token. Iterate in the
+    # Fallback: scan response for any legal SAN-or-drop token. Iterate in the
     # order the model wrote them so the first plausible move wins.
     legal_index = _build_legal_index(legal_action_strings)
-    for match in _SAN_TOKEN_RE.finditer(response):
+    for match in _MOVE_TOKEN_RE.finditer(response):
         token = match.group(1)
-        canonical = _normalize_san(token)
+        canonical = _normalize_move(token)
         if canonical in legal_index:
             return ParseResult(
                 legal_action=legal_index[canonical],

--- a/kaggle_environments/envs/open_spiel_env/games/crazyhouse/visualizer/default/e2e/crazyhouse.test.ts
+++ b/kaggle_environments/envs/open_spiel_env/games/crazyhouse/visualizer/default/e2e/crazyhouse.test.ts
@@ -1,0 +1,67 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Crazyhouse Visualizer (Default)', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+  });
+
+  test('renders the game', async ({ page }) => {
+    // 8x8 board grid
+    const firstCell = page.locator('#cell-0-0');
+    const lastCell = page.locator('#cell-7-7');
+    await expect(firstCell).toBeVisible();
+    await expect(lastCell).toBeVisible();
+
+    const pieceImages = page.locator('div[id^="cell-"] img');
+    await expect(pieceImages.first()).toBeVisible();
+    const pieceCount = await pieceImages.count();
+    expect(pieceCount).toBeGreaterThan(0);
+
+    const crazyhouseTitle = page.locator('h1').filter({ hasText: 'Crazyhouse' });
+    await expect(crazyhouseTitle).toBeVisible();
+    const headerImages = page.locator('h1').locator('..').locator('img');
+    const imgCount = await headerImages.count();
+    expect(imgCount).toBeGreaterThanOrEqual(2);
+
+    // Pocket panels (black above white) are part of the default layout.
+    const blackPocket = page.locator('div').filter({ hasText: /^Black pocket$/ });
+    const whitePocket = page.locator('div').filter({ hasText: /^White pocket$/ });
+    await expect(blackPocket.first()).toBeVisible();
+    await expect(whitePocket.first()).toBeVisible();
+
+    const statusText = page.locator('p').filter({ hasText: /Move|Final|to move|wins/ });
+    await expect(statusText.first()).toBeVisible();
+  });
+
+  test('displays correct game state at mid-game', async ({ page }) => {
+    const slider = page.locator('input[type="range"]');
+    await slider.waitFor({ state: 'visible' });
+
+    // Navigate to mid-game step
+    const maxValue = await slider.getAttribute('max');
+    const midStep = Math.floor(parseInt(maxValue || '0') / 2);
+    await slider.fill(String(midStep));
+    await page.waitForTimeout(200);
+
+    const pieceImages = page.locator('div[id^="cell-"] img');
+    await expect(pieceImages.first()).toBeVisible();
+    const pieceCount = await pieceImages.count();
+    expect(pieceCount).toBeGreaterThan(0);
+
+    // Should still show a turn indicator (game not over yet)
+    const statusText = page.locator('p').filter({ hasText: /Move|to move/ });
+    await expect(statusText.first()).toBeVisible();
+  });
+
+  test('displays winner at end of game', async ({ page }) => {
+    const slider = page.locator('input[type="range"]');
+    await slider.waitFor({ state: 'visible' });
+
+    const maxValue = await slider.getAttribute('max');
+    await slider.fill(maxValue || '0');
+    await page.waitForTimeout(200);
+
+    const winnerText = page.locator('p').filter({ hasText: /wins|Draw|Final/ });
+    await expect(winnerText.first()).toBeVisible();
+  });
+});

--- a/kaggle_environments/envs/open_spiel_env/games/crazyhouse/visualizer/default/index.html
+++ b/kaggle_environments/envs/open_spiel_env/games/crazyhouse/visualizer/default/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Crazyhouse Visualizer</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="/src/main.ts"></script>
+  </body>
+</html>

--- a/kaggle_environments/envs/open_spiel_env/games/crazyhouse/visualizer/default/package.json
+++ b/kaggle_environments/envs/open_spiel_env/games/crazyhouse/visualizer/default/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@kaggle-environments/open-spiel-crazyhouse-visualizer",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "dev-with-replay": "cross-env VITE_REPLAY_FILE=./replays/test-replay.json vite",
+    "build": "tsc && vite build",
+    "preview": "vite preview"
+  },
+  "devDependencies": {
+    "cross-env": "^10.1.0",
+    "typescript": "^5.0.0",
+    "vite": "^5.0.0"
+  },
+  "dependencies": {
+    "@kaggle-environments/core": "workspace:*"
+  }
+}

--- a/kaggle_environments/envs/open_spiel_env/games/crazyhouse/visualizer/default/src/crazyhouse_renderer.ts
+++ b/kaggle_environments/envs/open_spiel_env/games/crazyhouse/visualizer/default/src/crazyhouse_renderer.ts
@@ -1,0 +1,381 @@
+import { RendererOptions } from '@kaggle-environments/core';
+import {
+  DARK_SQUARE_COLOR,
+  DEFAULT_NUM_COLS,
+  DEFAULT_NUM_ROWS,
+  LIGHT_SQUARE_COLOR,
+  PIECE_IMAGES_SRC,
+} from '../../../../chess/visualizer/default/src/consts';
+
+interface CrazyhouseObservation {
+  fen: string;
+  board: string[][];
+  side_to_move: 'w' | 'b';
+  castling_rights: string;
+  en_passant: string;
+  halfmove_clock: number;
+  fullmove_number: number;
+  pockets: { white: Record<string, number>; black: Record<string, number> };
+  current_player: 'white' | 'black' | number;
+  is_terminal: boolean;
+  winner: 'white' | 'black' | 'draw' | null;
+}
+
+const POCKET_PIECE_ORDER = ['Q', 'R', 'B', 'N', 'P'];
+const POCKET_PIECE_SIZE = 28;
+const POCKET_BG = '#f0d9b5';
+const POCKET_BORDER = '#b58863';
+
+function parseObservation(step: any): CrazyhouseObservation | null {
+  const raw = step?.[0]?.observation?.observationString;
+  if (!raw || typeof raw !== 'string') return null;
+  try {
+    return JSON.parse(raw) as CrazyhouseObservation;
+  } catch {
+    return null;
+  }
+}
+
+function buildPocketHtml(pocket: Record<string, number>, color: 'white' | 'black'): string {
+  const items: string[] = [];
+  for (const type of POCKET_PIECE_ORDER) {
+    const count = pocket[type] ?? 0;
+    if (count <= 0) continue;
+    const key = color === 'white' ? type : type.toLowerCase();
+    const src = PIECE_IMAGES_SRC[key];
+    if (!src) continue;
+    items.push(`
+      <div style="display:flex; align-items:center; gap:4px;">
+        <img src="${src}" style="width:${POCKET_PIECE_SIZE}px; height:${POCKET_PIECE_SIZE}px;" />
+        <span style="color:#3a2a1a; font-weight:700; font-size:14px;">×${count}</span>
+      </div>
+    `);
+  }
+  if (items.length === 0) {
+    return `<div style="color:#7a6a55; font-style:italic; font-size:0.85rem;">empty</div>`;
+  }
+  return items.join('');
+}
+
+export function renderer(options: RendererOptions) {
+  const { replay, step, parent } = options;
+  const steps = (replay as any).steps as any[];
+  const playerNames = (replay as any).info?.TeamNames || [];
+  const width = parent.clientWidth || 400;
+  const height = parent.clientHeight || 400;
+
+  let currentRendererContainer: HTMLElement | null = null;
+  let currentBoardContainer: HTMLElement | null = null;
+  let currentBoardElement: HTMLElement | null = null;
+  let blackPocketElement: HTMLElement | null = null;
+  let whitePocketElement: HTMLElement | null = null;
+  let statusTextElement: HTMLParagraphElement | null = null;
+  let winnerTextElement: HTMLParagraphElement | null = null;
+  let squareSize = 0;
+
+  function _clearState(parentElementToClear: HTMLElement) {
+    if (!parentElementToClear) return false;
+    parentElementToClear.innerHTML = '';
+    return true;
+  }
+
+  function makePocketBox(label: string): HTMLElement {
+    const box = document.createElement('div');
+    Object.assign(box.style, {
+      backgroundColor: POCKET_BG,
+      border: `2px solid ${POCKET_BORDER}`,
+      borderRadius: '8px',
+      padding: '8px 10px',
+      display: 'flex',
+      flexDirection: 'column',
+      gap: '4px',
+      height: '120px',
+    });
+    const heading = document.createElement('div');
+    heading.textContent = label;
+    Object.assign(heading.style, {
+      color: '#3a2a1a',
+      fontSize: '0.8rem',
+      fontWeight: '700',
+      letterSpacing: '0.04em',
+      textTransform: 'uppercase',
+    });
+    const items = document.createElement('div');
+    items.className = 'pocket-items';
+    Object.assign(items.style, {
+      display: 'flex',
+      flexWrap: 'wrap',
+      alignItems: 'center',
+      gap: '8px 12px',
+    });
+    box.appendChild(heading);
+    box.appendChild(items);
+    return box;
+  }
+
+  function _buildVisualizer(parentElement: HTMLElement, rows: number, cols: number) {
+    const isMobile = window.innerWidth < 768;
+
+    currentRendererContainer = document.createElement('div');
+    Object.assign(currentRendererContainer.style, {
+      display: 'flex',
+      flexDirection: 'column',
+      alignItems: 'center',
+      padding: isMobile ? '10px' : '20px',
+      boxSizing: 'border-box',
+      width: '100%',
+      height: '100%',
+      backgroundColor: '#202124',
+    });
+    parentElement.appendChild(currentRendererContainer);
+
+    // Header: White player on the left, title in middle, Black player on the right.
+    // OpenSpiel's crazyhouse maps player 0 -> Black and player 1 -> White, so
+    // playerNames[1] is White and playerNames[0] is Black.
+    const headerContainer = document.createElement('div');
+    Object.assign(headerContainer.style, {
+      display: 'flex',
+      justifyContent: 'center',
+      alignItems: 'center',
+      width: '100%',
+      marginBottom: '0.75rem',
+      color: 'white',
+      flexShrink: '0',
+      flexDirection: isMobile ? 'column' : 'row',
+    });
+    const whitePlayerContainer = document.createElement('div');
+    Object.assign(whitePlayerContainer.style, { display: 'flex', alignItems: 'center' });
+    const whitePawn = document.createElement('img');
+    whitePawn.src = PIECE_IMAGES_SRC.P;
+    Object.assign(whitePawn.style, { height: '30px', marginRight: '8px' });
+    const whiteName = document.createElement('span');
+    whiteName.textContent = playerNames.length > 1 ? playerNames[1] : 'White';
+    Object.assign(whiteName.style, { fontSize: isMobile ? '1rem' : '1.1rem', fontWeight: 'bold' });
+    whitePlayerContainer.appendChild(whitePawn);
+    whitePlayerContainer.appendChild(whiteName);
+
+    const titleElement = document.createElement('h1');
+    titleElement.textContent = 'Crazyhouse';
+    Object.assign(titleElement.style, {
+      fontSize: isMobile ? '1.3rem' : '1.6rem',
+      fontWeight: 'bold',
+      textAlign: 'center',
+      color: '#e5e7eb',
+      margin: isMobile ? '8px 0' : '0 32px',
+    });
+
+    const blackPlayerContainer = document.createElement('div');
+    Object.assign(blackPlayerContainer.style, { display: 'flex', alignItems: 'center' });
+    const blackName = document.createElement('span');
+    blackName.textContent = playerNames.length > 0 ? playerNames[0] : 'Black';
+    Object.assign(blackName.style, { fontSize: isMobile ? '1rem' : '1.1rem', fontWeight: 'bold' });
+    const blackPawn = document.createElement('img');
+    blackPawn.src = PIECE_IMAGES_SRC.p;
+    Object.assign(blackPawn.style, { height: '30px', marginLeft: '8px' });
+    blackPlayerContainer.appendChild(blackName);
+    blackPlayerContainer.appendChild(blackPawn);
+
+    headerContainer.appendChild(whitePlayerContainer);
+    headerContainer.appendChild(titleElement);
+    headerContainer.appendChild(blackPlayerContainer);
+    currentRendererContainer.appendChild(headerContainer);
+
+    // Board + side pocket panel laid out horizontally.
+    const boardRow = document.createElement('div');
+    Object.assign(boardRow.style, {
+      display: 'flex',
+      justifyContent: 'center',
+      alignItems: 'stretch',
+      gap: '16px',
+      flexGrow: '1',
+      width: '100%',
+      minHeight: '0',
+    });
+    currentRendererContainer.appendChild(boardRow);
+
+    currentBoardContainer = document.createElement('div');
+    Object.assign(currentBoardContainer.style, {
+      display: 'flex',
+      justifyContent: 'center',
+      alignItems: 'center',
+      flexGrow: '1',
+      minWidth: '0',
+      minHeight: '0',
+    });
+    boardRow.appendChild(currentBoardContainer);
+
+    currentBoardElement = document.createElement('div');
+    Object.assign(currentBoardElement.style, {
+      display: 'grid',
+      border: '2px solid #333',
+    });
+    currentBoardContainer.appendChild(currentBoardElement);
+    for (let r = 0; r < rows; r++) {
+      for (let c = 0; c < cols; c++) {
+        const square = document.createElement('div');
+        square.id = `cell-${r}-${c}`;
+        Object.assign(square.style, {
+          backgroundColor: (r + c) % 2 === 0 ? LIGHT_SQUARE_COLOR : DARK_SQUARE_COLOR,
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+        });
+        currentBoardElement.appendChild(square);
+      }
+    }
+
+    // Side panel: pockets stacked, with Black on top (matches board orientation
+    // where rank 8 / Black is at the top).
+    const pocketPanel = document.createElement('div');
+    Object.assign(pocketPanel.style, {
+      display: 'flex',
+      flexDirection: 'column',
+      justifyContent: 'space-evenly',
+      gap: '12px',
+      flexShrink: '0',
+      width: isMobile ? '120px' : '160px',
+    });
+    boardRow.appendChild(pocketPanel);
+
+    blackPocketElement = makePocketBox('Black pocket');
+    whitePocketElement = makePocketBox('White pocket');
+    pocketPanel.appendChild(blackPocketElement);
+    pocketPanel.appendChild(whitePocketElement);
+
+    // Status panel.
+    const statusContainer = document.createElement('div');
+    Object.assign(statusContainer.style, {
+      padding: '6px 12px',
+      backgroundColor: 'white',
+      borderRadius: '8px',
+      boxShadow: '0 4px 6px -1px rgba(0,0,0,0.1), 0 2px 4px -1px rgba(0,0,0,0.06)',
+      textAlign: 'center',
+      minWidth: '200px',
+      maxWidth: '90vw',
+      marginTop: '10px',
+      flexShrink: '0',
+    });
+    currentRendererContainer.appendChild(statusContainer);
+
+    statusTextElement = document.createElement('p');
+    Object.assign(statusTextElement.style, {
+      fontSize: isMobile ? '0.85rem' : '1rem',
+      fontWeight: '600',
+      margin: '0 0 4px 0',
+    });
+    statusContainer.appendChild(statusTextElement);
+
+    winnerTextElement = document.createElement('p');
+    Object.assign(winnerTextElement.style, {
+      fontSize: isMobile ? '0.9rem' : '1.05rem',
+      fontWeight: '700',
+      margin: '0',
+    });
+    statusContainer.appendChild(winnerTextElement);
+
+    return true;
+  }
+
+  function _renderBoard(obs: CrazyhouseObservation | null, displayRows: number, displayCols: number) {
+    if (
+      !currentBoardContainer ||
+      !currentBoardElement ||
+      !blackPocketElement ||
+      !whitePocketElement ||
+      !statusTextElement ||
+      !winnerTextElement ||
+      !obs
+    ) {
+      return;
+    }
+
+    const containerWidth = currentBoardContainer.clientWidth || width;
+    const containerHeight = currentBoardContainer.clientHeight || height;
+    let smallestEdge = Math.min(containerWidth, containerHeight);
+    smallestEdge = smallestEdge > 200 ? smallestEdge - 24 : smallestEdge;
+    const newSquareSize = Math.floor(smallestEdge / displayCols);
+
+    if (newSquareSize !== squareSize) {
+      squareSize = newSquareSize;
+      Object.assign(currentBoardElement.style, {
+        gridTemplateColumns: `repeat(${displayCols}, ${squareSize}px)`,
+        gridTemplateRows: `repeat(${displayRows}, ${squareSize}px)`,
+        width: `${displayCols * squareSize}px`,
+        height: `${displayRows * squareSize}px`,
+      });
+      currentBoardElement.querySelectorAll('div[id^="cell-"]').forEach((square) => {
+        const div = square as HTMLDivElement;
+        div.style.width = `${squareSize}px`;
+        div.style.height = `${squareSize}px`;
+      });
+    }
+
+    // Pieces.
+    for (let r = 0; r < displayRows; r++) {
+      for (let c = 0; c < displayCols; c++) {
+        const cell = currentBoardElement.querySelector(`#cell-${r}-${c}`);
+        if (cell) cell.innerHTML = '';
+      }
+    }
+    const pieceSize = Math.floor(squareSize * 0.9);
+    for (let r = 0; r < displayRows; r++) {
+      const row = obs.board[r] ?? [];
+      for (let c = 0; c < displayCols; c++) {
+        const piece = row[c];
+        const cell = currentBoardElement.querySelector(`#cell-${r}-${c}`);
+        if (!cell || !piece || piece === '.') continue;
+        const src = PIECE_IMAGES_SRC[piece];
+        if (!src) continue;
+        const img = document.createElement('img');
+        img.src = src;
+        img.style.width = `${pieceSize}px`;
+        img.style.height = `${pieceSize}px`;
+        cell.appendChild(img);
+      }
+    }
+
+    // Pockets — write into the .pocket-items slot inside each box.
+    const blackItems = blackPocketElement.querySelector('.pocket-items') as HTMLElement | null;
+    const whiteItems = whitePocketElement.querySelector('.pocket-items') as HTMLElement | null;
+    if (blackItems) blackItems.innerHTML = buildPocketHtml(obs.pockets?.black ?? {}, 'black');
+    if (whiteItems) whiteItems.innerHTML = buildPocketHtml(obs.pockets?.white ?? {}, 'white');
+
+    // Status.
+    statusTextElement.innerHTML = '';
+    winnerTextElement.innerHTML = '';
+    if (obs.is_terminal) {
+      const winnerLabel =
+        obs.winner === 'draw'
+          ? 'Draw'
+          : obs.winner
+            ? `🎉 ${obs.winner[0].toUpperCase()}${obs.winner.slice(1)} wins!`
+            : 'Game over';
+      statusTextElement.textContent = 'Final';
+      winnerTextElement.innerHTML = `<span style="color:black;">${winnerLabel}</span>`;
+    } else {
+      const sideLabel = obs.side_to_move === 'w' ? 'White' : 'Black';
+      const playerName =
+        typeof obs.current_player === 'string' && playerNames.length > 1
+          ? obs.current_player === 'white'
+            ? playerNames[1]
+            : playerNames[0]
+          : null;
+      const turnText = playerName ? `${sideLabel} (${playerName})` : sideLabel;
+      statusTextElement.innerHTML = `<span style="color:black;">Move ${obs.fullmove_number} — ${turnText} to move</span>`;
+    }
+  }
+
+  if (!_clearState(parent)) {
+    parent.innerHTML = "<p style='color:red; font-family: sans-serif;'>Renderer setup failed.</p>";
+    return;
+  }
+
+  _buildVisualizer(parent, DEFAULT_NUM_ROWS, DEFAULT_NUM_COLS);
+
+  const obs = steps && steps.length > step ? parseObservation(steps[step]) : null;
+
+  // Defer rendering to next frame so the flex container has a measured size.
+  requestAnimationFrame(() => {
+    _renderBoard(obs, DEFAULT_NUM_ROWS, DEFAULT_NUM_COLS);
+  });
+}

--- a/kaggle_environments/envs/open_spiel_env/games/crazyhouse/visualizer/default/src/main.ts
+++ b/kaggle_environments/envs/open_spiel_env/games/crazyhouse/visualizer/default/src/main.ts
@@ -1,0 +1,17 @@
+import { createReplayVisualizer, ReplayAdapter } from '@kaggle-environments/core';
+import { renderer } from './crazyhouse_renderer';
+
+const app = document.getElementById('app');
+if (app) {
+  if (import.meta.env?.DEV && import.meta.hot) {
+    import.meta.hot.accept();
+  }
+  createReplayVisualizer(
+    app,
+    new ReplayAdapter({
+      gameName: 'open_spiel_crazyhouse',
+      renderer: renderer as any,
+      ui: 'side-panel',
+    })
+  );
+}

--- a/kaggle_environments/envs/open_spiel_env/games/crazyhouse/visualizer/default/tsconfig.json
+++ b/kaggle_environments/envs/open_spiel_env/games/crazyhouse/visualizer/default/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../../../../../../web/tsconfig.base.json",
+  "compilerOptions": {
+    "allowJs": true
+  },
+  "include": ["src"]
+}

--- a/kaggle_environments/envs/open_spiel_env/games/crazyhouse/visualizer/default/vite.config.ts
+++ b/kaggle_environments/envs/open_spiel_env/games/crazyhouse/visualizer/default/vite.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig, mergeConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+import baseConfig from '../../../../../../../web/vite.config.base';
+
+// React plugin is needed because this visualizer uses ReplayAdapter which uses React internally
+export default mergeConfig(
+  baseConfig,
+  defineConfig({
+    plugins: [react()],
+  })
+);

--- a/kaggle_environments/envs/open_spiel_env/games/crazyhouse/visualizer/default/vite.config.ts
+++ b/kaggle_environments/envs/open_spiel_env/games/crazyhouse/visualizer/default/vite.config.ts
@@ -1,11 +1,9 @@
 import { defineConfig, mergeConfig } from 'vite';
-import react from '@vitejs/plugin-react';
 import baseConfig from '../../../../../../../web/vite.config.base';
 
-// React plugin is needed because this visualizer uses ReplayAdapter which uses React internally
 export default mergeConfig(
   baseConfig,
   defineConfig({
-    plugins: [react()],
+    publicDir: 'replays',
   })
 );

--- a/kaggle_environments/envs/open_spiel_env/open_spiel_env.py
+++ b/kaggle_environments/envs/open_spiel_env/open_spiel_env.py
@@ -863,6 +863,7 @@ GAMES_LIST = [
     "checkers",
     "chess",
     "connect_four",
+    "crazyhouse",
     "dark_hex",
     "gin_rummy",
     "go(board_size=9)",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -365,6 +365,22 @@ importers:
         specifier: ^5.0.0
         version: 5.4.21(@types/node@25.2.1)
 
+  kaggle_environments/envs/open_spiel_env/games/crazyhouse/visualizer/default:
+    dependencies:
+      '@kaggle-environments/core':
+        specifier: workspace:*
+        version: link:../../../../../../../web/core
+    devDependencies:
+      cross-env:
+        specifier: ^10.1.0
+        version: 10.1.0
+      typescript:
+        specifier: ^5.0.0
+        version: 5.9.3
+      vite:
+        specifier: ^5.0.0
+        version: 5.4.21(@types/node@25.2.1)
+
   kaggle_environments/envs/open_spiel_env/games/dark_hex/visualizer/default:
     dependencies:
       '@kaggle-environments/core':

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ dependencies = [
     # Fixed due to litellm supply chain attack, hopefully can remove later.
     "litellm <= 1.82.4",
     "numpy >= 2.0",
-    "open_spiel >= 1.6.8",
+    "open_spiel >= 1.6.13",
     "pettingzoo == 1.24.0",
     "pokerkit==0.6.3",
     "pydantic >= 2.11.4",

--- a/tests/envs/open_spiel_env/games/crazyhouse/crazyhouse_proxy_test.py
+++ b/tests/envs/open_spiel_env/games/crazyhouse/crazyhouse_proxy_test.py
@@ -1,0 +1,125 @@
+"""Tests for the proxied Crazyhouse game."""
+
+import json
+
+import pyspiel
+from absl.testing import absltest
+
+from kaggle_environments.envs.open_spiel_env.games.crazyhouse import crazyhouse_proxy
+
+
+def _play(state, san):
+    """Apply the legal action whose action_to_string matches ``san``."""
+    for action in state.legal_actions():
+        if state.action_to_string(state.current_player(), action) == san:
+            state.apply_action(action)
+            return
+    raise AssertionError(f"move {san!r} not legal here")
+
+
+class CrazyhouseProxyTest(absltest.TestCase):
+    def test_game_is_registered(self):
+        game = pyspiel.load_game("crazyhouse_proxy")
+        self.assertIsInstance(game, crazyhouse_proxy.CrazyhouseGame)
+
+    def test_random_sim(self):
+        game = crazyhouse_proxy.CrazyhouseGame()
+        pyspiel.random_sim_test(game, num_sims=3, serialize=False, verbose=False)
+
+    def test_initial_state_to_json(self):
+        game = crazyhouse_proxy.CrazyhouseGame()
+        state = game.new_initial_state()
+        d = json.loads(state.to_json())
+
+        # Standard chess starting position.
+        self.assertEqual(d["fen"].split()[0], "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR")
+        self.assertEqual(d["side_to_move"], "w")
+        self.assertEqual(d["castling_rights"], "KQkq")
+        self.assertEqual(d["en_passant"], "-")
+        self.assertEqual(d["halfmove_clock"], 0)
+        self.assertEqual(d["fullmove_number"], 1)
+        self.assertEqual(d["current_player"], "white")
+        self.assertFalse(d["is_terminal"])
+        self.assertIsNone(d["winner"])
+        self.assertEqual(d["pockets"], {"white": {}, "black": {}})
+
+    def test_board_layout_matches_fen(self):
+        """Board[0] is rank 8 (Black back rank); board[7] is rank 1 (White)."""
+        game = crazyhouse_proxy.CrazyhouseGame()
+        state = game.new_initial_state()
+        d = state.state_dict()
+        self.assertEqual(d["board"][0], list("rnbqkbnr"))
+        self.assertEqual(d["board"][1], list("pppppppp"))
+        self.assertEqual(d["board"][6], list("PPPPPPPP"))
+        self.assertEqual(d["board"][7], list("RNBQKBNR"))
+        for rank in d["board"][2:6]:
+            self.assertEqual(rank, ["."] * 8)
+
+    def test_observation_string_is_json(self):
+        game = crazyhouse_proxy.CrazyhouseGame()
+        state = game.new_initial_state()
+        # Both observation_string and __str__ produce parseable JSON.
+        self.assertEqual(json.loads(state.observation_string(0)), state.state_dict())
+        self.assertEqual(json.loads(str(state)), state.state_dict())
+
+    def test_current_player_labels(self):
+        """OpenSpiel uses 1=White, 0=Black for crazyhouse — the proxy
+        converts those raw ids into the human-readable colour labels."""
+        game = crazyhouse_proxy.CrazyhouseGame()
+        state = game.new_initial_state()
+
+        self.assertEqual(state.current_player(), 1)
+        self.assertEqual(state.state_dict()["current_player"], "white")
+
+        _play(state, "e4")
+        self.assertEqual(state.current_player(), 0)
+        self.assertEqual(state.state_dict()["current_player"], "black")
+
+    def test_capture_populates_pocket(self):
+        """After 1.e4 d5 2.exd5 Black has lost a pawn; White's pocket gains
+        a pawn. After 2...Qxd5 Black recaptures and gains a pawn too."""
+        game = crazyhouse_proxy.CrazyhouseGame()
+        state = game.new_initial_state()
+        _play(state, "e4")
+        _play(state, "d5")
+        _play(state, "exd5")
+        d = state.state_dict()
+        self.assertEqual(d["pockets"]["white"], {"P": 1})
+        self.assertEqual(d["pockets"]["black"], {})
+
+        _play(state, "Qxd5")
+        d = state.state_dict()
+        self.assertEqual(d["pockets"]["white"], {"P": 1})
+        self.assertEqual(d["pockets"]["black"], {"P": 1})
+        # FEN bracketed pocket section preserves both players.
+        self.assertIn("[Pp]", d["fen"])
+
+    def test_drop_consumes_pocket(self):
+        """Dropping P@e4 from a pocketed pawn removes it from the pocket."""
+        game = crazyhouse_proxy.CrazyhouseGame()
+        state = game.new_initial_state()
+        for san in ["e4", "d5", "exd5", "Qxd5"]:
+            _play(state, san)
+        # White has 1 pawn in pocket; drop it on e4.
+        _play(state, "P@e4")
+        d = state.state_dict()
+        self.assertEqual(d["pockets"]["white"], {})
+        self.assertEqual(d["board"][4][4], "P")  # e4 == board[4][4] (rank 4, file e)
+
+    def test_terminal_winner(self):
+        """Fool's mate produces a Black win; the proxy reports it."""
+        game = crazyhouse_proxy.CrazyhouseGame()
+        state = game.new_initial_state()
+        # 1. f3 e5 2. g4 Qh4#
+        for san in ["f3", "e5", "g4", "Qh4#"]:
+            _play(state, san)
+        self.assertTrue(state.is_terminal())
+        d = state.state_dict()
+        self.assertTrue(d["is_terminal"])
+        self.assertEqual(d["winner"], "black")
+        # Once terminal, current_player is the OpenSpiel terminal sentinel.
+        self.assertNotIn(d["current_player"], ("white", "black"))
+
+
+if __name__ == "__main__":
+    absltest.main()

--- a/tests/envs/open_spiel_env/games/crazyhouse/harness_test.py
+++ b/tests/envs/open_spiel_env/games/crazyhouse/harness_test.py
@@ -1,0 +1,379 @@
+"""Tests for the Crazyhouse LLM harness."""
+
+from unittest.mock import MagicMock, patch
+
+import pyspiel
+from absl.testing import absltest
+
+from kaggle_environments.core_harness import ParseResult, create_agent_fn
+from kaggle_environments.envs.open_spiel_env.games.crazyhouse import crazyhouse_proxy
+from kaggle_environments.envs.open_spiel_env.games.crazyhouse.harness import (
+    generate_prompt,
+    get_legal_moves,
+    parse_response,
+)
+
+
+def _play(state, san):
+    for action in state.legal_actions():
+        if state.action_to_string(state.current_player(), action) == san:
+            state.apply_action(action)
+            return
+    raise AssertionError(f"move {san!r} not legal here")
+
+
+def _make_observation(state, game, player_id=None):
+    """Build a harness-style observation dict from a Crazyhouse state."""
+    pid = state.current_player() if player_id is None else player_id
+    return {
+        "observationString": state.observation_string(0),
+        "playerId": pid,
+        "currentPlayer": state.current_player(),
+        "serializedGameAndState": pyspiel.serialize_game_and_state(
+            game.__wrapped__, state.__wrapped__
+        ),
+    }
+
+
+class ParseResponseTest(absltest.TestCase):
+    def test_parse_pawn_push_from_json(self):
+        legal = ["e4", "d4", "Nf3", "Nc3"]
+        result = parse_response('```json\n{"move": "e4"}\n```', legal)
+        self.assertEqual(result.legal_action, "e4")
+        self.assertEqual(result.raw_action, "e4")
+
+    def test_parse_piece_move(self):
+        legal = ["e4", "Nf3", "Nc3"]
+        result = parse_response('```json\n{"move": "Nf3"}\n```', legal)
+        self.assertEqual(result.legal_action, "Nf3")
+
+    def test_parse_drop(self):
+        legal = ["e4", "P@e4", "P@d4", "N@d5"]
+        result = parse_response('```json\n{"move": "P@e4"}\n```', legal)
+        self.assertEqual(result.legal_action, "P@e4")
+
+    def test_parse_drop_lowercase_piece(self):
+        """Models often emit ``p@e4`` — match it to the canonical ``P@e4``."""
+        legal = ["P@e4", "P@d4"]
+        result = parse_response('```json\n{"move": "p@e4"}\n```', legal)
+        self.assertEqual(result.legal_action, "P@e4")
+
+    def test_parse_castling(self):
+        legal = ["O-O", "O-O-O", "Nf3"]
+        result = parse_response('```json\n{"move": "O-O"}\n```', legal)
+        self.assertEqual(result.legal_action, "O-O")
+
+    def test_parse_castling_zero_form(self):
+        """Some clients write 0-0 for castling — accept it."""
+        legal = ["O-O", "Nf3"]
+        result = parse_response('```json\n{"move": "0-0"}\n```', legal)
+        self.assertEqual(result.legal_action, "O-O")
+
+    def test_parse_capture_with_check(self):
+        legal = ["e4", "Bb5+", "Nf3"]
+        result = parse_response('```json\n{"move": "Bb5+"}\n```', legal)
+        self.assertEqual(result.legal_action, "Bb5+")
+
+    def test_parse_drops_check_suffix_when_unique(self):
+        """If only one legal move strips to ``Bb5``, accept ``Bb5`` for it."""
+        legal = ["e4", "Bb5+"]
+        result = parse_response('```json\n{"move": "Bb5"}\n```', legal)
+        self.assertEqual(result.legal_action, "Bb5+")
+
+    def test_parse_case_insensitive_pawn(self):
+        legal = ["e4", "Nf3"]
+        result = parse_response('```json\n{"move": "E4"}\n```', legal)
+        self.assertEqual(result.legal_action, "e4")
+
+    def test_parse_bare_json(self):
+        legal = ["e4", "Nf3"]
+        result = parse_response('I think {"move": "Nf3"} is best.', legal)
+        self.assertEqual(result.legal_action, "Nf3")
+        self.assertEqual(result.raw_action, "Nf3")
+
+    def test_parse_fallback_scan(self):
+        """Falls back to scanning prose for any legal SAN token."""
+        legal = ["e4", "d4", "Nc3"]
+        result = parse_response("In this position I think Nc3 wins material.", legal)
+        self.assertEqual(result.legal_action, "Nc3")
+
+    def test_parse_malformed_json_falls_back(self):
+        legal = ["e4", "Nf3"]
+        result = parse_response("```json\n{bad json}\n```\nI play e4.", legal)
+        self.assertEqual(result.legal_action, "e4")
+
+    def test_parse_illegal_returns_none(self):
+        legal = ["e4", "d4"]
+        result = parse_response('```json\n{"move": "Ke2"}\n```', legal)
+        self.assertIsNone(result.legal_action)
+        self.assertEqual(result.raw_action, "Ke2")
+
+    def test_parse_no_match_returns_none(self):
+        legal = ["e4", "d4"]
+        result = parse_response("I have no idea what to play.", legal)
+        self.assertIsNone(result.legal_action)
+        self.assertIsNone(result.raw_action)
+
+    def test_parse_returns_parse_result(self):
+        result = parse_response('```json\n{"move": "e4"}\n```', ["e4"])
+        self.assertIsInstance(result, ParseResult)
+
+
+class GeneratePromptTest(absltest.TestCase):
+    def test_basic_prompt(self):
+        observation = {
+            "observationString": '{"pockets": {"white": {}, "black": {}}}',
+            "playerId": 1,
+        }
+        prompt = generate_prompt(observation, [])
+        self.assertIn("Crazyhouse", prompt)
+        self.assertIn("White", prompt)
+        self.assertIn("(W)", prompt)
+        self.assertIn("pocket", prompt.lower())
+        self.assertIn("drop", prompt.lower())
+
+    def test_black_player(self):
+        observation = {
+            "observationString": '{"pockets": {"white": {}, "black": {}}}',
+            "playerId": 0,
+        }
+        prompt = generate_prompt(observation, [])
+        self.assertIn("Black", prompt)
+        self.assertIn("(B)", prompt)
+
+    def test_pocket_rendered(self):
+        observation = {
+            "observationString": (
+                '{"pockets": {"white": {"P": 2, "N": 1}, "black": {"R": 1}}}'
+            ),
+            "playerId": 1,
+        }
+        prompt = generate_prompt(observation, [])
+        self.assertIn("Your pocket: 1xN, 2xP", prompt)
+        self.assertIn("Opponent pocket: 1xR", prompt)
+
+    def test_empty_pocket_marker(self):
+        observation = {
+            "observationString": '{"pockets": {"white": {}, "black": {}}}',
+            "playerId": 1,
+        }
+        prompt = generate_prompt(observation, [])
+        self.assertIn("Your pocket: (empty)", prompt)
+        self.assertIn("Opponent pocket: (empty)", prompt)
+
+    def test_move_history_included(self):
+        observation = {
+            "observationString": "{}",
+            "playerId": 1,
+        }
+        prompt = generate_prompt(observation, ["e4", "d5", "exd5"])
+        self.assertIn("e4 d5 exd5", prompt)
+
+    def test_rethink_suffix(self):
+        observation = {
+            "observationString": "{}",
+            "playerId": 1,
+        }
+        prompt = generate_prompt(
+            observation,
+            [],
+            previous_response="I want Ke2",
+            previous_action="Ke2",
+        )
+        self.assertIn("Your previous response was", prompt)
+        self.assertIn("Ke2", prompt)
+        self.assertIn("not in the legal moves", prompt)
+
+    def test_no_rethink_on_first_attempt(self):
+        observation = {
+            "observationString": "{}",
+            "playerId": 1,
+        }
+        prompt = generate_prompt(observation, [])
+        self.assertNotIn("Your previous response was", prompt)
+
+
+class GetLegalMovesTest(absltest.TestCase):
+    def test_from_provided_actions(self):
+        observation = {
+            "legalActions": [89, 656],
+            "legalActionStrings": ["a3", "Nc3"],
+        }
+        result = get_legal_moves(observation)
+        self.assertEqual(result, {89: "a3", 656: "Nc3"})
+
+    def test_from_serialized_state(self):
+        game = crazyhouse_proxy.CrazyhouseGame()
+        state = game.new_initial_state()
+        observation = _make_observation(state, game)
+        result = get_legal_moves(observation)
+        # Standard chess opening: 20 legal moves (16 pawn pushes + 4 knight).
+        self.assertEqual(len(result), 20)
+        self.assertIn("e4", result.values())
+        self.assertIn("Nf3", result.values())
+
+    def test_drops_appear_after_capture(self):
+        """After a capture the side-to-move can drop the captured piece."""
+        game = crazyhouse_proxy.CrazyhouseGame()
+        state = game.new_initial_state()
+        for san in ["e4", "d5", "exd5", "Qxd5"]:
+            _play(state, san)
+        observation = _make_observation(state, game)
+        result = get_legal_moves(observation)
+        drops = [s for s in result.values() if "@" in s]
+        self.assertTrue(drops, "expected at least one drop available")
+        self.assertIn("P@e4", drops)
+
+    def test_empty_serialized(self):
+        observation = {"serializedGameAndState": ""}
+        result = get_legal_moves(observation)
+        self.assertEqual(result, {})
+
+    def test_returns_int_string_dict(self):
+        observation = {
+            "legalActions": [89],
+            "legalActionStrings": ["a3"],
+        }
+        result = get_legal_moves(observation)
+        self.assertIsInstance(result, dict)
+        for k, v in result.items():
+            self.assertIsInstance(k, int)
+            self.assertIsInstance(v, str)
+
+
+def _make_mock_response(content):
+    resp = MagicMock()
+    resp.usage = MagicMock(prompt_tokens=10, completion_tokens=20)
+    resp.choices = [
+        MagicMock(message=MagicMock(content=content), finish_reason="stop")
+    ]
+    return resp
+
+
+class _CrazyhouseHarness:
+    """Adapter wrapping module-level functions into the GameHarness protocol."""
+
+    def get_legal_moves(self, observation):
+        return get_legal_moves(observation)
+
+    def make_prompt(self, observation, move_history, previous_response=None, previous_action=None):
+        return generate_prompt(observation, move_history, previous_response, previous_action)
+
+    def parse_response(self, response, legal_action_strings):
+        return parse_response(response, legal_action_strings)
+
+
+class AgentIntegrationTest(absltest.TestCase):
+    """Drive the harness through ``create_agent_fn`` from ``core_harness``."""
+
+    @patch.dict(
+        "os.environ",
+        {
+            "MODEL_NAME": "test-model",
+            "MODEL_PROXY_KEY": "test-key",
+            "MODEL_PROXY_URL": "dummy_url",
+        },
+    )
+    @patch("kaggle_environments.core_harness.litellm")
+    def test_setup_step_returns_inactive(self, mock_litellm):
+        mock_litellm.drop_params = True
+        agent = create_agent_fn(_CrazyhouseHarness())
+
+        result = agent({"step": 0, "remainingOverageTime": 60}, {})
+
+        self.assertIsNone(result["submission"])
+        self.assertEqual(result["status"], "INACTIVE")
+        mock_litellm.completion.assert_not_called()
+
+    @patch.dict(
+        "os.environ",
+        {
+            "MODEL_NAME": "test-model",
+            "MODEL_PROXY_KEY": "test-key",
+            "MODEL_PROXY_URL": "dummy_url",
+        },
+    )
+    @patch("kaggle_environments.core_harness.litellm")
+    def test_successful_move(self, mock_litellm):
+        mock_litellm.drop_params = True
+        mock_litellm.completion.return_value = _make_mock_response(
+            '```json\n{"move": "e4"}\n```',
+        )
+
+        agent = create_agent_fn(_CrazyhouseHarness())
+
+        game = crazyhouse_proxy.CrazyhouseGame()
+        state = game.new_initial_state()
+        observation = _make_observation(state, game)
+
+        result = agent(observation, {})
+
+        # action id 92 == "e4" in OpenSpiel's chess action encoding.
+        e4_action = next(
+            a for a in state.legal_actions()
+            if state.action_to_string(state.current_player(), a) == "e4"
+        )
+        self.assertEqual(result["submission"], e4_action)
+        self.assertEqual(result["actionString"], "e4")
+        self.assertEqual(result["status"], "OK")
+
+    @patch.dict(
+        "os.environ",
+        {
+            "MODEL_NAME": "test-model",
+            "MODEL_PROXY_KEY": "test-key",
+            "MODEL_PROXY_URL": "dummy_url",
+        },
+    )
+    @patch("kaggle_environments.core_harness.litellm")
+    def test_retry_on_bad_parse(self, mock_litellm):
+        mock_litellm.drop_params = True
+        mock_litellm.completion.side_effect = [
+            _make_mock_response('```json\n{"move": "Ke2"}\n```'),
+            _make_mock_response('```json\n{"move": "e4"}\n```'),
+        ]
+
+        agent = create_agent_fn(_CrazyhouseHarness())
+
+        game = crazyhouse_proxy.CrazyhouseGame()
+        state = game.new_initial_state()
+        observation = _make_observation(state, game)
+
+        result = agent(observation, {})
+
+        e4_action = next(
+            a for a in state.legal_actions()
+            if state.action_to_string(state.current_player(), a) == "e4"
+        )
+        self.assertEqual(result["submission"], e4_action)
+        self.assertEqual(mock_litellm.completion.call_count, 2)
+
+    @patch.dict(
+        "os.environ",
+        {
+            "MODEL_NAME": "test-model",
+            "MODEL_PROXY_KEY": "test-key",
+            "MODEL_PROXY_URL": "dummy_url",
+        },
+    )
+    @patch("kaggle_environments.core_harness.litellm")
+    def test_raises_after_two_failures(self, mock_litellm):
+        mock_litellm.drop_params = True
+        mock_litellm.completion.return_value = _make_mock_response(
+            "I don't know what to play",
+        )
+
+        agent = create_agent_fn(_CrazyhouseHarness())
+
+        game = crazyhouse_proxy.CrazyhouseGame()
+        state = game.new_initial_state()
+        observation = _make_observation(state, game)
+
+        with self.assertRaises(ValueError):
+            agent(observation, {})
+
+        self.assertEqual(mock_litellm.completion.call_count, 2)
+
+
+if __name__ == "__main__":
+    absltest.main()

--- a/tests/envs/open_spiel_env/games/crazyhouse/harness_test.py
+++ b/tests/envs/open_spiel_env/games/crazyhouse/harness_test.py
@@ -92,7 +92,7 @@ class ParseResponseTest(absltest.TestCase):
         self.assertEqual(result.raw_action, "Nf3")
 
     def test_parse_fallback_scan(self):
-        """Falls back to scanning prose for any legal SAN token."""
+        """Falls back to scanning prose for any legal move token."""
         legal = ["e4", "d4", "Nc3"]
         result = parse_response("In this position I think Nc3 wins material.", legal)
         self.assertEqual(result.legal_action, "Nc3")

--- a/tests/envs/open_spiel_env/test_open_spiel_env.py
+++ b/tests/envs/open_spiel_env/test_open_spiel_env.py
@@ -293,6 +293,60 @@ class OpenSpielEnvTest(absltest.TestCase):
         self.assertEqual(json_data["rewards"][0], open_spiel_env.DEFAULT_INVALID_ACTION_REWARD)
         self.assertEqual(json_data["rewards"][1], -open_spiel_env.DEFAULT_INVALID_ACTION_REWARD)
 
+    def test_crazyhouse_agent_playthrough(self):
+        env = make(
+            "open_spiel_crazyhouse",
+            configuration={"includeLegalActions": True},
+            debug=True,
+        )
+        env.run(["random", "random"])
+        playthrough = env.toJSON()
+        self.assertEqual(playthrough["name"], "open_spiel_crazyhouse")
+        self.assertTrue(all(status == "DONE" for status in playthrough["statuses"]))
+
+    def test_crazyhouse_initial_observation(self):
+        # The proxy emits structured JSON parsed from the Crazyhouse FEN. The
+        # initial position has empty pockets and white (player 1 in OpenSpiel's
+        # crazyhouse encoding) to move.
+        env = make("open_spiel_crazyhouse", debug=True)
+        env.reset()
+        kaggle_state = env.step([{"submission": -1}, {"submission": -1}])
+        obs = json.loads(kaggle_state[1]["observation"]["observationString"])
+        self.assertEqual(obs["current_player"], "white")
+        self.assertEqual(obs["side_to_move"], "w")
+        self.assertEqual(obs["castling_rights"], "KQkq")
+        self.assertEqual(obs["fullmove_number"], 1)
+        self.assertEqual(obs["pockets"], {"white": {}, "black": {}})
+        self.assertFalse(obs["is_terminal"])
+        self.assertIsNone(obs["winner"])
+        # Board is 8 ranks x 8 files, rank 8 first; white pieces are uppercase.
+        self.assertEqual(len(obs["board"]), 8)
+        self.assertEqual(obs["board"][0], list("rnbqkbnr"))
+        self.assertEqual(obs["board"][7], list("RNBQKBNR"))
+
+    def test_crazyhouse_pocket_after_capture(self):
+        # After 1.e4 d5 2.exd5 white captures a pawn and gains a pawn in pocket.
+        # Use the proxy game directly to assert pocket parsing.
+        game = pyspiel.load_game("crazyhouse_proxy")
+        state = game.new_initial_state()
+        for san in ("e4", "d5", "exd5"):
+            action = next(a for a in state.legal_actions() if state.action_to_string(a) == san)
+            state.apply_action(action)
+        obs = json.loads(state.observation_string(0))
+        self.assertEqual(obs["pockets"]["white"], {"P": 1})
+        self.assertEqual(obs["pockets"]["black"], {})
+
+    def test_crazyhouse_invalid_action(self):
+        env = make("open_spiel_crazyhouse", debug=True)
+        env.reset()
+        env.step([{"submission": -1}, {"submission": -1}])  # Setup step.
+        # In crazyhouse player 1 (White) moves first; player 0 must send -1.
+        env.step([{"submission": -1}, {"submission": 999999}])  # Invalid action.
+        self.assertTrue(env.done)
+        json_data = env.toJSON()
+        self.assertEqual(json_data["rewards"][1], open_spiel_env.DEFAULT_INVALID_ACTION_REWARD)
+        self.assertEqual(json_data["rewards"][0], -open_spiel_env.DEFAULT_INVALID_ACTION_REWARD)
+
     def test_serialized_game_and_state(self):
         env = make("open_spiel_tic_tac_toe", debug=True)
         env.reset()

--- a/uv.lock
+++ b/uv.lock
@@ -1355,7 +1355,7 @@ wheels = [
 
 [[package]]
 name = "kaggle-environments"
-version = "1.26.7"
+version = "1.29.0"
 source = { editable = "." }
 dependencies = [
     { name = "flask" },
@@ -1408,9 +1408,9 @@ requires-dist = [
     { name = "gymnax", specifier = "==0.0.8" },
     { name = "jax" },
     { name = "jsonschema", specifier = ">=3.0.1" },
-    { name = "litellm" },
+    { name = "litellm", specifier = "<=1.82.4" },
     { name = "numpy", specifier = ">=2.0" },
-    { name = "open-spiel", specifier = ">=1.6.8" },
+    { name = "open-spiel", specifier = ">=1.6.13" },
     { name = "pettingzoo", specifier = "==1.24.0" },
     { name = "pokerkit", specifier = "==0.6.3" },
     { name = "pydantic", specifier = ">=2.11.4" },
@@ -2179,33 +2179,33 @@ wheels = [
 
 [[package]]
 name = "open-spiel"
-version = "1.6.11"
+version = "1.6.13"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "absl-py" },
     { name = "attrs" },
     { name = "ml-collections" },
     { name = "numpy" },
-    { name = "pip" },
     { name = "scipy" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/2e/95/4e9367a1d84e557d83d61ccadad1b4dd5608edcd08a33b38f3d5e6432edd/open_spiel-1.6.11.tar.gz", hash = "sha256:ed667d2f0a6691666dd6bc47396429bfdbff9bb71430fc178ff8bca2a9c79004", size = 5451152, upload-time = "2026-01-04T23:45:57.571Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/38/7b/ecac49a9cb4fa5965e5c7dd3f7b779c888daa8c16524f281ae29bcc86523/open_spiel-1.6.13.tar.gz", hash = "sha256:5d7ea172e2edae5bfa7b26d084278ba4b872ae17c11ba3de9c9346fb7dd30813", size = 5556479, upload-time = "2026-05-01T12:55:58.053Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ab/b5/309360c7ebcf58ffdc2a6c5450df641b41b885edaf712ad7c4e4ff7d13cc/open_spiel-1.6.11-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:01807d21aaa84ecb5d92651e4dec3cee5cff1d3f77381d8aaf2b56131a608b4b", size = 5827268, upload-time = "2026-01-04T23:45:35.019Z" },
-    { url = "https://files.pythonhosted.org/packages/51/da/936af0b809f025556d0d612234f03a7c27c0a110b91e88dbbe375532a036/open_spiel-1.6.11-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:31af9b00b1b3cae38221ab4e4ba7399b9fa028a036aefe7168b3435141edcfa6", size = 5914901, upload-time = "2026-01-04T23:45:36.721Z" },
-    { url = "https://files.pythonhosted.org/packages/37/8a/2c10bce8ee9dcd08665493fe020aa742fd54bb9544419f6317a7bc6f9f11/open_spiel-1.6.11-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:ec43cc292ea2099feaab3d8e2419fa7083aed7d340fc55879c21439a8bd10ede", size = 6737434, upload-time = "2026-01-04T23:45:38.356Z" },
-    { url = "https://files.pythonhosted.org/packages/1e/f0/764d45546a60a853a20d1e42f38e125c200d93af068e0bfa8d3af4b45aab/open_spiel-1.6.11-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:0148132cdc2cc333c6584c4d8cd3a78332e3a979d84f588c8523b880bdef3a04", size = 7067662, upload-time = "2026-01-04T23:45:39.971Z" },
-    { url = "https://files.pythonhosted.org/packages/69/2c/8b754e707d445475177e91e00ea7e80e72ce0e04ecd8258d24bc00cebcd1/open_spiel-1.6.11-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:a71735e1d71494fbe7e3a1838b5e487e7d7256cdd73f8054fa42649576c95f02", size = 5823227, upload-time = "2026-01-04T23:45:41.597Z" },
-    { url = "https://files.pythonhosted.org/packages/4f/04/8f18c43fe938e144f6496c7dd150fe4eb7bb6f12dcb561a3d4984e5cccc3/open_spiel-1.6.11-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:83e5fea8ed3343a392e954c1a12ad3d819af8ba8ac2594f3bb3d3d42deea4026", size = 5921188, upload-time = "2026-01-04T23:45:43.151Z" },
-    { url = "https://files.pythonhosted.org/packages/00/c4/35554a0316bc1c56dce8a14c54257203be9993530d502d3c5aada186d921/open_spiel-1.6.11-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:9a88f99a2f16bd7e23f84deb684692b2fa2b75ab8a1ea128630d6d5a0dd0a2f5", size = 6735228, upload-time = "2026-01-04T23:45:44.785Z" },
-    { url = "https://files.pythonhosted.org/packages/bd/d4/9f0ddfad637924e08f58dcda88b3cc517ec179db576ac954f9e01114c775/open_spiel-1.6.11-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:a0de4fb658518d48ec344d9c167d58d01a160bd09035ec1422d76a95c4b6553e", size = 7067051, upload-time = "2026-01-04T23:45:46.045Z" },
-    { url = "https://files.pythonhosted.org/packages/ae/68/7f3c1faac14eaa7f02e6a21ea73370820bfcf68280cf08290d69c338024a/open_spiel-1.6.11-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:a9c902c11879813cc3dedde7b3a4f917095952c17ea8c1e26d312fe853858a96", size = 5827956, upload-time = "2026-01-04T23:45:47.631Z" },
-    { url = "https://files.pythonhosted.org/packages/ce/6a/cf765db272583fa6199948a11395a1c28db54367044fa66065b809ce71fa/open_spiel-1.6.11-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:ae1634ab642b6d677adaa711732e439ace1d0ac77bbf7ab0cfb08c5631a3dad8", size = 5924218, upload-time = "2026-01-04T23:45:48.906Z" },
-    { url = "https://files.pythonhosted.org/packages/d9/c9/9b1f04ce933ccf6e8c897540c510822a4c1edc47fbcbd7c309519c433dd6/open_spiel-1.6.11-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:1c19aa8c0c79b57915a955f6c09eadf52563dec52573122b515a87a7ee8401e2", size = 6735469, upload-time = "2026-01-04T23:45:50.159Z" },
-    { url = "https://files.pythonhosted.org/packages/a6/8f/08b2043efad19465403ff9eaac5d03cc7b335e190847b8d55ee479e0db7d/open_spiel-1.6.11-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:2c9f91ebd6113b6d76f332d07107a6c98396c6c67707a72d1f85462f8f89581b", size = 7066801, upload-time = "2026-01-04T23:45:51.361Z" },
-    { url = "https://files.pythonhosted.org/packages/44/90/7085d7d6fe7dd5bb516d6b443adf7f29b6694719ab26b47702e470b4b669/open_spiel-1.6.11-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:3cc259a5b400fca213aac56560b319c397ced212601191ab69a1e1bc783f7aca", size = 5389665, upload-time = "2026-01-04T23:45:52.597Z" },
-    { url = "https://files.pythonhosted.org/packages/74/18/319dbb77ff161066f409f60c0426ba1c6c8e6ed02a32126c8b0dfe262e30/open_spiel-1.6.11-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:3c8f2dc1e19bda7196934f80d6de22299c68079a42de8e9c0274a7a8a77c1def", size = 6736267, upload-time = "2026-01-04T23:45:55.093Z" },
-    { url = "https://files.pythonhosted.org/packages/db/43/a1dd61bfa4958ccc04b52cf6f85af2d12d37c87e91be78334fd42a33e654/open_spiel-1.6.11-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:b84a19af4771edb50a105d54b47c562256e2890581985e01614399c4590414b9", size = 7067362, upload-time = "2026-01-04T23:45:56.274Z" },
+    { url = "https://files.pythonhosted.org/packages/12/62/eeed8b582d57db9036b97a7c539a549ac27840e0a10c9dfced982efb16c8/open_spiel-1.6.13-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:e06b40814d9676c706f97f82011acad83038348f73cf3a580a0f6a248c1091e8", size = 12455976, upload-time = "2026-05-01T12:55:18.924Z" },
+    { url = "https://files.pythonhosted.org/packages/06/04/9d8b743b2f8dfe4e8a4a06272f9988378b5553c93fe78a60729851167d14/open_spiel-1.6.13-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:dc28159b98592508f8bb329abbceb6326e92645adf98352a279ce82a71bd5697", size = 14697656, upload-time = "2026-05-01T12:55:22.236Z" },
+    { url = "https://files.pythonhosted.org/packages/01/66/892d7f2f0e64bba7ea81951e5c138d8c0f7777d50a227f49477b0d4f9d08/open_spiel-1.6.13-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:dd97c77809700e8a2ff64279b1285e007e88dfd88a828cec2878e58931b61f92", size = 15434696, upload-time = "2026-05-01T12:55:24.919Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/64/dd1f0e23599f40631f1a2d9075e48fc176c53f7506d5b7c47bdc2bd022b8/open_spiel-1.6.13-cp311-cp311-win_amd64.whl", hash = "sha256:cfabe00ec4e09b4fc923cffcb4abbd22fc7248a7e3fb44e7b98212530053e6dd", size = 10084295, upload-time = "2026-05-01T12:55:49.449Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/de/e5693e173ebbfe4c77700bccc57c9bdab291800123200d0227df50e7aee5/open_spiel-1.6.13-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:9b83c8e2b4fa8a175b9d14ef007f0df82421eb84483040e9ee63a496da27a989", size = 12489395, upload-time = "2026-05-01T12:55:27.721Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/d6/7fc87cefff2eababa90488bd30e02b5a5474990570454784ccfc6345a275/open_spiel-1.6.13-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6086ab01df7e4bc0ff061c31bee1ddf6a614fe307e0d2532142ad61cd75784fc", size = 14718799, upload-time = "2026-05-01T12:55:29.991Z" },
+    { url = "https://files.pythonhosted.org/packages/47/80/4c8e048cce92a6dc01e656decc0df137a2abd33eaf588e64021c4475839f/open_spiel-1.6.13-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bf3f5c121f405cab65bf49268ba9d2eabb0e8111c2c0701c1a57f1aee2da1483", size = 15465662, upload-time = "2026-05-01T12:55:32.396Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/c9/761fbcd98efca2c78eb6090d4a715dfbe6118027a6e6a055603c0848b01b/open_spiel-1.6.13-cp312-cp312-win_amd64.whl", hash = "sha256:fe02a144bcf76576c6faf97fbec53e09f14f09c3a9f5e05206c6eb6a5fe073c2", size = 10093597, upload-time = "2026-05-01T12:55:51.549Z" },
+    { url = "https://files.pythonhosted.org/packages/58/a5/7a8b35679ea0250204b8daf5673ad42eb27c0e57af254408921f785741a6/open_spiel-1.6.13-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:472ade7d8f0bdf4101ccaf3ad8ea16a680ebae21797fc781fd8e5c60ebf921db", size = 12489709, upload-time = "2026-05-01T12:55:34.666Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/22/ceb7605f04d2e8a16158af23c4e553eb00cf8fef11b171e3368e4ef1365b/open_spiel-1.6.13-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8b90a2c0126702c1e25f8a04d472ba94b1ab96993447ecaac2d9727d243f2f67", size = 14718744, upload-time = "2026-05-01T12:55:36.822Z" },
+    { url = "https://files.pythonhosted.org/packages/87/2f/e1ac1fb8d3cbdd28cd835e8b51cda49790e4487ded1c2224f7480cdc0377/open_spiel-1.6.13-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:90ed74cb98c36ecae693e98e4aa974058eff69f07222d99f1b9b1578a75b3464", size = 15465581, upload-time = "2026-05-01T12:55:39.465Z" },
+    { url = "https://files.pythonhosted.org/packages/80/6a/dbf90712f46efeec61bd4d021754f6a6508ddd60607d64e4903c383629e2/open_spiel-1.6.13-cp313-cp313-win_amd64.whl", hash = "sha256:0146f31fa2f93cd9f5f95a363eed6a4cdada5cb375662961f5ed728e0ae0327f", size = 10093362, upload-time = "2026-05-01T12:55:54.071Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/ed/420edc8b12a633b8f4eec936c64499cc4aa438ea4a2e9985cf5bf4b9b0c2/open_spiel-1.6.13-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:3407cf03513bc93bb0e06a2cb1feac791bdbcd4cc73bf90e77cfe72c3d06b761", size = 12025021, upload-time = "2026-05-01T12:55:42.158Z" },
+    { url = "https://files.pythonhosted.org/packages/25/36/baf7029c4622735c1f594535c4246b89935a62a420cdecfc0c71ce08acdb/open_spiel-1.6.13-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2465a09816befe021265ed0f2c1433bc19842ecfc86cd1b51bb82fe992016b18", size = 14723700, upload-time = "2026-05-01T12:55:44.592Z" },
+    { url = "https://files.pythonhosted.org/packages/83/9f/4abc57621babefe97d5f100187b8aa2cdc4dbc338bca60d462cb78597536/open_spiel-1.6.13-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ed074560e223042ea8bd684385b114622cf5c4c2d41c5429209e6d5b86cfd636", size = 15469323, upload-time = "2026-05-01T12:55:47.13Z" },
+    { url = "https://files.pythonhosted.org/packages/14/cb/45a835bb8fd31639b267dc2d44044cb591594807426e24b1f14101007789/open_spiel-1.6.13-cp314-cp314-win_amd64.whl", hash = "sha256:2fd621ae28b16abac112e6b2c2a60a598a176170d3fa56c1b36663ce30890f92", size = 10171882, upload-time = "2026-05-01T12:55:56.138Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Onboards Crazyhouse with proxy, harness, visualizer, and tests. 

Unlike with basic chess, a proxy is needed to parse OpenSpiel's bracketed Crazyhouse-FEN into structured JSON exposing both pockets. The harness parser tolerates lowercase drops (p@e4) and zero-form castling (0-0) since models commonly emit those. Visualizer looks nearly identical to the chess v1 visualizer but adds black/white pocket panels above and below the board.    