### PR TITLE
Fix Orbit Wars fleet tunneling through rotating planets

### DIFF
--- a/kaggle_environments/envs/orbit_wars/orbit_wars.py
+++ b/kaggle_environments/envs/orbit_wars/orbit_wars.py
@@ -43,6 +43,27 @@ def point_to_segment_distance(p, v, w):
     return distance(p, projection)
 
 
+def swept_pair_hit(A, B, P0, P1, r):
+    """True iff a fleet moving A->B and a planet moving P0->P1 come within r
+    of each other for some t in [0, 1]. Treats both segments as linear over
+    the tick (planet rotation is linearised to its chord)."""
+    d0x, d0y = A[0] - P0[0], A[1] - P0[1]
+    dvx = (B[0] - A[0]) - (P1[0] - P0[0])
+    dvy = (B[1] - A[1]) - (P1[1] - P0[1])
+    a = dvx * dvx + dvy * dvy
+    b = 2.0 * (d0x * dvx + d0y * dvy)
+    c = d0x * d0x + d0y * d0y - r * r
+    if a < 1e-12:
+        return c <= 0.0
+    disc = b * b - 4.0 * a * c
+    if disc < 0.0:
+        return False
+    sq = math.sqrt(disc)
+    t1 = (-b - sq) / (2.0 * a)
+    t2 = (-b + sq) / (2.0 * a)
+    return t2 >= 0.0 and t1 <= 1.0
+
+
 def generate_planets(rng=None):
     if rng is None:
         rng = random
@@ -492,7 +513,59 @@ def interpreter(state, env):
         if planet[1] != -1:
             planet[5] += planet[6]
 
-    # 2. Fleet Movement (with continuous collision detection)
+    # 2. Compute each planet's end-of-tick position up front, so fleet
+    # movement can use a swept-pair (continuous) check that accounts for
+    # both objects moving in the same tick.
+    angular_velocity = obs0.angular_velocity
+    step = get(obs0, "step", 1)
+    comet_pid_set = set(obs0.comet_planet_ids)
+    initial_by_id = {p[0]: p for p in obs0.initial_planets}
+
+    # planet_paths: pid -> (old_pos, new_pos, check_collision)
+    # check_collision=False means the planet appears mid-tick (first comet
+    # placement) and shouldn't be tested against fleets this tick.
+    planet_paths = {}
+    expired_comet_pids = []
+
+    for planet in obs0.planets:
+        if planet[0] in comet_pid_set:
+            continue
+        old_pos = (planet[2], planet[3])
+        new_pos = old_pos
+        initial_p = initial_by_id.get(planet[0])
+        if initial_p is not None:
+            dx = initial_p[2] - CENTER
+            dy = initial_p[3] - CENTER
+            r = math.sqrt(dx ** 2 + dy ** 2)
+            if r + planet[4] < ROTATION_RADIUS_LIMIT:
+                initial_angle = math.atan2(dy, dx)
+                current_angle = initial_angle + angular_velocity * step
+                new_pos = (
+                    CENTER + r * math.cos(current_angle),
+                    CENTER + r * math.sin(current_angle),
+                )
+        planet_paths[planet[0]] = (old_pos, new_pos, True)
+
+    for group in obs0.comets:
+        group["path_index"] += 1
+        idx = group["path_index"]
+        for i, pid in enumerate(group["planet_ids"]):
+            planet = next((p for p in obs0.planets if p[0] == pid), None)
+            if planet is None:
+                continue
+            p_path = group["paths"][i]
+            old_pos = (planet[2], planet[3])
+            if idx >= len(p_path):
+                expired_comet_pids.append(pid)
+                # Comet stays put this tick; remove after combat.
+                planet_paths[pid] = (old_pos, old_pos, True)
+            else:
+                new_pos = (p_path[idx][0], p_path[idx][1])
+                # First placement uses an off-board placeholder for old_pos.
+                check = old_pos[0] >= 0
+                planet_paths[pid] = (old_pos, new_pos, check)
+
+    # 3. Fleet Movement (with continuous swept-pair collision detection)
     # Speed scales with fleet size: 1 ship = 1/turn, max = shipSpeed (default 6)
     max_speed = configuration.shipSpeed
     fleets_to_remove = []
@@ -513,8 +586,11 @@ def interpreter(state, env):
         # or sun still get credit for hitting a planet along the way.
         hit_planet = False
         for planet in obs0.planets:
-            planet_pos = (planet[2], planet[3])
-            if point_to_segment_distance(planet_pos, old_pos, new_pos) < planet[4]:
+            path = planet_paths.get(planet[0])
+            if path is None or not path[2]:
+                continue
+            p_old, p_new, _ = path
+            if swept_pair_hit(old_pos, new_pos, p_old, p_new, planet[4]):
                 combat_lists[planet[0]].append(fleet)
                 fleets_to_remove.append(fleet)
                 hit_planet = True
@@ -532,64 +608,11 @@ def interpreter(state, env):
             fleets_to_remove.append(fleet)
             continue
 
-    # 3. Planet Movement & Sweep
-    angular_velocity = obs0.angular_velocity
-    step = get(obs0, "step", 1)
-    comet_pid_set = set(obs0.comet_planet_ids)
-    initial_by_id = {p[0]: p for p in obs0.initial_planets}
-
-    def sweep_fleets(planet, old_pos, new_pos):
-        """Check if any fleet is caught by a planet moving from old to new."""
-        if old_pos == new_pos:
-            return
-        for fleet in obs0.fleets:
-            if fleet not in fleets_to_remove:
-                if (
-                    point_to_segment_distance((fleet[2], fleet[3]), old_pos, new_pos)
-                    < planet[4]
-                ):
-                    combat_lists[planet[0]].append(fleet)
-                    fleets_to_remove.append(fleet)
-
-    # Regular planet rotation
+    # 4. Apply planet movement (collisions were already resolved above).
     for planet in obs0.planets:
-        if planet[0] in comet_pid_set:
-            continue
-        initial_p = initial_by_id.get(planet[0])
-        if not initial_p:
-            continue
-        dx = initial_p[2] - CENTER
-        dy = initial_p[3] - CENTER
-        r = math.sqrt(dx**2 + dy**2)
-        old_pos = (planet[2], planet[3])
-
-        if r + planet[4] < ROTATION_RADIUS_LIMIT:
-            initial_angle = math.atan2(dy, dx)
-            current_angle = initial_angle + angular_velocity * step
-            planet[2] = CENTER + r * math.cos(current_angle)
-            planet[3] = CENTER + r * math.sin(current_angle)
-
-        sweep_fleets(planet, old_pos, (planet[2], planet[3]))
-
-    # Comet movement along pre-computed paths
-    expired_comet_pids = []
-    for group in obs0.comets:
-        group["path_index"] += 1
-        idx = group["path_index"]
-        for i, pid in enumerate(group["planet_ids"]):
-            planet = next((p for p in obs0.planets if p[0] == pid), None)
-            if planet is None:
-                continue
-            p_path = group["paths"][i]
-            if idx >= len(p_path):
-                expired_comet_pids.append(pid)
-            else:
-                old_pos = (planet[2], planet[3])
-                planet[2] = p_path[idx][0]
-                planet[3] = p_path[idx][1]
-                # Skip sweep on first placement (old_pos is off-board placeholder)
-                if old_pos[0] >= 0:
-                    sweep_fleets(planet, old_pos, (planet[2], planet[3]))
+        path = planet_paths.get(planet[0])
+        if path is not None:
+            planet[2], planet[3] = path[1]
 
     # Remove expired comets immediately
     if expired_comet_pids:
@@ -609,7 +632,7 @@ def interpreter(state, env):
 
     obs0.fleets = [f for f in obs0.fleets if f not in fleets_to_remove]
 
-    # 4. Combat Resolution
+    # 5. Combat Resolution
     for pid, planet_fleets in combat_lists.items():
         planet = next((p for p in obs0.planets if p[0] == pid), None)
         if not planet or not planet_fleets:

--- a/kaggle_environments/envs/orbit_wars/test_orbit_wars.py
+++ b/kaggle_environments/envs/orbit_wars/test_orbit_wars.py
@@ -299,6 +299,47 @@ class TestOrbitWars(unittest.TestCase):
             for i in range(1, 4)
         ]
 
+    def test_fleet_does_not_tunnel_through_rotating_planet(self):
+        # Both fleet and planet move during the tick. The fleet's path and the
+        # planet's path each pass through (50, 50) with the closest approach
+        # to the *other* object's start/end snapshot exactly equal to the
+        # planet radius. Treating either body as static for the full tick
+        # (the original two-phase check) misses a collision that the swept
+        # pair check catches at t=0.5.
+        #
+        # Setup:
+        #   shipSpeed=2, ships=1000  -> fleet speed = 2.0 exactly
+        #   Fleet path: (49, 50) -> (51, 50)
+        #   angular_velocity=pi, step=1  -> planet rotates pi rad
+        #   Planet path: (50, 52) -> (50, 48)  (orbital r=2, initial angle pi/2)
+        #   Planet radius = 1.0
+        # Phase-1 check: dist((50,52), segment (49,50)-(51,50)) = 2.0 > 1.0 (miss)
+        # Phase-2 check: dist((51,50), segment (50,52)-(50,48)) = 1.0, not < 1.0 (miss)
+        # Swept-pair: |D(t)|^2 = 20t^2 - 20t + 5; |D(0.5)| = 0 (overlap)
+        planets = [[0, -1, 50.0, 52.0, 1.0, 10, 0]]
+        fleets = [[0, 0, 49.0, 50.0, 0.0, 1, 1000]]
+        state = self._make_state(planets, fleets, step=1)
+        state[0].observation.angular_velocity = math.pi
+
+        env = SimpleNamespace(
+            configuration=SimpleNamespace(
+                shipSpeed=2, episodeSteps=500, cometSpeed=4
+            ),
+            done=False,
+        )
+
+        new_state = interpreter(state, env)
+        obs = new_state[0].observation
+
+        # Fleet should have collided with the planet, not tunneled past it.
+        self.assertEqual(
+            len(obs.fleets), 0, "fleet tunneled through rotating planet"
+        )
+        # Planet was neutral with 10 ships; 1000 attackers capture it,
+        # leaving 990 ships under player 0.
+        self.assertEqual(obs.planets[0][1], 0)
+        self.assertEqual(obs.planets[0][5], 990)
+
     def test_rewards_set_at_max_steps(self):
         # When the game reaches episodeSteps without elimination,
         # rewards should reflect each player's total ships.


### PR DESCRIPTION
The previous two-phase collision check treated either the fleet or the planet as static for the full tick, so a fleet flying past a rotating inner planet could pass through it without combat being resolved. Replay 75649154 contained 13 such events in a single 339-step game.

- Add `swept_pair_hit(A, B, P0, P1, r)` solving |D(t)|^2 = a t^2 + b t
  + c for a root in [0, 1], where both objects move linearly across the tick (planet rotation linearised to its chord).
- Reorder the interpreter to precompute each planet's end-of-tick position (rotation + comet pathing) before fleet movement, then run swept-pair per (fleet, planet) pair, then apply planet positions. Drops the redundant post-rotation `sweep_fleets` pass.
- Preserve first-comet-placement skip and expired-comet semantics.
- Add `test_fleet_does_not_tunnel_through_rotating_planet` reproducing the bug: fleet (1000 ships, speed 2) crossing (49,50)->(51,50) while a r=1 planet rotates (50,52)->(50,48). Both legacy point/segment checks miss (d=2 and d=1, neither strictly < r); swept-pair detects overlap at t=0.5.