### PR TITLE
Rebalance kaggriculture and kaggriculture beginner

### DIFF
--- a/kaggle_environments/envs/kaggriculture/README.md
+++ b/kaggle_environments/envs/kaggriculture/README.md
@@ -82,7 +82,7 @@ CARE banks a yield bonus that is paid out on the animal's next scheduled product
 
 ### Market Action
 
-Each turn you can execute as many market actions are desired. This is an ordered list and market orders will be processed in order simultaneously (one from each player) while both players have orders.
+Each turn you can submit up to `maxMarketOrdersPerTurn` (default 10) market actions; any orders past that limit are silently dropped. This is an ordered list and market orders will be processed in order simultaneously (one from each player) while both players have orders.
 
 - BUY\_SEED — Purchase N units of a single item from the market.  
   - BUY\_SEED WHEAT 1  
@@ -154,7 +154,7 @@ As the season progresses, new shops unlock at regular intervals (every `townShop
 
 Each unlocked shop consumes one of every product it demands every `townShopSellInterval` turns (default 2). So with the default interval, a shop demanding wheat removes 12 wheat from the market per day. Single-product shops consume 2x.
 
-In addition, the town center consumes one of every product every `townCenterSellInterval` turns (default 6). After day 10 this is increased to 2 of each, and after day 20 it is increased to 4 of each.
+In addition, the town center consumes one of every product (excluding fertilizer) every `townCenterSellInterval` turns (default 6). After day 10 this is increased to 2 of each, and after day 20 it is increased to 4 of each.
 
 | Shop Type | Increases Demand For |
 | :---- | :---- |
@@ -164,8 +164,8 @@ In addition, the town center consumes one of every product every `townCenterSell
 | Yarn Store | wool (2x) |
 | Ice Cream Shop | strawberries, milk, wheat |
 | Pet Cafe | carrots (2x) |
-| Smoothie Shop | strawberries, milk, melon |
-| Farmers Market | all plants |
+| Smoothie Shop | strawberries, milk |
+| Farmers Market | wheat, carrots, tomatoes, strawberries |
 
 ## Market Mechanics
 
@@ -331,7 +331,8 @@ Per-crop seed costs and per-product base prices are not configurable; they are d
 | :---- | :---- | :---- |
 | episodeSteps | 720 | Total turns in the season (24 turns × 30 days) |
 | boardSize | 10 | Width and height (in tiles) of each player's square farm. Advanced uses 10 = four 5x5 quadrants |
-| startingMoney | 150 | Coins each player starts with |
+| startingMoney | 2000 | Coins each player starts with |
+| maxMarketOrdersPerTurn | 10 | Maximum number of market orders processed per player per turn; extras are silently dropped |
 | turnsPerDay | 24 | Number of turns that make up one in-game day |
 | shedCapacity | 100 | Max non-seed items the shed can hold; overflow at end-of-day drop is discarded |
 | weedSpawnChance | 0.005 | Per-tile probability of a weed spawning on an empty unlocked tile during end-of-day refresh |

--- a/kaggle_environments/envs/kaggriculture/kaggriculture.json
+++ b/kaggle_environments/envs/kaggriculture/kaggriculture.json
@@ -16,8 +16,14 @@
     "startingMoney": {
       "description": "Money each player starts with.",
       "type": "integer",
-      "default": 150,
+      "default": 2000,
       "minimum": 0
+    },
+    "maxMarketOrdersPerTurn": {
+      "description": "Maximum number of market orders processed per player per turn. Extra orders beyond this limit are silently dropped.",
+      "type": "integer",
+      "default": 10,
+      "minimum": 1
     },
     "turnsPerDay": {
       "description": "Number of turns that make up one in-game day.",

--- a/kaggle_environments/envs/kaggriculture/kaggriculture.py
+++ b/kaggle_environments/envs/kaggriculture/kaggriculture.py
@@ -59,11 +59,11 @@ SHOPS = {
     "YARN_STORE":     ["WOOL"],
     "ICE_CREAM_SHOP": ["STRAWBERRY", "MILK", "WHEAT"],
     "PET_CAFE":       ["CARROT"],
-    "SMOOTHIE_SHOP":  ["STRAWBERRY", "MILK", "MELON"],
-    "FARMERS_MARKET": ["WHEAT", "CARROT", "TOMATO", "STRAWBERRY", "MELON"],
+    "SMOOTHIE_SHOP":  ["STRAWBERRY", "MILK"],
+    "FARMERS_MARKET": ["WHEAT", "CARROT", "TOMATO", "STRAWBERRY"],
 }
 
-TOWN_CENTER_PRODUCTS = PRODUCTS
+TOWN_CENTER_PRODUCTS = [p for p in PRODUCTS if p != "FERTILIZER"]
 
 # Town center demand schedule: (day_threshold, multiplier), highest threshold first.
 TOWN_CENTER_DEMAND_SCHEDULE = [(20, 4), (10, 2), (0, 1)]
@@ -473,12 +473,14 @@ def _process_market(state, env):
     farms = obs0.farms
     privates = [s.observation.private for s in state]
     board_size = int(get(env.configuration, "boardSize", 10))
+    max_orders = max(1, int(get(env.configuration, "maxMarketOrdersPerTurn", 10)))
 
     queues = []
     for s in state:
         action = s.action if isinstance(s.action, dict) else {}
         m = action.get("market", []) if isinstance(action, dict) else []
-        queues.append(list(m) if isinstance(m, list) else [])
+        q = list(m) if isinstance(m, list) else []
+        queues.append(q[:max_orders])
 
     max_len = max((len(q) for q in queues), default=0)
     for i in range(max_len):

--- a/kaggle_environments/envs/kaggriculture_beginner/README.md
+++ b/kaggle_environments/envs/kaggriculture_beginner/README.md
@@ -43,7 +43,7 @@ Each Farmer can be given an action every turn.
 
 ### **Market Action**
 
-Each turn you can execute as many market actions are desired. This is an ordered list and market orders will be processed in order simultaneously (one from each player) while both players have orders.
+Each turn you can submit up to `maxMarketOrdersPerTurn` (default 10) market actions; any orders past that limit are silently dropped. This is an ordered list and market orders will be processed in order simultaneously (one from each player) while both players have orders.
 
 - BUY\_SEED — Purchase N units of a single seed type from the market.  
   - BUY\_SEED WHEAT 1  
@@ -161,6 +161,7 @@ Three built-in agents are available by name: `"pass"`, `"random"`, and `"starter
 | `boardSize` | 5 | Side length (in tiles) of each player's square farm |
 | `startingMoney` | 150 | Coins each player starts with |
 | `turnsPerDay` | 24 | Number of turns that make up one in-game day |
+| `maxMarketOrdersPerTurn` | 10 | Max market orders processed per player per turn; extras are silently dropped |
 | `actTimeout` | 1 | Per-turn agent action timeout (seconds) |
 
 Per-crop seed costs and sale prices are not configurable in the beginner version — they are fixed in the `CROPS` table inside the interpreter (see the Object Types table above for the values).

--- a/kaggle_environments/envs/kaggriculture_beginner/kaggriculture_beginner.json
+++ b/kaggle_environments/envs/kaggriculture_beginner/kaggriculture_beginner.json
@@ -24,6 +24,12 @@
       "type": "integer",
       "default": 24,
       "minimum": 1
+    },
+    "maxMarketOrdersPerTurn": {
+      "description": "Maximum number of market orders processed per player per turn. Extra orders beyond this limit are silently dropped.",
+      "type": "integer",
+      "default": 10,
+      "minimum": 1
     }
   },
   "reward": {

--- a/kaggle_environments/envs/kaggriculture_beginner/kaggriculture_beginner.py
+++ b/kaggle_environments/envs/kaggriculture_beginner/kaggriculture_beginner.py
@@ -197,16 +197,17 @@ def _try_harvest(farm, fx, fy, day):
     return (crop_name, yield_units)
 
 
-def _process_market(state):
+def _process_market(state, max_orders=10):
     """Round-robin process market queues across players. With BUY_SEED at fixed
-    prices the order doesn't matter, but we still keep it consistent with the 
+    prices the order doesn't matter, but we still keep it consistent with the
     behavior for the advanced version of kaggriculture."""
     obs0 = state[0].observation
     queues = []
     for s in state:
         action = s.action if isinstance(s.action, dict) else {}
         market = action.get("market", []) if isinstance(action, dict) else []
-        queues.append(list(market) if isinstance(market, list) else [])
+        q = list(market) if isinstance(market, list) else []
+        queues.append(q[:max_orders])
 
     max_len = max((len(q) for q in queues), default=0)
     for i in range(max_len):
@@ -311,6 +312,7 @@ def interpreter(state, env):
     configuration = env.configuration
     turns_per_day = max(1, int(get(configuration, "turnsPerDay", 24)))
     board_size = int(get(configuration, "boardSize", 5))
+    max_orders = max(1, int(get(configuration, "maxMarketOrdersPerTurn", 10)))
 
     step = get(obs0, "step", 0)
     day = step // turns_per_day
@@ -323,7 +325,7 @@ def interpreter(state, env):
             crop_name, units = result
             obs0.farms[i]["money"] += float(CROPS[crop_name]["price"] * units)
 
-    _process_market(state)
+    _process_market(state, max_orders)
 
     for farm in obs0.farms:
         _decay_plants(farm, step)

--- a/tests/envs/kaggriculture/test_kaggriculture.py
+++ b/tests/envs/kaggriculture/test_kaggriculture.py
@@ -8,6 +8,7 @@ from kaggle_environments.envs.kaggriculture.kaggriculture import (
     MARKET_PARAMS,
     PRODUCTS,
     SHOPS,
+    TOWN_CENTER_PRODUCTS,
     _apply_unit_action,
     _commit_unit,
     _daily_refresh_animals,
@@ -676,3 +677,77 @@ def test_animal_table_has_expected_animals():
 def test_products_table_includes_animal_products_and_fertilizer():
     for p in ("EGG", "MILK", "WOOL", "FERTILIZER"):
         assert p in PRODUCTS
+
+
+# --- Balance changes --------------------------------------------------------
+
+def test_no_shop_consumes_melon():
+    for shop, products in SHOPS.items():
+        assert "MELON" not in products, f"{shop} should not consume MELON"
+
+
+def test_town_center_excludes_fertilizer():
+    assert "FERTILIZER" not in TOWN_CENTER_PRODUCTS
+    # All other PRODUCTS are still consumed by the town center.
+    for p in PRODUCTS:
+        if p == "FERTILIZER":
+            continue
+        assert p in TOWN_CENTER_PRODUCTS
+
+
+def test_town_center_does_not_drain_fertilizer_inventory():
+    """Run a short episode and confirm fertilizer inventory never drops below
+    its initial I0 from town/shop consumption (no one consumes it)."""
+    env = make("kaggriculture", configuration={"episodeSteps": 100, "seed": 7})
+    env.run(["pass", "pass"])
+    j = env.toJSON()
+    initial = MARKET_PARAMS["FERTILIZER"]["I0"]
+    for step in j["steps"]:
+        inv = step[0]["observation"]["market"]["inventory"]["FERTILIZER"]
+        assert inv >= initial, f"FERTILIZER inventory dropped to {inv} (initial {initial})"
+
+
+def test_market_orders_capped_at_default_ten():
+    """An 11th market order in a single turn is silently dropped."""
+    def buyer(obs):
+        if obs.get("step", 0) == 0:
+            # 11 BUY_SEED orders for cheap wheat seeds (cost 10 each).
+            return {
+                "farmer": ["PASS"],
+                "hands": [],
+                "market": [["BUY_SEED", "WHEAT", 1]] * 11,
+            }
+        return {"farmer": ["PASS"], "hands": [], "market": []}
+
+    env = make("kaggriculture", configuration={"episodeSteps": 5, "startingMoney": 1000})
+    env.run([buyer, "pass"])
+    j = env.toJSON()
+    p0_priv = j["steps"][1][0]["observation"]["private"]
+    assert p0_priv["seeds"]["WHEAT"] == 10  # 11th order dropped
+
+
+def test_market_order_limit_is_configurable():
+    def buyer(obs):
+        if obs.get("step", 0) == 0:
+            return {
+                "farmer": ["PASS"],
+                "hands": [],
+                "market": [["BUY_SEED", "WHEAT", 1]] * 5,
+            }
+        return {"farmer": ["PASS"], "hands": [], "market": []}
+
+    env = make(
+        "kaggriculture",
+        configuration={"episodeSteps": 5, "startingMoney": 1000, "maxMarketOrdersPerTurn": 3},
+    )
+    env.run([buyer, "pass"])
+    j = env.toJSON()
+    p0_priv = j["steps"][1][0]["observation"]["private"]
+    assert p0_priv["seeds"]["WHEAT"] == 3
+
+
+def test_default_starting_money_is_2000():
+    env = make("kaggriculture", configuration={"episodeSteps": 3})
+    env.run(["pass", "pass"])
+    j = env.toJSON()
+    assert j["rewards"] == [2000.0, 2000.0]

--- a/tests/envs/kaggriculture_beginner/test_kaggriculture_beginner.py
+++ b/tests/envs/kaggriculture_beginner/test_kaggriculture_beginner.py
@@ -287,3 +287,42 @@ def test_random_agent_runs_full_episode():
 
 def test_crop_table_has_all_expected_crops():
     assert set(CROPS) == {"WHEAT", "CARROT", "TOMATO", "STRAWBERRY", "MELON"}
+
+
+def test_market_orders_capped_at_default_ten():
+    """An 11th market order in a single turn is silently dropped."""
+    def buyer(obs):
+        if obs.get("step", 0) == 0:
+            return {
+                "farmer": ["PASS"],
+                "market": [["BUY_SEED", "WHEAT", 1]] * 11,
+            }
+        return {"farmer": ["PASS"], "market": []}
+
+    env = make(
+        "kaggriculture_beginner",
+        configuration={"episodeSteps": 5, "startingMoney": 1000},
+    )
+    env.run([buyer, "pass"])
+    j = env.toJSON()
+    final_obs = j["steps"][-1][0]["observation"]
+    assert final_obs["farms"][0]["seeds"]["WHEAT"] == 10
+
+
+def test_market_order_limit_is_configurable():
+    def buyer(obs):
+        if obs.get("step", 0) == 0:
+            return {
+                "farmer": ["PASS"],
+                "market": [["BUY_SEED", "WHEAT", 1]] * 5,
+            }
+        return {"farmer": ["PASS"], "market": []}
+
+    env = make(
+        "kaggriculture_beginner",
+        configuration={"episodeSteps": 5, "startingMoney": 1000, "maxMarketOrdersPerTurn": 3},
+    )
+    env.run([buyer, "pass"])
+    j = env.toJSON()
+    final_obs = j["steps"][-1][0]["observation"]
+    assert final_obs["farms"][0]["seeds"]["WHEAT"] == 3


### PR DESCRIPTION
- limit to 10 market orders per turn (if you send more they aren't executed) - make the configurable
- starting money to 2k (the first 6 days were always the same, this allows some variety) (this also increases production early so we can keep the market down
- remove melon consumption from the shops (fine to keep for TC I think). melons are way too OP
- verify TC doesn't buy fertilizer when it buys all other items