### PR TITLE
Set kaggriculture_beginner default playback speed

### DIFF
--- a/kaggle_environments/envs/kaggriculture_beginner/visualizer/default/src/main.ts
+++ b/kaggle_environments/envs/kaggriculture_beginner/visualizer/default/src/main.ts
@@ -1,5 +1,6 @@
 import { createReplayVisualizer, ReplayAdapter } from '@kaggle-environments/core';
 import { renderer } from './renderer';
+import { getKaggricultureStepRenderTime } from './timing';
 import './style.css';
 
 const app = document.getElementById('app');
@@ -17,5 +18,7 @@ createReplayVisualizer(
     gameName: 'kaggriculture_beginner',
     renderer: renderer as any,
     ui: 'inline',
+    getStepRenderTime: (step, replayMode, speedModifier) =>
+      getKaggricultureStepRenderTime(step, replayMode, speedModifier),
   })
 );

--- a/kaggle_environments/envs/kaggriculture_beginner/visualizer/default/src/timing.ts
+++ b/kaggle_environments/envs/kaggriculture_beginner/visualizer/default/src/timing.ts
@@ -1,0 +1,12 @@
+import { defaultGetStepRenderTime } from '@kaggle-environments/core';
+import type { BaseGameStep, ReplayMode } from '@kaggle-environments/core';
+
+const KAGGRICULTURE_STEP_DURATION = 352; // 440 * 0.8 — 20% faster than orbit_wars to keep longer games snappy
+
+export const getKaggricultureStepRenderTime = (
+  gameStep: BaseGameStep,
+  replayMode: ReplayMode,
+  speedModifier: number
+): number => {
+  return defaultGetStepRenderTime(gameStep, replayMode, speedModifier, KAGGRICULTURE_STEP_DURATION);
+};


### PR DESCRIPTION
Add a custom getStepRenderTime mirroring orbit_wars's pattern, with a 352ms step duration (440 * 0.8) so the longer kaggriculture games stay snappy on default 1x speed.