### PR TITLE
Fix generate_returns logging

### DIFF
--- a/kaggle_environments/core_harness.py
+++ b/kaggle_environments/core_harness.py
@@ -271,6 +271,30 @@ def _build_call_detail(
     return detail
 
 
+def _build_generate_return(record: dict[str, Any]) -> dict[str, Any]:
+    """Build a legacy ``GenerateReturn``-shaped dict from a call record.
+
+    Omits raw prompts and responses to avoid duplicating large content
+    already available via ``call_details`` and ``thoughts``.
+    """
+    gr: dict[str, Any] = {
+        "request_for_logging": {
+            "model": record["model"],
+        },
+        "response_for_logging": {
+            "finish_reason": record.get("finish_reason"),
+        },
+        "generation_tokens": record.get("generation_tokens"),
+        "prompt_tokens": record.get("prompt_tokens"),
+        "total_tokens": record.get("total_tokens"),
+        "duration_success_only_secs": record.get("duration_secs"),
+    }
+    reasoning = record.get("reasoning_tokens")
+    if reasoning is not None:
+        gr["reasoning_tokens"] = reasoning
+    return gr
+
+
 # ---------------------------------------------------------------------------
 # Setup
 # ---------------------------------------------------------------------------
@@ -344,6 +368,9 @@ def create_agent_fn(
             setup_done = True
 
         save_prompt = bool(config.get("savePrompt", True)) if config else True
+        include_generate_returns = (
+            bool(config.get("includeGenerateReturns", False)) if config else False
+        )
 
         observation = obs if isinstance(obs, dict) else vars(obs)
 
@@ -468,8 +495,11 @@ def create_agent_fn(
                         for r in call_records
                     ],
                 }
-                if hasattr(game_harness, "augment_action"):
-                    game_harness.augment_action(action, call_records)
+                if include_generate_returns:
+                    action["generate_returns"] = [
+                        json.dumps(_build_generate_return(r))
+                        for r in call_records
+                    ]
                 return action
 
             # -- parse failed → prepare rethink --

--- a/kaggle_environments/envs/open_spiel_env/games/go/debug_match_runner.py
+++ b/kaggle_environments/envs/open_spiel_env/games/go/debug_match_runner.py
@@ -34,9 +34,6 @@ class _GoHarness:
     def parse_response(self, response, legal_action_strings):
         return harness.parse_response(response, legal_action_strings)
 
-    def augment_action(self, action, call_records):
-        return harness.augment_action(action, call_records)
-
 
 def _wrap_litellm_with_logging() -> None:
     """Replace litellm.completion with a version that prints I/O."""

--- a/kaggle_environments/envs/open_spiel_env/games/go/harness.py
+++ b/kaggle_environments/envs/open_spiel_env/games/go/harness.py
@@ -158,37 +158,6 @@ def generate_prompt(
     return prompt
 
 
-def augment_action(
-    action: dict[str, Any],
-    call_records: list[dict[str, Any]],
-) -> None:
-    """Add backwards-compatible ``generate_returns`` to the action dict.
-
-    Each element mirrors the ``GenerateReturn`` shape consumed by the Go
-    visualizer and cost-tracking pipelines, but omits raw prompts and
-    responses (already available via ``call_details`` and ``thoughts``).
-    """
-    generate_returns: list[dict[str, Any]] = []
-    for record in call_records:
-        gr: dict[str, Any] = {
-            "request_for_logging": {
-                "model": record["model"],
-            },
-            "response_for_logging": {
-                "finish_reason": record.get("finish_reason"),
-            },
-            "generation_tokens": record.get("generation_tokens"),
-            "prompt_tokens": record.get("prompt_tokens"),
-            "total_tokens": record.get("total_tokens"),
-            "duration_success_only_secs": record.get("duration_secs"),
-        }
-        reasoning = record.get("reasoning_tokens")
-        if reasoning is not None:
-            gr["reasoning_tokens"] = reasoning
-        generate_returns.append(gr)
-    action["generate_returns"] = [json.dumps(g) for g in generate_returns]
-
-
 def parse_response(
     response: str, legal_action_strings: Sequence[str],
 ) -> ParseResult:

--- a/kaggle_environments/envs/open_spiel_env/open_spiel_env.py
+++ b/kaggle_environments/envs/open_spiel_env/open_spiel_env.py
@@ -180,6 +180,15 @@ CONFIGURATION_SPEC_TEMPLATE = {
         "type": "boolean",
         "default": False,
     },
+    "includeGenerateReturns": {
+        "description": (
+            "If true, include a legacy generate_returns field on each action"
+            " with per-LLM-call metadata (model, token counts, finish reason,"
+            " duration). Useful for cost tracking and visualization pipelines."
+        ),
+        "type": "boolean",
+        "default": False,
+    },
 }
 
 OBSERVATION_SPEC_TEMPLATE = {

--- a/tests/core_harness_test.py
+++ b/tests/core_harness_test.py
@@ -278,6 +278,37 @@ class CoreHarnessTest(absltest.TestCase):
         self.assertEqual(result["call_details"][0]["response"], "garbage")
         self.assertEqual(result["call_details"][1]["response"], "move_2")
 
+    def test_include_generate_returns(self):
+        harness = _SimpleHarness()
+        agent = create_agent_fn(harness)
+        with patch.dict("os.environ", _ENV, clear=False), patch.object(
+            core_harness.litellm,
+            "completion",
+            return_value=_fake_completion("move_0"),
+        ):
+            result = agent({}, {"includeGenerateReturns": True})
+
+        import json
+        self.assertIn("generate_returns", result)
+        self.assertLen(result["generate_returns"], 1)
+        gr = json.loads(result["generate_returns"][0])
+        self.assertEqual(gr["request_for_logging"]["model"], "test-model")
+        self.assertEqual(gr["generation_tokens"], 1)
+        self.assertEqual(gr["prompt_tokens"], 1)
+        self.assertEqual(gr["total_tokens"], 2)
+
+    def test_generate_returns_omitted_by_default(self):
+        harness = _SimpleHarness()
+        agent = create_agent_fn(harness)
+        with patch.dict("os.environ", _ENV, clear=False), patch.object(
+            core_harness.litellm,
+            "completion",
+            return_value=_fake_completion("move_0"),
+        ):
+            result = agent({}, {})
+
+        self.assertNotIn("generate_returns", result)
+
     def test_move_history_accumulates_across_calls(self):
         harness = _SimpleHarness()
         agent = create_agent_fn(harness)

--- a/tests/envs/open_spiel_env/games/go/harness_test.py
+++ b/tests/envs/open_spiel_env/games/go/harness_test.py
@@ -9,7 +9,6 @@ from absl.testing import absltest
 from kaggle_environments.core_harness import ParseResult, create_agent_fn
 from kaggle_environments.envs.open_spiel_env.games.go import go_proxy
 from kaggle_environments.envs.open_spiel_env.games.go.harness import (
-    augment_action,
     get_legal_moves,
     generate_prompt,
     parse_response,
@@ -216,9 +215,6 @@ class _GoHarness:
     def parse_response(self, response, legal_action_strings):
         return parse_response(response, legal_action_strings)
 
-    def augment_action(self, action, call_records):
-        return augment_action(action, call_records)
-
 
 class AgentIntegrationTest(absltest.TestCase):
     """Test the Go harness through ``create_agent_fn`` from ``core_harness``."""
@@ -381,7 +377,7 @@ class AgentIntegrationTest(absltest.TestCase):
         state = game.new_initial_state()
         observation = _make_observation(state, game)
 
-        result = agent(observation, {})
+        result = agent(observation, {"includeGenerateReturns": True})
 
         self.assertIn("generate_returns", result)
         self.assertLen(result["generate_returns"], 1)
@@ -395,6 +391,31 @@ class AgentIntegrationTest(absltest.TestCase):
         self.assertNotIn("main_response", gr)
         self.assertNotIn("messages", gr["request_for_logging"])
         self.assertNotIn("content", gr["response_for_logging"])
+
+    @patch.dict(
+        "os.environ",
+        {
+            "MODEL_NAME": "test-model",
+            "MODEL_PROXY_KEY": "test-key",
+            "MODEL_PROXY_URL": "dummy_url",
+        },
+    )
+    @patch("kaggle_environments.core_harness.litellm")
+    def test_generate_returns_omitted_by_default(self, mock_litellm):
+        mock_litellm.drop_params = True
+        mock_litellm.completion.return_value = _make_mock_response(
+            '```json\n{"move": "e5"}\n```',
+        )
+
+        agent = create_agent_fn(_GoHarness())
+
+        game = go_proxy.GoGame({"board_size": 9, "komi": 7.5})
+        state = game.new_initial_state()
+        observation = _make_observation(state, game)
+
+        result = agent(observation, {})
+
+        self.assertNotIn("generate_returns", result)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Previously we added a new optional harness function `augment_action`. However the script we inject for all runs does not look for this function, so it was not called.

Instead, support `generate_returns` logging generically for all open spiel games. Extract it from the Go harness.