### PR TITLE
Record LLM call details in core_harness

### DIFF
--- a/kaggle_environments/core_harness.py
+++ b/kaggle_environments/core_harness.py
@@ -468,6 +468,8 @@ def create_agent_fn(
                         for r in call_records
                     ],
                 }
+                if hasattr(game_harness, "augment_action"):
+                    game_harness.augment_action(action, call_records)
                 return action
 
             # -- parse failed → prepare rethink --

--- a/kaggle_environments/core_harness.py
+++ b/kaggle_environments/core_harness.py
@@ -226,13 +226,14 @@ def _call_llm(
             "generation_tokens": getattr(
                 usage_obj, "completion_tokens", None,
             ),
-            "reasoning_tokens": reasoning_tokens,
             "total_tokens": getattr(usage_obj, "total_tokens", None),
             "finish_reason": getattr(
                 response.choices[0], "finish_reason", None,
             ),
             "duration_secs": round(duration, 3),
         }
+        if reasoning_tokens is not None:
+            details["reasoning_tokens"] = reasoning_tokens
         _TELEMETRY(
             llm_call_success=True,
             duration_secs=details["duration_secs"],
@@ -259,11 +260,12 @@ def _build_call_detail(
         "response": record["content"],
         "prompt_tokens": record["prompt_tokens"],
         "generation_tokens": record["generation_tokens"],
-        "reasoning_tokens": record["reasoning_tokens"],
         "total_tokens": record["total_tokens"],
         "finish_reason": record["finish_reason"],
         "duration_secs": record["duration_secs"],
     }
+    if "reasoning_tokens" in record:
+        detail["reasoning_tokens"] = record["reasoning_tokens"]
     if save_prompt:
         detail["prompt"] = record["prompt"]
     return detail

--- a/kaggle_environments/core_harness.py
+++ b/kaggle_environments/core_harness.py
@@ -343,7 +343,7 @@ def create_agent_fn(
             )
             setup_done = True
 
-        save_prompt = bool(config.get("savePrompt", False)) if config else False
+        save_prompt = bool(config.get("savePrompt", True)) if config else True
 
         observation = obs if isinstance(obs, dict) else vars(obs)
 

--- a/kaggle_environments/core_harness.py
+++ b/kaggle_environments/core_harness.py
@@ -186,7 +186,19 @@ def _call_llm(
     model_name: str,
     litellm_kwargs: dict[str, Any],
 ) -> tuple[str, dict[str, Any]]:
-    """Call the LLM and return ``(response_text, usage_dict)``."""
+    """Call the LLM and return ``(response_text, call_details)``.
+
+    ``call_details`` contains per-call usage and metadata::
+
+        {
+            "prompt_tokens": int | None,
+            "generation_tokens": int | None,
+            "reasoning_tokens": int | None,
+            "total_tokens": int | None,
+            "finish_reason": str | None,
+            "duration_secs": float,
+        }
+    """
     _TELEMETRY(calling_llm=True)
     start = time.perf_counter()
     try:
@@ -198,18 +210,36 @@ def _call_llm(
         )
         content = response.choices[0].message.content.strip()
         duration = time.perf_counter() - start
-        usage = {
-            "prompt_tokens": getattr(response.usage, "prompt_tokens", None),
-            "completion_tokens": getattr(
-                response.usage, "completion_tokens", None,
+
+        usage_obj = getattr(response, "usage", None)
+        ctd = (
+            getattr(usage_obj, "completion_tokens_details", None)
+            if usage_obj
+            else None
+        )
+        reasoning_tokens = (
+            getattr(ctd, "reasoning_tokens", None) if ctd else None
+        )
+
+        details: dict[str, Any] = {
+            "prompt_tokens": getattr(usage_obj, "prompt_tokens", None),
+            "generation_tokens": getattr(
+                usage_obj, "completion_tokens", None,
             ),
+            "reasoning_tokens": reasoning_tokens,
+            "total_tokens": getattr(usage_obj, "total_tokens", None),
+            "finish_reason": getattr(
+                response.choices[0], "finish_reason", None,
+            ),
+            "duration_secs": round(duration, 3),
         }
         _TELEMETRY(
             llm_call_success=True,
-            duration_secs=round(duration, 3),
-            **usage,
+            duration_secs=details["duration_secs"],
+            prompt_tokens=details["prompt_tokens"],
+            completion_tokens=details["generation_tokens"],
         )
-        return content, usage
+        return content, details
     except Exception as exc:
         duration = time.perf_counter() - start
         _TELEMETRY(
@@ -217,6 +247,26 @@ def _call_llm(
             duration_secs=round(duration, 3),
         )
         raise
+
+
+def _build_call_detail(
+    record: dict[str, Any],
+    save_prompt: bool,
+) -> dict[str, Any]:
+    """Build a single ``call_details`` entry from an internal call record."""
+    detail: dict[str, Any] = {
+        "model": record["model"],
+        "response": record["content"],
+        "prompt_tokens": record["prompt_tokens"],
+        "generation_tokens": record["generation_tokens"],
+        "reasoning_tokens": record["reasoning_tokens"],
+        "total_tokens": record["total_tokens"],
+        "finish_reason": record["finish_reason"],
+        "duration_secs": record["duration_secs"],
+    }
+    if save_prompt:
+        detail["prompt"] = record["prompt"]
+    return detail
 
 
 # ---------------------------------------------------------------------------
@@ -348,6 +398,7 @@ def create_agent_fn(
         previous_action: str | None = None
         last_content = ""
         all_responses: list[str] = []
+        call_records: list[dict[str, Any]] = []
 
         for attempt in range(max_retries):
             if attempt == 0:
@@ -365,9 +416,17 @@ def create_agent_fn(
             )
 
             try:
-                content, _usage = _call_llm(prompt, model_name, litellm_kwargs)
+                content, call_details = _call_llm(
+                    prompt, model_name, litellm_kwargs,
+                )
                 last_content = content
                 all_responses.append(content)
+                call_records.append({
+                    "content": content,
+                    "prompt": prompt,
+                    "model": model_name,
+                    **call_details,
+                })
             except Exception as exc:
                 _log.error(
                     "LLM call failed on attempt %d: %s", attempt + 1, exc,
@@ -402,9 +461,11 @@ def create_agent_fn(
                     "actionString": action_str,
                     "thoughts": result.thoughts if result.thoughts is not None else last_content,
                     "status": "OK",
+                    "call_details": [
+                        _build_call_detail(r, save_prompt)
+                        for r in call_records
+                    ],
                 }
-                if save_prompt:
-                    action["prompt"] = prompt
                 return action
 
             # -- parse failed → prepare rethink --

--- a/kaggle_environments/envs/open_spiel_env/games/go/debug_match_runner.py
+++ b/kaggle_environments/envs/open_spiel_env/games/go/debug_match_runner.py
@@ -34,6 +34,9 @@ class _GoHarness:
     def parse_response(self, response, legal_action_strings):
         return harness.parse_response(response, legal_action_strings)
 
+    def augment_action(self, action, call_records):
+        return harness.augment_action(action, call_records)
+
 
 def _wrap_litellm_with_logging() -> None:
     """Replace litellm.completion with a version that prints I/O."""

--- a/kaggle_environments/envs/open_spiel_env/games/go/harness.py
+++ b/kaggle_environments/envs/open_spiel_env/games/go/harness.py
@@ -158,6 +158,37 @@ def generate_prompt(
     return prompt
 
 
+def augment_action(
+    action: dict[str, Any],
+    call_records: list[dict[str, Any]],
+) -> None:
+    """Add backwards-compatible ``generate_returns`` to the action dict.
+
+    Each element mirrors the ``GenerateReturn`` shape consumed by the Go
+    visualizer and cost-tracking pipelines, but omits raw prompts and
+    responses (already available via ``call_details`` and ``thoughts``).
+    """
+    generate_returns: list[dict[str, Any]] = []
+    for record in call_records:
+        gr: dict[str, Any] = {
+            "request_for_logging": {
+                "model": record["model"],
+            },
+            "response_for_logging": {
+                "finish_reason": record.get("finish_reason"),
+            },
+            "generation_tokens": record.get("generation_tokens"),
+            "prompt_tokens": record.get("prompt_tokens"),
+            "total_tokens": record.get("total_tokens"),
+            "duration_success_only_secs": record.get("duration_secs"),
+        }
+        reasoning = record.get("reasoning_tokens")
+        if reasoning is not None:
+            gr["reasoning_tokens"] = reasoning
+        generate_returns.append(gr)
+    action["generate_returns"] = [json.dumps(g) for g in generate_returns]
+
+
 def parse_response(
     response: str, legal_action_strings: Sequence[str],
 ) -> ParseResult:

--- a/kaggle_environments/envs/open_spiel_env/open_spiel_env.py
+++ b/kaggle_environments/envs/open_spiel_env/open_spiel_env.py
@@ -166,13 +166,10 @@ CONFIGURATION_SPEC_TEMPLATE = {
     },
     "savePrompt": {
         "description": (
-            "If true, the LLM prompt produced by the harness is included as a"
-            " 'prompt' field on the action returned by core_harness, which causes"
-            " it to be persisted in the episode replay. Defaults to false to keep"
-            " replays small."
+            "If disabled, skip logging LLM prompts in the replay file."
         ),
         "type": "boolean",
-        "default": False,
+        "default": True,
     },
     "freeForm": {
         "description": (

--- a/kaggle_environments/envs/word_association/word_association.json
+++ b/kaggle_environments/envs/word_association/word_association.json
@@ -46,9 +46,9 @@
       "default": true
     },
     "savePrompt": {
-      "description": "If true, the LLM prompt produced by the harness is included as a 'prompt' field on the action returned by core_harness, which causes it to be persisted in the episode replay. Defaults to false to keep replays small.",
+      "description": "If disabled, skip logging LLM prompts in the replay file.", 
       "type": "boolean",
-      "default": false
+      "default": true
     }
   },
   "observation": {

--- a/tests/core_harness_test.py
+++ b/tests/core_harness_test.py
@@ -205,7 +205,7 @@ class CoreHarnessTest(absltest.TestCase):
         self.assertIn("prompt", result["call_details"][0])
         self.assertEqual(result["call_details"][0]["prompt"], harness.prompts[-1])
 
-    def test_prompt_omitted_from_call_details_by_default(self):
+    def test_prompt_included_in_call_details_by_default(self):
         harness = _SimpleHarness()
         agent = create_agent_fn(harness)
         with patch.dict("os.environ", _ENV, clear=False), patch.object(
@@ -214,6 +214,18 @@ class CoreHarnessTest(absltest.TestCase):
             return_value=_fake_completion("move_1"),
         ):
             result = agent({}, {})
+
+        self.assertIn("prompt", result["call_details"][0])
+
+    def test_prompt_omitted_when_save_prompt_false(self):
+        harness = _SimpleHarness()
+        agent = create_agent_fn(harness)
+        with patch.dict("os.environ", _ENV, clear=False), patch.object(
+            core_harness.litellm,
+            "completion",
+            return_value=_fake_completion("move_1"),
+        ):
+            result = agent({}, {"savePrompt": False})
 
         self.assertNotIn("prompt", result["call_details"][0])
 
@@ -237,7 +249,7 @@ class CoreHarnessTest(absltest.TestCase):
         self.assertEqual(cd["finish_reason"], "stop")
         self.assertEqual(cd["response"], "move_1")
         self.assertEqual(cd["model"], "test-model")
-        self.assertNotIn("prompt", cd)
+        self.assertIn("prompt", cd)
 
     def test_call_details_includes_prompt_when_save_prompt(self):
         harness = _SimpleHarness()

--- a/tests/core_harness_test.py
+++ b/tests/core_harness_test.py
@@ -51,10 +51,13 @@ def _fake_completion(content: str):
     class _Choice:
         def __init__(self, c):
             self.message = _Msg(c)
+            self.finish_reason = "stop"
 
     class _Usage:
         prompt_tokens = 1
         completion_tokens = 1
+        total_tokens = 2
+        completion_tokens_details = None
 
     class _Resp:
         def __init__(self, c):
@@ -188,7 +191,7 @@ class CoreHarnessTest(absltest.TestCase):
         self.assertIn("calling_llm", kinds)
         self.assertIn("action_is_legal", kinds)
 
-    def test_save_prompt_includes_prompt_in_action(self):
+    def test_save_prompt_in_call_details(self):
         harness = _SimpleHarness()
         agent = create_agent_fn(harness)
         with patch.dict("os.environ", _ENV, clear=False), patch.object(
@@ -199,9 +202,10 @@ class CoreHarnessTest(absltest.TestCase):
             result = agent({}, {"savePrompt": True})
 
         self.assertEqual(result["submission"], 1)
-        self.assertEqual(result["prompt"], harness.prompts[-1])
+        self.assertIn("prompt", result["call_details"][0])
+        self.assertEqual(result["call_details"][0]["prompt"], harness.prompts[-1])
 
-    def test_save_prompt_omitted_by_default(self):
+    def test_prompt_omitted_from_call_details_by_default(self):
         harness = _SimpleHarness()
         agent = create_agent_fn(harness)
         with patch.dict("os.environ", _ENV, clear=False), patch.object(
@@ -211,7 +215,56 @@ class CoreHarnessTest(absltest.TestCase):
         ):
             result = agent({}, {})
 
-        self.assertNotIn("prompt", result)
+        self.assertNotIn("prompt", result["call_details"][0])
+
+    def test_call_details_present_on_success(self):
+        harness = _SimpleHarness()
+        agent = create_agent_fn(harness)
+        with patch.dict("os.environ", _ENV, clear=False), patch.object(
+            core_harness.litellm,
+            "completion",
+            return_value=_fake_completion("move_1"),
+        ):
+            result = agent({}, {})
+
+        self.assertIn("call_details", result)
+        self.assertLen(result["call_details"], 1)
+        cd = result["call_details"][0]
+        self.assertEqual(cd["generation_tokens"], 1)
+        self.assertEqual(cd["prompt_tokens"], 1)
+        self.assertEqual(cd["total_tokens"], 2)
+        self.assertIsNone(cd["reasoning_tokens"])
+        self.assertEqual(cd["finish_reason"], "stop")
+        self.assertEqual(cd["response"], "move_1")
+        self.assertEqual(cd["model"], "test-model")
+        self.assertNotIn("prompt", cd)
+
+    def test_call_details_includes_prompt_when_save_prompt(self):
+        harness = _SimpleHarness()
+        agent = create_agent_fn(harness)
+        with patch.dict("os.environ", _ENV, clear=False), patch.object(
+            core_harness.litellm,
+            "completion",
+            return_value=_fake_completion("move_1"),
+        ):
+            result = agent({}, {"savePrompt": True})
+
+        cd = result["call_details"][0]
+        self.assertIn("prompt", cd)
+        self.assertEqual(cd["prompt"], harness.prompts[-1])
+
+    def test_call_details_per_retry(self):
+        harness = _SimpleHarness()
+        agent = create_agent_fn(harness, max_retries=3)
+        responses = [_fake_completion("garbage"), _fake_completion("move_2")]
+        with patch.dict("os.environ", _ENV, clear=False), patch.object(
+            core_harness.litellm, "completion", side_effect=responses,
+        ):
+            result = agent({}, {})
+
+        self.assertLen(result["call_details"], 2)
+        self.assertEqual(result["call_details"][0]["response"], "garbage")
+        self.assertEqual(result["call_details"][1]["response"], "move_2")
 
     def test_move_history_accumulates_across_calls(self):
         harness = _SimpleHarness()
@@ -387,8 +440,8 @@ class FreeFormHarnessTest(absltest.TestCase):
         ):
             result = agent({}, {"freeForm": True, "savePrompt": True})
 
-        self.assertIn("prompt", result)
-        self.assertEqual(result["prompt"], harness.prompts[-1])
+        self.assertIn("prompt", result["call_details"][0])
+        self.assertEqual(result["call_details"][0]["prompt"], harness.prompts[-1])
 
     def test_none_legal_moves_without_free_form_config_returns_inactive(self):
         """get_legal_moves() returns None but freeForm not in config → empty-obs path."""

--- a/tests/core_harness_test.py
+++ b/tests/core_harness_test.py
@@ -233,7 +233,7 @@ class CoreHarnessTest(absltest.TestCase):
         self.assertEqual(cd["generation_tokens"], 1)
         self.assertEqual(cd["prompt_tokens"], 1)
         self.assertEqual(cd["total_tokens"], 2)
-        self.assertIsNone(cd["reasoning_tokens"])
+        self.assertNotIn("reasoning_tokens", cd)
         self.assertEqual(cd["finish_reason"], "stop")
         self.assertEqual(cd["response"], "move_1")
         self.assertEqual(cd["model"], "test-model")

--- a/tests/envs/open_spiel_env/games/go/harness_test.py
+++ b/tests/envs/open_spiel_env/games/go/harness_test.py
@@ -356,7 +356,7 @@ class AgentIntegrationTest(absltest.TestCase):
         self.assertEqual(cd["total_tokens"], 30)
         self.assertEqual(cd["finish_reason"], "stop")
         self.assertIn("move", cd["response"])
-        self.assertNotIn("prompt", cd)  # savePrompt is False
+        self.assertIn("prompt", cd)  # savePrompt defaults to True
 
 
     @patch.dict(

--- a/tests/envs/open_spiel_env/games/go/harness_test.py
+++ b/tests/envs/open_spiel_env/games/go/harness_test.py
@@ -187,7 +187,12 @@ class GetLegalMovesTest(absltest.TestCase):
 def _make_mock_response(content):
     """Create a mock LiteLLM response."""
     resp = MagicMock()
-    resp.usage = MagicMock(prompt_tokens=10, completion_tokens=20)
+    resp.usage = MagicMock(
+        prompt_tokens=10,
+        completion_tokens=20,
+        total_tokens=30,
+        completion_tokens_details=None,
+    )
     resp.choices = [
         MagicMock(
             message=MagicMock(content=content),
@@ -312,6 +317,41 @@ class AgentIntegrationTest(absltest.TestCase):
             agent(observation, {})
 
         self.assertEqual(mock_litellm.completion.call_count, 2)
+
+
+    @patch.dict(
+        "os.environ",
+        {
+            "MODEL_NAME": "test-model",
+            "MODEL_PROXY_KEY": "test-key",
+            "MODEL_PROXY_URL": "dummy_url",
+        },
+    )
+    @patch("kaggle_environments.core_harness.litellm")
+    def test_call_details_present(self, mock_litellm):
+        """Action includes call_details with usage information."""
+        mock_litellm.drop_params = True
+        mock_litellm.completion.return_value = _make_mock_response(
+            '```json\n{"move": "e5"}\n```',
+        )
+
+        agent = create_agent_fn(_GoHarness())
+
+        game = go_proxy.GoGame({"board_size": 9, "komi": 7.5})
+        state = game.new_initial_state()
+        observation = _make_observation(state, game)
+
+        result = agent(observation, {})
+
+        self.assertIn("call_details", result)
+        self.assertLen(result["call_details"], 1)
+        cd = result["call_details"][0]
+        self.assertEqual(cd["generation_tokens"], 20)
+        self.assertEqual(cd["prompt_tokens"], 10)
+        self.assertEqual(cd["total_tokens"], 30)
+        self.assertEqual(cd["finish_reason"], "stop")
+        self.assertIn("move", cd["response"])
+        self.assertNotIn("prompt", cd)  # savePrompt is False
 
 
 if __name__ == "__main__":

--- a/tests/envs/open_spiel_env/games/go/harness_test.py
+++ b/tests/envs/open_spiel_env/games/go/harness_test.py
@@ -1,5 +1,6 @@
 """Tests for Go LLM harness."""
 
+import json
 from unittest.mock import MagicMock, patch
 
 import pyspiel
@@ -8,6 +9,7 @@ from absl.testing import absltest
 from kaggle_environments.core_harness import ParseResult, create_agent_fn
 from kaggle_environments.envs.open_spiel_env.games.go import go_proxy
 from kaggle_environments.envs.open_spiel_env.games.go.harness import (
+    augment_action,
     get_legal_moves,
     generate_prompt,
     parse_response,
@@ -214,6 +216,9 @@ class _GoHarness:
     def parse_response(self, response, legal_action_strings):
         return parse_response(response, legal_action_strings)
 
+    def augment_action(self, action, call_records):
+        return augment_action(action, call_records)
+
 
 class AgentIntegrationTest(absltest.TestCase):
     """Test the Go harness through ``create_agent_fn`` from ``core_harness``."""
@@ -352,6 +357,44 @@ class AgentIntegrationTest(absltest.TestCase):
         self.assertEqual(cd["finish_reason"], "stop")
         self.assertIn("move", cd["response"])
         self.assertNotIn("prompt", cd)  # savePrompt is False
+
+
+    @patch.dict(
+        "os.environ",
+        {
+            "MODEL_NAME": "test-model",
+            "MODEL_PROXY_KEY": "test-key",
+            "MODEL_PROXY_URL": "dummy_url",
+        },
+    )
+    @patch("kaggle_environments.core_harness.litellm")
+    def test_generate_returns_present(self, mock_litellm):
+        """Action includes legacy generate_returns without raw prompts/responses."""
+        mock_litellm.drop_params = True
+        mock_litellm.completion.return_value = _make_mock_response(
+            '```json\n{"move": "e5"}\n```',
+        )
+
+        agent = create_agent_fn(_GoHarness())
+
+        game = go_proxy.GoGame({"board_size": 9, "komi": 7.5})
+        state = game.new_initial_state()
+        observation = _make_observation(state, game)
+
+        result = agent(observation, {})
+
+        self.assertIn("generate_returns", result)
+        self.assertLen(result["generate_returns"], 1)
+        gr = json.loads(result["generate_returns"][0])
+        self.assertEqual(gr["generation_tokens"], 20)
+        self.assertEqual(gr["prompt_tokens"], 10)
+        self.assertEqual(gr["total_tokens"], 30)
+        self.assertEqual(gr["request_for_logging"]["model"], "test-model")
+        self.assertEqual(gr["response_for_logging"]["finish_reason"], "stop")
+        # No raw content duplicated
+        self.assertNotIn("main_response", gr)
+        self.assertNotIn("messages", gr["request_for_logging"])
+        self.assertNotIn("content", gr["response_for_logging"])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
`core_harness` is currently not logging usage details in the replay, nor any details about retried calls. Introduce a standard JSON field with one entry for every time we make an LLM call, similar to the legacy `generate_returns` field from the google3 harness.