### PR TITLE
fix: customize cta

### DIFF
--- a/kaggle_environments/envs/open_spiel_env/games/chess/visualizer/v2/src/components/BoardControls.tsx
+++ b/kaggle_environments/envs/open_spiel_env/games/chess/visualizer/v2/src/components/BoardControls.tsx
@@ -56,7 +56,7 @@ export default function BoardControls() {
       </WithPopover>
 
       <AnimatePresence>
-        {game.isGameOver() && (
+        {game.moveNumber() === 1 && game.turn() === 'w' && (
           <motion.div
             className={styles.settingsCta}
             initial={{ opacity: 0 }}


### PR DESCRIPTION
Fixes up the check to decide whether to display the "Customize Your Experience" call-to-action shown before the first move takes place.

<img width="1190" height="906" alt="Screenshot 2026-05-07 at 16 28 26" src="https://github.com/user-attachments/assets/9a58656b-a98b-40d1-b8ca-3b147545fd65" />
