### PR TITLE
Fix coin game header showing players stacked vertically

### DIFF
--- a/kaggle_environments/envs/open_spiel_env/games/coin_game/visualizer/default/src/style.css
+++ b/kaggle_environments/envs/open_spiel_env/games/coin_game/visualizer/default/src/style.css
@@ -50,8 +50,11 @@ body,
     background-color 300ms;
   white-space: nowrap;
   display: inline-flex;
+  flex-direction: row;
   align-items: center;
   gap: 8px;
+  width: auto;
+  height: auto;
 }
 
 .header .player.active {


### PR DESCRIPTION
The host @kaggle-environments/core stylesheet defines a global .player { display: flex; flex-direction: column; width: 100%; height: 100%; } that leaks into the renderer's .header .player rule. The renderer was overriding display but not flex-direction or width/height, so the dot+name and pref pill stacked vertically inside an over-stretched box.

Explicitly set flex-direction: row and width/height: auto on the header player pill to override the leaked properties.