### PR TITLE
Set 60 min timeout on litellm calls

### DIFF
--- a/kaggle_environments/core_harness.py
+++ b/kaggle_environments/core_harness.py
@@ -190,6 +190,7 @@ def _call_llm(
         response = litellm.completion(
             model=model_name,
             messages=[{"role": "user", "content": prompt}],
+            timeout=3600,
             **litellm_kwargs,
         )
         content = response.choices[0].message.content.strip()


### PR DESCRIPTION
Matches what the legacy harness does, and the typical overall turn timeout we set.