### PR TITLE
Fix maze crawler visualizer control bar to match parchment theme

### DIFF
--- a/kaggle_environments/envs/crawl/visualizer/default/src/style.css
+++ b/kaggle_environments/envs/crawl/visualizer/default/src/style.css
@@ -14,11 +14,13 @@ html, body {
 
 /* EpisodePlayer wrapper (.player) and its inline-controls strip use MUI's
    dark `paper` color by default. Repaint them as parchment so the page
-   matches the renderer's sketched-paper feel. */
+   matches the renderer's sketched-paper feel. The deepest selector targets
+   the PlaybackControls root, which sets a dark backgroundColor inline. */
 .player,
 .player > div,
 .player > div > div:last-child,
-.player > div > div:last-child > div {
+.player > div > div:last-child > div,
+.player > div > div:last-child > div > div {
   background-color: #f5f1e2 !important;
 }
 
@@ -29,6 +31,19 @@ html, body {
 }
 
 .player button {
+  color: #050001 !important;
+}
+
+/* PlaybackControls renders the seed badge as a <button> with a dark inline
+   background and border. Repaint it to match the parchment select styling. */
+.player > div > div:last-child > div > div > button[aria-label^="Episode seed"] {
+  background-color: #f1f1f1 !important;
+  border: 1px dashed #3c3b37 !important;
+}
+
+/* PlaybackControls' step counter is a <span> with hardcoded white inline
+   color. Force it dark so it remains readable on parchment. */
+.player > div > div:last-child > div > div > span {
   color: #050001 !important;
 }
 


### PR DESCRIPTION
## Summary

The PlaybackControls component renders its root `<div>` with an inline `backgroundColor: '#1a1a1a'`, plus a hardcoded white step counter, white seed badge text, and a dark `#2a2a2a` seed badge background. The crawl visualizer's existing parchment override (`.player > div > div:last-child > div`) only reaches the `InlineControlsContainer` one level above `PlaybackControls`, so the control strip rendered as a dark band with low-contrast icons — especially noticeable when the parent app is in dark mode (icons appeared dark-on-dark and the seed/step labels lost contrast).

This change extends the parchment override one DOM level deeper to repaint the `PlaybackControls` root, and adds two targeted overrides:

- The seed badge (`<button aria-label="Episode seed ...">`) now uses the same parchment-style fill and dashed border as the speed `<select>`.
- The step counter `<span>` is repainted dark so it reads on parchment instead of vanishing into it.

The result is a control bar that's fully consistent with the sketched-paper renderer in both light and dark parent themes.

## Test plan

- [x] `pnpm build` in `kaggle_environments/envs/crawl/visualizer/default` succeeds
- [x] Loaded `pnpm dev-with-replay` in a browser and verified the control bar (seed badge, restart/prev/play/next icons, slider, step counter, speed select) all render with parchment background and readable dark text
- [ ] Smoke test in kaggleazure with the visualizer iframe in dark mode