### PR TITLE
Support free-form actions in core_harness.py

### DIFF
--- a/kaggle_environments/core_harness.py
+++ b/kaggle_environments/core_harness.py
@@ -108,13 +108,16 @@ class ParseResult:
 
     Attributes:
         legal_action: The legal action string that was matched, or ``None``
-            if no legal move could be matched.
+            if no legal move could be matched.  Used for enumerable actions.
         raw_action: The raw move the model attempted to play (even if
             illegal).  Used to build rethink prompts.
+        submission: The validated action for free-form action spaces, or
+            ``None`` if parsing failed.  Ignored for enumerable actions.
     """
 
     legal_action: str | None = None
     raw_action: str | None = None
+    submission: Any = None
 
 
 # ---------------------------------------------------------------------------
@@ -128,8 +131,12 @@ class GameHarness(Protocol):
     def get_legal_moves(
         self,
         observation: Mapping[str, Any],
-    ) -> dict[int, str]:
-        """Return a mapping from legal action id to its string form."""
+    ) -> dict[int, str] | None:
+        """Return a mapping from legal action id to its string form.
+
+        Return ``None`` to indicate a free-form action space where the
+        LLM response is not constrained to an enumerable set of moves.
+        """
         ...
 
     def make_prompt(
@@ -150,12 +157,15 @@ class GameHarness(Protocol):
     def parse_response(
         self,
         response: str,
-        legal_action_strings: Sequence[str],
+        legal_action_strings: Sequence[str] | None,
     ) -> ParseResult:
         """Extract a move from the LLM response.
 
-        Returns a ``ParseResult``.  If ``legal_action`` is not ``None`` it
-        must be one of the strings in ``legal_action_strings``.
+        Returns a ``ParseResult``.  For enumerable actions, if
+        ``legal_action`` is not ``None`` it must be one of the strings in
+        ``legal_action_strings``.  For free-form actions
+        (``legal_action_strings is None``), set ``submission`` on the
+        result instead.
         """
         ...
 
@@ -240,7 +250,7 @@ def create_agent_fn(
     game_harness: GameHarness,
     *,
     max_retries: int = 2,
-) -> Callable[[Any, dict[str, Any]], dict[str, int]]:
+) -> Callable[[Any, dict[str, Any]], dict[str, Any]]:
     """Create a Kaggle-compatible agent function from a ``GameHarness``.
 
     Args:
@@ -250,7 +260,7 @@ def create_agent_fn(
             attempt).
 
     Returns:
-        ``agent_fn(obs, config) -> {"submission": int, ...}``
+        ``agent_fn(obs, config) -> {"submission": <action>, ...}``
     """
     # --- closure state (per agent, not per module) ---
     setup_done = False
@@ -302,21 +312,26 @@ def create_agent_fn(
 
         # -- legal moves --
         legal_moves = game_harness.get_legal_moves(observation)
-        if not legal_moves:
-            # Distinguish "obs not yet populated" (None signals) from a real
-            # bug (it IS our turn but the game offers nothing).
-            if player_id is None and current_player is None:
-                _log.warning(
-                    "core_harness: agent invoked with empty observation "
-                    "(keys=%s); returning no-op.",
-                    sorted(observation.keys()),
-                )
-                _TELEMETRY(inactive_call="empty_obs")
-                return {"submission": None, "status": "INACTIVE"}
-            _TELEMETRY(no_legal_actions=True)
-            raise ValueError("No legal actions available.")
-        legal_action_strings = list(legal_moves.values())
-        legal_actions = list(legal_moves.keys())
+        free_form = legal_moves is None
+
+        if free_form:
+            legal_action_strings = None
+        else:
+            if not legal_moves:
+                # Distinguish "obs not yet populated" (None signals) from
+                # a real bug (it IS our turn but the game offers nothing).
+                if player_id is None and current_player is None:
+                    _log.warning(
+                        "core_harness: agent invoked with empty observation "
+                        "(keys=%s); returning no-op.",
+                        sorted(observation.keys()),
+                    )
+                    _TELEMETRY(inactive_call="empty_obs")
+                    return {"submission": None, "status": "INACTIVE"}
+                _TELEMETRY(no_legal_actions=True)
+                raise ValueError("No legal actions available.")
+            legal_action_strings = list(legal_moves.values())
+            legal_actions = list(legal_moves.keys())
 
         # -- prompt / parse / retry loop --
         previous_response: str | None = None
@@ -351,19 +366,30 @@ def create_agent_fn(
 
             result = game_harness.parse_response(content, legal_action_strings)
 
-            if result.legal_action is not None:
+            # -- check for a valid action --
+            matched_submission: Any = None
+            action_str: str | None = None
+
+            if free_form and result.submission is not None:
+                matched_submission = result.submission
+                action_str = str(result.submission)
+            elif not free_form and result.legal_action is not None:
                 idx = legal_action_strings.index(result.legal_action)
-                move_history.append(result.legal_action)
+                matched_submission = legal_actions[idx]
+                action_str = result.legal_action
+
+            if action_str is not None:
+                move_history.append(action_str)
                 _TELEMETRY(
                     action_is_legal=True,
                     legal_action={
                         "raw_action": result.raw_action,
-                        "legal_action": result.legal_action,
+                        "legal_action": action_str,
                     },
                 )
                 action: dict[str, Any] = {
-                    "submission": legal_actions[idx],
-                    "actionString": result.legal_action,
+                    "submission": matched_submission,
+                    "actionString": action_str,
                     "thoughts": last_content,
                     "status": "OK",
                 }

--- a/kaggle_environments/core_harness.py
+++ b/kaggle_environments/core_harness.py
@@ -311,13 +311,14 @@ def create_agent_fn(
             return {"submission": None, "status": "INACTIVE"}
 
         # -- legal moves --
+        allow_free_form = bool(config.get("freeForm", False)) if config else False
         legal_moves = game_harness.get_legal_moves(observation)
-        free_form = legal_moves is None
+        free_form = legal_moves is None and allow_free_form
 
-        if free_form:
-            legal_action_strings = None
-        else:
-            if not legal_moves:
+        if not legal_moves:
+            if free_form:
+                legal_action_strings = None
+            else:
                 # Distinguish "obs not yet populated" (None signals) from
                 # a real bug (it IS our turn but the game offers nothing).
                 if player_id is None and current_player is None:
@@ -330,6 +331,7 @@ def create_agent_fn(
                     return {"submission": None, "status": "INACTIVE"}
                 _TELEMETRY(no_legal_actions=True)
                 raise ValueError("No legal actions available.")
+        else:
             legal_action_strings = list(legal_moves.values())
             legal_actions = list(legal_moves.keys())
 

--- a/kaggle_environments/envs/open_spiel_env/open_spiel_env.py
+++ b/kaggle_environments/envs/open_spiel_env/open_spiel_env.py
@@ -168,6 +168,15 @@ CONFIGURATION_SPEC_TEMPLATE = {
         "type": "boolean",
         "default": False,
     },
+    "freeForm": {
+        "description": (
+            "If true, the core harness allows free-form actions"
+            " (get_legal_moves may return None) on turns where the action"
+            " space is not enumerable. Defaults to false for OpenSpiel games."
+        ),
+        "type": "boolean",
+        "default": False,
+    },
 }
 
 OBSERVATION_SPEC_TEMPLATE = {

--- a/kaggle_environments/envs/word_association/word_association.json
+++ b/kaggle_environments/envs/word_association/word_association.json
@@ -39,6 +39,16 @@
       "type": ["integer", "null"],
       "default": null,
       "description": "Seed for random board generation. Set to null for random play."
+    },
+    "freeForm": {
+      "description": "If true, the core harness allows free-form actions (get_legal_moves may return None) on turns where the action space is not enumerable, such as Cluemaster clue-giving.",
+      "type": "boolean",
+      "default": true
+    },
+    "savePrompt": {
+      "description": "If true, the LLM prompt produced by the harness is included as a 'prompt' field on the action returned by core_harness, which causes it to be persisted in the episode replay. Defaults to false to keep replays small.",
+      "type": "boolean",
+      "default": false
     }
   },
   "observation": {

--- a/tests/core_harness_test.py
+++ b/tests/core_harness_test.py
@@ -310,7 +310,7 @@ class FreeFormHarnessTest(absltest.TestCase):
             "completion",
             return_value=_fake_completion('{"clue": "ANIMAL", "number": 2}'),
         ):
-            result = agent({}, {})
+            result = agent({}, {"freeForm": True})
 
         self.assertEqual(result["submission"], {"clue": "ANIMAL", "number": 2})
         self.assertEqual(result["status"], "OK")
@@ -325,7 +325,7 @@ class FreeFormHarnessTest(absltest.TestCase):
         with patch.dict("os.environ", _ENV, clear=False), patch.object(
             core_harness.litellm, "completion", side_effect=responses,
         ) as mock_call:
-            result = agent({}, {})
+            result = agent({}, {"freeForm": True})
 
         self.assertEqual(result["submission"], {"clue": "OCEAN", "number": 3})
         self.assertEqual(mock_call.call_count, 2)
@@ -340,7 +340,7 @@ class FreeFormHarnessTest(absltest.TestCase):
             return_value=_fake_completion("garbage"),
         ):
             with self.assertRaisesRegex(ValueError, "Failed to parse"):
-                agent({}, {})
+                agent({}, {"freeForm": True})
 
     def test_free_form_move_history_accumulates(self):
         harness = _FreeFormHarness()
@@ -352,8 +352,8 @@ class FreeFormHarnessTest(absltest.TestCase):
         with patch.dict("os.environ", _ENV, clear=False), patch.object(
             core_harness.litellm, "completion", side_effect=responses,
         ):
-            agent({}, {})
-            agent({}, {})
+            agent({}, {"freeForm": True})
+            agent({}, {"freeForm": True})
 
         self.assertIn("ANIMAL", harness.prompts[1])
 
@@ -368,8 +368,8 @@ class FreeFormHarnessTest(absltest.TestCase):
         with patch.dict("os.environ", _ENV, clear=False), patch.object(
             core_harness.litellm, "completion", side_effect=responses,
         ):
-            r1 = agent({}, {})
-            r2 = agent({}, {})
+            r1 = agent({}, {"freeForm": True})
+            r2 = agent({}, {"freeForm": True})
 
         # First call: free-form → submission is the dict
         self.assertEqual(r1["submission"], {"clue": "ANIMAL", "number": 2})
@@ -385,10 +385,31 @@ class FreeFormHarnessTest(absltest.TestCase):
             "completion",
             return_value=_fake_completion('{"clue": "FIRE", "number": 1}'),
         ):
-            result = agent({}, {"savePrompt": True})
+            result = agent({}, {"freeForm": True, "savePrompt": True})
 
         self.assertIn("prompt", result)
         self.assertEqual(result["prompt"], harness.prompts[-1])
+
+    def test_none_legal_moves_without_free_form_config_returns_inactive(self):
+        """get_legal_moves() returns None but freeForm not in config → empty-obs path."""
+        harness = _FreeFormHarness()
+        agent = create_agent_fn(harness)
+        with patch.dict("os.environ", _ENV, clear=False), patch.object(
+            core_harness.litellm, "completion",
+        ) as mock_call:
+            # No playerId/currentPlayer → treated as empty obs
+            result = agent({"remainingOverageTime": 60, "step": 0}, {})
+        self.assertEqual(result, {"submission": None, "status": "INACTIVE"})
+        mock_call.assert_not_called()
+
+    def test_none_legal_moves_without_free_form_config_raises(self):
+        """get_legal_moves() returns None but freeForm not in config → error when active."""
+        harness = _FreeFormHarness()
+        agent = create_agent_fn(harness)
+        active_obs = {"playerId": 0, "currentPlayer": 0, "isTerminal": False}
+        with patch.dict("os.environ", _ENV, clear=False):
+            with self.assertRaisesRegex(ValueError, "No legal actions"):
+                agent(active_obs, {})
 
 
 class ParseResultTest(absltest.TestCase):

--- a/tests/core_harness_test.py
+++ b/tests/core_harness_test.py
@@ -227,17 +227,186 @@ class CoreHarnessTest(absltest.TestCase):
         self.assertIn("move_0", harness.prompts[1])
 
 
+class _FreeFormHarness:
+    """Harness that returns None from get_legal_moves (free-form actions)."""
+
+    def __init__(self):
+        self.prompts: list[str] = []
+
+    def get_legal_moves(self, observation):
+        return None
+
+    def make_prompt(self, observation, move_history, previous_response=None, previous_action=None):
+        prompt = f"history={move_history} prev={previous_action}"
+        self.prompts.append(prompt)
+        return prompt
+
+    def parse_response(self, response, legal_action_strings):
+        assert legal_action_strings is None
+        try:
+            import json
+            parsed = json.loads(response)
+            if "clue" in parsed:
+                return ParseResult(
+                    submission={"clue": parsed["clue"], "number": parsed["number"]},
+                    raw_action=response,
+                )
+        except Exception:
+            pass
+        return ParseResult(raw_action=response)
+
+
+class _MixedHarness:
+    """Harness that alternates between free-form and enumerable each call."""
+
+    def __init__(self):
+        self.call_count = 0
+        self.prompts: list[str] = []
+
+    def get_legal_moves(self, observation):
+        self.call_count += 1
+        if self.call_count % 2 == 1:
+            return None  # odd calls: free-form
+        return {0: "PASS", 1: "word_A", 2: "word_B"}  # even calls: enumerable
+
+    def make_prompt(self, observation, move_history, previous_response=None, previous_action=None):
+        prompt = f"history={move_history} prev={previous_action}"
+        self.prompts.append(prompt)
+        return prompt
+
+    def parse_response(self, response, legal_action_strings):
+        if legal_action_strings is None:
+            try:
+                import json
+                parsed = json.loads(response)
+                return ParseResult(submission=parsed, raw_action=response)
+            except Exception:
+                return ParseResult(raw_action=response)
+        else:
+            response = response.strip()
+            if response in legal_action_strings:
+                return ParseResult(legal_action=response, raw_action=response)
+            return ParseResult(raw_action=response)
+
+
+class FreeFormHarnessTest(absltest.TestCase):
+
+    def setUp(self):
+        super().setUp()
+        self.events: list[dict] = []
+        set_telemetry_exporter(
+            lambda module, **kw: self.events.append({"module": module, **kw})
+        )
+
+    def tearDown(self):
+        set_telemetry_exporter(lambda module, **kwargs: None)
+        super().tearDown()
+
+    def test_free_form_succeeds(self):
+        harness = _FreeFormHarness()
+        agent = create_agent_fn(harness)
+        with patch.dict("os.environ", _ENV, clear=False), patch.object(
+            core_harness.litellm,
+            "completion",
+            return_value=_fake_completion('{"clue": "ANIMAL", "number": 2}'),
+        ):
+            result = agent({}, {})
+
+        self.assertEqual(result["submission"], {"clue": "ANIMAL", "number": 2})
+        self.assertEqual(result["status"], "OK")
+
+    def test_free_form_retry_then_succeeds(self):
+        harness = _FreeFormHarness()
+        agent = create_agent_fn(harness, max_retries=3)
+        responses = [
+            _fake_completion("not json"),
+            _fake_completion('{"clue": "OCEAN", "number": 3}'),
+        ]
+        with patch.dict("os.environ", _ENV, clear=False), patch.object(
+            core_harness.litellm, "completion", side_effect=responses,
+        ) as mock_call:
+            result = agent({}, {})
+
+        self.assertEqual(result["submission"], {"clue": "OCEAN", "number": 3})
+        self.assertEqual(mock_call.call_count, 2)
+        self.assertIn("prev=not json", harness.prompts[1])
+
+    def test_free_form_all_attempts_fail_raises(self):
+        harness = _FreeFormHarness()
+        agent = create_agent_fn(harness, max_retries=2)
+        with patch.dict("os.environ", _ENV, clear=False), patch.object(
+            core_harness.litellm,
+            "completion",
+            return_value=_fake_completion("garbage"),
+        ):
+            with self.assertRaisesRegex(ValueError, "Failed to parse"):
+                agent({}, {})
+
+    def test_free_form_move_history_accumulates(self):
+        harness = _FreeFormHarness()
+        agent = create_agent_fn(harness)
+        responses = [
+            _fake_completion('{"clue": "ANIMAL", "number": 2}'),
+            _fake_completion('{"clue": "OCEAN", "number": 1}'),
+        ]
+        with patch.dict("os.environ", _ENV, clear=False), patch.object(
+            core_harness.litellm, "completion", side_effect=responses,
+        ):
+            agent({}, {})
+            agent({}, {})
+
+        self.assertIn("ANIMAL", harness.prompts[1])
+
+    def test_mixed_harness_alternates_modes(self):
+        """Free-form on first call, enumerable on second."""
+        harness = _MixedHarness()
+        agent = create_agent_fn(harness)
+        responses = [
+            _fake_completion('{"clue": "ANIMAL", "number": 2}'),
+            _fake_completion("word_A"),
+        ]
+        with patch.dict("os.environ", _ENV, clear=False), patch.object(
+            core_harness.litellm, "completion", side_effect=responses,
+        ):
+            r1 = agent({}, {})
+            r2 = agent({}, {})
+
+        # First call: free-form → submission is the dict
+        self.assertEqual(r1["submission"], {"clue": "ANIMAL", "number": 2})
+        # Second call: enumerable → submission is the action id (int)
+        self.assertEqual(r2["submission"], 1)
+        self.assertEqual(r2["actionString"], "word_A")
+
+    def test_free_form_save_prompt(self):
+        harness = _FreeFormHarness()
+        agent = create_agent_fn(harness)
+        with patch.dict("os.environ", _ENV, clear=False), patch.object(
+            core_harness.litellm,
+            "completion",
+            return_value=_fake_completion('{"clue": "FIRE", "number": 1}'),
+        ):
+            result = agent({}, {"savePrompt": True})
+
+        self.assertIn("prompt", result)
+        self.assertEqual(result["prompt"], harness.prompts[-1])
+
+
 class ParseResultTest(absltest.TestCase):
 
     def test_defaults(self):
         r = ParseResult()
         self.assertIsNone(r.legal_action)
         self.assertIsNone(r.raw_action)
+        self.assertIsNone(r.submission)
 
     def test_frozen(self):
         r = ParseResult(legal_action="a", raw_action="a")
         with self.assertRaises(dataclasses.FrozenInstanceError):
             r.legal_action = "b"  # type: ignore[misc]
+
+    def test_submission_field(self):
+        r = ParseResult(submission={"clue": "test", "number": 1})
+        self.assertEqual(r.submission, {"clue": "test", "number": 1})
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
 Summary                                                                                                                                                       
                                                                                                                                                                
  - Extends core_harness to support games with free-form (non-enumerable) action spaces alongside the existing enumerable action flow                           
  - When `get_legal_moves()` returns `None`, the harness enters free-form mode where `parse_response()` validates the LLM output and returns the action directly via a new `ParseResult.submission` field                                                                                                                             
  - This is per-turn, so a single game can mix both modes (e.g. word_association's cluemaster is free-form, guesser is enumerable)                              
                                                                                                                                                                
  Test plan                                                                                                                                                     
                                                                                                                                                                
  - All 14 existing enumerable-action tests pass unchanged                                                                                                      
  - New tests for free-form success, retry, exhaustion, move history accumulation, and `save_prompt `                                                           
  - New test for mixed-mode harness that alternates free-form and enumerable across turns       