### PR TITLE
Update core_harness to support explicitly parsed thoughts

### DIFF
--- a/kaggle_environments/core_harness.py
+++ b/kaggle_environments/core_harness.py
@@ -116,11 +116,14 @@ class ParseResult:
             illegal).  Used to build rethink prompts.
         submission: The validated action for free-form action spaces, or
             ``None`` if parsing failed.  Ignored for enumerable actions.
+        thoughts: Optional extracted reasoning/thinking text.  When set,
+            the core harness records this instead of the full LLM response.
     """
 
     legal_action: str | None = None
     raw_action: str | None = None
     submission: Any = None
+    thoughts: str | None = None
 
 
 # ---------------------------------------------------------------------------
@@ -397,7 +400,7 @@ def create_agent_fn(
                 action: dict[str, Any] = {
                     "submission": matched_submission,
                     "actionString": action_str,
-                    "thoughts": last_content,
+                    "thoughts": result.thoughts if result.thoughts is not None else last_content,
                     "status": "OK",
                 }
                 if save_prompt:

--- a/kaggle_environments/envs/word_association/harness/main.py
+++ b/kaggle_environments/envs/word_association/harness/main.py
@@ -356,6 +356,7 @@ def parse_response(
         return ParseResult(raw_action=response[:200])
 
     # --- Cluemaster (free-form) ---
+    thinking = parsed.get("thinking")
     if legal_action_strings is None:
         clue = parsed.get("clue")
         number = parsed.get("number")
@@ -363,31 +364,32 @@ def parse_response(
             try:
                 num = int(number)
             except (ValueError, TypeError):
-                return ParseResult(raw_action=response[:200])
+                return ParseResult(raw_action=response[:200], thoughts=thinking)
             return ParseResult(
                 submission={"clue": str(clue), "number": num},
                 raw_action=json.dumps({"clue": str(clue), "number": num}),
+                thoughts=thinking,
             )
-        return ParseResult(raw_action=response[:200])
+        return ParseResult(raw_action=response[:200], thoughts=thinking)
 
     # --- Guesser (enumerable) ---
     guess = parsed.get("guess")
     if guess is None:
-        return ParseResult(raw_action=response[:200])
+        return ParseResult(raw_action=response[:200], thoughts=thinking)
 
     raw = str(guess)
     try:
         guess_int = int(guess)
     except (ValueError, TypeError):
-        return ParseResult(legal_action=None, raw_action=raw)
+        return ParseResult(legal_action=None, raw_action=raw, thoughts=thinking)
 
     # Match by index prefix in legal_action_strings (e.g. "4: APPLE").
     target = f"{guess_int}:"
     for legal in legal_action_strings:
         if legal.startswith(target):
-            return ParseResult(legal_action=legal, raw_action=raw)
+            return ParseResult(legal_action=legal, raw_action=raw, thoughts=thinking)
 
-    return ParseResult(legal_action=None, raw_action=raw)
+    return ParseResult(legal_action=None, raw_action=raw, thoughts=thinking)
 
 
 # --- Agent wiring -----------------------------------------------------------


### PR DESCRIPTION
Currently, `core_harness` treats the entire LLM response as its "thoughts." Support `ParseResult` containing explicitly extracted thoughts, and fall back to the whole response.

Also set this up for Word Association.