### PR TITLE
Display agent team names in kaggriculture_beginner visualizer

### DIFF
--- a/kaggle_environments/envs/kaggriculture_beginner/visualizer/default/src/renderFarm.ts
+++ b/kaggle_environments/envs/kaggriculture_beginner/visualizer/default/src/renderFarm.ts
@@ -54,13 +54,19 @@ function seedRow(): string {
   </div>`;
 }
 
-function farmPanel(player: 1 | 2, rows: number, cols: number): string {
+function escapeHtml(value: string): string {
+  return value.replace(/[&<>"']/g, (ch) =>
+    ch === '&' ? '&amp;' : ch === '<' ? '&lt;' : ch === '>' ? '&gt;' : ch === '"' ? '&quot;' : '&#39;'
+  );
+}
+
+function farmPanel(player: 1 | 2, rows: number, cols: number, name: string): string {
   return `
     <section class="farm-panel" data-player="${player}">
       <header class="farm-header sketched-border" style="${woodBg}">
         <span class="player-name">
           <img class="player-name-icon" src="${spriteSrc(`farmer_p${player}`)}" alt="farmer p${player}" />
-          Player ${player}
+          <span class="player-name-text">${escapeHtml(name)}</span>
         </span>
         <span class="player-balance">
           <img class="balance-icon" src="${spriteSrc('coin')}" alt="coins" />
@@ -90,13 +96,13 @@ function statusPanel(): string {
   `;
 }
 
-export function buildSkeleton(root: HTMLElement, board: BoardSize): void {
+export function buildSkeleton(root: HTMLElement, board: BoardSize, playerNames: [string, string]): void {
   root.innerHTML = `
     <div class="demo-container" style="${grassBg}">
       <main class="demo-main">
-        ${farmPanel(1, board.rows, board.cols)}
+        ${farmPanel(1, board.rows, board.cols, playerNames[0])}
         ${statusPanel()}
-        ${farmPanel(2, board.rows, board.cols)}
+        ${farmPanel(2, board.rows, board.cols, playerNames[1])}
       </main>
     </div>
   `;

--- a/kaggle_environments/envs/kaggriculture_beginner/visualizer/default/src/renderer.ts
+++ b/kaggle_environments/envs/kaggriculture_beginner/visualizer/default/src/renderer.ts
@@ -24,15 +24,20 @@ function getObservation(replay: any, step: number): any | null {
   return agentStep?.observation ?? null;
 }
 
+function getPlayerNames(agents: RendererOptions['agents']): [string, string] {
+  return [0, 1].map((i) => agents?.[i]?.name || `Player ${i + 1}`) as [string, string];
+}
+
 export function renderer(options: RendererOptions): void {
-  const { parent, replay, step } = options;
+  const { parent, replay, step, agents } = options;
   if (!parent || !replay) return;
 
   const board = inferBoardSize(replay);
-  const expectedKey = `${board.rows}x${board.cols}`;
+  const playerNames = getPlayerNames(agents);
+  const expectedKey = `${board.rows}x${board.cols}|${playerNames[0]}|${playerNames[1]}`;
   let cached = skeletonCache.get(parent);
   if (!cached || cached.key !== expectedKey) {
-    buildSkeleton(parent, board);
+    buildSkeleton(parent, board, playerNames);
     cached = { key: expectedKey, refs: collectRefs(parent, board) };
     skeletonCache.set(parent, cached);
   }


### PR DESCRIPTION
Mirror the orbit_wars renderer pattern: read agent names from RendererOptions.agents and use them in the per-player farm header, falling back to 'Player N' when no name is provided. Cache the skeleton keyed on names so the header rebuilds when they change.