### PR TITLE
Fix crawl visualizer controls being cut off at bottom of viewport

### DIFF
--- a/kaggle_environments/envs/crawl/visualizer/default/src/style.css
+++ b/kaggle_environments/envs/crawl/visualizer/default/src/style.css
@@ -32,6 +32,21 @@ html, body {
   color: #050001 !important;
 }
 
+/* The core player wraps the renderer in `.viewer` (no min-height: 0) and
+   injects `box-sizing: content-box` for everything under
+   `.game-renderer-isolation`. Without these overrides the padding on
+   `.renderer-container` overflows its parent and pushes the inline controls
+   off the bottom of the viewport. */
+.player .viewer {
+  min-height: 0;
+  overflow: hidden;
+}
+
+.game-renderer-isolation .renderer-container,
+.game-renderer-isolation .renderer-container * {
+  box-sizing: border-box;
+}
+
 .renderer-container {
   display: flex;
   flex-direction: column;
@@ -42,7 +57,6 @@ html, body {
   background-color: #f5f1e2;
   overflow: hidden;
   font-family: 'Inter', sans-serif;
-  box-sizing: border-box;
   padding: 12px;
   color: #050001;
   container-type: inline-size;


### PR DESCRIPTION
The core player wraps the renderer in a .viewer div without min-height: 0 and injects box-sizing: content-box for everything under .game-renderer-isolation. The padding on .renderer-container therefore overflowed its parent, pushing the inline controls strip ~30px below the viewport.

Add .player .viewer { min-height: 0; overflow: hidden } so the viewer can shrink to its flex allocation, and a higher-specificity border-box rule for .renderer-container and its descendants to override the global content-box injection.