### PR TITLE
fix: move capitalization

### DIFF
--- a/kaggle_environments/envs/open_spiel_env/games/chess/visualizer/v2/src/utils/getStepLabel.ts
+++ b/kaggle_environments/envs/open_spiel_env/games/chess/visualizer/v2/src/utils/getStepLabel.ts
@@ -5,7 +5,7 @@ export function getStepLabel(step: BaseGameStep) {
   const player = step.players.find((p) => p.isTurn);
 
   if (player) {
-    const move = player.actionDisplayText?.toUpperCase() ?? '';
+    const move = player.actionDisplayText ?? '';
     return `Plays ${move}`;
   }
 


### PR DESCRIPTION
The moves in the LLM thought logs titles had all alphabet characters capitalized.

In chess notation, capitalization has meaning, it's always used to denote the piece, and should not be used for the coordinates of squares.

This change removes the uppercasing that was going on where it shouldn't have been.

<img width="1139" height="936" alt="Screenshot 2026-05-08 at 15 03 48" src="https://github.com/user-attachments/assets/24d1bb83-7a8d-492e-98ec-d372cb6954ba" />
