### PR TITLE
fix(chess): prevent kaggle "close" button overlapping the game

### DIFF
--- a/kaggle_environments/envs/open_spiel_env/games/chess/visualizer/v2/src/components/Layout.module.css
+++ b/kaggle_environments/envs/open_spiel_env/games/chess/visualizer/v2/src/components/Layout.module.css
@@ -16,7 +16,7 @@
   padding-inline: 1.25em;
   color: #050001;
   transition: opacity 400ms ease;
-  color: #050001;
+  padding-block: 1.5rem;
 }
 
 .playableArea:not([data-loaded]) {


### PR DESCRIPTION
This adds some spacing to the top and bottom of the board. It may introduce a scrollbar on less-tall devices, but after talking with design this is preferred over the overlap.

<img width="370" height="662" alt="Screenshot 2026-05-07 at 18 29 16" src="https://github.com/user-attachments/assets/6ba16b77-1a27-418f-9a0a-e577ea3e4089" />
