### PR TITLE
Orbit Wars: swap player 2 orange for Wong vermillion

### DIFF
--- a/kaggle_environments/envs/orbit_wars/orbit_wars.js
+++ b/kaggle_environments/envs/orbit_wars/orbit_wars.js
@@ -72,8 +72,8 @@ async function renderer(context) {
   const current_step = environment.steps[step];
   const obs = current_step[0].observation;
 
-  // Wong palette — colorblind-safe (blue, orange, teal, yellow, neutral grey)
-  const colors = ['#0072B2', '#E69F00', '#009E73', '#F0E442', '#888888'];
+  // Wong palette — colorblind-safe (blue, vermillion, teal, yellow, neutral grey)
+  const colors = ['#0072B2', '#D55E00', '#009E73', '#F0E442', '#888888'];
 
   // Draw Comet tails (before planets so tails render behind)
   const cometPidSet = new Set(obs.comet_planet_ids || []);

--- a/kaggle_environments/envs/orbit_wars/visualizer/default/src/renderer.ts
+++ b/kaggle_environments/envs/orbit_wars/visualizer/default/src/renderer.ts
@@ -6,8 +6,8 @@ const BOARD_SIZE = 100;
 const CENTER = 50;
 const SUN_RADIUS = 10;
 
-// Wong palette — colorblind-safe (blue, orange, teal, yellow)
-const PLAYER_COLORS = ['#0072B2', '#E69F00', '#009E73', '#F0E442'];
+// Wong palette — colorblind-safe (blue, vermillion, teal, yellow)
+const PLAYER_COLORS = ['#0072B2', '#D55E00', '#009E73', '#F0E442'];
 const NEUTRAL_COLOR = '#666666';
 
 // Text size presets: [planetFont, deltaFont, fleetFont, stepFont]

--- a/kaggle_environments/envs/orbit_wars/visualizer/playable/src/render/colors.ts
+++ b/kaggle_environments/envs/orbit_wars/visualizer/playable/src/render/colors.ts
@@ -1,5 +1,5 @@
-// Wong palette — colorblind-safe (blue, orange, teal, yellow)
-export const PLAYER_COLORS = ['#0072B2', '#E69F00', '#009E73', '#F0E442'];
+// Wong palette — colorblind-safe (blue, vermillion, teal, yellow)
+export const PLAYER_COLORS = ['#0072B2', '#D55E00', '#009E73', '#F0E442'];
 export const NEUTRAL_COLOR = '#666666';
 
 export function ownerColor(owner: number): string {


### PR DESCRIPTION
Increase contrast between player 2 and player 3 by switching from Wong orange (#E69F00) to Wong vermillion (#D55E00), which is much more distinguishable from the yellow (#F0E442) used for player 3. Same colorblind-safe palette.