### PR TITLE
feat: forfeit and draw

### DIFF
--- a/kaggle_environments/envs/open_spiel_env/games/chess/visualizer/v2/replays/test-replay-draw.json
+++ b/kaggle_environments/envs/open_spiel_env/games/chess/visualizer/v2/replays/test-replay-draw.json
@@ -1,0 +1,6336 @@
+{
+  "configuration": {
+    "actTimeout": 3600,
+    "episodeSteps": 17795,
+    "includeLegalActions": false,
+    "loadPresetHands": false,
+    "metadata": {},
+    "observationType": "observation",
+    "openSpielGameName": "chess",
+    "openSpielGameParameters": {
+      "chess960": false
+    },
+    "openSpielGameString": "chess()",
+    "runTimeout": 108000,
+    "savePrompt": false,
+    "seed": 583561998,
+    "strictMode": false,
+    "useImage": false,
+    "useOpenings": false
+  },
+  "description": "Kaggle environment wrapper for OpenSpiel games.\nFor game implementation details see:\nhttps://github.com/google-deepmind/open_spiel/tree/master/open_spiel/games",
+  "id": "77bb4e0e-48e4-11f1-9475-0242ac130203",
+  "info": {
+    "Agents": [
+      {
+        "Name": "GPT-5.5",
+        "ThumbnailUrl": "https://storage.googleapis.com/kaggle-organizations/5089/thumbnail.png?t=2025-08-14-19-21-59"
+      },
+      {
+        "Name": "Gemini 3.1 Pro Preview",
+        "ThumbnailUrl": "https://storage.googleapis.com/kaggle-organizations/855/thumbnail.png"
+      }
+    ],
+    "EpisodeId": 75929702,
+    "LiveVideoPath": null,
+    "TeamNames": ["GPT-5.5", "Gemini 3.1 Pro Preview"],
+    "actionHistory": [
+      "2426",
+      "1258",
+      "3572",
+      "1841",
+      "1842",
+      "1431",
+      "3132",
+      "3572",
+      "656",
+      "89",
+      "1215",
+      "2425",
+      "3010",
+      "1808",
+      "1768",
+      "749",
+      "30",
+      "1065",
+      "2571",
+      "1942",
+      "3196",
+      "3131",
+      "1384",
+      "4177",
+      "3854",
+      "381",
+      "615",
+      "498",
+      "1869",
+      "2001",
+      "2977",
+      "2975",
+      "4350",
+      "1431",
+      "1770",
+      "2581",
+      "1257",
+      "4673",
+      "4673",
+      "656",
+      "2627",
+      "1895",
+      "2940",
+      "1386",
+      "1358",
+      "3634",
+      "2528",
+      "254",
+      "4496",
+      "3110",
+      "3705",
+      "2948",
+      "2161",
+      "1771",
+      "2833",
+      "2059",
+      "3853",
+      "2002",
+      "3326",
+      "3166",
+      "1358",
+      "1406",
+      "3561",
+      "1694",
+      "3050",
+      "1637",
+      "2497",
+      "1212",
+      "2425",
+      "1882",
+      "3593",
+      "32",
+      "2016",
+      "1770",
+      "3666",
+      "2498",
+      "4178",
+      "2571",
+      "2498",
+      "1986",
+      "2571",
+      "1914",
+      "2686",
+      "1999",
+      "4323",
+      "3548",
+      "3739",
+      "819",
+      "3196",
+      "911",
+      "3812",
+      "3037",
+      "4437",
+      "4218",
+      "3344",
+      "3694",
+      "4361",
+      "674",
+      "2685",
+      "1357",
+      "2174",
+      "704",
+      "1649",
+      "819",
+      "978",
+      "892",
+      "2322",
+      "4350",
+      "3325",
+      "3327",
+      "423",
+      "3707",
+      "891",
+      "3196",
+      "861",
+      "2644",
+      "715",
+      "2716",
+      "1225",
+      "2644",
+      "715",
+      "2716",
+      "1225"
+    ],
+    "moveDurations": [
+      5.766, 7.902, 8.987, 12.889, 10.641, 8.098, 10.943, 10.543, 11.024, 6.751,
+      14.31, 9.109, 15.593, 19.945, 11.159, 31.595, 15.86, 22.579, 17.615,
+      93.318, 12.602, 25.164, 27.127, 196.046, 21.224, 237.682, 25.255, 67.683,
+      34.904, 279.651, 28.748, 256.537, 58.286, 84.066, 195.418, 202.767,
+      43.712, 184.822, 48.975, 184.581, 214.164, 354.426, 170.547, 244.092,
+      84.378, 568.132, 142.327, 202.138, 25.871, 49.439, 39.959, 99.049, 49.757,
+      179.029, 24.17, 552.532, 48.161, 269.889, 113.07, 116.526, 31.208,
+      195.892, 15.664, 447.983, 36.005, 441.663, 10.462, 100.695, 22.84,
+      137.446, 19.186, 681.104, 15.545, 258.435, 42.505, 326.443, 53.545,
+      111.328, 62.973, 512.531, 42.113, 1185.539, 60.746, 884.886, 25.184,
+      611.889, 47.354, 561.286, 43.759, 500.194, 43.04, 301.268, 66.899,
+      227.678, 21.888, 218.16, 53.197, 631.721, 155.127, 739.092, 35.352,
+      726.027, 32.4, 441.775, 30.175, 396.986, 27.992, 367.015, 49.653,
+      1786.216, 99.532, 486.259, 107.461, 387.494, 57.287, 299.069, 103.883,
+      1124.499, 61.761, 293.176, 65.796, 425.995, 22.796
+    ],
+    "openSpielGameStringResolved": "chess(chess960=False)",
+    "stateHistory": [
+      "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1",
+      "rnbqkbnr/pppppppp/8/8/4P3/8/PPPP1PPP/RNBQKBNR b KQkq - 0 1",
+      "rnbqkbnr/pp1ppppp/8/2p5/4P3/8/PPPP1PPP/RNBQKBNR w KQkq - 0 2",
+      "rnbqkbnr/pp1ppppp/8/2p5/4P3/5N2/PPPP1PPP/RNBQKB1R b KQkq - 1 2",
+      "rnbqkbnr/pp2pppp/3p4/2p5/4P3/5N2/PPPP1PPP/RNBQKB1R w KQkq - 0 3",
+      "rnbqkbnr/pp2pppp/3p4/2p5/3PP3/5N2/PPP2PPP/RNBQKB1R b KQkq - 0 3",
+      "rnbqkbnr/pp2pppp/3p4/8/3pP3/5N2/PPP2PPP/RNBQKB1R w KQkq - 0 4",
+      "rnbqkbnr/pp2pppp/3p4/8/3NP3/8/PPP2PPP/RNBQKB1R b KQkq - 0 4",
+      "rnbqkb1r/pp2pppp/3p1n2/8/3NP3/8/PPP2PPP/RNBQKB1R w KQkq - 1 5",
+      "rnbqkb1r/pp2pppp/3p1n2/8/3NP3/2N5/PPP2PPP/R1BQKB1R b KQkq - 2 5",
+      "rnbqkb1r/1p2pppp/p2p1n2/8/3NP3/2N5/PPP2PPP/R1BQKB1R w KQkq - 0 6",
+      "rnbqkb1r/1p2pppp/p2p1n2/6B1/3NP3/2N5/PPP2PPP/R2QKB1R b KQkq - 1 6",
+      "rnbqkb1r/1p3ppp/p2ppn2/6B1/3NP3/2N5/PPP2PPP/R2QKB1R w KQkq - 0 7",
+      "rnbqkb1r/1p3ppp/p2ppn2/6B1/3NPP2/2N5/PPP3PP/R2QKB1R b KQkq - 0 7",
+      "rnb1kb1r/1p3ppp/pq1ppn2/6B1/3NPP2/2N5/PPP3PP/R2QKB1R w KQkq - 1 8",
+      "rnb1kb1r/1p3ppp/pq1ppn2/6B1/3NPP2/2N5/PPPQ2PP/R3KB1R b KQkq - 2 8",
+      "rnb1kb1r/1p3ppp/p2ppn2/6B1/3NPP2/2N5/PqPQ2PP/R3KB1R w KQkq - 0 9",
+      "rnb1kb1r/1p3ppp/p2ppn2/6B1/3NPP2/2N5/PqPQ2PP/1R2KB1R b Kkq - 1 9",
+      "rnb1kb1r/1p3ppp/p2ppn2/6B1/3NPP2/q1N5/P1PQ2PP/1R2KB1R w Kkq - 2 10",
+      "rnb1kb1r/1p3ppp/p2ppn2/4P1B1/3N1P2/q1N5/P1PQ2PP/1R2KB1R b Kkq - 0 10",
+      "rnb1kb1r/1p3ppp/p3pn2/4p1B1/3N1P2/q1N5/P1PQ2PP/1R2KB1R w Kkq - 0 11",
+      "rnb1kb1r/1p3ppp/p3pn2/4P1B1/3N4/q1N5/P1PQ2PP/1R2KB1R b Kkq - 0 11",
+      "rnb1kb1r/1p1n1ppp/p3p3/4P1B1/3N4/q1N5/P1PQ2PP/1R2KB1R w Kkq - 1 12",
+      "rnb1kb1r/1p1n1ppp/p3p3/4P1B1/3NN3/q7/P1PQ2PP/1R2KB1R b Kkq - 2 12",
+      "rnb1kb1r/1p1n1pp1/p3p2p/4P1B1/3NN3/q7/P1PQ2PP/1R2KB1R w Kkq - 0 13",
+      "rnb1kb1r/1p1n1pp1/p3p2p/4P3/3NN2B/q7/P1PQ2PP/1R2KB1R b Kkq - 1 13",
+      "rnb1kb1r/1p1n1pp1/p3p2p/4P3/3NN2B/8/q1PQ2PP/1R2KB1R w Kkq - 0 14",
+      "rnb1kb1r/1p1n1pp1/p3p2p/4P3/3NN2B/8/q1PQ2PP/3RKB1R b Kkq - 1 14",
+      "rnb1kb1r/1p1n1pp1/p3p2p/3qP3/3NN2B/8/2PQ2PP/3RKB1R w Kkq - 2 15",
+      "rnb1kb1r/1p1n1pp1/p3p2p/3qP3/3NN2B/4Q3/2P3PP/3RKB1R b Kkq - 3 15",
+      "rnb1kb1r/1p1n1pp1/p3p2p/4q3/3NN2B/4Q3/2P3PP/3RKB1R w Kkq - 0 16",
+      "rnb1kb1r/1p1n1pp1/p3p2p/4q3/3NN2B/4Q3/2P1B1PP/3RK2R b Kkq - 1 16",
+      "rnb1k2r/1p1n1pp1/p3p2p/2b1q3/3NN2B/4Q3/2P1B1PP/3RK2R w Kkq - 2 17",
+      "rnb1k2r/1p1n1pp1/p3p2p/2b1q3/3NN3/4Q1B1/2P1B1PP/3RK2R b Kkq - 3 17",
+      "rnb1k2r/1p1n1pp1/p3p2p/4q3/3bN3/4Q1B1/2P1B1PP/3RK2R w Kkq - 0 18",
+      "rnb1k2r/1p1n1pp1/p3p2p/4q3/3RN3/4Q1B1/2P1B1PP/4K2R b Kkq - 0 18",
+      "rnb1k2r/1p1n1pp1/p3p2p/q7/3RN3/4Q1B1/2P1B1PP/4K2R w Kkq - 1 19",
+      "rnb1k2r/1p1n1pp1/p3p2p/q7/3RN3/2P1Q1B1/4B1PP/4K2R b Kkq - 0 19",
+      "rnb2rk1/1p1n1pp1/p3p2p/q7/3RN3/2P1Q1B1/4B1PP/4K2R w K - 1 20",
+      "rnb2rk1/1p1n1pp1/p3p2p/q7/3RN3/2P1Q1B1/4B1PP/5RK1 b - - 2 20",
+      "r1b2rk1/1p1n1pp1/p1n1p2p/q7/3RN3/2P1Q1B1/4B1PP/5RK1 w - - 3 21",
+      "r1b2rk1/1p1n1pp1/p1n1pN1p/q7/3R4/2P1Q1B1/4B1PP/5RK1 b - - 4 21",
+      "r1b2rk1/1p3pp1/p1n1pn1p/q7/3R4/2P1Q1B1/4B1PP/5RK1 w - - 0 22",
+      "r1b2rk1/1p3pp1/p1n1pR1p/q7/3R4/2P1Q1B1/4B1PP/6K1 b - - 0 22",
+      "r1b2rk1/1p3pp1/p3pR1p/q7/3n4/2P1Q1B1/4B1PP/6K1 w - - 0 23",
+      "r1b2rk1/1p3pp1/p3pR1p/q7/3P4/4Q1B1/4B1PP/6K1 b - - 0 23",
+      "r1b2rk1/1p3p2/p3pp1p/q7/3P4/4Q1B1/4B1PP/6K1 w - - 0 24",
+      "r1b2rk1/1p3p2/p3pp1Q/q7/3P4/6B1/4B1PP/6K1 b - - 0 24",
+      "r1b2rk1/1p3p2/p3pp1Q/6q1/3P4/6B1/4B1PP/6K1 w - - 1 25",
+      "r1b2rk1/1p3p2/p3pp2/6Q1/3P4/6B1/4B1PP/6K1 b - - 0 25",
+      "r1b2rk1/1p3p2/p3p3/6p1/3P4/6B1/4B1PP/6K1 w - - 0 26",
+      "r1b2rk1/1p3p2/p2Bp3/6p1/3P4/8/4B1PP/6K1 b - - 1 26",
+      "r1br2k1/1p3p2/p2Bp3/6p1/3P4/8/4B1PP/6K1 w - - 2 27",
+      "r1br2k1/1p2Bp2/p3p3/6p1/3P4/8/4B1PP/6K1 b - - 3 27",
+      "r1b3k1/1p2Bp2/p3p3/6p1/3r4/8/4B1PP/6K1 w - - 0 28",
+      "r1b3k1/1p3p2/p3p3/6B1/3r4/8/4B1PP/6K1 b - - 0 28",
+      "r1b3k1/1p3p2/p3p3/3r2B1/8/8/4B1PP/6K1 w - - 1 29",
+      "r1b3k1/1p3p2/p3pB2/3r4/8/8/4B1PP/6K1 b - - 2 29",
+      "r1b3k1/1p3p2/p3pB2/5r2/8/8/4B1PP/6K1 w - - 3 30",
+      "r1b3k1/1p3p2/p3p3/5r2/8/2B5/4B1PP/6K1 b - - 4 30",
+      "r1b3k1/1p3p2/p3p3/2r5/8/2B5/4B1PP/6K1 w - - 5 31",
+      "r1b3k1/1p3p2/p3p3/2r5/3B4/8/4B1PP/6K1 b - - 6 31",
+      "r1b3k1/1p3p2/p3p3/8/3B4/8/4B1PP/2r3K1 w - - 7 32",
+      "r1b3k1/1p3p2/p3p3/8/3B4/8/4BKPP/2r5 b - - 8 32",
+      "r1b3k1/1p3p2/p3p3/8/3B4/8/2r1BKPP/8 w - - 9 33",
+      "r1b3k1/1p3p2/p3p3/8/3B4/4K3/2r1B1PP/8 b - - 10 33",
+      "r1b3k1/1p3p2/p3p3/8/3B4/4K3/4r1PP/8 w - - 0 34",
+      "r1b3k1/1p3p2/p3p3/8/3B4/8/4K1PP/8 b - - 0 34",
+      "r5k1/1p1b1p2/p3p3/8/3B4/8/4K1PP/8 w - - 1 35",
+      "r5k1/1p1b1p2/p3p3/8/3B4/4K3/6PP/8 b - - 2 35",
+      "r5k1/1p3p2/p1b1p3/8/3B4/4K3/6PP/8 w - - 3 36",
+      "r5k1/1p3p2/p1b1p3/8/3B4/4K1P1/7P/8 b - - 0 36",
+      "3r2k1/1p3p2/p1b1p3/8/3B4/4K1P1/7P/8 w - - 1 37",
+      "3r2k1/1p3p2/p1b1pB2/8/8/4K1P1/7P/8 b - - 2 37",
+      "6k1/1p3p2/p1b1pB2/3r4/8/4K1P1/7P/8 w - - 3 38",
+      "6k1/1p3p2/p1b1pB2/3r4/6P1/4K3/7P/8 b - - 0 38",
+      "6k1/1p3p2/p1b2B2/3rp3/6P1/4K3/7P/8 w - - 0 39",
+      "6k1/1p3p2/p1b2B2/3rp3/6PP/4K3/8/8 b - - 0 39",
+      "6k1/1p3p2/p1b2B2/3r4/4p1PP/4K3/8/8 w - - 0 40",
+      "6k1/1p3p2/p1b2B2/3r4/4K1PP/8/8/8 b - - 0 40",
+      "6k1/1p3p2/p1br1B2/8/4K1PP/8/8/8 w - - 1 41",
+      "6k1/1p3p2/p1br1B2/4K3/6PP/8/8/8 b - - 2 41",
+      "6k1/1p3p2/p1b2B2/3rK3/6PP/8/8/8 w - - 3 42",
+      "6k1/1p3p2/p1b2B2/3r4/5KPP/8/8/8 b - - 4 42",
+      "6k1/1p3p2/p1b2B2/1r6/5KPP/8/8/8 w - - 5 43",
+      "6k1/1p3p2/p1b2B2/1r5P/5KP1/8/8/8 b - - 0 43",
+      "8/1p3p1k/p1b2B2/1r5P/5KP1/8/8/8 w - - 1 44",
+      "8/1p3p1k/p1b2B2/1r4PP/5K2/8/8/8 b - - 0 44",
+      "8/1p3p1k/p1b2B2/6PP/1r3K2/8/8/8 w - - 1 45",
+      "8/1p3p1k/p1b2B2/4K1PP/1r6/8/8/8 b - - 2 45",
+      "8/1p3p1k/p1b2B2/4K1PP/7r/8/8/8 w - - 3 46",
+      "8/1p3p1k/p1b2BP1/4K2P/7r/8/8/8 b - - 0 46",
+      "8/1p5k/p1b2Bp1/4K2P/7r/8/8/8 w - - 0 47",
+      "8/1p5k/p1b2BP1/4K3/7r/8/8/8 b - - 0 47",
+      "8/1p6/p1b2Bk1/4K3/7r/8/8/8 w - - 0 48",
+      "8/1p6/p1b3k1/4K3/7B/8/8/8 b - - 0 48",
+      "8/1p6/p1b5/4K2k/7B/8/8/8 w - - 1 49",
+      "3B4/1p6/p1b5/4K2k/8/8/8/8 b - - 2 49",
+      "3B4/8/p1b5/1p2K2k/8/8/8/8 w - - 0 50",
+      "3B4/8/p1bK4/1p5k/8/8/8/8 b - - 1 50",
+      "3B4/1b6/p2K4/1p5k/8/8/8/8 w - - 2 51",
+      "3B4/1bK5/p7/1p5k/8/8/8/8 b - - 3 51",
+      "3B4/2K5/p7/1p5k/8/5b2/8/8 w - - 4 52",
+      "3B4/8/pK6/1p5k/8/5b2/8/8 b - - 5 52",
+      "3B4/8/pK6/7k/1p6/5b2/8/8 w - - 0 53",
+      "3B4/8/K7/7k/1p6/5b2/8/8 b - - 0 53",
+      "3B4/8/K7/7k/8/1p3b2/8/8 w - - 0 54",
+      "8/8/K4B2/7k/8/1p3b2/8/8 b - - 1 54",
+      "8/8/K4Bk1/8/8/1p3b2/8/8 w - - 2 55",
+      "8/8/K5k1/8/8/1p3b2/1B6/8 b - - 3 55",
+      "8/8/K5k1/3b4/8/1p6/1B6/8 w - - 4 56",
+      "8/8/6k1/1K1b4/8/1p6/1B6/8 b - - 5 56",
+      "8/8/8/1K1b1k2/8/1p6/1B6/8 w - - 6 57",
+      "8/8/8/3b1k2/1K6/1p6/1B6/8 b - - 7 57",
+      "8/8/8/3b4/1K2k3/1p6/1B6/8 w - - 8 58",
+      "8/8/8/3b4/4k3/1pK5/1B6/8 b - - 9 58",
+      "8/8/8/3b4/8/1pK1k3/1B6/8 w - - 10 59",
+      "8/8/8/3b4/8/1pK1k3/8/2B5 b - - 11 59",
+      "8/8/8/3b4/4k3/1pK5/8/2B5 w - - 12 60",
+      "8/8/8/3b4/4k3/1pK5/1B6/8 b - - 13 60",
+      "8/8/8/3b4/8/1pK1k3/1B6/8 w - - 14 61",
+      "8/8/8/3b4/8/1pK1k3/8/2B5 b - - 15 61",
+      "8/8/8/3b4/4k3/1pK5/8/2B5 w - - 16 62",
+      "8/8/8/3b4/4k3/1pK5/1B6/8 b - - 17 62"
+    ]
+  },
+  "module_version": "1.29.0",
+  "name": "open_spiel_chess",
+  "rewards": [0.0, 0.0],
+  "schema_version": 1,
+  "specification": {
+    "action": {
+      "default": {
+        "submission": -1
+      },
+      "description": "Action object MUST contain a field `submission`, and MAY contain arbitrary additional information.",
+      "type": "object"
+    },
+    "agents": [2],
+    "configuration": {
+      "actTimeout": {
+        "default": 3600,
+        "description": "Maximum runtime (seconds) to obtain an action from an agent.",
+        "minimum": 0,
+        "type": "number"
+      },
+      "episodeSteps": {
+        "default": 17795,
+        "description": "Maximum number of steps in the episode.",
+        "minimum": 1,
+        "type": "integer"
+      },
+      "includeLegalActions": {
+        "default": false,
+        "description": "If true, include legalActions and legalActionStrings in observations. Defaults to false since these can be derived from serializedGameAndState.",
+        "type": "boolean"
+      },
+      "initialActions": {
+        "description": "Actions applied to initial state before play begins to set up starting position.",
+        "type": "array"
+      },
+      "loadPresetHands": {
+        "default": false,
+        "description": "Repeated poker only. Load preset hand chance actions from preset_hands.jsonl.",
+        "type": "boolean"
+      },
+      "metadata": {
+        "default": {},
+        "description": "Arbitrary metadata.",
+        "properties": {},
+        "type": "object"
+      },
+      "observationType": {
+        "default": "observation",
+        "description": "Type of observation string: 'observation' or 'information_state'.",
+        "type": "string"
+      },
+      "openSpielGameName": {
+        "default": "chess",
+        "description": "The short_name of the OpenSpiel game to load.",
+        "type": "string"
+      },
+      "openSpielGameParameters": {
+        "default": {
+          "chess960": false
+        },
+        "description": "Game parameters for Open Spiel game.",
+        "properties": {},
+        "type": "object"
+      },
+      "openSpielGameString": {
+        "default": "chess()",
+        "description": "The full game string including parameters.",
+        "type": "string"
+      },
+      "presetHands": {
+        "description": "Repeated poker only. List of per-hand chance action sequences to use instead of random chance.",
+        "type": "array"
+      },
+      "runTimeout": {
+        "default": 172800,
+        "description": "Maximum runtime (seconds) of an episode (not necessarily DONE).",
+        "minimum": 0,
+        "type": "number"
+      },
+      "savePrompt": {
+        "default": false,
+        "description": "If true, the LLM prompt produced by the harness is included as a 'prompt' field on the action returned by core_harness, which causes it to be persisted in the episode replay. Defaults to false to keep replays small.",
+        "type": "boolean"
+      },
+      "seed": {
+        "description": "Integer currently only used for selecting starting position.",
+        "type": "number"
+      },
+      "strictMode": {
+        "default": false,
+        "description": "If true, agents must return only {'submission': int} (no extra fields like 'thoughts'), and per-agent TIMEOUT/ERROR/INVALID counts as a loss for the offending agent only \u2014 other agents win. If false (default), any agent error halts and voids the entire episode, matching the lenient research-mode behavior.",
+        "type": "boolean"
+      },
+      "useImage": {
+        "default": false,
+        "description": "If true, indicates the observation is intended to be rendered as an image. Note that currently the agent harness is responsible for the actual rendering; no image is passed in the observation.",
+        "type": "boolean"
+      },
+      "useOpenings": {
+        "default": false,
+        "description": "Whether to start from a position in an opening book.",
+        "type": "boolean"
+      }
+    },
+    "info": {},
+    "observation": {
+      "default": {},
+      "properties": {
+        "currentPlayer": {
+          "description": "ID of player whose turn it is.",
+          "type": "integer"
+        },
+        "isTerminal": {
+          "description": "Boolean indicating game end.",
+          "type": "boolean"
+        },
+        "legalActionStrings": {
+          "description": "List of OpenSpiel legal action strings. Only included if includeLegalActions is true.",
+          "type": "array"
+        },
+        "legalActions": {
+          "description": "List of OpenSpiel legal action integers. Only included if includeLegalActions is true.",
+          "type": "array"
+        },
+        "observationString": {
+          "description": "String representation of state.",
+          "type": "string"
+        },
+        "openSpielGameName": {
+          "default": "chess",
+          "description": "Short name of the OpenSpiel game.",
+          "type": "string"
+        },
+        "openSpielGameString": {
+          "default": "chess()",
+          "description": "Full game string including parameters.",
+          "type": "string"
+        },
+        "playerId": {
+          "description": "ID of the agent receiving this observation.",
+          "type": "integer"
+        },
+        "remainingOverageTime": 60,
+        "serializedGameAndState": {
+          "description": "Enables reconstructing the Game and State objects.",
+          "type": "string"
+        },
+        "step": 0
+      },
+      "remainingOverageTime": {
+        "default": 12,
+        "description": "Total remaining banked time (seconds) that can be used in excess of per-step actTimeouts -- agent is disqualified with TIMEOUT status when this drops below 0.",
+        "minimum": 0,
+        "shared": false,
+        "type": "number"
+      },
+      "step": {
+        "default": 0,
+        "description": "Current step within the episode.",
+        "minimum": 0,
+        "shared": true,
+        "type": "integer"
+      }
+    },
+    "reward": {
+      "default": 0.0,
+      "type": ["number", "null"]
+    }
+  },
+  "statuses": ["DONE", "DONE"],
+  "steps": [
+    [
+      {
+        "action": {
+          "submission": -1
+        },
+        "info": {},
+        "observation": {
+          "remainingOverageTime": 12,
+          "step": 0
+        },
+        "reward": 0.0,
+        "status": "ACTIVE"
+      },
+      {
+        "action": {
+          "submission": -1
+        },
+        "info": {},
+        "observation": {
+          "remainingOverageTime": 12
+        },
+        "reward": 0.0,
+        "status": "ACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "actionString": null,
+          "generate_returns": [],
+          "status": "OK; Setup step; model not called.",
+          "submission": -1,
+          "thoughts": null
+        },
+        "info": {},
+        "observation": {
+          "currentPlayer": 1,
+          "isTerminal": false,
+          "observationString": "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1",
+          "playerId": 0,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n\n\n",
+          "step": 1
+        },
+        "reward": null,
+        "status": "INACTIVE"
+      },
+      {
+        "action": {
+          "actionString": null,
+          "generate_returns": [],
+          "status": "OK; Setup step; model not called.",
+          "submission": -1,
+          "thoughts": null
+        },
+        "info": {
+          "actionApplied": null,
+          "actionSubmitted": null,
+          "actionSubmittedToString": null,
+          "agentSelfReportedStatus": "OK; Setup step; model not called.",
+          "timeTaken": null
+        },
+        "observation": {
+          "currentPlayer": 1,
+          "isTerminal": false,
+          "observationString": "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1",
+          "playerId": 1,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n\n\n"
+        },
+        "reward": null,
+        "status": "ACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "submission": -1
+        },
+        "info": {},
+        "observation": {
+          "currentPlayer": 0,
+          "isTerminal": false,
+          "observationString": "rnbqkbnr/pppppppp/8/8/4P3/8/PPPP1PPP/RNBQKBNR b KQkq - 0 1",
+          "playerId": 0,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n\n",
+          "step": 2
+        },
+        "reward": null,
+        "status": "ACTIVE"
+      },
+      {
+        "action": {
+          "actionString": "e4",
+          "generate_returns": [
+            "{\n  \"main_response\": \"The game is in the initial starting position. As White, the goal is to control the center of the board, develop pieces, and prepare for king safety (castling). \\n\\nThe move 1. e4 is one of the most popular and strongest opening moves in chess. It immediately takes control of the central d5 and f5 squares, and opens lines for the rapid development of the light-squared bishop and the queen.\\n\\nFinal Answer: e4\",\n  \"main_response_and_thoughts\": \"\",\n  \"request_for_logging\": {\n    \"model\": \"google/gemini-3.1-pro-preview\",\n    \"messages\": [\n      {\n        \"role\": \"user\",\n        \"content\": [\n          {\n            \"type\": \"text\",\n            \"text\": \"Let's play chess. The current game state in Forsyth-Edwards Notation (FEN) notation is:\\nrnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1\\nThe moves played so far are:\\n1.\\nYou are playing as player White.\\nIt is now your turn. Play your strongest move. The move MUST be legal. Reason step by step to come up with your move, then output your final answer in the format \\\"Final Answer: X\\\" where X is your chosen move in standard algebraic notation (SAN).\\n\"\n          }\n        ]\n      }\n    ],\n    \"config\": {\n      \"temperature\": \"NOT_GIVEN\",\n      \"top_p\": \"NOT_GIVEN\",\n      \"max_completion_tokens\": \"NOT_GIVEN\"\n    },\n    \"stream_options\": {\n      \"include_usage\": true\n    }\n  },\n  \"response_for_logging\": {\n    \"response_chunks\": [\n      {\n        \"id\": \"fY76afvdHMudmecPmbT14Qk\",\n        \"choices\": [\n          {\n            \"delta\": {\n              \"content\": \" and the queen.\\n\\nFinal Answer: e4\",\n              \"role\": \"assistant\"\n            },\n            \"finish_reason\": \"stop\",\n            \"index\": 0\n          }\n        ],\n        \"created\": 1778028157,\n        \"model\": \"google/gemini-3.1-pro-preview\",\n        \"object\": \"chat.completion.chunk\",\n        \"usage\": {\n          \"completion_tokens\": 94,\n          \"prompt_tokens\": 128,\n          \"total_tokens\": 380,\n          \"cost\": {\n            \"input_tokens_cost_nanodollars\": 256000,\n            \"output_tokens_cost_nanodollars\": 3024000\n          },\n          \"total_backend_latency_ms\": 3384\n        }\n      }\n    ]\n  },\n  \"generation_tokens\": 94,\n  \"prompt_tokens\": 128,\n  \"reasoning_tokens\": null,\n  \"total_tokens\": 380,\n  \"duration_success_only_secs\": 4.524658100001034\n}"
+          ],
+          "status": "OK",
+          "submission": 2426,
+          "thoughts": "The game is in the initial starting position. As White, the goal is to control the center of the board, develop pieces, and prepare for king safety (castling). \n\nThe move 1. e4 is one of the most popular and strongest opening moves in chess. It immediately takes control of the central d5 and f5 squares, and opens lines for the rapid development of the light-squared bishop and the queen.\n\nFinal Answer: e4"
+        },
+        "info": {
+          "actionApplied": 2426,
+          "actionSubmitted": 2426,
+          "actionSubmittedToString": "e4",
+          "agentSelfReportedStatus": "OK",
+          "timeTaken": 5.766
+        },
+        "observation": {
+          "currentPlayer": 0,
+          "isTerminal": false,
+          "observationString": "rnbqkbnr/pppppppp/8/8/4P3/8/PPPP1PPP/RNBQKBNR b KQkq - 0 1",
+          "playerId": 1,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n\n"
+        },
+        "reward": null,
+        "status": "INACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "actionString": "c5",
+          "generate_returns": [
+            "{\n  \"main_response\": \"Final Answer: c5\",\n  \"main_response_and_thoughts\": \"\",\n  \"request_for_logging\": {\n    \"model\": \"openai/gpt-5.5-2026-04-23\",\n    \"messages\": [\n      {\n        \"role\": \"user\",\n        \"content\": [\n          {\n            \"type\": \"text\",\n            \"text\": \"Let's play chess. The current game state in Forsyth-Edwards Notation (FEN) notation is:\\nrnbqkbnr/pppppppp/8/8/4P3/8/PPPP1PPP/RNBQKBNR b KQkq - 0 1\\nThe moves played so far are:\\n1. e4\\nYou are playing as player Black.\\nIt is now your turn. Play your strongest move. The move MUST be legal. Reason step by step to come up with your move, then output your final answer in the format \\\"Final Answer: X\\\" where X is your chosen move in standard algebraic notation (SAN).\\n\"\n          }\n        ]\n      }\n    ],\n    \"config\": {\n      \"temperature\": \"NOT_GIVEN\",\n      \"top_p\": \"NOT_GIVEN\",\n      \"max_completion_tokens\": \"NOT_GIVEN\",\n      \"reasoning_effort\": \"high\"\n    },\n    \"stream_options\": {\n      \"include_usage\": true\n    }\n  },\n  \"response_for_logging\": {\n    \"response_chunks\": [\n      {\n        \"id\": \"chatcmpl-DcKdXgFLqyWglsJzBXvctOlMkbq6J\",\n        \"created\": 1778028163,\n        \"model\": \"openai/gpt-5.5-2026-04-23\",\n        \"object\": \"chat.completion.chunk\",\n        \"usage\": {\n          \"completion_tokens\": 263,\n          \"prompt_tokens\": 147,\n          \"total_tokens\": 410,\n          \"cost\": {\n            \"input_tokens_cost_nanodollars\": 735000,\n            \"output_tokens_cost_nanodollars\": 7890000\n          },\n          \"total_backend_latency_ms\": 5406\n        }\n      }\n    ]\n  },\n  \"generation_tokens\": 263,\n  \"prompt_tokens\": 147,\n  \"reasoning_tokens\": null,\n  \"total_tokens\": 410,\n  \"duration_success_only_secs\": 6.623042144001374\n}"
+          ],
+          "status": "OK",
+          "submission": 1258,
+          "thoughts": "Final Answer: c5"
+        },
+        "info": {
+          "actionApplied": 1258,
+          "actionSubmitted": 1258,
+          "actionSubmittedToString": "c5",
+          "agentSelfReportedStatus": "OK",
+          "timeTaken": 7.902
+        },
+        "observation": {
+          "currentPlayer": 1,
+          "isTerminal": false,
+          "observationString": "rnbqkbnr/pp1ppppp/8/2p5/4P3/8/PPPP1PPP/RNBQKBNR w KQkq - 0 2",
+          "playerId": 0,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n1258\n\n",
+          "step": 3
+        },
+        "reward": null,
+        "status": "INACTIVE"
+      },
+      {
+        "action": {
+          "submission": -1
+        },
+        "info": {},
+        "observation": {
+          "currentPlayer": 1,
+          "isTerminal": false,
+          "observationString": "rnbqkbnr/pp1ppppp/8/2p5/4P3/8/PPPP1PPP/RNBQKBNR w KQkq - 0 2",
+          "playerId": 1,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n1258\n\n"
+        },
+        "reward": null,
+        "status": "ACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "submission": -1
+        },
+        "info": {},
+        "observation": {
+          "currentPlayer": 0,
+          "isTerminal": false,
+          "observationString": "rnbqkbnr/pp1ppppp/8/2p5/4P3/5N2/PPPP1PPP/RNBQKB1R b KQkq - 1 2",
+          "playerId": 0,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n1258\n3572\n\n",
+          "step": 4
+        },
+        "reward": null,
+        "status": "ACTIVE"
+      },
+      {
+        "action": {
+          "actionString": "Nf3",
+          "generate_returns": [
+            "{\n  \"main_response\": \"The current position is the starting point of the Sicilian Defense, arising after the moves 1. e4 c5. \\n\\nTo challenge Black's control over the center and prepare for rapid development, White's most popular, flexible, and objectively strongest move is 2. Nf3. \\n\\nBy playing 2. Nf3, White controls the central d4 and e5 squares and prepares to strike in the center with 3. d4, opening up the position for active piece play (the \\\"Open Sicilian\\\"). It also clears the way for the light-squared bishop and kingside castling. \\n\\nOther alternatives like 2. Nc3 (Closed Sicilian) or 2. c3 (Alapin Variation) are also completely playable, but 2. Nf3 is considered the absolute main line, putting the maximum theoretical pressure on Black.\\n\\nFinal Answer: Nf3\",\n  \"main_response_and_thoughts\": \"\",\n  \"request_for_logging\": {\n    \"model\": \"google/gemini-3.1-pro-preview\",\n    \"messages\": [\n      {\n        \"role\": \"user\",\n        \"content\": [\n          {\n            \"type\": \"text\",\n            \"text\": \"Let's play chess. The current game state in Forsyth-Edwards Notation (FEN) notation is:\\nrnbqkbnr/pp1ppppp/8/2p5/4P3/8/PPPP1PPP/RNBQKBNR w KQkq - 0 2\\nThe moves played so far are:\\n1. e4 c5 2.\\nYou are playing as player White.\\nIt is now your turn. Play your strongest move. The move MUST be legal. Reason step by step to come up with your move, then output your final answer in the format \\\"Final Answer: X\\\" where X is your chosen move in standard algebraic notation (SAN).\\n\"\n          }\n        ]\n      }\n    ],\n    \"config\": {\n      \"temperature\": \"NOT_GIVEN\",\n      \"top_p\": \"NOT_GIVEN\",\n      \"max_completion_tokens\": \"NOT_GIVEN\"\n    },\n    \"stream_options\": {\n      \"include_usage\": true\n    }\n  },\n  \"response_for_logging\": {\n    \"response_chunks\": [\n      {\n        \"id\": \"io76ae-QOviMmecPq_Dk8QQ\",\n        \"choices\": [\n          {\n            \"delta\": {\n              \"content\": \" main line, putting the maximum theoretical pressure on Black.\\n\\nFinal Answer: Nf3\",\n              \"role\": \"assistant\"\n            },\n            \"finish_reason\": \"stop\",\n            \"index\": 0\n          }\n        ],\n        \"created\": 1778028170,\n        \"model\": \"google/gemini-3.1-pro-preview\",\n        \"object\": \"chat.completion.chunk\",\n        \"usage\": {\n          \"completion_tokens\": 182,\n          \"prompt_tokens\": 142,\n          \"total_tokens\": 796,\n          \"cost\": {\n            \"input_tokens_cost_nanodollars\": 284000,\n            \"output_tokens_cost_nanodollars\": 7848000\n          },\n          \"total_backend_latency_ms\": 6803\n        }\n      }\n    ]\n  },\n  \"generation_tokens\": 182,\n  \"prompt_tokens\": 142,\n  \"reasoning_tokens\": null,\n  \"total_tokens\": 796,\n  \"duration_success_only_secs\": 7.8031911270009005\n}"
+          ],
+          "status": "OK",
+          "submission": 3572,
+          "thoughts": "The current position is the starting point of the Sicilian Defense, arising after the moves 1. e4 c5. \n\nTo challenge Black's control over the center and prepare for rapid development, White's most popular, flexible, and objectively strongest move is 2. Nf3. \n\nBy playing 2. Nf3, White controls the central d4 and e5 squares and prepares to strike in the center with 3. d4, opening up the position for active piece play (the \"Open Sicilian\"). It also clears the way for the light-squared bishop and kingside castling. \n\nOther alternatives like 2. Nc3 (Closed Sicilian) or 2. c3 (Alapin Variation) are also completely playable, but 2. Nf3 is considered the absolute main line, putting the maximum theoretical pressure on Black.\n\nFinal Answer: Nf3"
+        },
+        "info": {
+          "actionApplied": 3572,
+          "actionSubmitted": 3572,
+          "actionSubmittedToString": "Nf3",
+          "agentSelfReportedStatus": "OK",
+          "timeTaken": 8.987
+        },
+        "observation": {
+          "currentPlayer": 0,
+          "isTerminal": false,
+          "observationString": "rnbqkbnr/pp1ppppp/8/2p5/4P3/5N2/PPPP1PPP/RNBQKB1R b KQkq - 1 2",
+          "playerId": 1,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n1258\n3572\n\n"
+        },
+        "reward": null,
+        "status": "INACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "actionString": "d6",
+          "generate_returns": [
+            "{\n  \"main_response\": \"Final Answer: d6\",\n  \"main_response_and_thoughts\": \"\",\n  \"request_for_logging\": {\n    \"model\": \"openai/gpt-5.5-2026-04-23\",\n    \"messages\": [\n      {\n        \"role\": \"user\",\n        \"content\": [\n          {\n            \"type\": \"text\",\n            \"text\": \"Let's play chess. The current game state in Forsyth-Edwards Notation (FEN) notation is:\\nrnbqkbnr/pp1ppppp/8/2p5/4P3/5N2/PPPP1PPP/RNBQKB1R b KQkq - 1 2\\nThe moves played so far are:\\n1. e4 c5 2. Nf3\\nYou are playing as player Black.\\nIt is now your turn. Play your strongest move. The move MUST be legal. Reason step by step to come up with your move, then output your final answer in the format \\\"Final Answer: X\\\" where X is your chosen move in standard algebraic notation (SAN).\\n\"\n          }\n        ]\n      }\n    ],\n    \"config\": {\n      \"temperature\": \"NOT_GIVEN\",\n      \"top_p\": \"NOT_GIVEN\",\n      \"max_completion_tokens\": \"NOT_GIVEN\",\n      \"reasoning_effort\": \"high\"\n    },\n    \"stream_options\": {\n      \"include_usage\": true\n    }\n  },\n  \"response_for_logging\": {\n    \"response_chunks\": [\n      {\n        \"id\": \"chatcmpl-DcKdo8XkchN1UEWgoy8jCZgv3U1UH\",\n        \"created\": 1778028180,\n        \"model\": \"openai/gpt-5.5-2026-04-23\",\n        \"object\": \"chat.completion.chunk\",\n        \"usage\": {\n          \"completion_tokens\": 526,\n          \"prompt_tokens\": 160,\n          \"total_tokens\": 686,\n          \"cost\": {\n            \"input_tokens_cost_nanodollars\": 800000,\n            \"output_tokens_cost_nanodollars\": 15780000\n          },\n          \"total_backend_latency_ms\": 9594\n        }\n      }\n    ]\n  },\n  \"generation_tokens\": 526,\n  \"prompt_tokens\": 160,\n  \"reasoning_tokens\": null,\n  \"total_tokens\": 686,\n  \"duration_success_only_secs\": 10.19640324699867\n}"
+          ],
+          "status": "OK",
+          "submission": 1841,
+          "thoughts": "Final Answer: d6"
+        },
+        "info": {
+          "actionApplied": 1841,
+          "actionSubmitted": 1841,
+          "actionSubmittedToString": "d6",
+          "agentSelfReportedStatus": "OK",
+          "timeTaken": 12.889
+        },
+        "observation": {
+          "currentPlayer": 1,
+          "isTerminal": false,
+          "observationString": "rnbqkbnr/pp2pppp/3p4/2p5/4P3/5N2/PPPP1PPP/RNBQKB1R w KQkq - 0 3",
+          "playerId": 0,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n1258\n3572\n1841\n\n",
+          "step": 5
+        },
+        "reward": null,
+        "status": "INACTIVE"
+      },
+      {
+        "action": {
+          "submission": -1
+        },
+        "info": {},
+        "observation": {
+          "currentPlayer": 1,
+          "isTerminal": false,
+          "observationString": "rnbqkbnr/pp2pppp/3p4/2p5/4P3/5N2/PPPP1PPP/RNBQKB1R w KQkq - 0 3",
+          "playerId": 1,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n1258\n3572\n1841\n\n"
+        },
+        "reward": null,
+        "status": "ACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "submission": -1
+        },
+        "info": {},
+        "observation": {
+          "currentPlayer": 0,
+          "isTerminal": false,
+          "observationString": "rnbqkbnr/pp2pppp/3p4/2p5/3PP3/5N2/PPP2PPP/RNBQKB1R b KQkq - 0 3",
+          "playerId": 0,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n1258\n3572\n1841\n1842\n\n",
+          "step": 6
+        },
+        "reward": null,
+        "status": "ACTIVE"
+      },
+      {
+        "action": {
+          "actionString": "d4",
+          "generate_returns": [
+            "{\n  \"main_response\": \"The current position is reached after the opening moves 1. e4 c5 2. Nf3 d6. This is the starting position of the traditional Open Sicilian Defense and its many variations (like the Najdorf, Dragon, Classical, and Scheveningen).\\n\\nAs White, your most principled, ambitious, and widely played move is to immediately strike at the center with your d-pawn. \\n\\n1. By playing 3. d4, you challenge Black's control of the center.\\n2. If Black plays the standard response 3... cxd4, you will recapture with 4. Nxd4, centralizing your knight on a powerful square.\\n3. This early central break opens up lines for your pieces, particularly allowing your dark-squared bishop to develop easily and opening the d-file for your queen.\\n\\nWhile 3. Bb5+ (the Moscow Variation) is also a very solid and popular alternative, 3. d4 remains the absolute main line and tests Black's setup most critically.\\n\\nFinal Answer: d4\",\n  \"main_response_and_thoughts\": \"\",\n  \"request_for_logging\": {\n    \"model\": \"google/gemini-3.1-pro-preview\",\n    \"messages\": [\n      {\n        \"role\": \"user\",\n        \"content\": [\n          {\n            \"type\": \"text\",\n            \"text\": \"Let's play chess. The current game state in Forsyth-Edwards Notation (FEN) notation is:\\nrnbqkbnr/pp2pppp/3p4/2p5/4P3/5N2/PPPP1PPP/RNBQKB1R w KQkq - 0 3\\nThe moves played so far are:\\n1. e4 c5 2. Nf3 d6 3.\\nYou are playing as player White.\\nIt is now your turn. Play your strongest move. The move MUST be legal. Reason step by step to come up with your move, then output your final answer in the format \\\"Final Answer: X\\\" where X is your chosen move in standard algebraic notation (SAN).\\n\"\n          }\n        ]\n      }\n    ],\n    \"config\": {\n      \"temperature\": \"NOT_GIVEN\",\n      \"top_p\": \"NOT_GIVEN\",\n      \"max_completion_tokens\": \"NOT_GIVEN\"\n    },\n    \"stream_options\": {\n      \"include_usage\": true\n    }\n  },\n  \"response_for_logging\": {\n    \"response_chunks\": [\n      {\n        \"id\": \"oI76aeb9IfiMmecPq_Dk8QQ\",\n        \"choices\": [\n          {\n            \"delta\": {\n              \"role\": \"assistant\"\n            },\n            \"finish_reason\": \"stop\",\n            \"index\": 0\n          }\n        ],\n        \"created\": 1778028192,\n        \"model\": \"google/gemini-3.1-pro-preview\",\n        \"object\": \"chat.completion.chunk\",\n        \"usage\": {\n          \"completion_tokens\": 219,\n          \"prompt_tokens\": 153,\n          \"total_tokens\": 922,\n          \"cost\": {\n            \"input_tokens_cost_nanodollars\": 306000,\n            \"output_tokens_cost_nanodollars\": 9228000\n          },\n          \"total_backend_latency_ms\": 8192\n        }\n      }\n    ]\n  },\n  \"generation_tokens\": 219,\n  \"prompt_tokens\": 153,\n  \"reasoning_tokens\": null,\n  \"total_tokens\": 922,\n  \"duration_success_only_secs\": 8.691450538999561\n}"
+          ],
+          "status": "OK",
+          "submission": 1842,
+          "thoughts": "The current position is reached after the opening moves 1. e4 c5 2. Nf3 d6. This is the starting position of the traditional Open Sicilian Defense and its many variations (like the Najdorf, Dragon, Classical, and Scheveningen).\n\nAs White, your most principled, ambitious, and widely played move is to immediately strike at the center with your d-pawn. \n\n1. By playing 3. d4, you challenge Black's control of the center.\n2. If Black plays the standard response 3... cxd4, you will recapture with 4. Nxd4, centralizing your knight on a powerful square.\n3. This early central break opens up lines for your pieces, particularly allowing your dark-squared bishop to develop easily and opening the d-file for your queen.\n\nWhile 3. Bb5+ (the Moscow Variation) is also a very solid and popular alternative, 3. d4 remains the absolute main line and tests Black's setup most critically.\n\nFinal Answer: d4"
+        },
+        "info": {
+          "actionApplied": 1842,
+          "actionSubmitted": 1842,
+          "actionSubmittedToString": "d4",
+          "agentSelfReportedStatus": "OK",
+          "timeTaken": 10.641
+        },
+        "observation": {
+          "currentPlayer": 0,
+          "isTerminal": false,
+          "observationString": "rnbqkbnr/pp2pppp/3p4/2p5/3PP3/5N2/PPP2PPP/RNBQKB1R b KQkq - 0 3",
+          "playerId": 1,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n1258\n3572\n1841\n1842\n\n"
+        },
+        "reward": null,
+        "status": "INACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "actionString": "cxd4",
+          "generate_returns": [
+            "{\n  \"main_response\": \"Final Answer: cxd4\",\n  \"main_response_and_thoughts\": \"\",\n  \"request_for_logging\": {\n    \"model\": \"openai/gpt-5.5-2026-04-23\",\n    \"messages\": [\n      {\n        \"role\": \"user\",\n        \"content\": [\n          {\n            \"type\": \"text\",\n            \"text\": \"Let's play chess. The current game state in Forsyth-Edwards Notation (FEN) notation is:\\nrnbqkbnr/pp2pppp/3p4/2p5/3PP3/5N2/PPP2PPP/RNBQKB1R b KQkq - 0 3\\nThe moves played so far are:\\n1. e4 c5 2. Nf3 d6 3. d4\\nYou are playing as player Black.\\nIt is now your turn. Play your strongest move. The move MUST be legal. Reason step by step to come up with your move, then output your final answer in the format \\\"Final Answer: X\\\" where X is your chosen move in standard algebraic notation (SAN).\\n\"\n          }\n        ]\n      }\n    ],\n    \"config\": {\n      \"temperature\": \"NOT_GIVEN\",\n      \"top_p\": \"NOT_GIVEN\",\n      \"max_completion_tokens\": \"NOT_GIVEN\",\n      \"reasoning_effort\": \"high\"\n    },\n    \"stream_options\": {\n      \"include_usage\": true\n    }\n  },\n  \"response_for_logging\": {\n    \"response_chunks\": [\n      {\n        \"id\": \"chatcmpl-DcKeB7LqYsWkI78bgslXreKm2Dbzz\",\n        \"created\": 1778028203,\n        \"model\": \"openai/gpt-5.5-2026-04-23\",\n        \"object\": \"chat.completion.chunk\",\n        \"usage\": {\n          \"completion_tokens\": 370,\n          \"prompt_tokens\": 167,\n          \"total_tokens\": 537,\n          \"cost\": {\n            \"input_tokens_cost_nanodollars\": 835000,\n            \"output_tokens_cost_nanodollars\": 11100000\n          },\n          \"total_backend_latency_ms\": 6284\n        }\n      }\n    ]\n  },\n  \"generation_tokens\": 370,\n  \"prompt_tokens\": 167,\n  \"reasoning_tokens\": null,\n  \"total_tokens\": 537,\n  \"duration_success_only_secs\": 6.8938458649990935\n}"
+          ],
+          "status": "OK",
+          "submission": 1431,
+          "thoughts": "Final Answer: cxd4"
+        },
+        "info": {
+          "actionApplied": 1431,
+          "actionSubmitted": 1431,
+          "actionSubmittedToString": "cxd4",
+          "agentSelfReportedStatus": "OK",
+          "timeTaken": 8.098
+        },
+        "observation": {
+          "currentPlayer": 1,
+          "isTerminal": false,
+          "observationString": "rnbqkbnr/pp2pppp/3p4/8/3pP3/5N2/PPP2PPP/RNBQKB1R w KQkq - 0 4",
+          "playerId": 0,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n1258\n3572\n1841\n1842\n1431\n\n",
+          "step": 7
+        },
+        "reward": null,
+        "status": "INACTIVE"
+      },
+      {
+        "action": {
+          "submission": -1
+        },
+        "info": {},
+        "observation": {
+          "currentPlayer": 1,
+          "isTerminal": false,
+          "observationString": "rnbqkbnr/pp2pppp/3p4/8/3pP3/5N2/PPP2PPP/RNBQKB1R w KQkq - 0 4",
+          "playerId": 1,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n1258\n3572\n1841\n1842\n1431\n\n"
+        },
+        "reward": null,
+        "status": "ACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "submission": -1
+        },
+        "info": {},
+        "observation": {
+          "currentPlayer": 0,
+          "isTerminal": false,
+          "observationString": "rnbqkbnr/pp2pppp/3p4/8/3NP3/8/PPP2PPP/RNBQKB1R b KQkq - 0 4",
+          "playerId": 0,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n1258\n3572\n1841\n1842\n1431\n3132\n\n",
+          "step": 8
+        },
+        "reward": null,
+        "status": "ACTIVE"
+      },
+      {
+        "action": {
+          "actionString": "Nxd4",
+          "generate_returns": [
+            "{\n  \"main_response\": \"To determine the best move in this position, let's analyze the current state of the game. We are playing the Open Variation of the Sicilian Defense. \\n\\nThe move order so far has been:\\n1. e4 c5 (The Sicilian Defense)\\n2. Nf3 d6 \\n3. d4 cxd4 \\n\\nBlack has just captured our central pawn on d4. To maintain our central presence, capitalize on our lead in development, and continue the most principled and challenging line of the Open Sicilian, we must recapture the pawn. \\n\\nThe most natural and strongest move here is to recapture with the knight on f3. This centralizes the knight on an active square (d4), opens lines for our queen and light-squared bishop, and prepares for further piece development like Nc3. Recapturing with the queen (4. Qxd4 - the Chekhover Variation) is playable but allows Black to gain a tempo later with ...Nc6. \\n\\nTherefore, capturing with the knight is universally regarded as the best continuation.\\n\\nFinal Answer: Nxd4\",\n  \"main_response_and_thoughts\": \"\",\n  \"request_for_logging\": {\n    \"model\": \"google/gemini-3.1-pro-preview\",\n    \"messages\": [\n      {\n        \"role\": \"user\",\n        \"content\": [\n          {\n            \"type\": \"text\",\n            \"text\": \"Let's play chess. The current game state in Forsyth-Edwards Notation (FEN) notation is:\\nrnbqkbnr/pp2pppp/3p4/8/3pP3/5N2/PPP2PPP/RNBQKB1R w KQkq - 0 4\\nThe moves played so far are:\\n1. e4 c5 2. Nf3 d6 3. d4 cxd4 4.\\nYou are playing as player White.\\nIt is now your turn. Play your strongest move. The move MUST be legal. Reason step by step to come up with your move, then output your final answer in the format \\\"Final Answer: X\\\" where X is your chosen move in standard algebraic notation (SAN).\\n\"\n          }\n        ]\n      }\n    ],\n    \"config\": {\n      \"temperature\": \"NOT_GIVEN\",\n      \"top_p\": \"NOT_GIVEN\",\n      \"max_completion_tokens\": \"NOT_GIVEN\"\n    },\n    \"stream_options\": {\n      \"include_usage\": true\n    }\n  },\n  \"response_for_logging\": {\n    \"response_chunks\": [\n      {\n        \"id\": \"s476aavvBPiMmecPq_Dk8QQ\",\n        \"choices\": [\n          {\n            \"delta\": {\n              \"content\": \" knight is universally regarded as the best continuation.\\n\\nFinal Answer: Nxd4\",\n              \"role\": \"assistant\"\n            },\n            \"finish_reason\": \"stop\",\n            \"index\": 0\n          }\n        ],\n        \"created\": 1778028211,\n        \"model\": \"google/gemini-3.1-pro-preview\",\n        \"object\": \"chat.completion.chunk\",\n        \"usage\": {\n          \"completion_tokens\": 221,\n          \"prompt_tokens\": 159,\n          \"total_tokens\": 1076,\n          \"cost\": {\n            \"input_tokens_cost_nanodollars\": 318000,\n            \"output_tokens_cost_nanodollars\": 11004000\n          },\n          \"total_backend_latency_ms\": 9253\n        }\n      }\n    ]\n  },\n  \"generation_tokens\": 221,\n  \"prompt_tokens\": 159,\n  \"reasoning_tokens\": null,\n  \"total_tokens\": 1076,\n  \"duration_success_only_secs\": 9.738709878000009\n}"
+          ],
+          "status": "OK",
+          "submission": 3132,
+          "thoughts": "To determine the best move in this position, let's analyze the current state of the game. We are playing the Open Variation of the Sicilian Defense. \n\nThe move order so far has been:\n1. e4 c5 (The Sicilian Defense)\n2. Nf3 d6 \n3. d4 cxd4 \n\nBlack has just captured our central pawn on d4. To maintain our central presence, capitalize on our lead in development, and continue the most principled and challenging line of the Open Sicilian, we must recapture the pawn. \n\nThe most natural and strongest move here is to recapture with the knight on f3. This centralizes the knight on an active square (d4), opens lines for our queen and light-squared bishop, and prepares for further piece development like Nc3. Recapturing with the queen (4. Qxd4 - the Chekhover Variation) is playable but allows Black to gain a tempo later with ...Nc6. \n\nTherefore, capturing with the knight is universally regarded as the best continuation.\n\nFinal Answer: Nxd4"
+        },
+        "info": {
+          "actionApplied": 3132,
+          "actionSubmitted": 3132,
+          "actionSubmittedToString": "Nxd4",
+          "agentSelfReportedStatus": "OK",
+          "timeTaken": 10.943
+        },
+        "observation": {
+          "currentPlayer": 0,
+          "isTerminal": false,
+          "observationString": "rnbqkbnr/pp2pppp/3p4/8/3NP3/8/PPP2PPP/RNBQKB1R b KQkq - 0 4",
+          "playerId": 1,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n1258\n3572\n1841\n1842\n1431\n3132\n\n"
+        },
+        "reward": null,
+        "status": "INACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "actionString": "Nf6",
+          "generate_returns": [
+            "{\n  \"main_response\": \"Black develops with tempo by attacking the e4 pawn and enters main Open Sicilian lines.\\n\\nFinal Answer: Nf6\",\n  \"main_response_and_thoughts\": \"\",\n  \"request_for_logging\": {\n    \"model\": \"openai/gpt-5.5-2026-04-23\",\n    \"messages\": [\n      {\n        \"role\": \"user\",\n        \"content\": [\n          {\n            \"type\": \"text\",\n            \"text\": \"Let's play chess. The current game state in Forsyth-Edwards Notation (FEN) notation is:\\nrnbqkbnr/pp2pppp/3p4/8/3NP3/8/PPP2PPP/RNBQKB1R b KQkq - 0 4\\nThe moves played so far are:\\n1. e4 c5 2. Nf3 d6 3. d4 cxd4 4. Nxd4\\nYou are playing as player Black.\\nIt is now your turn. Play your strongest move. The move MUST be legal. Reason step by step to come up with your move, then output your final answer in the format \\\"Final Answer: X\\\" where X is your chosen move in standard algebraic notation (SAN).\\n\"\n          }\n        ]\n      }\n    ],\n    \"config\": {\n      \"temperature\": \"NOT_GIVEN\",\n      \"top_p\": \"NOT_GIVEN\",\n      \"max_completion_tokens\": \"NOT_GIVEN\",\n      \"reasoning_effort\": \"high\"\n    },\n    \"stream_options\": {\n      \"include_usage\": true\n    }\n  },\n  \"response_for_logging\": {\n    \"response_chunks\": [\n      {\n        \"id\": \"chatcmpl-DcKeUABvW88QSSbKYtYEIeeShB7eU\",\n        \"created\": 1778028222,\n        \"model\": \"openai/gpt-5.5-2026-04-23\",\n        \"object\": \"chat.completion.chunk\",\n        \"usage\": {\n          \"completion_tokens\": 456,\n          \"prompt_tokens\": 172,\n          \"total_tokens\": 628,\n          \"cost\": {\n            \"input_tokens_cost_nanodollars\": 860000,\n            \"output_tokens_cost_nanodollars\": 13680000\n          },\n          \"total_backend_latency_ms\": 8223\n        }\n      }\n    ]\n  },\n  \"generation_tokens\": 456,\n  \"prompt_tokens\": 172,\n  \"reasoning_tokens\": null,\n  \"total_tokens\": 628,\n  \"duration_success_only_secs\": 9.351058370000828\n}"
+          ],
+          "status": "OK",
+          "submission": 3572,
+          "thoughts": "Black develops with tempo by attacking the e4 pawn and enters main Open Sicilian lines.\n\nFinal Answer: Nf6"
+        },
+        "info": {
+          "actionApplied": 3572,
+          "actionSubmitted": 3572,
+          "actionSubmittedToString": "Nf6",
+          "agentSelfReportedStatus": "OK",
+          "timeTaken": 10.543
+        },
+        "observation": {
+          "currentPlayer": 1,
+          "isTerminal": false,
+          "observationString": "rnbqkb1r/pp2pppp/3p1n2/8/3NP3/8/PPP2PPP/RNBQKB1R w KQkq - 1 5",
+          "playerId": 0,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n1258\n3572\n1841\n1842\n1431\n3132\n3572\n\n",
+          "step": 9
+        },
+        "reward": null,
+        "status": "INACTIVE"
+      },
+      {
+        "action": {
+          "submission": -1
+        },
+        "info": {},
+        "observation": {
+          "currentPlayer": 1,
+          "isTerminal": false,
+          "observationString": "rnbqkb1r/pp2pppp/3p1n2/8/3NP3/8/PPP2PPP/RNBQKB1R w KQkq - 1 5",
+          "playerId": 1,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n1258\n3572\n1841\n1842\n1431\n3132\n3572\n\n"
+        },
+        "reward": null,
+        "status": "ACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "submission": -1
+        },
+        "info": {},
+        "observation": {
+          "currentPlayer": 0,
+          "isTerminal": false,
+          "observationString": "rnbqkb1r/pp2pppp/3p1n2/8/3NP3/2N5/PPP2PPP/R1BQKB1R b KQkq - 2 5",
+          "playerId": 0,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n1258\n3572\n1841\n1842\n1431\n3132\n3572\n656\n\n",
+          "step": 10
+        },
+        "reward": null,
+        "status": "ACTIVE"
+      },
+      {
+        "action": {
+          "actionString": "Nc3",
+          "generate_returns": [
+            "{\n  \"main_response\": \"The current position arises from the classic Open Sicilian defense after Black attacks the e4 pawn with 4... Nf6. \\n\\nTo defend the e4 pawn and continue developing your pieces, the most principled, common, and strongest move is to bring out the queenside knight. This prepares White to face any of Black's main Sicilian setups (such as the Najdorf with 5... a6, the Dragon with 5... g6, the Classical with 5... Nc6, or the Scheveningen with 5... e6).\\n\\nStep-by-step reasoning:\\n1. Black's last move (4... Nf6) directly attacks the undefended e4 pawn.\\n2. White must respond to this threat. While moves like 5. f3 or 5. Bd3 technically defend the pawn, 5. Nc3 is by far the most natural and optimal move.\\n3. 5. Nc3 develops a piece to its best square, centralizes control, strictly defends e4, and keeps White's options flexible for various attacking formations (like the English Attack with Be3/f3, or the main line classical setups with Be2/Bg5). \\n\\nFinal Answer: Nc3\",\n  \"main_response_and_thoughts\": \"\",\n  \"request_for_logging\": {\n    \"model\": \"google/gemini-3.1-pro-preview\",\n    \"messages\": [\n      {\n        \"role\": \"user\",\n        \"content\": [\n          {\n            \"type\": \"text\",\n            \"text\": \"Let's play chess. The current game state in Forsyth-Edwards Notation (FEN) notation is:\\nrnbqkb1r/pp2pppp/3p1n2/8/3NP3/8/PPP2PPP/RNBQKB1R w KQkq - 1 5\\nThe moves played so far are:\\n1. e4 c5 2. Nf3 d6 3. d4 cxd4 4. Nxd4 Nf6 5.\\nYou are playing as player White.\\nIt is now your turn. Play your strongest move. The move MUST be legal. Reason step by step to come up with your move, then output your final answer in the format \\\"Final Answer: X\\\" where X is your chosen move in standard algebraic notation (SAN).\\n\"\n          }\n        ]\n      }\n    ],\n    \"config\": {\n      \"temperature\": \"NOT_GIVEN\",\n      \"top_p\": \"NOT_GIVEN\",\n      \"max_completion_tokens\": \"NOT_GIVEN\"\n    },\n    \"stream_options\": {\n      \"include_usage\": true\n    }\n  },\n  \"response_for_logging\": {\n    \"response_chunks\": [\n      {\n        \"id\": \"yI76acebJauEm9IP2rm86QE\",\n        \"choices\": [\n          {\n            \"delta\": {\n              \"content\": \" or the main line classical setups with Be2/Bg5). \\n\\nFinal Answer: Nc3\",\n              \"role\": \"assistant\"\n            },\n            \"finish_reason\": \"stop\",\n            \"index\": 0\n          }\n        ],\n        \"created\": 1778028232,\n        \"model\": \"google/gemini-3.1-pro-preview\",\n        \"object\": \"chat.completion.chunk\",\n        \"usage\": {\n          \"completion_tokens\": 255,\n          \"prompt_tokens\": 167,\n          \"total_tokens\": 1095,\n          \"cost\": {\n            \"input_tokens_cost_nanodollars\": 334000,\n            \"output_tokens_cost_nanodollars\": 11136000\n          },\n          \"total_backend_latency_ms\": 8865\n        }\n      }\n    ]\n  },\n  \"generation_tokens\": 255,\n  \"prompt_tokens\": 167,\n  \"reasoning_tokens\": null,\n  \"total_tokens\": 1095,\n  \"duration_success_only_secs\": 9.339241691999632\n}"
+          ],
+          "status": "OK",
+          "submission": 656,
+          "thoughts": "The current position arises from the classic Open Sicilian defense after Black attacks the e4 pawn with 4... Nf6. \n\nTo defend the e4 pawn and continue developing your pieces, the most principled, common, and strongest move is to bring out the queenside knight. This prepares White to face any of Black's main Sicilian setups (such as the Najdorf with 5... a6, the Dragon with 5... g6, the Classical with 5... Nc6, or the Scheveningen with 5... e6).\n\nStep-by-step reasoning:\n1. Black's last move (4... Nf6) directly attacks the undefended e4 pawn.\n2. White must respond to this threat. While moves like 5. f3 or 5. Bd3 technically defend the pawn, 5. Nc3 is by far the most natural and optimal move.\n3. 5. Nc3 develops a piece to its best square, centralizes control, strictly defends e4, and keeps White's options flexible for various attacking formations (like the English Attack with Be3/f3, or the main line classical setups with Be2/Bg5). \n\nFinal Answer: Nc3"
+        },
+        "info": {
+          "actionApplied": 656,
+          "actionSubmitted": 656,
+          "actionSubmittedToString": "Nc3",
+          "agentSelfReportedStatus": "OK",
+          "timeTaken": 11.024
+        },
+        "observation": {
+          "currentPlayer": 0,
+          "isTerminal": false,
+          "observationString": "rnbqkb1r/pp2pppp/3p1n2/8/3NP3/2N5/PPP2PPP/R1BQKB1R b KQkq - 2 5",
+          "playerId": 1,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n1258\n3572\n1841\n1842\n1431\n3132\n3572\n656\n\n"
+        },
+        "reward": null,
+        "status": "INACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "actionString": "a6",
+          "generate_returns": [
+            "{\n  \"main_response\": \"Final Answer: a6\",\n  \"main_response_and_thoughts\": \"\",\n  \"request_for_logging\": {\n    \"model\": \"openai/gpt-5.5-2026-04-23\",\n    \"messages\": [\n      {\n        \"role\": \"user\",\n        \"content\": [\n          {\n            \"type\": \"text\",\n            \"text\": \"Let's play chess. The current game state in Forsyth-Edwards Notation (FEN) notation is:\\nrnbqkb1r/pp2pppp/3p1n2/8/3NP3/2N5/PPP2PPP/R1BQKB1R b KQkq - 2 5\\nThe moves played so far are:\\n1. e4 c5 2. Nf3 d6 3. d4 cxd4 4. Nxd4 Nf6 5. Nc3\\nYou are playing as player Black.\\nIt is now your turn. Play your strongest move. The move MUST be legal. Reason step by step to come up with your move, then output your final answer in the format \\\"Final Answer: X\\\" where X is your chosen move in standard algebraic notation (SAN).\\n\"\n          }\n        ]\n      }\n    ],\n    \"config\": {\n      \"temperature\": \"NOT_GIVEN\",\n      \"top_p\": \"NOT_GIVEN\",\n      \"max_completion_tokens\": \"NOT_GIVEN\",\n      \"reasoning_effort\": \"high\"\n    },\n    \"stream_options\": {\n      \"include_usage\": true\n    }\n  },\n  \"response_for_logging\": {\n    \"response_chunks\": [\n      {\n        \"id\": \"chatcmpl-DcKepVmDSDzARb3La6rHF0o2qTi0Q\",\n        \"created\": 1778028243,\n        \"model\": \"openai/gpt-5.5-2026-04-23\",\n        \"object\": \"chat.completion.chunk\",\n        \"usage\": {\n          \"completion_tokens\": 309,\n          \"prompt_tokens\": 184,\n          \"total_tokens\": 493,\n          \"cost\": {\n            \"input_tokens_cost_nanodollars\": 920000,\n            \"output_tokens_cost_nanodollars\": 9270000\n          },\n          \"total_backend_latency_ms\": 4888\n        }\n      }\n    ]\n  },\n  \"generation_tokens\": 309,\n  \"prompt_tokens\": 184,\n  \"reasoning_tokens\": null,\n  \"total_tokens\": 493,\n  \"duration_success_only_secs\": 5.577456321001591\n}"
+          ],
+          "status": "OK",
+          "submission": 89,
+          "thoughts": "Final Answer: a6"
+        },
+        "info": {
+          "actionApplied": 89,
+          "actionSubmitted": 89,
+          "actionSubmittedToString": "a6",
+          "agentSelfReportedStatus": "OK",
+          "timeTaken": 6.751
+        },
+        "observation": {
+          "currentPlayer": 1,
+          "isTerminal": false,
+          "observationString": "rnbqkb1r/1p2pppp/p2p1n2/8/3NP3/2N5/PPP2PPP/R1BQKB1R w KQkq - 0 6",
+          "playerId": 0,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n1258\n3572\n1841\n1842\n1431\n3132\n3572\n656\n89\n\n",
+          "step": 11
+        },
+        "reward": null,
+        "status": "INACTIVE"
+      },
+      {
+        "action": {
+          "submission": -1
+        },
+        "info": {},
+        "observation": {
+          "currentPlayer": 1,
+          "isTerminal": false,
+          "observationString": "rnbqkb1r/1p2pppp/p2p1n2/8/3NP3/2N5/PPP2PPP/R1BQKB1R w KQkq - 0 6",
+          "playerId": 1,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n1258\n3572\n1841\n1842\n1431\n3132\n3572\n656\n89\n\n"
+        },
+        "reward": null,
+        "status": "ACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "submission": -1
+        },
+        "info": {},
+        "observation": {
+          "currentPlayer": 0,
+          "isTerminal": false,
+          "observationString": "rnbqkb1r/1p2pppp/p2p1n2/6B1/3NP3/2N5/PPP2PPP/R2QKB1R b KQkq - 1 6",
+          "playerId": 0,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n1258\n3572\n1841\n1842\n1431\n3132\n3572\n656\n89\n1215\n\n",
+          "step": 12
+        },
+        "reward": null,
+        "status": "ACTIVE"
+      },
+      {
+        "action": {
+          "actionString": "Bg5",
+          "generate_returns": [
+            "{\n  \"main_response\": \"The current position is the starting position of the famous Najdorf Variation in the Sicilian Defense, reached after 1. e4 c5 2. Nf3 d6 3. d4 cxd4 4. Nxd4 Nf6 5. Nc3 a6. \\n\\nAt this juncture, White has several very strong and established theoretical options, including 6. Be3 (the English Attack), 6. Be2 (the Opocensky Variation), 6. Bc4 (the Fischer-Sozin Attack), and 6. h3 (the Adams Attack). \\n\\nHowever, the most classical and arguably the most forcing main-line approach is 6. Bg5. By developing the bishop to g5, White puts immediate pressure on the knight at f6, preparing to meet 6... e6 with 7. f4, gaining space and threatening to push e4-e5. This move leads to extremely sharp and rich positions (such as the Poisoned Pawn Variation or the Old Main Line) and has been a favorite of legendary attacking players throughout chess history.\\n\\nFinal Answer: Bg5\",\n  \"main_response_and_thoughts\": \"\",\n  \"request_for_logging\": {\n    \"model\": \"google/gemini-3.1-pro-preview\",\n    \"messages\": [\n      {\n        \"role\": \"user\",\n        \"content\": [\n          {\n            \"type\": \"text\",\n            \"text\": \"Let's play chess. The current game state in Forsyth-Edwards Notation (FEN) notation is:\\nrnbqkb1r/1p2pppp/p2p1n2/8/3NP3/2N5/PPP2PPP/R1BQKB1R w KQkq - 0 6\\nThe moves played so far are:\\n1. e4 c5 2. Nf3 d6 3. d4 cxd4 4. Nxd4 Nf6 5. Nc3 a6 6.\\nYou are playing as player White.\\nIt is now your turn. Play your strongest move. The move MUST be legal. Reason step by step to come up with your move, then output your final answer in the format \\\"Final Answer: X\\\" where X is your chosen move in standard algebraic notation (SAN).\\n\"\n          }\n        ]\n      }\n    ],\n    \"config\": {\n      \"temperature\": \"NOT_GIVEN\",\n      \"top_p\": \"NOT_GIVEN\",\n      \"max_completion_tokens\": \"NOT_GIVEN\"\n    },\n    \"stream_options\": {\n      \"include_usage\": true\n    }\n  },\n  \"response_for_logging\": {\n    \"response_chunks\": [\n      {\n        \"id\": \"2o76afTpFPiMmecPq_Dk8QQ\",\n        \"choices\": [\n          {\n            \"delta\": {\n              \"content\": \" the Old Main Line) and has been a favorite of legendary attacking players throughout chess history.\\n\\nFinal Answer: Bg5\",\n              \"role\": \"assistant\"\n            },\n            \"finish_reason\": \"stop\",\n            \"index\": 0\n          }\n        ],\n        \"created\": 1778028250,\n        \"model\": \"google/gemini-3.1-pro-preview\",\n        \"object\": \"chat.completion.chunk\",\n        \"usage\": {\n          \"completion_tokens\": 230,\n          \"prompt_tokens\": 179,\n          \"total_tokens\": 1521,\n          \"cost\": {\n            \"input_tokens_cost_nanodollars\": 358000,\n            \"output_tokens_cost_nanodollars\": 16104000\n          },\n          \"total_backend_latency_ms\": 12694\n        }\n      }\n    ]\n  },\n  \"generation_tokens\": 230,\n  \"prompt_tokens\": 179,\n  \"reasoning_tokens\": null,\n  \"total_tokens\": 1521,\n  \"duration_success_only_secs\": 13.168864749000932\n}"
+          ],
+          "status": "OK",
+          "submission": 1215,
+          "thoughts": "The current position is the starting position of the famous Najdorf Variation in the Sicilian Defense, reached after 1. e4 c5 2. Nf3 d6 3. d4 cxd4 4. Nxd4 Nf6 5. Nc3 a6. \n\nAt this juncture, White has several very strong and established theoretical options, including 6. Be3 (the English Attack), 6. Be2 (the Opocensky Variation), 6. Bc4 (the Fischer-Sozin Attack), and 6. h3 (the Adams Attack). \n\nHowever, the most classical and arguably the most forcing main-line approach is 6. Bg5. By developing the bishop to g5, White puts immediate pressure on the knight at f6, preparing to meet 6... e6 with 7. f4, gaining space and threatening to push e4-e5. This move leads to extremely sharp and rich positions (such as the Poisoned Pawn Variation or the Old Main Line) and has been a favorite of legendary attacking players throughout chess history.\n\nFinal Answer: Bg5"
+        },
+        "info": {
+          "actionApplied": 1215,
+          "actionSubmitted": 1215,
+          "actionSubmittedToString": "Bg5",
+          "agentSelfReportedStatus": "OK",
+          "timeTaken": 14.31
+        },
+        "observation": {
+          "currentPlayer": 0,
+          "isTerminal": false,
+          "observationString": "rnbqkb1r/1p2pppp/p2p1n2/6B1/3NP3/2N5/PPP2PPP/R2QKB1R b KQkq - 1 6",
+          "playerId": 1,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n1258\n3572\n1841\n1842\n1431\n3132\n3572\n656\n89\n1215\n\n"
+        },
+        "reward": null,
+        "status": "INACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "actionString": "e6",
+          "generate_returns": [
+            "{\n  \"main_response\": \"6...e6 is the strongest and most theoretically established move here, entering the main lines of the Najdorf. It reinforces d5, prepares ...Be7, and keeps Black\\u2019s structure flexible while challenging White\\u2019s Bg5 setup.\\n\\nFinal Answer: e6\",\n  \"main_response_and_thoughts\": \"\",\n  \"request_for_logging\": {\n    \"model\": \"openai/gpt-5.5-2026-04-23\",\n    \"messages\": [\n      {\n        \"role\": \"user\",\n        \"content\": [\n          {\n            \"type\": \"text\",\n            \"text\": \"Let's play chess. The current game state in Forsyth-Edwards Notation (FEN) notation is:\\nrnbqkb1r/1p2pppp/p2p1n2/6B1/3NP3/2N5/PPP2PPP/R2QKB1R b KQkq - 1 6\\nThe moves played so far are:\\n1. e4 c5 2. Nf3 d6 3. d4 cxd4 4. Nxd4 Nf6 5. Nc3 a6 6. Bg5\\nYou are playing as player Black.\\nIt is now your turn. Play your strongest move. The move MUST be legal. Reason step by step to come up with your move, then output your final answer in the format \\\"Final Answer: X\\\" where X is your chosen move in standard algebraic notation (SAN).\\n\"\n          }\n        ]\n      }\n    ],\n    \"config\": {\n      \"temperature\": \"NOT_GIVEN\",\n      \"top_p\": \"NOT_GIVEN\",\n      \"max_completion_tokens\": \"NOT_GIVEN\",\n      \"reasoning_effort\": \"high\"\n    },\n    \"stream_options\": {\n      \"include_usage\": true\n    }\n  },\n  \"response_for_logging\": {\n    \"response_chunks\": [\n      {\n        \"id\": \"chatcmpl-DcKfBUEa7wYUTPrKtdtF3tD5G9wmN\",\n        \"created\": 1778028265,\n        \"model\": \"openai/gpt-5.5-2026-04-23\",\n        \"object\": \"chat.completion.chunk\",\n        \"usage\": {\n          \"completion_tokens\": 373,\n          \"prompt_tokens\": 194,\n          \"total_tokens\": 567,\n          \"cost\": {\n            \"input_tokens_cost_nanodollars\": 970000,\n            \"output_tokens_cost_nanodollars\": 11190000\n          },\n          \"total_backend_latency_ms\": 6497\n        }\n      }\n    ]\n  },\n  \"generation_tokens\": 373,\n  \"prompt_tokens\": 194,\n  \"reasoning_tokens\": null,\n  \"total_tokens\": 567,\n  \"duration_success_only_secs\": 6.9615453139995225\n}"
+          ],
+          "status": "OK",
+          "submission": 2425,
+          "thoughts": "6...e6 is the strongest and most theoretically established move here, entering the main lines of the Najdorf. It reinforces d5, prepares ...Be7, and keeps Black\u2019s structure flexible while challenging White\u2019s Bg5 setup.\n\nFinal Answer: e6"
+        },
+        "info": {
+          "actionApplied": 2425,
+          "actionSubmitted": 2425,
+          "actionSubmittedToString": "e6",
+          "agentSelfReportedStatus": "OK",
+          "timeTaken": 9.109
+        },
+        "observation": {
+          "currentPlayer": 1,
+          "isTerminal": false,
+          "observationString": "rnbqkb1r/1p3ppp/p2ppn2/6B1/3NP3/2N5/PPP2PPP/R2QKB1R w KQkq - 0 7",
+          "playerId": 0,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n1258\n3572\n1841\n1842\n1431\n3132\n3572\n656\n89\n1215\n2425\n\n",
+          "step": 13
+        },
+        "reward": null,
+        "status": "INACTIVE"
+      },
+      {
+        "action": {
+          "submission": -1
+        },
+        "info": {},
+        "observation": {
+          "currentPlayer": 1,
+          "isTerminal": false,
+          "observationString": "rnbqkb1r/1p3ppp/p2ppn2/6B1/3NP3/2N5/PPP2PPP/R2QKB1R w KQkq - 0 7",
+          "playerId": 1,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n1258\n3572\n1841\n1842\n1431\n3132\n3572\n656\n89\n1215\n2425\n\n"
+        },
+        "reward": null,
+        "status": "ACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "submission": -1
+        },
+        "info": {},
+        "observation": {
+          "currentPlayer": 0,
+          "isTerminal": false,
+          "observationString": "rnbqkb1r/1p3ppp/p2ppn2/6B1/3NPP2/2N5/PPP3PP/R2QKB1R b KQkq - 0 7",
+          "playerId": 0,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n1258\n3572\n1841\n1842\n1431\n3132\n3572\n656\n89\n1215\n2425\n3010\n\n",
+          "step": 14
+        },
+        "reward": null,
+        "status": "ACTIVE"
+      },
+      {
+        "action": {
+          "actionString": "f4",
+          "generate_returns": [
+            "{\n  \"main_response\": \"The current position is one of the most thoroughly analyzed and famous tabiyas in chess theory: the main line of the Sicilian Defense, Najdorf Variation (6. Bg5 e6). \\n\\nIn this sharp and complex opening, White has developed aggressively to challenge Black's setup. The most principled, theoretically challenging, and historically strongest move here is **7. f4**.\\n\\nHere's a breakdown of why this is the best move:\\n1. **Central Control and Space:** By pushing the f-pawn, White bolsters the e4 pawn and grabs more space in the center and on the kingside.\\n2. **Immediate Threat:** It prepares the immediate threat of pushing `e5`, which would attack the pinned knight on f6. Black is forced to respond accurately to prevent this (usually with moves like 7... Be7, 7... Qb6, 7... Nbd7, or 7... b5).\\n3. **Attacking Potential:** 7. f4 sets the stage for a vicious kingside attack. It opens the f-file for the rook once White castles (often queenside in these lines) and prepares to swing the Queen into the attack with moves like Qf3. \\n\\nThis move has been the standard main line for decades, championed by attacking legends like Bobby Fischer and Garry Kasparov, and remains the top choice of modern chess engines.\\n\\nFinal Answer: f4\",\n  \"main_response_and_thoughts\": \"\",\n  \"request_for_logging\": {\n    \"model\": \"google/gemini-3.1-pro-preview\",\n    \"messages\": [\n      {\n        \"role\": \"user\",\n        \"content\": [\n          {\n            \"type\": \"text\",\n            \"text\": \"Let's play chess. The current game state in Forsyth-Edwards Notation (FEN) notation is:\\nrnbqkb1r/1p3ppp/p2ppn2/6B1/3NP3/2N5/PPP2PPP/R2QKB1R w KQkq - 0 7\\nThe moves played so far are:\\n1. e4 c5 2. Nf3 d6 3. d4 cxd4 4. Nxd4 Nf6 5. Nc3 a6 6. Bg5 e6 7.\\nYou are playing as player White.\\nIt is now your turn. Play your strongest move. The move MUST be legal. Reason step by step to come up with your move, then output your final answer in the format \\\"Final Answer: X\\\" where X is your chosen move in standard algebraic notation (SAN).\\n\"\n          }\n        ]\n      }\n    ],\n    \"config\": {\n      \"temperature\": \"NOT_GIVEN\",\n      \"top_p\": \"NOT_GIVEN\",\n      \"max_completion_tokens\": \"NOT_GIVEN\"\n    },\n    \"stream_options\": {\n      \"include_usage\": true\n    }\n  },\n  \"response_for_logging\": {\n    \"response_chunks\": [\n      {\n        \"id\": \"8Y76ab21LdCfmecP0erHwQ0\",\n        \"choices\": [\n          {\n            \"delta\": {\n              \"content\": \" chess engines.\\n\\nFinal Answer: f4\",\n              \"role\": \"assistant\"\n            },\n            \"finish_reason\": \"stop\",\n            \"index\": 0\n          }\n        ],\n        \"created\": 1778028273,\n        \"model\": \"google/gemini-3.1-pro-preview\",\n        \"object\": \"chat.completion.chunk\",\n        \"usage\": {\n          \"completion_tokens\": 294,\n          \"prompt_tokens\": 187,\n          \"total_tokens\": 1543,\n          \"cost\": {\n            \"input_tokens_cost_nanodollars\": 374000,\n            \"output_tokens_cost_nanodollars\": 16272000\n          },\n          \"total_backend_latency_ms\": 13438\n        }\n      }\n    ]\n  },\n  \"generation_tokens\": 294,\n  \"prompt_tokens\": 187,\n  \"reasoning_tokens\": null,\n  \"total_tokens\": 1543,\n  \"duration_success_only_secs\": 13.940120528000989\n}"
+          ],
+          "status": "OK",
+          "submission": 3010,
+          "thoughts": "The current position is one of the most thoroughly analyzed and famous tabiyas in chess theory: the main line of the Sicilian Defense, Najdorf Variation (6. Bg5 e6). \n\nIn this sharp and complex opening, White has developed aggressively to challenge Black's setup. The most principled, theoretically challenging, and historically strongest move here is **7. f4**.\n\nHere's a breakdown of why this is the best move:\n1. **Central Control and Space:** By pushing the f-pawn, White bolsters the e4 pawn and grabs more space in the center and on the kingside.\n2. **Immediate Threat:** It prepares the immediate threat of pushing `e5`, which would attack the pinned knight on f6. Black is forced to respond accurately to prevent this (usually with moves like 7... Be7, 7... Qb6, 7... Nbd7, or 7... b5).\n3. **Attacking Potential:** 7. f4 sets the stage for a vicious kingside attack. It opens the f-file for the rook once White castles (often queenside in these lines) and prepares to swing the Queen into the attack with moves like Qf3. \n\nThis move has been the standard main line for decades, championed by attacking legends like Bobby Fischer and Garry Kasparov, and remains the top choice of modern chess engines.\n\nFinal Answer: f4"
+        },
+        "info": {
+          "actionApplied": 3010,
+          "actionSubmitted": 3010,
+          "actionSubmittedToString": "f4",
+          "agentSelfReportedStatus": "OK",
+          "timeTaken": 15.593
+        },
+        "observation": {
+          "currentPlayer": 0,
+          "isTerminal": false,
+          "observationString": "rnbqkb1r/1p3ppp/p2ppn2/6B1/3NPP2/2N5/PPP3PP/R2QKB1R b KQkq - 0 7",
+          "playerId": 1,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n1258\n3572\n1841\n1842\n1431\n3132\n3572\n656\n89\n1215\n2425\n3010\n\n"
+        },
+        "reward": null,
+        "status": "INACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "actionString": "Qb6",
+          "generate_returns": [
+            "{\n  \"main_response\": \"Final Answer: Qb6\",\n  \"main_response_and_thoughts\": \"\",\n  \"request_for_logging\": {\n    \"model\": \"openai/gpt-5.5-2026-04-23\",\n    \"messages\": [\n      {\n        \"role\": \"user\",\n        \"content\": [\n          {\n            \"type\": \"text\",\n            \"text\": \"Let's play chess. The current game state in Forsyth-Edwards Notation (FEN) notation is:\\nrnbqkb1r/1p3ppp/p2ppn2/6B1/3NPP2/2N5/PPP3PP/R2QKB1R b KQkq - 0 7\\nThe moves played so far are:\\n1. e4 c5 2. Nf3 d6 3. d4 cxd4 4. Nxd4 Nf6 5. Nc3 a6 6. Bg5 e6 7. f4\\nYou are playing as player Black.\\nIt is now your turn. Play your strongest move. The move MUST be legal. Reason step by step to come up with your move, then output your final answer in the format \\\"Final Answer: X\\\" where X is your chosen move in standard algebraic notation (SAN).\\n\"\n          }\n        ]\n      }\n    ],\n    \"config\": {\n      \"temperature\": \"NOT_GIVEN\",\n      \"top_p\": \"NOT_GIVEN\",\n      \"max_completion_tokens\": \"NOT_GIVEN\",\n      \"reasoning_effort\": \"high\"\n    },\n    \"stream_options\": {\n      \"include_usage\": true\n    }\n  },\n  \"response_for_logging\": {\n    \"response_chunks\": [\n      {\n        \"id\": \"chatcmpl-DcKfZcWWD4UaHFM8zO1PlPO5RAtBV\",\n        \"created\": 1778028289,\n        \"model\": \"openai/gpt-5.5-2026-04-23\",\n        \"object\": \"chat.completion.chunk\",\n        \"usage\": {\n          \"completion_tokens\": 1045,\n          \"prompt_tokens\": 201,\n          \"total_tokens\": 1246,\n          \"cost\": {\n            \"input_tokens_cost_nanodollars\": 1005000,\n            \"output_tokens_cost_nanodollars\": 31350000\n          },\n          \"total_backend_latency_ms\": 17583\n        }\n      }\n    ]\n  },\n  \"generation_tokens\": 1045,\n  \"prompt_tokens\": 201,\n  \"reasoning_tokens\": null,\n  \"total_tokens\": 1246,\n  \"duration_success_only_secs\": 18.246313145000386\n}"
+          ],
+          "status": "OK",
+          "submission": 1808,
+          "thoughts": "Final Answer: Qb6"
+        },
+        "info": {
+          "actionApplied": 1808,
+          "actionSubmitted": 1808,
+          "actionSubmittedToString": "Qb6",
+          "agentSelfReportedStatus": "OK",
+          "timeTaken": 19.945
+        },
+        "observation": {
+          "currentPlayer": 1,
+          "isTerminal": false,
+          "observationString": "rnb1kb1r/1p3ppp/pq1ppn2/6B1/3NPP2/2N5/PPP3PP/R2QKB1R w KQkq - 1 8",
+          "playerId": 0,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n1258\n3572\n1841\n1842\n1431\n3132\n3572\n656\n89\n1215\n2425\n3010\n1808\n\n",
+          "step": 15
+        },
+        "reward": null,
+        "status": "INACTIVE"
+      },
+      {
+        "action": {
+          "submission": -1
+        },
+        "info": {},
+        "observation": {
+          "currentPlayer": 1,
+          "isTerminal": false,
+          "observationString": "rnb1kb1r/1p3ppp/pq1ppn2/6B1/3NPP2/2N5/PPP3PP/R2QKB1R w KQkq - 1 8",
+          "playerId": 1,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n1258\n3572\n1841\n1842\n1431\n3132\n3572\n656\n89\n1215\n2425\n3010\n1808\n\n"
+        },
+        "reward": null,
+        "status": "ACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "submission": -1
+        },
+        "info": {},
+        "observation": {
+          "currentPlayer": 0,
+          "isTerminal": false,
+          "observationString": "rnb1kb1r/1p3ppp/pq1ppn2/6B1/3NPP2/2N5/PPPQ2PP/R3KB1R b KQkq - 2 8",
+          "playerId": 0,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n1258\n3572\n1841\n1842\n1431\n3132\n3572\n656\n89\n1215\n2425\n3010\n1808\n1768\n\n",
+          "step": 16
+        },
+        "reward": null,
+        "status": "ACTIVE"
+      },
+      {
+        "action": {
+          "actionString": "Qd2",
+          "generate_returns": [
+            "{\n  \"main_response\": \"The current position is a well-known theoretical crossroads in the Sicilian Defense, Najdorf Variation. Black has played 7... Qb6, immediately attacking the b2 pawn and pressuring the d4 knight. This leads to the infamous \\\"Poisoned Pawn\\\" variation.\\n\\nWhite's most aggressive, principally sound, and theoretically critical move is to offer the b2 pawn as a sacrifice to accelerate development and seize the initiative. \\n\\nBy playing 8. Qd2, White defends the knight on d4 and prepares to meet 8... Qxb2 with 9. Rb1, trapping the black queen if she is not careful and opening lines against Black's underdeveloped kingside. It forces a highly complex and deeply analyzed tactical battle where White gains massive compensation in the form of rapid piece activity and central control in exchange for the pawn.\\n\\nFinal Answer: Qd2\",\n  \"main_response_and_thoughts\": \"\",\n  \"request_for_logging\": {\n    \"model\": \"google/gemini-3.1-pro-preview\",\n    \"messages\": [\n      {\n        \"role\": \"user\",\n        \"content\": [\n          {\n            \"type\": \"text\",\n            \"text\": \"Let's play chess. The current game state in Forsyth-Edwards Notation (FEN) notation is:\\nrnb1kb1r/1p3ppp/pq1ppn2/6B1/3NPP2/2N5/PPP3PP/R2QKB1R w KQkq - 1 8\\nThe moves played so far are:\\n1. e4 c5 2. Nf3 d6 3. d4 cxd4 4. Nxd4 Nf6 5. Nc3 a6 6. Bg5 e6 7. f4 Qb6 8.\\nYou are playing as player White.\\nIt is now your turn. Play your strongest move. The move MUST be legal. Reason step by step to come up with your move, then output your final answer in the format \\\"Final Answer: X\\\" where X is your chosen move in standard algebraic notation (SAN).\\n\"\n          }\n        ]\n      }\n    ],\n    \"config\": {\n      \"temperature\": \"NOT_GIVEN\",\n      \"top_p\": \"NOT_GIVEN\",\n      \"max_completion_tokens\": \"NOT_GIVEN\"\n    },\n    \"stream_options\": {\n      \"include_usage\": true\n    }\n  },\n  \"response_for_logging\": {\n    \"response_chunks\": [\n      {\n        \"id\": \"FY_6aen3E4-SmecPifn04Ak\",\n        \"choices\": [\n          {\n            \"delta\": {\n              \"content\": \"2\",\n              \"role\": \"assistant\"\n            },\n            \"finish_reason\": \"stop\",\n            \"index\": 0\n          }\n        ],\n        \"created\": 1778028309,\n        \"model\": \"google/gemini-3.1-pro-preview\",\n        \"object\": \"chat.completion.chunk\",\n        \"usage\": {\n          \"completion_tokens\": 177,\n          \"prompt_tokens\": 195,\n          \"total_tokens\": 1142,\n          \"cost\": {\n            \"input_tokens_cost_nanodollars\": 390000,\n            \"output_tokens_cost_nanodollars\": 11364000\n          },\n          \"total_backend_latency_ms\": 9469\n        }\n      }\n    ]\n  },\n  \"generation_tokens\": 177,\n  \"prompt_tokens\": 195,\n  \"reasoning_tokens\": null,\n  \"total_tokens\": 1142,\n  \"duration_success_only_secs\": 9.95869496100022\n}"
+          ],
+          "status": "OK",
+          "submission": 1768,
+          "thoughts": "The current position is a well-known theoretical crossroads in the Sicilian Defense, Najdorf Variation. Black has played 7... Qb6, immediately attacking the b2 pawn and pressuring the d4 knight. This leads to the infamous \"Poisoned Pawn\" variation.\n\nWhite's most aggressive, principally sound, and theoretically critical move is to offer the b2 pawn as a sacrifice to accelerate development and seize the initiative. \n\nBy playing 8. Qd2, White defends the knight on d4 and prepares to meet 8... Qxb2 with 9. Rb1, trapping the black queen if she is not careful and opening lines against Black's underdeveloped kingside. It forces a highly complex and deeply analyzed tactical battle where White gains massive compensation in the form of rapid piece activity and central control in exchange for the pawn.\n\nFinal Answer: Qd2"
+        },
+        "info": {
+          "actionApplied": 1768,
+          "actionSubmitted": 1768,
+          "actionSubmittedToString": "Qd2",
+          "agentSelfReportedStatus": "OK",
+          "timeTaken": 11.159
+        },
+        "observation": {
+          "currentPlayer": 0,
+          "isTerminal": false,
+          "observationString": "rnb1kb1r/1p3ppp/pq1ppn2/6B1/3NPP2/2N5/PPPQ2PP/R3KB1R b KQkq - 2 8",
+          "playerId": 1,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n1258\n3572\n1841\n1842\n1431\n3132\n3572\n656\n89\n1215\n2425\n3010\n1808\n1768\n\n"
+        },
+        "reward": null,
+        "status": "INACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "actionString": "Qxb2",
+          "generate_returns": [
+            "{\n  \"main_response\": \"The strongest move is to enter the Najdorf Poisoned Pawn line by taking the b2-pawn. The path from b6 to b2 is clear, and Black wins a pawn while threatening the rook on a1.\\n\\nFinal Answer: Qxb2\",\n  \"main_response_and_thoughts\": \"\",\n  \"request_for_logging\": {\n    \"model\": \"openai/gpt-5.5-2026-04-23\",\n    \"messages\": [\n      {\n        \"role\": \"user\",\n        \"content\": [\n          {\n            \"type\": \"text\",\n            \"text\": \"Let's play chess. The current game state in Forsyth-Edwards Notation (FEN) notation is:\\nrnb1kb1r/1p3ppp/pq1ppn2/6B1/3NPP2/2N5/PPPQ2PP/R3KB1R b KQkq - 2 8\\nThe moves played so far are:\\n1. e4 c5 2. Nf3 d6 3. d4 cxd4 4. Nxd4 Nf6 5. Nc3 a6 6. Bg5 e6 7. f4 Qb6 8. Qd2\\nYou are playing as player Black.\\nIt is now your turn. Play your strongest move. The move MUST be legal. Reason step by step to come up with your move, then output your final answer in the format \\\"Final Answer: X\\\" where X is your chosen move in standard algebraic notation (SAN).\\n\"\n          }\n        ]\n      }\n    ],\n    \"config\": {\n      \"temperature\": \"NOT_GIVEN\",\n      \"top_p\": \"NOT_GIVEN\",\n      \"max_completion_tokens\": \"NOT_GIVEN\",\n      \"reasoning_effort\": \"high\"\n    },\n    \"stream_options\": {\n      \"include_usage\": true\n    }\n  },\n  \"response_for_logging\": {\n    \"response_chunks\": [\n      {\n        \"id\": \"chatcmpl-DcKg5PUyVsOUqzPAogCTf4atHme1Y\",\n        \"created\": 1778028321,\n        \"model\": \"openai/gpt-5.5-2026-04-23\",\n        \"object\": \"chat.completion.chunk\",\n        \"usage\": {\n          \"completion_tokens\": 1444,\n          \"prompt_tokens\": 211,\n          \"total_tokens\": 1655,\n          \"cost\": {\n            \"input_tokens_cost_nanodollars\": 1055000,\n            \"output_tokens_cost_nanodollars\": 43320000\n          },\n          \"total_backend_latency_ms\": 28371\n        }\n      }\n    ]\n  },\n  \"generation_tokens\": 1444,\n  \"prompt_tokens\": 211,\n  \"reasoning_tokens\": null,\n  \"total_tokens\": 1655,\n  \"duration_success_only_secs\": 28.899921832000473\n}"
+          ],
+          "status": "OK",
+          "submission": 749,
+          "thoughts": "The strongest move is to enter the Najdorf Poisoned Pawn line by taking the b2-pawn. The path from b6 to b2 is clear, and Black wins a pawn while threatening the rook on a1.\n\nFinal Answer: Qxb2"
+        },
+        "info": {
+          "actionApplied": 749,
+          "actionSubmitted": 749,
+          "actionSubmittedToString": "Qxb2",
+          "agentSelfReportedStatus": "OK",
+          "timeTaken": 31.595
+        },
+        "observation": {
+          "currentPlayer": 1,
+          "isTerminal": false,
+          "observationString": "rnb1kb1r/1p3ppp/p2ppn2/6B1/3NPP2/2N5/PqPQ2PP/R3KB1R w KQkq - 0 9",
+          "playerId": 0,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n1258\n3572\n1841\n1842\n1431\n3132\n3572\n656\n89\n1215\n2425\n3010\n1808\n1768\n749\n\n",
+          "step": 17
+        },
+        "reward": null,
+        "status": "INACTIVE"
+      },
+      {
+        "action": {
+          "submission": -1
+        },
+        "info": {},
+        "observation": {
+          "currentPlayer": 1,
+          "isTerminal": false,
+          "observationString": "rnb1kb1r/1p3ppp/p2ppn2/6B1/3NPP2/2N5/PqPQ2PP/R3KB1R w KQkq - 0 9",
+          "playerId": 1,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n1258\n3572\n1841\n1842\n1431\n3132\n3572\n656\n89\n1215\n2425\n3010\n1808\n1768\n749\n\n"
+        },
+        "reward": null,
+        "status": "ACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "submission": -1
+        },
+        "info": {},
+        "observation": {
+          "currentPlayer": 0,
+          "isTerminal": false,
+          "observationString": "rnb1kb1r/1p3ppp/p2ppn2/6B1/3NPP2/2N5/PqPQ2PP/1R2KB1R b Kkq - 1 9",
+          "playerId": 0,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n1258\n3572\n1841\n1842\n1431\n3132\n3572\n656\n89\n1215\n2425\n3010\n1808\n1768\n749\n30\n\n",
+          "step": 18
+        },
+        "reward": null,
+        "status": "ACTIVE"
+      },
+      {
+        "action": {
+          "actionString": "Rb1",
+          "generate_returns": [
+            "{\n  \"main_response\": \"In the current position, we are looking at the famous Poisoned Pawn Variation of the Sicilian Najdorf. Black has just captured the \\\"poisoned\\\" b2 pawn with 8... Qxb2, which simultaneously attacks White's undefended rook on a1. \\n\\nWhite's most critical, strongest, and most popular theoretical response here is to move the attacked rook to b1. This achieves two things: it moves the rook to safety and immediately counter-attacks Black's queen on b2. \\n\\nSince the b-file is now open, this rook will be excellently placed. Black is virtually forced to retreat their queen to a3 (9... Qa3) to avoid being captured and to stay active. After Black's queen retreats, White will follow up with aggressive moves (such as 10. f5, 10. Be2, or 10. e5 depending on the line) to capitalize on their massive lead in development and attacking initiative, compensating for the sacrificed pawn.\\n\\nFinal Answer: Rb1\",\n  \"main_response_and_thoughts\": \"\",\n  \"request_for_logging\": {\n    \"model\": \"google/gemini-3.1-pro-preview\",\n    \"messages\": [\n      {\n        \"role\": \"user\",\n        \"content\": [\n          {\n            \"type\": \"text\",\n            \"text\": \"Let's play chess. The current game state in Forsyth-Edwards Notation (FEN) notation is:\\nrnb1kb1r/1p3ppp/p2ppn2/6B1/3NPP2/2N5/PqPQ2PP/R3KB1R w KQkq - 0 9\\nThe moves played so far are:\\n1. e4 c5 2. Nf3 d6 3. d4 cxd4 4. Nxd4 Nf6 5. Nc3 a6 6. Bg5 e6 7. f4 Qb6 8. Qd2 Qxb2 9.\\nYou are playing as player White.\\nIt is now your turn. Play your strongest move. The move MUST be legal. Reason step by step to come up with your move, then output your final answer in the format \\\"Final Answer: X\\\" where X is your chosen move in standard algebraic notation (SAN).\\n\"\n          }\n        ]\n      }\n    ],\n    \"config\": {\n      \"temperature\": \"NOT_GIVEN\",\n      \"top_p\": \"NOT_GIVEN\",\n      \"max_completion_tokens\": \"NOT_GIVEN\"\n    },\n    \"stream_options\": {\n      \"include_usage\": true\n    }\n  },\n  \"response_for_logging\": {\n    \"response_chunks\": [\n      {\n        \"id\": \"QI_6abWUBcudmecPmbT14Qk\",\n        \"choices\": [\n          {\n            \"delta\": {\n              \"content\": \"\\n\\nFinal Answer: Rb1\",\n              \"role\": \"assistant\"\n            },\n            \"finish_reason\": \"stop\",\n            \"index\": 0\n          }\n        ],\n        \"created\": 1778028352,\n        \"model\": \"google/gemini-3.1-pro-preview\",\n        \"object\": \"chat.completion.chunk\",\n        \"usage\": {\n          \"completion_tokens\": 214,\n          \"prompt_tokens\": 203,\n          \"total_tokens\": 1623,\n          \"cost\": {\n            \"input_tokens_cost_nanodollars\": 406000,\n            \"output_tokens_cost_nanodollars\": 17040000\n          },\n          \"total_backend_latency_ms\": 14181\n        }\n      }\n    ]\n  },\n  \"generation_tokens\": 214,\n  \"prompt_tokens\": 203,\n  \"reasoning_tokens\": null,\n  \"total_tokens\": 1623,\n  \"duration_success_only_secs\": 14.642808078000598\n}"
+          ],
+          "status": "OK",
+          "submission": 30,
+          "thoughts": "In the current position, we are looking at the famous Poisoned Pawn Variation of the Sicilian Najdorf. Black has just captured the \"poisoned\" b2 pawn with 8... Qxb2, which simultaneously attacks White's undefended rook on a1. \n\nWhite's most critical, strongest, and most popular theoretical response here is to move the attacked rook to b1. This achieves two things: it moves the rook to safety and immediately counter-attacks Black's queen on b2. \n\nSince the b-file is now open, this rook will be excellently placed. Black is virtually forced to retreat their queen to a3 (9... Qa3) to avoid being captured and to stay active. After Black's queen retreats, White will follow up with aggressive moves (such as 10. f5, 10. Be2, or 10. e5 depending on the line) to capitalize on their massive lead in development and attacking initiative, compensating for the sacrificed pawn.\n\nFinal Answer: Rb1"
+        },
+        "info": {
+          "actionApplied": 30,
+          "actionSubmitted": 30,
+          "actionSubmittedToString": "Rb1",
+          "agentSelfReportedStatus": "OK",
+          "timeTaken": 15.86
+        },
+        "observation": {
+          "currentPlayer": 0,
+          "isTerminal": false,
+          "observationString": "rnb1kb1r/1p3ppp/p2ppn2/6B1/3NPP2/2N5/PqPQ2PP/1R2KB1R b Kkq - 1 9",
+          "playerId": 1,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n1258\n3572\n1841\n1842\n1431\n3132\n3572\n656\n89\n1215\n2425\n3010\n1808\n1768\n749\n30\n\n"
+        },
+        "reward": null,
+        "status": "INACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "actionString": "Qa3",
+          "generate_returns": [
+            "{\n  \"main_response\": \"Final Answer: Qa3\",\n  \"main_response_and_thoughts\": \"\",\n  \"request_for_logging\": {\n    \"model\": \"openai/gpt-5.5-2026-04-23\",\n    \"messages\": [\n      {\n        \"role\": \"user\",\n        \"content\": [\n          {\n            \"type\": \"text\",\n            \"text\": \"Let's play chess. The current game state in Forsyth-Edwards Notation (FEN) notation is:\\nrnb1kb1r/1p3ppp/p2ppn2/6B1/3NPP2/2N5/PqPQ2PP/1R2KB1R b Kkq - 1 9\\nThe moves played so far are:\\n1. e4 c5 2. Nf3 d6 3. d4 cxd4 4. Nxd4 Nf6 5. Nc3 a6 6. Bg5 e6 7. f4 Qb6 8. Qd2 Qxb2 9. Rb1\\nYou are playing as player Black.\\nIt is now your turn. Play your strongest move. The move MUST be legal. Reason step by step to come up with your move, then output your final answer in the format \\\"Final Answer: X\\\" where X is your chosen move in standard algebraic notation (SAN).\\n\"\n          }\n        ]\n      }\n    ],\n    \"config\": {\n      \"temperature\": \"NOT_GIVEN\",\n      \"top_p\": \"NOT_GIVEN\",\n      \"max_completion_tokens\": \"NOT_GIVEN\",\n      \"reasoning_effort\": \"high\"\n    },\n    \"stream_options\": {\n      \"include_usage\": true\n    }\n  },\n  \"response_for_logging\": {\n    \"response_chunks\": [\n      {\n        \"id\": \"chatcmpl-DcKgqOksrByn8q0PYVYAA0kHwA23t\",\n        \"created\": 1778028368,\n        \"model\": \"openai/gpt-5.5-2026-04-23\",\n        \"object\": \"chat.completion.chunk\",\n        \"usage\": {\n          \"completion_tokens\": 1044,\n          \"prompt_tokens\": 220,\n          \"total_tokens\": 1264,\n          \"cost\": {\n            \"input_tokens_cost_nanodollars\": 1100000,\n            \"output_tokens_cost_nanodollars\": 31320000\n          },\n          \"total_backend_latency_ms\": 20747\n        }\n      }\n    ]\n  },\n  \"generation_tokens\": 1044,\n  \"prompt_tokens\": 220,\n  \"reasoning_tokens\": null,\n  \"total_tokens\": 1264,\n  \"duration_success_only_secs\": 21.34125155500078\n}"
+          ],
+          "status": "OK",
+          "submission": 1065,
+          "thoughts": "Final Answer: Qa3"
+        },
+        "info": {
+          "actionApplied": 1065,
+          "actionSubmitted": 1065,
+          "actionSubmittedToString": "Qa3",
+          "agentSelfReportedStatus": "OK",
+          "timeTaken": 22.579
+        },
+        "observation": {
+          "currentPlayer": 1,
+          "isTerminal": false,
+          "observationString": "rnb1kb1r/1p3ppp/p2ppn2/6B1/3NPP2/q1N5/P1PQ2PP/1R2KB1R w Kkq - 2 10",
+          "playerId": 0,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n1258\n3572\n1841\n1842\n1431\n3132\n3572\n656\n89\n1215\n2425\n3010\n1808\n1768\n749\n30\n1065\n\n",
+          "step": 19
+        },
+        "reward": null,
+        "status": "INACTIVE"
+      },
+      {
+        "action": {
+          "submission": -1
+        },
+        "info": {},
+        "observation": {
+          "currentPlayer": 1,
+          "isTerminal": false,
+          "observationString": "rnb1kb1r/1p3ppp/p2ppn2/6B1/3NPP2/q1N5/P1PQ2PP/1R2KB1R w Kkq - 2 10",
+          "playerId": 1,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n1258\n3572\n1841\n1842\n1431\n3132\n3572\n656\n89\n1215\n2425\n3010\n1808\n1768\n749\n30\n1065\n\n"
+        },
+        "reward": null,
+        "status": "ACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "submission": -1
+        },
+        "info": {},
+        "observation": {
+          "currentPlayer": 0,
+          "isTerminal": false,
+          "observationString": "rnb1kb1r/1p3ppp/p2ppn2/4P1B1/3N1P2/q1N5/P1PQ2PP/1R2KB1R b Kkq - 0 10",
+          "playerId": 0,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n1258\n3572\n1841\n1842\n1431\n3132\n3572\n656\n89\n1215\n2425\n3010\n1808\n1768\n749\n30\n1065\n2571\n\n",
+          "step": 20
+        },
+        "reward": null,
+        "status": "ACTIVE"
+      },
+      {
+        "action": {
+          "actionString": "e5",
+          "generate_returns": [
+            "{\n  \"main_response\": \"In the Poisoned Pawn Variation of the Najdorf Sicilian, White has sacrificed the b2 pawn to rapidly develop their pieces, open files, and gain an initiative against the uncastled Black king. \\n\\nFrom the current position, White has several very strong and forcing options, primarily `10. e5`, `10. f5`, and `10. Be2`. \\n\\nOpting for `10. e5` immediately strikes at the center, challenging Black's setup and dislodging the knight on f6. \\nIf Black plays the expected `10... dxe5`, White responds with `11. fxe5`, forcing the knight to retreat (typically to `11... Nfd7`). This exposes Black to further aggressive ideas. From there, White often follows up with `12. Ne4`, utilizing the actively placed pieces to swarm the center and kingside before Black can catch up in development or tuck their King into safety. \\n\\nThis move directly forces the issue, capitalizing on White's massive lead in development and centralized forces.\\n\\nFinal Answer: e5\",\n  \"main_response_and_thoughts\": \"\",\n  \"request_for_logging\": {\n    \"model\": \"google/gemini-3.1-pro-preview\",\n    \"messages\": [\n      {\n        \"role\": \"user\",\n        \"content\": [\n          {\n            \"type\": \"text\",\n            \"text\": \"Let's play chess. The current game state in Forsyth-Edwards Notation (FEN) notation is:\\nrnb1kb1r/1p3ppp/p2ppn2/6B1/3NPP2/q1N5/P1PQ2PP/1R2KB1R w Kkq - 2 10\\nThe moves played so far are:\\n1. e4 c5 2. Nf3 d6 3. d4 cxd4 4. Nxd4 Nf6 5. Nc3 a6 6. Bg5 e6 7. f4 Qb6 8. Qd2 Qxb2 9. Rb1 Qa3 10.\\nYou are playing as player White.\\nIt is now your turn. Play your strongest move. The move MUST be legal. Reason step by step to come up with your move, then output your final answer in the format \\\"Final Answer: X\\\" where X is your chosen move in standard algebraic notation (SAN).\\n\"\n          }\n        ]\n      }\n    ],\n    \"config\": {\n      \"temperature\": \"NOT_GIVEN\",\n      \"top_p\": \"NOT_GIVEN\",\n      \"max_completion_tokens\": \"NOT_GIVEN\"\n    },\n    \"stream_options\": {\n      \"include_usage\": true\n    }\n  },\n  \"response_for_logging\": {\n    \"response_chunks\": [\n      {\n        \"id\": \"Zo_6afepILWKmecPxOar6Aw\",\n        \"choices\": [\n          {\n            \"delta\": {\n              \"content\": \" on White's massive lead in development and centralized forces.\\n\\nFinal Answer: e5\",\n              \"role\": \"assistant\"\n            },\n            \"finish_reason\": \"stop\",\n            \"index\": 0\n          }\n        ],\n        \"created\": 1778028390,\n        \"model\": \"google/gemini-3.1-pro-preview\",\n        \"object\": \"chat.completion.chunk\",\n        \"usage\": {\n          \"completion_tokens\": 229,\n          \"prompt_tokens\": 215,\n          \"total_tokens\": 2278,\n          \"cost\": {\n            \"input_tokens_cost_nanodollars\": 430000,\n            \"output_tokens_cost_nanodollars\": 24756000\n          },\n          \"total_backend_latency_ms\": 15935\n        }\n      }\n    ]\n  },\n  \"generation_tokens\": 229,\n  \"prompt_tokens\": 215,\n  \"reasoning_tokens\": null,\n  \"total_tokens\": 2278,\n  \"duration_success_only_secs\": 16.395325896999566\n}"
+          ],
+          "status": "OK",
+          "submission": 2571,
+          "thoughts": "In the Poisoned Pawn Variation of the Najdorf Sicilian, White has sacrificed the b2 pawn to rapidly develop their pieces, open files, and gain an initiative against the uncastled Black king. \n\nFrom the current position, White has several very strong and forcing options, primarily `10. e5`, `10. f5`, and `10. Be2`. \n\nOpting for `10. e5` immediately strikes at the center, challenging Black's setup and dislodging the knight on f6. \nIf Black plays the expected `10... dxe5`, White responds with `11. fxe5`, forcing the knight to retreat (typically to `11... Nfd7`). This exposes Black to further aggressive ideas. From there, White often follows up with `12. Ne4`, utilizing the actively placed pieces to swarm the center and kingside before Black can catch up in development or tuck their King into safety. \n\nThis move directly forces the issue, capitalizing on White's massive lead in development and centralized forces.\n\nFinal Answer: e5"
+        },
+        "info": {
+          "actionApplied": 2571,
+          "actionSubmitted": 2571,
+          "actionSubmittedToString": "e5",
+          "agentSelfReportedStatus": "OK",
+          "timeTaken": 17.615
+        },
+        "observation": {
+          "currentPlayer": 0,
+          "isTerminal": false,
+          "observationString": "rnb1kb1r/1p3ppp/p2ppn2/4P1B1/3N1P2/q1N5/P1PQ2PP/1R2KB1R b Kkq - 0 10",
+          "playerId": 1,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n1258\n3572\n1841\n1842\n1431\n3132\n3572\n656\n89\n1215\n2425\n3010\n1808\n1768\n749\n30\n1065\n2571\n\n"
+        },
+        "reward": null,
+        "status": "INACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "actionString": "dxe5",
+          "generate_returns": [
+            "{\n  \"main_response\": \"I need to address White\\u2019s advanced e5-pawn, which is attacking the knight on f6 and gaining space. The most principled move is to capture it immediately with the d-pawn, challenging White\\u2019s center and keeping Black\\u2019s Poisoned Pawn structure viable.\\n\\nFinal Answer: dxe5\",\n  \"main_response_and_thoughts\": \"\",\n  \"request_for_logging\": {\n    \"model\": \"openai/gpt-5.5-2026-04-23\",\n    \"messages\": [\n      {\n        \"role\": \"user\",\n        \"content\": [\n          {\n            \"type\": \"text\",\n            \"text\": \"Let's play chess. The current game state in Forsyth-Edwards Notation (FEN) notation is:\\nrnb1kb1r/1p3ppp/p2ppn2/4P1B1/3N1P2/q1N5/P1PQ2PP/1R2KB1R b Kkq - 0 10\\nThe moves played so far are:\\n1. e4 c5 2. Nf3 d6 3. d4 cxd4 4. Nxd4 Nf6 5. Nc3 a6 6. Bg5 e6 7. f4 Qb6 8. Qd2 Qxb2 9. Rb1 Qa3 10. e5\\nYou are playing as player Black.\\nIt is now your turn. Play your strongest move. The move MUST be legal. Reason step by step to come up with your move, then output your final answer in the format \\\"Final Answer: X\\\" where X is your chosen move in standard algebraic notation (SAN).\\n\"\n          }\n        ]\n      }\n    ],\n    \"config\": {\n      \"temperature\": \"NOT_GIVEN\",\n      \"top_p\": \"NOT_GIVEN\",\n      \"max_completion_tokens\": \"NOT_GIVEN\",\n      \"reasoning_effort\": \"high\"\n    },\n    \"stream_options\": {\n      \"include_usage\": true\n    }\n  },\n  \"response_for_logging\": {\n    \"response_chunks\": [\n      {\n        \"id\": \"chatcmpl-DcKhUULjrhBkkzqzUIJVTiWLJs2H0\",\n        \"created\": 1778028408,\n        \"model\": \"openai/gpt-5.5-2026-04-23\",\n        \"object\": \"chat.completion.chunk\",\n        \"usage\": {\n          \"completion_tokens\": 5243,\n          \"prompt_tokens\": 230,\n          \"total_tokens\": 5473,\n          \"cost\": {\n            \"input_tokens_cost_nanodollars\": 1150000,\n            \"output_tokens_cost_nanodollars\": 157290000\n          },\n          \"total_backend_latency_ms\": 91175\n        }\n      }\n    ]\n  },\n  \"generation_tokens\": 5243,\n  \"prompt_tokens\": 230,\n  \"reasoning_tokens\": null,\n  \"total_tokens\": 5473,\n  \"duration_success_only_secs\": 91.63322643600077\n}"
+          ],
+          "status": "OK",
+          "submission": 1942,
+          "thoughts": "I need to address White\u2019s advanced e5-pawn, which is attacking the knight on f6 and gaining space. The most principled move is to capture it immediately with the d-pawn, challenging White\u2019s center and keeping Black\u2019s Poisoned Pawn structure viable.\n\nFinal Answer: dxe5"
+        },
+        "info": {
+          "actionApplied": 1942,
+          "actionSubmitted": 1942,
+          "actionSubmittedToString": "dxe5",
+          "agentSelfReportedStatus": "OK",
+          "timeTaken": 93.318
+        },
+        "observation": {
+          "currentPlayer": 1,
+          "isTerminal": false,
+          "observationString": "rnb1kb1r/1p3ppp/p3pn2/4p1B1/3N1P2/q1N5/P1PQ2PP/1R2KB1R w Kkq - 0 11",
+          "playerId": 0,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n1258\n3572\n1841\n1842\n1431\n3132\n3572\n656\n89\n1215\n2425\n3010\n1808\n1768\n749\n30\n1065\n2571\n1942\n\n",
+          "step": 21
+        },
+        "reward": null,
+        "status": "INACTIVE"
+      },
+      {
+        "action": {
+          "submission": -1
+        },
+        "info": {},
+        "observation": {
+          "currentPlayer": 1,
+          "isTerminal": false,
+          "observationString": "rnb1kb1r/1p3ppp/p3pn2/4p1B1/3N1P2/q1N5/P1PQ2PP/1R2KB1R w Kkq - 0 11",
+          "playerId": 1,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n1258\n3572\n1841\n1842\n1431\n3132\n3572\n656\n89\n1215\n2425\n3010\n1808\n1768\n749\n30\n1065\n2571\n1942\n\n"
+        },
+        "reward": null,
+        "status": "ACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "submission": -1
+        },
+        "info": {},
+        "observation": {
+          "currentPlayer": 0,
+          "isTerminal": false,
+          "observationString": "rnb1kb1r/1p3ppp/p3pn2/4P1B1/3N4/q1N5/P1PQ2PP/1R2KB1R b Kkq - 0 11",
+          "playerId": 0,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n1258\n3572\n1841\n1842\n1431\n3132\n3572\n656\n89\n1215\n2425\n3010\n1808\n1768\n749\n30\n1065\n2571\n1942\n3196\n\n",
+          "step": 22
+        },
+        "reward": null,
+        "status": "ACTIVE"
+      },
+      {
+        "action": {
+          "actionString": "fxe5",
+          "generate_returns": [
+            "{\n  \"main_response\": \"The position reached is the famous \\\"Poisoned Pawn\\\" variation of the Sicilian Najdorf. You have played the aggressive 10. e5 thrust, challenging Black's control over the center and their knight on f6. Black responded with 10... dxe5, opening the d-file and testing your central tension.\\n\\nThe absolutely necessary, forcing, and best move here is to recapture the pawn with your f-pawn, kicking the knight and continuing the assault in the main line. \\n\\nAfter 11. fxe5, Black's knight must move (typically to d7), which sets the stage for one of the most deeply analyzed, sharpest, and theoretical battlegrounds in chess history where White continues with rapid development and an initiative (such as Ne4 or Bc4) while Black defends tenaciously and often tries to snatch more material.\\n\\nFinal Answer: fxe5\",\n  \"main_response_and_thoughts\": \"\",\n  \"request_for_logging\": {\n    \"model\": \"google/gemini-3.1-pro-preview\",\n    \"messages\": [\n      {\n        \"role\": \"user\",\n        \"content\": [\n          {\n            \"type\": \"text\",\n            \"text\": \"Let's play chess. The current game state in Forsyth-Edwards Notation (FEN) notation is:\\nrnb1kb1r/1p3ppp/p3pn2/4p1B1/3N1P2/q1N5/P1PQ2PP/1R2KB1R w Kkq - 0 11\\nThe moves played so far are:\\n1. e4 c5 2. Nf3 d6 3. d4 cxd4 4. Nxd4 Nf6 5. Nc3 a6 6. Bg5 e6 7. f4 Qb6 8. Qd2 Qxb2 9. Rb1 Qa3 10. e5 dxe5 11.\\nYou are playing as player White.\\nIt is now your turn. Play your strongest move. The move MUST be legal. Reason step by step to come up with your move, then output your final answer in the format \\\"Final Answer: X\\\" where X is your chosen move in standard algebraic notation (SAN).\\n\"\n          }\n        ]\n      }\n    ],\n    \"config\": {\n      \"temperature\": \"NOT_GIVEN\",\n      \"top_p\": \"NOT_GIVEN\",\n      \"max_completion_tokens\": \"NOT_GIVEN\"\n    },\n    \"stream_options\": {\n      \"include_usage\": true\n    }\n  },\n  \"response_for_logging\": {\n    \"response_chunks\": [\n      {\n        \"id\": \"1Y_6aYHxHPiMmecPq_Dk8QQ\",\n        \"choices\": [\n          {\n            \"delta\": {\n              \"content\": \" Black defends tenaciously and often tries to snatch more material.\\n\\nFinal Answer: fxe5\",\n              \"role\": \"assistant\"\n            },\n            \"finish_reason\": \"stop\",\n            \"index\": 0\n          }\n        ],\n        \"created\": 1778028501,\n        \"model\": \"google/gemini-3.1-pro-preview\",\n        \"object\": \"chat.completion.chunk\",\n        \"usage\": {\n          \"completion_tokens\": 185,\n          \"prompt_tokens\": 225,\n          \"total_tokens\": 1463,\n          \"cost\": {\n            \"input_tokens_cost_nanodollars\": 450000,\n            \"output_tokens_cost_nanodollars\": 14856000\n          },\n          \"total_backend_latency_ms\": 10887\n        }\n      }\n    ]\n  },\n  \"generation_tokens\": 185,\n  \"prompt_tokens\": 225,\n  \"reasoning_tokens\": null,\n  \"total_tokens\": 1463,\n  \"duration_success_only_secs\": 11.41814563600019\n}"
+          ],
+          "status": "OK",
+          "submission": 3196,
+          "thoughts": "The position reached is the famous \"Poisoned Pawn\" variation of the Sicilian Najdorf. You have played the aggressive 10. e5 thrust, challenging Black's control over the center and their knight on f6. Black responded with 10... dxe5, opening the d-file and testing your central tension.\n\nThe absolutely necessary, forcing, and best move here is to recapture the pawn with your f-pawn, kicking the knight and continuing the assault in the main line. \n\nAfter 11. fxe5, Black's knight must move (typically to d7), which sets the stage for one of the most deeply analyzed, sharpest, and theoretical battlegrounds in chess history where White continues with rapid development and an initiative (such as Ne4 or Bc4) while Black defends tenaciously and often tries to snatch more material.\n\nFinal Answer: fxe5"
+        },
+        "info": {
+          "actionApplied": 3196,
+          "actionSubmitted": 3196,
+          "actionSubmittedToString": "fxe5",
+          "agentSelfReportedStatus": "OK",
+          "timeTaken": 12.602
+        },
+        "observation": {
+          "currentPlayer": 0,
+          "isTerminal": false,
+          "observationString": "rnb1kb1r/1p3ppp/p3pn2/4P1B1/3N4/q1N5/P1PQ2PP/1R2KB1R b Kkq - 0 11",
+          "playerId": 1,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n1258\n3572\n1841\n1842\n1431\n3132\n3572\n656\n89\n1215\n2425\n3010\n1808\n1768\n749\n30\n1065\n2571\n1942\n3196\n\n"
+        },
+        "reward": null,
+        "status": "INACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "actionString": "Nfd7",
+          "generate_returns": [
+            "{\n  \"main_response\": \"White\\u2019s e5-pawn attacks the knight on f6, so Black should move it while keeping the extra pawn and maintaining the Poisoned Pawn structure. The strongest and main theoretical move is to retreat the attacked knight to d7.\\n\\nFinal Answer: Nfd7\",\n  \"main_response_and_thoughts\": \"\",\n  \"request_for_logging\": {\n    \"model\": \"openai/gpt-5.5-2026-04-23\",\n    \"messages\": [\n      {\n        \"role\": \"user\",\n        \"content\": [\n          {\n            \"type\": \"text\",\n            \"text\": \"Let's play chess. The current game state in Forsyth-Edwards Notation (FEN) notation is:\\nrnb1kb1r/1p3ppp/p3pn2/4P1B1/3N4/q1N5/P1PQ2PP/1R2KB1R b Kkq - 0 11\\nThe moves played so far are:\\n1. e4 c5 2. Nf3 d6 3. d4 cxd4 4. Nxd4 Nf6 5. Nc3 a6 6. Bg5 e6 7. f4 Qb6 8. Qd2 Qxb2 9. Rb1 Qa3 10. e5 dxe5 11. fxe5\\nYou are playing as player Black.\\nIt is now your turn. Play your strongest move. The move MUST be legal. Reason step by step to come up with your move, then output your final answer in the format \\\"Final Answer: X\\\" where X is your chosen move in standard algebraic notation (SAN).\\n\"\n          }\n        ]\n      }\n    ],\n    \"config\": {\n      \"temperature\": \"NOT_GIVEN\",\n      \"top_p\": \"NOT_GIVEN\",\n      \"max_completion_tokens\": \"NOT_GIVEN\",\n      \"reasoning_effort\": \"high\"\n    },\n    \"stream_options\": {\n      \"include_usage\": true\n    }\n  },\n  \"response_for_logging\": {\n    \"response_chunks\": [\n      {\n        \"id\": \"chatcmpl-DcKjCZDaDDRoHaj75J7vHtl2N8atx\",\n        \"created\": 1778028514,\n        \"model\": \"openai/gpt-5.5-2026-04-23\",\n        \"object\": \"chat.completion.chunk\",\n        \"usage\": {\n          \"completion_tokens\": 1346,\n          \"prompt_tokens\": 236,\n          \"total_tokens\": 1582,\n          \"cost\": {\n            \"input_tokens_cost_nanodollars\": 1180000,\n            \"output_tokens_cost_nanodollars\": 40380000\n          },\n          \"total_backend_latency_ms\": 22479\n        }\n      }\n    ]\n  },\n  \"generation_tokens\": 1346,\n  \"prompt_tokens\": 236,\n  \"reasoning_tokens\": null,\n  \"total_tokens\": 1582,\n  \"duration_success_only_secs\": 22.957814311999755\n}"
+          ],
+          "status": "OK",
+          "submission": 3131,
+          "thoughts": "White\u2019s e5-pawn attacks the knight on f6, so Black should move it while keeping the extra pawn and maintaining the Poisoned Pawn structure. The strongest and main theoretical move is to retreat the attacked knight to d7.\n\nFinal Answer: Nfd7"
+        },
+        "info": {
+          "actionApplied": 3131,
+          "actionSubmitted": 3131,
+          "actionSubmittedToString": "Nfd7",
+          "agentSelfReportedStatus": "OK",
+          "timeTaken": 25.164
+        },
+        "observation": {
+          "currentPlayer": 1,
+          "isTerminal": false,
+          "observationString": "rnb1kb1r/1p1n1ppp/p3p3/4P1B1/3N4/q1N5/P1PQ2PP/1R2KB1R w Kkq - 1 12",
+          "playerId": 0,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n1258\n3572\n1841\n1842\n1431\n3132\n3572\n656\n89\n1215\n2425\n3010\n1808\n1768\n749\n30\n1065\n2571\n1942\n3196\n3131\n\n",
+          "step": 23
+        },
+        "reward": null,
+        "status": "INACTIVE"
+      },
+      {
+        "action": {
+          "submission": -1
+        },
+        "info": {},
+        "observation": {
+          "currentPlayer": 1,
+          "isTerminal": false,
+          "observationString": "rnb1kb1r/1p1n1ppp/p3p3/4P1B1/3N4/q1N5/P1PQ2PP/1R2KB1R w Kkq - 1 12",
+          "playerId": 1,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n1258\n3572\n1841\n1842\n1431\n3132\n3572\n656\n89\n1215\n2425\n3010\n1808\n1768\n749\n30\n1065\n2571\n1942\n3196\n3131\n\n"
+        },
+        "reward": null,
+        "status": "ACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "submission": -1
+        },
+        "info": {},
+        "observation": {
+          "currentPlayer": 0,
+          "isTerminal": false,
+          "observationString": "rnb1kb1r/1p1n1ppp/p3p3/4P1B1/3NN3/q7/P1PQ2PP/1R2KB1R b Kkq - 2 12",
+          "playerId": 0,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n1258\n3572\n1841\n1842\n1431\n3132\n3572\n656\n89\n1215\n2425\n3010\n1808\n1768\n749\n30\n1065\n2571\n1942\n3196\n3131\n1384\n\n",
+          "step": 24
+        },
+        "reward": null,
+        "status": "ACTIVE"
+      },
+      {
+        "action": {
+          "actionString": "Ne4",
+          "generate_returns": [
+            "{\n  \"main_response\": \"The current position arises from the notoriously sharp Poisoned Pawn Variation of the Sicilian Najdorf. You have sacrificed your b2-pawn and allowed Black's Queen to infiltrate, but in return, you have obtained a massive lead in development, open files, and attacking chances.\\n\\nAfter Black's 11... Nfd7, attacking your e5-pawn and making room to challenge the center, White's most modern, dangerous, and theoretically critical response is **12. Ne4**. \\n\\nHere's the step-by-step reasoning for this move:\\n1. **Exploiting the d6 Weakness:** By moving the knight to e4, you immediately eye the gaping d6 hole in Black's camp. This square is severely weakened since Black has played ...e6 and the d-pawn is gone.\\n2. **Central Dominance and King Safety:** The e4 Knight helps cement control over the light squares. Black's main way to try to handle this is by grabbing a second pawn with 12... Qxa2, but after 13. Rd1 Qd5 14. Qe3 Qxe5 15. Be2, White simply keeps developing. \\n3. **Putting Black in a Straightjacket:** Even though Black may win another pawn, their King is stranded in the center, and White's pieces coordinate beautifully. The threat of Nd6+ or exploiting the pin on the d-file gives White crushing compensation. If Black tries to kick the Bishop with 12... h6, you can comfortably retreat 13. Bh4, and the pressure persists. \\n\\nThis move is the absolute main line today at the highest levels of correspondence and Grandmaster play, leading to rich, dynamic positions where White's activity outweighs the material deficit.\\n\\nFinal Answer: Ne4\",\n  \"main_response_and_thoughts\": \"\",\n  \"request_for_logging\": {\n    \"model\": \"google/gemini-3.1-pro-preview\",\n    \"messages\": [\n      {\n        \"role\": \"user\",\n        \"content\": [\n          {\n            \"type\": \"text\",\n            \"text\": \"Let's play chess. The current game state in Forsyth-Edwards Notation (FEN) notation is:\\nrnb1kb1r/1p1n1ppp/p3p3/4P1B1/3N4/q1N5/P1PQ2PP/1R2KB1R w Kkq - 1 12\\nThe moves played so far are:\\n1. e4 c5 2. Nf3 d6 3. d4 cxd4 4. Nxd4 Nf6 5. Nc3 a6 6. Bg5 e6 7. f4 Qb6 8. Qd2 Qxb2 9. Rb1 Qa3 10. e5 dxe5 11. fxe5 Nfd7 12.\\nYou are playing as player White.\\nIt is now your turn. Play your strongest move. The move MUST be legal. Reason step by step to come up with your move, then output your final answer in the format \\\"Final Answer: X\\\" where X is your chosen move in standard algebraic notation (SAN).\\n\"\n          }\n        ]\n      }\n    ],\n    \"config\": {\n      \"temperature\": \"NOT_GIVEN\",\n      \"top_p\": \"NOT_GIVEN\",\n      \"max_completion_tokens\": \"NOT_GIVEN\"\n    },\n    \"stream_options\": {\n      \"include_usage\": true\n    }\n  },\n  \"response_for_logging\": {\n    \"response_chunks\": [\n      {\n        \"id\": \"-4_6aaGaD8udmecPmbT14Qk\",\n        \"choices\": [\n          {\n            \"delta\": {\n              \"content\": \": Ne4\",\n              \"role\": \"assistant\"\n            },\n            \"finish_reason\": \"stop\",\n            \"index\": 0\n          }\n        ],\n        \"created\": 1778028539,\n        \"model\": \"google/gemini-3.1-pro-preview\",\n        \"object\": \"chat.completion.chunk\",\n        \"usage\": {\n          \"completion_tokens\": 383,\n          \"prompt_tokens\": 234,\n          \"total_tokens\": 3076,\n          \"cost\": {\n            \"input_tokens_cost_nanodollars\": 468000,\n            \"output_tokens_cost_nanodollars\": 34104000\n          },\n          \"total_backend_latency_ms\": 25448\n        }\n      }\n    ]\n  },\n  \"generation_tokens\": 383,\n  \"prompt_tokens\": 234,\n  \"reasoning_tokens\": null,\n  \"total_tokens\": 3076,\n  \"duration_success_only_secs\": 25.919173025999044\n}"
+          ],
+          "status": "OK",
+          "submission": 1384,
+          "thoughts": "The current position arises from the notoriously sharp Poisoned Pawn Variation of the Sicilian Najdorf. You have sacrificed your b2-pawn and allowed Black's Queen to infiltrate, but in return, you have obtained a massive lead in development, open files, and attacking chances.\n\nAfter Black's 11... Nfd7, attacking your e5-pawn and making room to challenge the center, White's most modern, dangerous, and theoretically critical response is **12. Ne4**. \n\nHere's the step-by-step reasoning for this move:\n1. **Exploiting the d6 Weakness:** By moving the knight to e4, you immediately eye the gaping d6 hole in Black's camp. This square is severely weakened since Black has played ...e6 and the d-pawn is gone.\n2. **Central Dominance and King Safety:** The e4 Knight helps cement control over the light squares. Black's main way to try to handle this is by grabbing a second pawn with 12... Qxa2, but after 13. Rd1 Qd5 14. Qe3 Qxe5 15. Be2, White simply keeps developing. \n3. **Putting Black in a Straightjacket:** Even though Black may win another pawn, their King is stranded in the center, and White's pieces coordinate beautifully. The threat of Nd6+ or exploiting the pin on the d-file gives White crushing compensation. If Black tries to kick the Bishop with 12... h6, you can comfortably retreat 13. Bh4, and the pressure persists. \n\nThis move is the absolute main line today at the highest levels of correspondence and Grandmaster play, leading to rich, dynamic positions where White's activity outweighs the material deficit.\n\nFinal Answer: Ne4"
+        },
+        "info": {
+          "actionApplied": 1384,
+          "actionSubmitted": 1384,
+          "actionSubmittedToString": "Ne4",
+          "agentSelfReportedStatus": "OK",
+          "timeTaken": 27.127
+        },
+        "observation": {
+          "currentPlayer": 0,
+          "isTerminal": false,
+          "observationString": "rnb1kb1r/1p1n1ppp/p3p3/4P1B1/3NN3/q7/P1PQ2PP/1R2KB1R b Kkq - 2 12",
+          "playerId": 1,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n1258\n3572\n1841\n1842\n1431\n3132\n3572\n656\n89\n1215\n2425\n3010\n1808\n1768\n749\n30\n1065\n2571\n1942\n3196\n3131\n1384\n\n"
+        },
+        "reward": null,
+        "status": "INACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "actionString": "h6",
+          "generate_returns": [
+            "{\n  \"main_response\": \"12...h6 attacks the bishop on g5 and is the main, most precise Poisoned Pawn move here, preparing to continue with ...Qxa2 after forcing the bishop to declare itself.\\n\\nFinal Answer: h6\",\n  \"main_response_and_thoughts\": \"\",\n  \"request_for_logging\": {\n    \"model\": \"openai/gpt-5.5-2026-04-23\",\n    \"messages\": [\n      {\n        \"role\": \"user\",\n        \"content\": [\n          {\n            \"type\": \"text\",\n            \"text\": \"Let's play chess. The current game state in Forsyth-Edwards Notation (FEN) notation is:\\nrnb1kb1r/1p1n1ppp/p3p3/4P1B1/3NN3/q7/P1PQ2PP/1R2KB1R b Kkq - 2 12\\nThe moves played so far are:\\n1. e4 c5 2. Nf3 d6 3. d4 cxd4 4. Nxd4 Nf6 5. Nc3 a6 6. Bg5 e6 7. f4 Qb6 8. Qd2 Qxb2 9. Rb1 Qa3 10. e5 dxe5 11. fxe5 Nfd7 12. Ne4\\nYou are playing as player Black.\\nIt is now your turn. Play your strongest move. The move MUST be legal. Reason step by step to come up with your move, then output your final answer in the format \\\"Final Answer: X\\\" where X is your chosen move in standard algebraic notation (SAN).\\n\"\n          }\n        ]\n      }\n    ],\n    \"config\": {\n      \"temperature\": \"NOT_GIVEN\",\n      \"top_p\": \"NOT_GIVEN\",\n      \"max_completion_tokens\": \"NOT_GIVEN\",\n      \"reasoning_effort\": \"high\"\n    },\n    \"stream_options\": {\n      \"include_usage\": true\n    }\n  },\n  \"response_for_logging\": {\n    \"response_chunks\": [\n      {\n        \"id\": \"chatcmpl-DcKk2tMfGbW5gFOck1kqu0WozMCHY\",\n        \"created\": 1778028566,\n        \"model\": \"openai/gpt-5.5-2026-04-23\",\n        \"object\": \"chat.completion.chunk\",\n        \"usage\": {\n          \"completion_tokens\": 10919,\n          \"prompt_tokens\": 244,\n          \"total_tokens\": 11163,\n          \"cost\": {\n            \"input_tokens_cost_nanodollars\": 1220000,\n            \"output_tokens_cost_nanodollars\": 327570000\n          },\n          \"total_backend_latency_ms\": 192823\n        }\n      }\n    ]\n  },\n  \"generation_tokens\": 10919,\n  \"prompt_tokens\": 244,\n  \"reasoning_tokens\": null,\n  \"total_tokens\": 11163,\n  \"duration_success_only_secs\": 193.83335557100145\n}"
+          ],
+          "status": "OK",
+          "submission": 4177,
+          "thoughts": "12...h6 attacks the bishop on g5 and is the main, most precise Poisoned Pawn move here, preparing to continue with ...Qxa2 after forcing the bishop to declare itself.\n\nFinal Answer: h6"
+        },
+        "info": {
+          "actionApplied": 4177,
+          "actionSubmitted": 4177,
+          "actionSubmittedToString": "h6",
+          "agentSelfReportedStatus": "OK",
+          "timeTaken": 196.046
+        },
+        "observation": {
+          "currentPlayer": 1,
+          "isTerminal": false,
+          "observationString": "rnb1kb1r/1p1n1pp1/p3p2p/4P1B1/3NN3/q7/P1PQ2PP/1R2KB1R w Kkq - 0 13",
+          "playerId": 0,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n1258\n3572\n1841\n1842\n1431\n3132\n3572\n656\n89\n1215\n2425\n3010\n1808\n1768\n749\n30\n1065\n2571\n1942\n3196\n3131\n1384\n4177\n\n",
+          "step": 25
+        },
+        "reward": null,
+        "status": "INACTIVE"
+      },
+      {
+        "action": {
+          "submission": -1
+        },
+        "info": {},
+        "observation": {
+          "currentPlayer": 1,
+          "isTerminal": false,
+          "observationString": "rnb1kb1r/1p1n1pp1/p3p2p/4P1B1/3NN3/q7/P1PQ2PP/1R2KB1R w Kkq - 0 13",
+          "playerId": 1,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n1258\n3572\n1841\n1842\n1431\n3132\n3572\n656\n89\n1215\n2425\n3010\n1808\n1768\n749\n30\n1065\n2571\n1942\n3196\n3131\n1384\n4177\n\n"
+        },
+        "reward": null,
+        "status": "ACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "submission": -1
+        },
+        "info": {},
+        "observation": {
+          "currentPlayer": 0,
+          "isTerminal": false,
+          "observationString": "rnb1kb1r/1p1n1pp1/p3p2p/4P3/3NN2B/q7/P1PQ2PP/1R2KB1R b Kkq - 1 13",
+          "playerId": 0,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n1258\n3572\n1841\n1842\n1431\n3132\n3572\n656\n89\n1215\n2425\n3010\n1808\n1768\n749\n30\n1065\n2571\n1942\n3196\n3131\n1384\n4177\n3854\n\n",
+          "step": 26
+        },
+        "reward": null,
+        "status": "ACTIVE"
+      },
+      {
+        "action": {
+          "actionString": "Bh4",
+          "generate_returns": [
+            "{\n  \"main_response\": \"The current position arises from the highly theoretical Poisoned Pawn Variation of the Sicilian Najdorf. You have aggressively sacrificed a pawn (the b2 pawn) for a significant lead in development, control of the center, and attacking chances.\\n\\nBlack's last move (12... h6) attacks your bishop on g5. The most principled, active, and standard move in this position is to retreat the bishop to h4. \\n\\nBy playing 13. Bh4, White keeps the bishop on the active h4-d8 diagonal where it maintains pressure against Black's position, specifically eyeing the d8 square and restricting Black's development. Relocating to h4 continues to leave the queenside and center ripe for attacking ideas (often involving sacrifices on e6 or pushing the c-pawn). Furthermore, it invites Black to capture another pawn with 13... Qxa2, diving deeper into the labyrinth of Poisoned Pawn theory, where White simply plays 14. Rd1 with massive centralized compensation and an impending attack against Black's king, which is still stuck in the center.\\n\\nFinal Answer: Bh4\",\n  \"main_response_and_thoughts\": \"\",\n  \"request_for_logging\": {\n    \"model\": \"google/gemini-3.1-pro-preview\",\n    \"messages\": [\n      {\n        \"role\": \"user\",\n        \"content\": [\n          {\n            \"type\": \"text\",\n            \"text\": \"Let's play chess. The current game state in Forsyth-Edwards Notation (FEN) notation is:\\nrnb1kb1r/1p1n1pp1/p3p2p/4P1B1/3NN3/q7/P1PQ2PP/1R2KB1R w Kkq - 0 13\\nThe moves played so far are:\\n1. e4 c5 2. Nf3 d6 3. d4 cxd4 4. Nxd4 Nf6 5. Nc3 a6 6. Bg5 e6 7. f4 Qb6 8. Qd2 Qxb2 9. Rb1 Qa3 10. e5 dxe5 11. fxe5 Nfd7 12. Ne4 h6 13.\\nYou are playing as player White.\\nIt is now your turn. Play your strongest move. The move MUST be legal. Reason step by step to come up with your move, then output your final answer in the format \\\"Final Answer: X\\\" where X is your chosen move in standard algebraic notation (SAN).\\n\"\n          }\n        ]\n      }\n    ],\n    \"config\": {\n      \"temperature\": \"NOT_GIVEN\",\n      \"top_p\": \"NOT_GIVEN\",\n      \"max_completion_tokens\": \"NOT_GIVEN\"\n    },\n    \"stream_options\": {\n      \"include_usage\": true\n    }\n  },\n  \"response_for_logging\": {\n    \"response_chunks\": [\n      {\n        \"id\": \"25D6aeztHNCfmecP0erHwQ0\",\n        \"choices\": [\n          {\n            \"delta\": {\n              \"content\": \" is still stuck in the center.\\n\\nFinal Answer: Bh4\",\n              \"role\": \"assistant\"\n            },\n            \"finish_reason\": \"stop\",\n            \"index\": 0\n          }\n        ],\n        \"created\": 1778028763,\n        \"model\": \"google/gemini-3.1-pro-preview\",\n        \"object\": \"chat.completion.chunk\",\n        \"usage\": {\n          \"completion_tokens\": 233,\n          \"prompt_tokens\": 242,\n          \"total_tokens\": 2130,\n          \"cost\": {\n            \"input_tokens_cost_nanodollars\": 484000,\n            \"output_tokens_cost_nanodollars\": 22656000\n          },\n          \"total_backend_latency_ms\": 18544\n        }\n      }\n    ]\n  },\n  \"generation_tokens\": 233,\n  \"prompt_tokens\": 242,\n  \"reasoning_tokens\": null,\n  \"total_tokens\": 2130,\n  \"duration_success_only_secs\": 19.012342235000688\n}"
+          ],
+          "status": "OK",
+          "submission": 3854,
+          "thoughts": "The current position arises from the highly theoretical Poisoned Pawn Variation of the Sicilian Najdorf. You have aggressively sacrificed a pawn (the b2 pawn) for a significant lead in development, control of the center, and attacking chances.\n\nBlack's last move (12... h6) attacks your bishop on g5. The most principled, active, and standard move in this position is to retreat the bishop to h4. \n\nBy playing 13. Bh4, White keeps the bishop on the active h4-d8 diagonal where it maintains pressure against Black's position, specifically eyeing the d8 square and restricting Black's development. Relocating to h4 continues to leave the queenside and center ripe for attacking ideas (often involving sacrifices on e6 or pushing the c-pawn). Furthermore, it invites Black to capture another pawn with 13... Qxa2, diving deeper into the labyrinth of Poisoned Pawn theory, where White simply plays 14. Rd1 with massive centralized compensation and an impending attack against Black's king, which is still stuck in the center.\n\nFinal Answer: Bh4"
+        },
+        "info": {
+          "actionApplied": 3854,
+          "actionSubmitted": 3854,
+          "actionSubmittedToString": "Bh4",
+          "agentSelfReportedStatus": "OK",
+          "timeTaken": 21.224
+        },
+        "observation": {
+          "currentPlayer": 0,
+          "isTerminal": false,
+          "observationString": "rnb1kb1r/1p1n1pp1/p3p2p/4P3/3NN2B/q7/P1PQ2PP/1R2KB1R b Kkq - 1 13",
+          "playerId": 1,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n1258\n3572\n1841\n1842\n1431\n3132\n3572\n656\n89\n1215\n2425\n3010\n1808\n1768\n749\n30\n1065\n2571\n1942\n3196\n3131\n1384\n4177\n3854\n\n"
+        },
+        "reward": null,
+        "status": "INACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "actionString": "Qxa2",
+          "generate_returns": [
+            "{\n  \"main_response\": \"Final Answer: Qxa2\",\n  \"main_response_and_thoughts\": \"\",\n  \"request_for_logging\": {\n    \"model\": \"openai/gpt-5.5-2026-04-23\",\n    \"messages\": [\n      {\n        \"role\": \"user\",\n        \"content\": [\n          {\n            \"type\": \"text\",\n            \"text\": \"Let's play chess. The current game state in Forsyth-Edwards Notation (FEN) notation is:\\nrnb1kb1r/1p1n1pp1/p3p2p/4P3/3NN2B/q7/P1PQ2PP/1R2KB1R b Kkq - 1 13\\nThe moves played so far are:\\n1. e4 c5 2. Nf3 d6 3. d4 cxd4 4. Nxd4 Nf6 5. Nc3 a6 6. Bg5 e6 7. f4 Qb6 8. Qd2 Qxb2 9. Rb1 Qa3 10. e5 dxe5 11. fxe5 Nfd7 12. Ne4 h6 13. Bh4\\nYou are playing as player Black.\\nIt is now your turn. Play your strongest move. The move MUST be legal. Reason step by step to come up with your move, then output your final answer in the format \\\"Final Answer: X\\\" where X is your chosen move in standard algebraic notation (SAN).\\n\"\n          }\n        ]\n      }\n    ],\n    \"config\": {\n      \"temperature\": \"NOT_GIVEN\",\n      \"top_p\": \"NOT_GIVEN\",\n      \"max_completion_tokens\": \"NOT_GIVEN\",\n      \"reasoning_effort\": \"high\"\n    },\n    \"stream_options\": {\n      \"include_usage\": true\n    }\n  },\n  \"response_for_logging\": {\n    \"response_chunks\": [\n      {\n        \"id\": \"chatcmpl-DcKnYSYU9kVbTny75B4bVpRgvXiY0\",\n        \"created\": 1778028784,\n        \"model\": \"openai/gpt-5.5-2026-04-23\",\n        \"object\": \"chat.completion.chunk\",\n        \"usage\": {\n          \"completion_tokens\": 13477,\n          \"prompt_tokens\": 251,\n          \"total_tokens\": 13728,\n          \"cost\": {\n            \"input_tokens_cost_nanodollars\": 1255000,\n            \"output_tokens_cost_nanodollars\": 404310000\n          },\n          \"total_backend_latency_ms\": 234933\n        }\n      }\n    ]\n  },\n  \"generation_tokens\": 13477,\n  \"prompt_tokens\": 251,\n  \"reasoning_tokens\": null,\n  \"total_tokens\": 13728,\n  \"duration_success_only_secs\": 235.42359826499887\n}"
+          ],
+          "status": "OK",
+          "submission": 381,
+          "thoughts": "Final Answer: Qxa2"
+        },
+        "info": {
+          "actionApplied": 381,
+          "actionSubmitted": 381,
+          "actionSubmittedToString": "Qxa2",
+          "agentSelfReportedStatus": "OK",
+          "timeTaken": 237.682
+        },
+        "observation": {
+          "currentPlayer": 1,
+          "isTerminal": false,
+          "observationString": "rnb1kb1r/1p1n1pp1/p3p2p/4P3/3NN2B/8/q1PQ2PP/1R2KB1R w Kkq - 0 14",
+          "playerId": 0,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n1258\n3572\n1841\n1842\n1431\n3132\n3572\n656\n89\n1215\n2425\n3010\n1808\n1768\n749\n30\n1065\n2571\n1942\n3196\n3131\n1384\n4177\n3854\n381\n\n",
+          "step": 27
+        },
+        "reward": null,
+        "status": "INACTIVE"
+      },
+      {
+        "action": {
+          "submission": -1
+        },
+        "info": {},
+        "observation": {
+          "currentPlayer": 1,
+          "isTerminal": false,
+          "observationString": "rnb1kb1r/1p1n1pp1/p3p2p/4P3/3NN2B/8/q1PQ2PP/1R2KB1R w Kkq - 0 14",
+          "playerId": 1,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n1258\n3572\n1841\n1842\n1431\n3132\n3572\n656\n89\n1215\n2425\n3010\n1808\n1768\n749\n30\n1065\n2571\n1942\n3196\n3131\n1384\n4177\n3854\n381\n\n"
+        },
+        "reward": null,
+        "status": "ACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "submission": -1
+        },
+        "info": {},
+        "observation": {
+          "currentPlayer": 0,
+          "isTerminal": false,
+          "observationString": "rnb1kb1r/1p1n1pp1/p3p2p/4P3/3NN2B/8/q1PQ2PP/3RKB1R b Kkq - 1 14",
+          "playerId": 0,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n1258\n3572\n1841\n1842\n1431\n3132\n3572\n656\n89\n1215\n2425\n3010\n1808\n1768\n749\n30\n1065\n2571\n1942\n3196\n3131\n1384\n4177\n3854\n381\n615\n\n",
+          "step": 28
+        },
+        "reward": null,
+        "status": "ACTIVE"
+      },
+      {
+        "action": {
+          "actionString": "Rd1",
+          "generate_returns": [
+            "{\n  \"main_response\": \"The position arises from the highly complex Poisoned Pawn Variation of the Najdorf Sicilian. Black has just grabbed a second pawn with 13... Qxa2, attacking your rook on b1. \\n\\nThe best and most theoretical response here is to centralize the attacked rook and place it on the same file as your Queen, generating immense pressure on the d-file while stepping out of danger. \\n\\nBy playing **14. Rd1**, White sacrifices another pawn (the e5 pawn is typically taken soon in the main lines) for rapid development, a dangerous initiative, and control over the center. The d1 Rook defends the d4 Knight and prepares for White's pieces to swarm the center and king-side. For example, if Black tries to centralize and challenge your knights with 14... Qd5, White simply follows up with 15. Qe3 Qxe5 16. Be2, leading to the incredibly sharp main line where White holds tremendous compensation for the sacrificed material. \\n\\nFinal Answer: Rd1\",\n  \"main_response_and_thoughts\": \"\",\n  \"request_for_logging\": {\n    \"model\": \"google/gemini-3.1-pro-preview\",\n    \"messages\": [\n      {\n        \"role\": \"user\",\n        \"content\": [\n          {\n            \"type\": \"text\",\n            \"text\": \"Let's play chess. The current game state in Forsyth-Edwards Notation (FEN) notation is:\\nrnb1kb1r/1p1n1pp1/p3p2p/4P3/3NN2B/8/q1PQ2PP/1R2KB1R w Kkq - 0 14\\nThe moves played so far are:\\n1. e4 c5 2. Nf3 d6 3. d4 cxd4 4. Nxd4 Nf6 5. Nc3 a6 6. Bg5 e6 7. f4 Qb6 8. Qd2 Qxb2 9. Rb1 Qa3 10. e5 dxe5 11. fxe5 Nfd7 12. Ne4 h6 13. Bh4 Qxa2 14.\\nYou are playing as player White.\\nIt is now your turn. Play your strongest move. The move MUST be legal. Reason step by step to come up with your move, then output your final answer in the format \\\"Final Answer: X\\\" where X is your chosen move in standard algebraic notation (SAN).\\n\"\n          }\n        ]\n      }\n    ],\n    \"config\": {\n      \"temperature\": \"NOT_GIVEN\",\n      \"top_p\": \"NOT_GIVEN\",\n      \"max_completion_tokens\": \"NOT_GIVEN\"\n    },\n    \"stream_options\": {\n      \"include_usage\": true\n    }\n  },\n  \"response_for_logging\": {\n    \"response_chunks\": [\n      {\n        \"id\": \"3ZH6afX9E9CfmecP0erHwQ0\",\n        \"choices\": [\n          {\n            \"delta\": {\n              \"content\": \" White holds tremendous compensation for the sacrificed material. \\n\\nFinal Answer: Rd1\",\n              \"role\": \"assistant\"\n            },\n            \"finish_reason\": \"stop\",\n            \"index\": 0\n          }\n        ],\n        \"created\": 1778029021,\n        \"model\": \"google/gemini-3.1-pro-preview\",\n        \"object\": \"chat.completion.chunk\",\n        \"usage\": {\n          \"completion_tokens\": 213,\n          \"prompt_tokens\": 248,\n          \"total_tokens\": 2808,\n          \"cost\": {\n            \"input_tokens_cost_nanodollars\": 496000,\n            \"output_tokens_cost_nanodollars\": 30720000\n          },\n          \"total_backend_latency_ms\": 23100\n        }\n      }\n    ]\n  },\n  \"generation_tokens\": 213,\n  \"prompt_tokens\": 248,\n  \"reasoning_tokens\": null,\n  \"total_tokens\": 2808,\n  \"duration_success_only_secs\": 23.602083833000506\n}"
+          ],
+          "status": "OK",
+          "submission": 615,
+          "thoughts": "The position arises from the highly complex Poisoned Pawn Variation of the Najdorf Sicilian. Black has just grabbed a second pawn with 13... Qxa2, attacking your rook on b1. \n\nThe best and most theoretical response here is to centralize the attacked rook and place it on the same file as your Queen, generating immense pressure on the d-file while stepping out of danger. \n\nBy playing **14. Rd1**, White sacrifices another pawn (the e5 pawn is typically taken soon in the main lines) for rapid development, a dangerous initiative, and control over the center. The d1 Rook defends the d4 Knight and prepares for White's pieces to swarm the center and king-side. For example, if Black tries to centralize and challenge your knights with 14... Qd5, White simply follows up with 15. Qe3 Qxe5 16. Be2, leading to the incredibly sharp main line where White holds tremendous compensation for the sacrificed material. \n\nFinal Answer: Rd1"
+        },
+        "info": {
+          "actionApplied": 615,
+          "actionSubmitted": 615,
+          "actionSubmittedToString": "Rd1",
+          "agentSelfReportedStatus": "OK",
+          "timeTaken": 25.255
+        },
+        "observation": {
+          "currentPlayer": 0,
+          "isTerminal": false,
+          "observationString": "rnb1kb1r/1p1n1pp1/p3p2p/4P3/3NN2B/8/q1PQ2PP/3RKB1R b Kkq - 1 14",
+          "playerId": 1,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n1258\n3572\n1841\n1842\n1431\n3132\n3572\n656\n89\n1215\n2425\n3010\n1808\n1768\n749\n30\n1065\n2571\n1942\n3196\n3131\n1384\n4177\n3854\n381\n615\n\n"
+        },
+        "reward": null,
+        "status": "INACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "actionString": "Qd5",
+          "generate_returns": [
+            "{\n  \"main_response\": \"Final Answer: Qd5\",\n  \"main_response_and_thoughts\": \"\",\n  \"request_for_logging\": {\n    \"model\": \"openai/gpt-5.5-2026-04-23\",\n    \"messages\": [\n      {\n        \"role\": \"user\",\n        \"content\": [\n          {\n            \"type\": \"text\",\n            \"text\": \"Let's play chess. The current game state in Forsyth-Edwards Notation (FEN) notation is:\\nrnb1kb1r/1p1n1pp1/p3p2p/4P3/3NN2B/8/q1PQ2PP/3RKB1R b Kkq - 1 14\\nThe moves played so far are:\\n1. e4 c5 2. Nf3 d6 3. d4 cxd4 4. Nxd4 Nf6 5. Nc3 a6 6. Bg5 e6 7. f4 Qb6 8. Qd2 Qxb2 9. Rb1 Qa3 10. e5 dxe5 11. fxe5 Nfd7 12. Ne4 h6 13. Bh4 Qxa2 14. Rd1\\nYou are playing as player Black.\\nIt is now your turn. Play your strongest move. The move MUST be legal. Reason step by step to come up with your move, then output your final answer in the format \\\"Final Answer: X\\\" where X is your chosen move in standard algebraic notation (SAN).\\n\"\n          }\n        ]\n      }\n    ],\n    \"config\": {\n      \"temperature\": \"NOT_GIVEN\",\n      \"top_p\": \"NOT_GIVEN\",\n      \"max_completion_tokens\": \"NOT_GIVEN\",\n      \"reasoning_effort\": \"high\"\n    },\n    \"stream_options\": {\n      \"include_usage\": true\n    }\n  },\n  \"response_for_logging\": {\n    \"response_chunks\": [\n      {\n        \"id\": \"chatcmpl-DcKrnh40KoQctEMq6Cj7Zp0eE1sCg\",\n        \"created\": 1778029047,\n        \"model\": \"openai/gpt-5.5-2026-04-23\",\n        \"object\": \"chat.completion.chunk\",\n        \"usage\": {\n          \"completion_tokens\": 3635,\n          \"prompt_tokens\": 258,\n          \"total_tokens\": 3893,\n          \"cost\": {\n            \"input_tokens_cost_nanodollars\": 1290000,\n            \"output_tokens_cost_nanodollars\": 109050000\n          },\n          \"total_backend_latency_ms\": 65064\n        }\n      }\n    ]\n  },\n  \"generation_tokens\": 3635,\n  \"prompt_tokens\": 258,\n  \"reasoning_tokens\": null,\n  \"total_tokens\": 3893,\n  \"duration_success_only_secs\": 66.04053421999924\n}"
+          ],
+          "status": "OK",
+          "submission": 498,
+          "thoughts": "Final Answer: Qd5"
+        },
+        "info": {
+          "actionApplied": 498,
+          "actionSubmitted": 498,
+          "actionSubmittedToString": "Qd5",
+          "agentSelfReportedStatus": "OK",
+          "timeTaken": 67.683
+        },
+        "observation": {
+          "currentPlayer": 1,
+          "isTerminal": false,
+          "observationString": "rnb1kb1r/1p1n1pp1/p3p2p/3qP3/3NN2B/8/2PQ2PP/3RKB1R w Kkq - 2 15",
+          "playerId": 0,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n1258\n3572\n1841\n1842\n1431\n3132\n3572\n656\n89\n1215\n2425\n3010\n1808\n1768\n749\n30\n1065\n2571\n1942\n3196\n3131\n1384\n4177\n3854\n381\n615\n498\n\n",
+          "step": 29
+        },
+        "reward": null,
+        "status": "INACTIVE"
+      },
+      {
+        "action": {
+          "submission": -1
+        },
+        "info": {},
+        "observation": {
+          "currentPlayer": 1,
+          "isTerminal": false,
+          "observationString": "rnb1kb1r/1p1n1pp1/p3p2p/3qP3/3NN2B/8/2PQ2PP/3RKB1R w Kkq - 2 15",
+          "playerId": 1,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n1258\n3572\n1841\n1842\n1431\n3132\n3572\n656\n89\n1215\n2425\n3010\n1808\n1768\n749\n30\n1065\n2571\n1942\n3196\n3131\n1384\n4177\n3854\n381\n615\n498\n\n"
+        },
+        "reward": null,
+        "status": "ACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "submission": -1
+        },
+        "info": {},
+        "observation": {
+          "currentPlayer": 0,
+          "isTerminal": false,
+          "observationString": "rnb1kb1r/1p1n1pp1/p3p2p/3qP3/3NN2B/4Q3/2P3PP/3RKB1R b Kkq - 3 15",
+          "playerId": 0,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n1258\n3572\n1841\n1842\n1431\n3132\n3572\n656\n89\n1215\n2425\n3010\n1808\n1768\n749\n30\n1065\n2571\n1942\n3196\n3131\n1384\n4177\n3854\n381\n615\n498\n1869\n\n",
+          "step": 30
+        },
+        "reward": null,
+        "status": "ACTIVE"
+      },
+      {
+        "action": {
+          "actionString": "Qe3",
+          "generate_returns": [
+            "{\n  \"main_response\": \"The position you've reached is one of the most famous and incredibly sharp tabiyas of the Sicilian Najdorf, Poisoned Pawn Variation. Black has grabbed both the b2 and a2 pawns, and has just centralized their queen with 14... Qd5 to attack your heavily centralized knights.\\n\\nRight now, your knight on e4 is hanging, and White must find a way to maintain the massive initiative built up for the sacrificed pawns. \\n\\nStep-by-step reasoning:\\n1. **Defending the Knights:** Your most pressing issue is the attack on your e4 knight. If you try to save it by moving it away (e.g., Nd6+), Black will gladly trade pieces (15. Nd6+ Bxd6 16. Qxd5 exd5 17. exd6) and emerge with an extra pawn and an easily playable endgame. \\n2. **Considering 15. Nc3:** Dropping the knight back with 15. Nc3 is met with 15... Qxe5+, forcing you to deal with an annoying check while giving Black a valuable tempo to consolidate their position.\\n3. **The Book Move (15. Qe3!):** Bringing the queen to e3 is the absolute best move and the established main line of this variation. \\n   - It seamlessly defends the e4 knight.\\n   - It keeps the defense of the d4 knight.\\n   - It refuses to give Black a check if they capture on e5. \\n   \\nIf Black takes the bait and plays 15... Qxe5, you will simply continue your rapid development with 16. Be2 (preparing to castle and bringing the final pieces into the attack, notably aiming at targets with Bg3). The overwhelming lead in development and centralized coordination gives White ample compensation for the missing pawns.\\n\\nFinal Answer: Qe3\",\n  \"main_response_and_thoughts\": \"\",\n  \"request_for_logging\": {\n    \"model\": \"google/gemini-3.1-pro-preview\",\n    \"messages\": [\n      {\n        \"role\": \"user\",\n        \"content\": [\n          {\n            \"type\": \"text\",\n            \"text\": \"Let's play chess. The current game state in Forsyth-Edwards Notation (FEN) notation is:\\nrnb1kb1r/1p1n1pp1/p3p2p/3qP3/3NN2B/8/2PQ2PP/3RKB1R w Kkq - 2 15\\nThe moves played so far are:\\n1. e4 c5 2. Nf3 d6 3. d4 cxd4 4. Nxd4 Nf6 5. Nc3 a6 6. Bg5 e6 7. f4 Qb6 8. Qd2 Qxb2 9. Rb1 Qa3 10. e5 dxe5 11. fxe5 Nfd7 12. Ne4 h6 13. Bh4 Qxa2 14. Rd1 Qd5 15.\\nYou are playing as player White.\\nIt is now your turn. Play your strongest move. The move MUST be legal. Reason step by step to come up with your move, then output your final answer in the format \\\"Final Answer: X\\\" where X is your chosen move in standard algebraic notation (SAN).\\n\"\n          }\n        ]\n      }\n    ],\n    \"config\": {\n      \"temperature\": \"NOT_GIVEN\",\n      \"top_p\": \"NOT_GIVEN\",\n      \"max_completion_tokens\": \"NOT_GIVEN\"\n    },\n    \"stream_options\": {\n      \"include_usage\": true\n    }\n  },\n  \"response_for_logging\": {\n    \"response_chunks\": [\n      {\n        \"id\": \"O5L6aZGMNsudmecPmbT14Qk\",\n        \"choices\": [\n          {\n            \"delta\": {\n              \"content\": \" missing pawns.\\n\\nFinal Answer: Qe3\",\n              \"role\": \"assistant\"\n            },\n            \"finish_reason\": \"stop\",\n            \"index\": 0\n          }\n        ],\n        \"created\": 1778029115,\n        \"model\": \"google/gemini-3.1-pro-preview\",\n        \"object\": \"chat.completion.chunk\",\n        \"usage\": {\n          \"completion_tokens\": 392,\n          \"prompt_tokens\": 255,\n          \"total_tokens\": 3551,\n          \"cost\": {\n            \"input_tokens_cost_nanodollars\": 510000,\n            \"output_tokens_cost_nanodollars\": 39552000\n          },\n          \"total_backend_latency_ms\": 31040\n        }\n      }\n    ]\n  },\n  \"generation_tokens\": 392,\n  \"prompt_tokens\": 255,\n  \"reasoning_tokens\": null,\n  \"total_tokens\": 3551,\n  \"duration_success_only_secs\": 31.553887083000518\n}"
+          ],
+          "status": "OK",
+          "submission": 1869,
+          "thoughts": "The position you've reached is one of the most famous and incredibly sharp tabiyas of the Sicilian Najdorf, Poisoned Pawn Variation. Black has grabbed both the b2 and a2 pawns, and has just centralized their queen with 14... Qd5 to attack your heavily centralized knights.\n\nRight now, your knight on e4 is hanging, and White must find a way to maintain the massive initiative built up for the sacrificed pawns. \n\nStep-by-step reasoning:\n1. **Defending the Knights:** Your most pressing issue is the attack on your e4 knight. If you try to save it by moving it away (e.g., Nd6+), Black will gladly trade pieces (15. Nd6+ Bxd6 16. Qxd5 exd5 17. exd6) and emerge with an extra pawn and an easily playable endgame. \n2. **Considering 15. Nc3:** Dropping the knight back with 15. Nc3 is met with 15... Qxe5+, forcing you to deal with an annoying check while giving Black a valuable tempo to consolidate their position.\n3. **The Book Move (15. Qe3!):** Bringing the queen to e3 is the absolute best move and the established main line of this variation. \n   - It seamlessly defends the e4 knight.\n   - It keeps the defense of the d4 knight.\n   - It refuses to give Black a check if they capture on e5. \n   \nIf Black takes the bait and plays 15... Qxe5, you will simply continue your rapid development with 16. Be2 (preparing to castle and bringing the final pieces into the attack, notably aiming at targets with Bg3). The overwhelming lead in development and centralized coordination gives White ample compensation for the missing pawns.\n\nFinal Answer: Qe3"
+        },
+        "info": {
+          "actionApplied": 1869,
+          "actionSubmitted": 1869,
+          "actionSubmittedToString": "Qe3",
+          "agentSelfReportedStatus": "OK",
+          "timeTaken": 34.904
+        },
+        "observation": {
+          "currentPlayer": 0,
+          "isTerminal": false,
+          "observationString": "rnb1kb1r/1p1n1pp1/p3p2p/3qP3/3NN2B/4Q3/2P3PP/3RKB1R b Kkq - 3 15",
+          "playerId": 1,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n1258\n3572\n1841\n1842\n1431\n3132\n3572\n656\n89\n1215\n2425\n3010\n1808\n1768\n749\n30\n1065\n2571\n1942\n3196\n3131\n1384\n4177\n3854\n381\n615\n498\n1869\n\n"
+        },
+        "reward": null,
+        "status": "INACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "actionString": "Qxe5",
+          "generate_returns": [
+            "{\n  \"main_response\": \"Final Answer: Qxe5\",\n  \"main_response_and_thoughts\": \"\",\n  \"request_for_logging\": {\n    \"model\": \"openai/gpt-5.5-2026-04-23\",\n    \"messages\": [\n      {\n        \"role\": \"user\",\n        \"content\": [\n          {\n            \"type\": \"text\",\n            \"text\": \"Let's play chess. The current game state in Forsyth-Edwards Notation (FEN) notation is:\\nrnb1kb1r/1p1n1pp1/p3p2p/3qP3/3NN2B/4Q3/2P3PP/3RKB1R b Kkq - 3 15\\nThe moves played so far are:\\n1. e4 c5 2. Nf3 d6 3. d4 cxd4 4. Nxd4 Nf6 5. Nc3 a6 6. Bg5 e6 7. f4 Qb6 8. Qd2 Qxb2 9. Rb1 Qa3 10. e5 dxe5 11. fxe5 Nfd7 12. Ne4 h6 13. Bh4 Qxa2 14. Rd1 Qd5 15. Qe3\\nYou are playing as player Black.\\nIt is now your turn. Play your strongest move. The move MUST be legal. Reason step by step to come up with your move, then output your final answer in the format \\\"Final Answer: X\\\" where X is your chosen move in standard algebraic notation (SAN).\\n\"\n          }\n        ]\n      }\n    ],\n    \"config\": {\n      \"temperature\": \"NOT_GIVEN\",\n      \"top_p\": \"NOT_GIVEN\",\n      \"max_completion_tokens\": \"NOT_GIVEN\",\n      \"reasoning_effort\": \"high\"\n    },\n    \"stream_options\": {\n      \"include_usage\": true\n    }\n  },\n  \"response_for_logging\": {\n    \"response_chunks\": [\n      {\n        \"id\": \"chatcmpl-DcKtSOZIEnu6pVtl5MrA5Q7Rfdvif\",\n        \"created\": 1778029150,\n        \"model\": \"openai/gpt-5.5-2026-04-23\",\n        \"object\": \"chat.completion.chunk\",\n        \"usage\": {\n          \"completion_tokens\": 15549,\n          \"prompt_tokens\": 270,\n          \"total_tokens\": 15819,\n          \"cost\": {\n            \"input_tokens_cost_nanodollars\": 1350000,\n            \"output_tokens_cost_nanodollars\": 466470000\n          },\n          \"total_backend_latency_ms\": 276948\n        }\n      }\n    ]\n  },\n  \"generation_tokens\": 15549,\n  \"prompt_tokens\": 270,\n  \"reasoning_tokens\": null,\n  \"total_tokens\": 15819,\n  \"duration_success_only_secs\": 277.40534113600006\n}"
+          ],
+          "status": "OK",
+          "submission": 2001,
+          "thoughts": "Final Answer: Qxe5"
+        },
+        "info": {
+          "actionApplied": 2001,
+          "actionSubmitted": 2001,
+          "actionSubmittedToString": "Qxe5",
+          "agentSelfReportedStatus": "OK",
+          "timeTaken": 279.651
+        },
+        "observation": {
+          "currentPlayer": 1,
+          "isTerminal": false,
+          "observationString": "rnb1kb1r/1p1n1pp1/p3p2p/4q3/3NN2B/4Q3/2P3PP/3RKB1R w Kkq - 0 16",
+          "playerId": 0,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n1258\n3572\n1841\n1842\n1431\n3132\n3572\n656\n89\n1215\n2425\n3010\n1808\n1768\n749\n30\n1065\n2571\n1942\n3196\n3131\n1384\n4177\n3854\n381\n615\n498\n1869\n2001\n\n",
+          "step": 31
+        },
+        "reward": null,
+        "status": "INACTIVE"
+      },
+      {
+        "action": {
+          "submission": -1
+        },
+        "info": {},
+        "observation": {
+          "currentPlayer": 1,
+          "isTerminal": false,
+          "observationString": "rnb1kb1r/1p1n1pp1/p3p2p/4q3/3NN2B/4Q3/2P3PP/3RKB1R w Kkq - 0 16",
+          "playerId": 1,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n1258\n3572\n1841\n1842\n1431\n3132\n3572\n656\n89\n1215\n2425\n3010\n1808\n1768\n749\n30\n1065\n2571\n1942\n3196\n3131\n1384\n4177\n3854\n381\n615\n498\n1869\n2001\n\n"
+        },
+        "reward": null,
+        "status": "ACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "submission": -1
+        },
+        "info": {},
+        "observation": {
+          "currentPlayer": 0,
+          "isTerminal": false,
+          "observationString": "rnb1kb1r/1p1n1pp1/p3p2p/4q3/3NN2B/4Q3/2P1B1PP/3RK2R b Kkq - 1 16",
+          "playerId": 0,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n1258\n3572\n1841\n1842\n1431\n3132\n3572\n656\n89\n1215\n2425\n3010\n1808\n1768\n749\n30\n1065\n2571\n1942\n3196\n3131\n1384\n4177\n3854\n381\n615\n498\n1869\n2001\n2977\n\n",
+          "step": 32
+        },
+        "reward": null,
+        "status": "ACTIVE"
+      },
+      {
+        "action": {
+          "actionString": "Be2",
+          "generate_returns": [
+            "{\n  \"main_response\": \"The position arises from the highly complex and heavily theoretical Poisoned Pawn Variation of the Sicilian Najdorf. Specifically, this is the modern 14. Rd1 line where White gambits a second (and even a third) pawn for a massive lead in development and dangerous attacking potential.\\n\\nBlack has just grabbed the e5 pawn with 15... Qxe5, meaning White is currently down three pawns. However, Black's development is severely lagging, the king is stuck in the center, and White's pieces are aggressively centralized. \\n\\nYour best move here is **16. Be2**. \\n\\n**Step-by-step reasoning:**\\n1. **Development & King Safety:** White's immediate priority is to finish minor piece development and get the king to safety. 16. Be2 develops the bishop, guards the d3 square, and prepares for Kingside castling (O-O). \\n2. **Tempo on the Queen:** Playing Be2 sets up the deadly threat of Bg3, which will attack the Black queen on e5. \\n3. **Avoiding immediate checks:** Playing 16. Bg3 directly allows Black the annoying 16... Qa5+ intermezzo, forcing White to play c3 and somewhat compromise the queenside or misplace a piece. 16. Be2 prevents any productive checks.\\n4. **Mainline Theory:** After 16. Be2, Black's most critical and standard response is 16... Bc5 (pinning the Knight on d4). White will then follow up with 17. Bg3. If Black plays 17... Qd5, White can reply with 18. c4! or 18. O-O, maintaining a blistering initiative that fully compensates for the material deficit. If Black plays 16... Nc6, White simply plays 17. Bg3 Qa5+ 18. c3, keeping immense pressure on the position.\\n\\nFinal Answer: Be2\",\n  \"main_response_and_thoughts\": \"\",\n  \"request_for_logging\": {\n    \"model\": \"google/gemini-3.1-pro-preview\",\n    \"messages\": [\n      {\n        \"role\": \"user\",\n        \"content\": [\n          {\n            \"type\": \"text\",\n            \"text\": \"Let's play chess. The current game state in Forsyth-Edwards Notation (FEN) notation is:\\nrnb1kb1r/1p1n1pp1/p3p2p/4q3/3NN2B/4Q3/2P3PP/3RKB1R w Kkq - 0 16\\nThe moves played so far are:\\n1. e4 c5 2. Nf3 d6 3. d4 cxd4 4. Nxd4 Nf6 5. Nc3 a6 6. Bg5 e6 7. f4 Qb6 8. Qd2 Qxb2 9. Rb1 Qa3 10. e5 dxe5 11. fxe5 Nfd7 12. Ne4 h6 13. Bh4 Qxa2 14. Rd1 Qd5 15. Qe3 Qxe5 16.\\nYou are playing as player White.\\nIt is now your turn. Play your strongest move. The move MUST be legal. Reason step by step to come up with your move, then output your final answer in the format \\\"Final Answer: X\\\" where X is your chosen move in standard algebraic notation (SAN).\\n\"\n          }\n        ]\n      }\n    ],\n    \"config\": {\n      \"temperature\": \"NOT_GIVEN\",\n      \"top_p\": \"NOT_GIVEN\",\n      \"max_completion_tokens\": \"NOT_GIVEN\"\n    },\n    \"stream_options\": {\n      \"include_usage\": true\n    }\n  },\n  \"response_for_logging\": {\n    \"response_chunks\": [\n      {\n        \"id\": \"dJP6acvrMsudmecPmbT14Qk\",\n        \"choices\": [\n          {\n            \"delta\": {\n              \"content\": \" pressure on the position.\\n\\nFinal Answer: Be2\",\n              \"role\": \"assistant\"\n            },\n            \"finish_reason\": \"stop\",\n            \"index\": 0\n          }\n        ],\n        \"created\": 1778029428,\n        \"model\": \"google/gemini-3.1-pro-preview\",\n        \"object\": \"chat.completion.chunk\",\n        \"usage\": {\n          \"completion_tokens\": 419,\n          \"prompt_tokens\": 264,\n          \"total_tokens\": 4128,\n          \"cost\": {\n            \"input_tokens_cost_nanodollars\": 528000,\n            \"output_tokens_cost_nanodollars\": 46368000\n          },\n          \"total_backend_latency_ms\": 26594\n        }\n      }\n    ]\n  },\n  \"generation_tokens\": 419,\n  \"prompt_tokens\": 264,\n  \"reasoning_tokens\": null,\n  \"total_tokens\": 4128,\n  \"duration_success_only_secs\": 27.064285721999113\n}"
+          ],
+          "status": "OK",
+          "submission": 2977,
+          "thoughts": "The position arises from the highly complex and heavily theoretical Poisoned Pawn Variation of the Sicilian Najdorf. Specifically, this is the modern 14. Rd1 line where White gambits a second (and even a third) pawn for a massive lead in development and dangerous attacking potential.\n\nBlack has just grabbed the e5 pawn with 15... Qxe5, meaning White is currently down three pawns. However, Black's development is severely lagging, the king is stuck in the center, and White's pieces are aggressively centralized. \n\nYour best move here is **16. Be2**. \n\n**Step-by-step reasoning:**\n1. **Development & King Safety:** White's immediate priority is to finish minor piece development and get the king to safety. 16. Be2 develops the bishop, guards the d3 square, and prepares for Kingside castling (O-O). \n2. **Tempo on the Queen:** Playing Be2 sets up the deadly threat of Bg3, which will attack the Black queen on e5. \n3. **Avoiding immediate checks:** Playing 16. Bg3 directly allows Black the annoying 16... Qa5+ intermezzo, forcing White to play c3 and somewhat compromise the queenside or misplace a piece. 16. Be2 prevents any productive checks.\n4. **Mainline Theory:** After 16. Be2, Black's most critical and standard response is 16... Bc5 (pinning the Knight on d4). White will then follow up with 17. Bg3. If Black plays 17... Qd5, White can reply with 18. c4! or 18. O-O, maintaining a blistering initiative that fully compensates for the material deficit. If Black plays 16... Nc6, White simply plays 17. Bg3 Qa5+ 18. c3, keeping immense pressure on the position.\n\nFinal Answer: Be2"
+        },
+        "info": {
+          "actionApplied": 2977,
+          "actionSubmitted": 2977,
+          "actionSubmittedToString": "Be2",
+          "agentSelfReportedStatus": "OK",
+          "timeTaken": 28.748
+        },
+        "observation": {
+          "currentPlayer": 0,
+          "isTerminal": false,
+          "observationString": "rnb1kb1r/1p1n1pp1/p3p2p/4q3/3NN2B/4Q3/2P1B1PP/3RK2R b Kkq - 1 16",
+          "playerId": 1,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n1258\n3572\n1841\n1842\n1431\n3132\n3572\n656\n89\n1215\n2425\n3010\n1808\n1768\n749\n30\n1065\n2571\n1942\n3196\n3131\n1384\n4177\n3854\n381\n615\n498\n1869\n2001\n2977\n\n"
+        },
+        "reward": null,
+        "status": "INACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "actionString": "Bc5",
+          "generate_returns": [
+            "{\n  \"main_response\": \"The strongest move is to develop with tempo and exploit the pins on White\\u2019s knights:\\n\\n- The queen on e5 attacks both knights, but cannot yet capture because White\\u2019s queen on e3 would recapture.\\n- Playing **...Bc5** pins the knight on d4 to the queen on e3.\\n- If the e4-knight moves, Black can play **...Qxe3**, winning White\\u2019s queen.\\n- This is the key tactical resource in the position.\\n\\nFinal Answer: Bc5\",\n  \"main_response_and_thoughts\": \"\",\n  \"request_for_logging\": {\n    \"model\": \"openai/gpt-5.5-2026-04-23\",\n    \"messages\": [\n      {\n        \"role\": \"user\",\n        \"content\": [\n          {\n            \"type\": \"text\",\n            \"text\": \"Let's play chess. The current game state in Forsyth-Edwards Notation (FEN) notation is:\\nrnb1kb1r/1p1n1pp1/p3p2p/4q3/3NN2B/4Q3/2P1B1PP/3RK2R b Kkq - 1 16\\nThe moves played so far are:\\n1. e4 c5 2. Nf3 d6 3. d4 cxd4 4. Nxd4 Nf6 5. Nc3 a6 6. Bg5 e6 7. f4 Qb6 8. Qd2 Qxb2 9. Rb1 Qa3 10. e5 dxe5 11. fxe5 Nfd7 12. Ne4 h6 13. Bh4 Qxa2 14. Rd1 Qd5 15. Qe3 Qxe5 16. Be2\\nYou are playing as player Black.\\nIt is now your turn. Play your strongest move. The move MUST be legal. Reason step by step to come up with your move, then output your final answer in the format \\\"Final Answer: X\\\" where X is your chosen move in standard algebraic notation (SAN).\\n\"\n          }\n        ]\n      }\n    ],\n    \"config\": {\n      \"temperature\": \"NOT_GIVEN\",\n      \"top_p\": \"NOT_GIVEN\",\n      \"max_completion_tokens\": \"NOT_GIVEN\",\n      \"reasoning_effort\": \"high\"\n    },\n    \"stream_options\": {\n      \"include_usage\": true\n    }\n  },\n  \"response_for_logging\": {\n    \"response_chunks\": [\n      {\n        \"id\": \"chatcmpl-DcKyPDaSM4gwtSSZDzsau55irD4x3\",\n        \"created\": 1778029457,\n        \"model\": \"openai/gpt-5.5-2026-04-23\",\n        \"object\": \"chat.completion.chunk\",\n        \"usage\": {\n          \"completion_tokens\": 14091,\n          \"prompt_tokens\": 278,\n          \"total_tokens\": 14369,\n          \"cost\": {\n            \"input_tokens_cost_nanodollars\": 1390000,\n            \"output_tokens_cost_nanodollars\": 422730000\n          },\n          \"total_backend_latency_ms\": 254871\n        }\n      }\n    ]\n  },\n  \"generation_tokens\": 14091,\n  \"prompt_tokens\": 278,\n  \"reasoning_tokens\": null,\n  \"total_tokens\": 14369,\n  \"duration_success_only_secs\": 255.354532673\n}"
+          ],
+          "status": "OK",
+          "submission": 2975,
+          "thoughts": "The strongest move is to develop with tempo and exploit the pins on White\u2019s knights:\n\n- The queen on e5 attacks both knights, but cannot yet capture because White\u2019s queen on e3 would recapture.\n- Playing **...Bc5** pins the knight on d4 to the queen on e3.\n- If the e4-knight moves, Black can play **...Qxe3**, winning White\u2019s queen.\n- This is the key tactical resource in the position.\n\nFinal Answer: Bc5"
+        },
+        "info": {
+          "actionApplied": 2975,
+          "actionSubmitted": 2975,
+          "actionSubmittedToString": "Bc5",
+          "agentSelfReportedStatus": "OK",
+          "timeTaken": 256.537
+        },
+        "observation": {
+          "currentPlayer": 1,
+          "isTerminal": false,
+          "observationString": "rnb1k2r/1p1n1pp1/p3p2p/2b1q3/3NN2B/4Q3/2P1B1PP/3RK2R w Kkq - 2 17",
+          "playerId": 0,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n1258\n3572\n1841\n1842\n1431\n3132\n3572\n656\n89\n1215\n2425\n3010\n1808\n1768\n749\n30\n1065\n2571\n1942\n3196\n3131\n1384\n4177\n3854\n381\n615\n498\n1869\n2001\n2977\n2975\n\n",
+          "step": 33
+        },
+        "reward": null,
+        "status": "INACTIVE"
+      },
+      {
+        "action": {
+          "submission": -1
+        },
+        "info": {},
+        "observation": {
+          "currentPlayer": 1,
+          "isTerminal": false,
+          "observationString": "rnb1k2r/1p1n1pp1/p3p2p/2b1q3/3NN2B/4Q3/2P1B1PP/3RK2R w Kkq - 2 17",
+          "playerId": 1,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n1258\n3572\n1841\n1842\n1431\n3132\n3572\n656\n89\n1215\n2425\n3010\n1808\n1768\n749\n30\n1065\n2571\n1942\n3196\n3131\n1384\n4177\n3854\n381\n615\n498\n1869\n2001\n2977\n2975\n\n"
+        },
+        "reward": null,
+        "status": "ACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "submission": -1
+        },
+        "info": {},
+        "observation": {
+          "currentPlayer": 0,
+          "isTerminal": false,
+          "observationString": "rnb1k2r/1p1n1pp1/p3p2p/2b1q3/3NN3/4Q1B1/2P1B1PP/3RK2R b Kkq - 3 17",
+          "playerId": 0,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n1258\n3572\n1841\n1842\n1431\n3132\n3572\n656\n89\n1215\n2425\n3010\n1808\n1768\n749\n30\n1065\n2571\n1942\n3196\n3131\n1384\n4177\n3854\n381\n615\n498\n1869\n2001\n2977\n2975\n4350\n\n",
+          "step": 34
+        },
+        "reward": null,
+        "status": "ACTIVE"
+      },
+      {
+        "action": {
+          "actionString": "Bg3",
+          "generate_returns": [
+            "{\n  \"main_response\": \"To determine the strongest move in this highly complex and sharp position (a deeply analyzed line of the Najdorf Poisoned Pawn Variation), we must evaluate the material and positional imbalances. White has sacrificed three pawns but in return has achieved a massive lead in development, a fully centralized army, and significant attacking potential. Black's Queen on e5 is aggressively placed but vulnerable, and the Black King remains uncastled in the center.\\n\\nHere is the step-by-step reasoning for White's best move:\\n\\n1. **Exploiting Vulnerabilities:** Black's Queen on e5 is sitting in the center of the board, making it a prime target. White must play energetically to justify the three-pawn deficit; any slow move allows Black to catch up in development (like playing ...Nc6 or ...O-O). \\n2. **Developing with Tempo:** The move **17. Bg3!** is exceptionally strong here. The Bishop retreats from h4 to g3, instantly attacking the Black Queen on e5. \\n3. **Restricting Black's Responses:** Black has no time to consolidate and is practically forced into one of a few critical responses to save the Queen:\\n   - If Black plays `17... Qd5` (keeping pressure on the pinned Knight on d4), White can simply castle `18. O-O`. Then, if Black tries to develop with `18... O-O` or `18... Nc6`, White strikes brilliantly with `19. c4!`, renewing the attack on the Queen and unraveling the position powerfully. \\n   - If Black decides to chop the pinned knight with `17... Bxd4`, White replies with `18. Rxd4!`. The rook centralizes and once again attacks the Queen on e5, opening the d-file for devastating tactics. Following `18... Qa5+ 19. c3`, White maintains an overwhelming initiative while Black's King remains stuck.\\n\\nBy attacking the Queen with the Bishop, White keeps the momentum and prevents Black from untangling their pieces. \\n\\nFinal Answer: Bg3\",\n  \"main_response_and_thoughts\": \"\",\n  \"request_for_logging\": {\n    \"model\": \"google/gemini-3.1-pro-preview\",\n    \"messages\": [\n      {\n        \"role\": \"user\",\n        \"content\": [\n          {\n            \"type\": \"text\",\n            \"text\": \"Let's play chess. The current game state in Forsyth-Edwards Notation (FEN) notation is:\\nrnb1k2r/1p1n1pp1/p3p2p/2b1q3/3NN2B/4Q3/2P1B1PP/3RK2R w Kkq - 2 17\\nThe moves played so far are:\\n1. e4 c5 2. Nf3 d6 3. d4 cxd4 4. Nxd4 Nf6 5. Nc3 a6 6. Bg5 e6 7. f4 Qb6 8. Qd2 Qxb2 9. Rb1 Qa3 10. e5 dxe5 11. fxe5 Nfd7 12. Ne4 h6 13. Bh4 Qxa2 14. Rd1 Qd5 15. Qe3 Qxe5 16. Be2 Bc5 17.\\nYou are playing as player White.\\nIt is now your turn. Play your strongest move. The move MUST be legal. Reason step by step to come up with your move, then output your final answer in the format \\\"Final Answer: X\\\" where X is your chosen move in standard algebraic notation (SAN).\\n\"\n          }\n        ]\n      }\n    ],\n    \"config\": {\n      \"temperature\": \"NOT_GIVEN\",\n      \"top_p\": \"NOT_GIVEN\",\n      \"max_completion_tokens\": \"NOT_GIVEN\"\n    },\n    \"stream_options\": {\n      \"include_usage\": true\n    }\n  },\n  \"response_for_logging\": {\n    \"response_chunks\": [\n      {\n        \"id\": \"kpT6aZvnB7WKmecPxOar6Aw\",\n        \"choices\": [\n          {\n            \"delta\": {\n              \"content\": \" the Queen with the Bishop, White keeps the momentum and prevents Black from untangling their pieces. \\n\\nFinal Answer: Bg3\",\n              \"role\": \"assistant\"\n            },\n            \"finish_reason\": \"stop\",\n            \"index\": 0\n          }\n        ],\n        \"created\": 1778029714,\n        \"model\": \"google/gemini-3.1-pro-preview\",\n        \"object\": \"chat.completion.chunk\",\n        \"usage\": {\n          \"completion_tokens\": 444,\n          \"prompt_tokens\": 275,\n          \"total_tokens\": 6463,\n          \"cost\": {\n            \"input_tokens_cost_nanodollars\": 550000,\n            \"output_tokens_cost_nanodollars\": 74256000\n          },\n          \"total_backend_latency_ms\": 56601\n        }\n      }\n    ]\n  },\n  \"generation_tokens\": 444,\n  \"prompt_tokens\": 275,\n  \"reasoning_tokens\": null,\n  \"total_tokens\": 6463,\n  \"duration_success_only_secs\": 57.08956856799887\n}"
+          ],
+          "status": "OK",
+          "submission": 4350,
+          "thoughts": "To determine the strongest move in this highly complex and sharp position (a deeply analyzed line of the Najdorf Poisoned Pawn Variation), we must evaluate the material and positional imbalances. White has sacrificed three pawns but in return has achieved a massive lead in development, a fully centralized army, and significant attacking potential. Black's Queen on e5 is aggressively placed but vulnerable, and the Black King remains uncastled in the center.\n\nHere is the step-by-step reasoning for White's best move:\n\n1. **Exploiting Vulnerabilities:** Black's Queen on e5 is sitting in the center of the board, making it a prime target. White must play energetically to justify the three-pawn deficit; any slow move allows Black to catch up in development (like playing ...Nc6 or ...O-O). \n2. **Developing with Tempo:** The move **17. Bg3!** is exceptionally strong here. The Bishop retreats from h4 to g3, instantly attacking the Black Queen on e5. \n3. **Restricting Black's Responses:** Black has no time to consolidate and is practically forced into one of a few critical responses to save the Queen:\n   - If Black plays `17... Qd5` (keeping pressure on the pinned Knight on d4), White can simply castle `18. O-O`. Then, if Black tries to develop with `18... O-O` or `18... Nc6`, White strikes brilliantly with `19. c4!`, renewing the attack on the Queen and unraveling the position powerfully. \n   - If Black decides to chop the pinned knight with `17... Bxd4`, White replies with `18. Rxd4!`. The rook centralizes and once again attacks the Queen on e5, opening the d-file for devastating tactics. Following `18... Qa5+ 19. c3`, White maintains an overwhelming initiative while Black's King remains stuck.\n\nBy attacking the Queen with the Bishop, White keeps the momentum and prevents Black from untangling their pieces. \n\nFinal Answer: Bg3"
+        },
+        "info": {
+          "actionApplied": 4350,
+          "actionSubmitted": 4350,
+          "actionSubmittedToString": "Bg3",
+          "agentSelfReportedStatus": "OK",
+          "timeTaken": 58.286
+        },
+        "observation": {
+          "currentPlayer": 0,
+          "isTerminal": false,
+          "observationString": "rnb1k2r/1p1n1pp1/p3p2p/2b1q3/3NN3/4Q1B1/2P1B1PP/3RK2R b Kkq - 3 17",
+          "playerId": 1,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n1258\n3572\n1841\n1842\n1431\n3132\n3572\n656\n89\n1215\n2425\n3010\n1808\n1768\n749\n30\n1065\n2571\n1942\n3196\n3131\n1384\n4177\n3854\n381\n615\n498\n1869\n2001\n2977\n2975\n4350\n\n"
+        },
+        "reward": null,
+        "status": "INACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "actionString": "Bxd4",
+          "generate_returns": [
+            "{\n  \"main_response\": \"White\\u2019s 17.Bg3 attacks the queen on e5, but Black has a strong zwischenzug: capturing the knight on d4 while attacking White\\u2019s queen on e3. If White takes the queen, Black recaptures White\\u2019s queen.\\n\\nFinal Answer: Bxd4\",\n  \"main_response_and_thoughts\": \"\",\n  \"request_for_logging\": {\n    \"model\": \"openai/gpt-5.5-2026-04-23\",\n    \"messages\": [\n      {\n        \"role\": \"user\",\n        \"content\": [\n          {\n            \"type\": \"text\",\n            \"text\": \"Let's play chess. The current game state in Forsyth-Edwards Notation (FEN) notation is:\\nrnb1k2r/1p1n1pp1/p3p2p/2b1q3/3NN3/4Q1B1/2P1B1PP/3RK2R b Kkq - 3 17\\nThe moves played so far are:\\n1. e4 c5 2. Nf3 d6 3. d4 cxd4 4. Nxd4 Nf6 5. Nc3 a6 6. Bg5 e6 7. f4 Qb6 8. Qd2 Qxb2 9. Rb1 Qa3 10. e5 dxe5 11. fxe5 Nfd7 12. Ne4 h6 13. Bh4 Qxa2 14. Rd1 Qd5 15. Qe3 Qxe5 16. Be2 Bc5 17. Bg3\\nYou are playing as player Black.\\nIt is now your turn. Play your strongest move. The move MUST be legal. Reason step by step to come up with your move, then output your final answer in the format \\\"Final Answer: X\\\" where X is your chosen move in standard algebraic notation (SAN).\\n\"\n          }\n        ]\n      }\n    ],\n    \"config\": {\n      \"temperature\": \"NOT_GIVEN\",\n      \"top_p\": \"NOT_GIVEN\",\n      \"max_completion_tokens\": \"NOT_GIVEN\",\n      \"reasoning_effort\": \"high\"\n    },\n    \"stream_options\": {\n      \"include_usage\": true\n    }\n  },\n  \"response_for_logging\": {\n    \"response_chunks\": [\n      {\n        \"id\": \"chatcmpl-DcL3VOcrSlFSzQu8nSmBU9qA90wqT\",\n        \"created\": 1778029773,\n        \"model\": \"openai/gpt-5.5-2026-04-23\",\n        \"object\": \"chat.completion.chunk\",\n        \"usage\": {\n          \"completion_tokens\": 4722,\n          \"prompt_tokens\": 289,\n          \"total_tokens\": 5011,\n          \"cost\": {\n            \"input_tokens_cost_nanodollars\": 1445000,\n            \"output_tokens_cost_nanodollars\": 141660000\n          },\n          \"total_backend_latency_ms\": 81716\n        }\n      }\n    ]\n  },\n  \"generation_tokens\": 4722,\n  \"prompt_tokens\": 289,\n  \"reasoning_tokens\": null,\n  \"total_tokens\": 5011,\n  \"duration_success_only_secs\": 82.2178020299998\n}"
+          ],
+          "status": "OK",
+          "submission": 1431,
+          "thoughts": "White\u2019s 17.Bg3 attacks the queen on e5, but Black has a strong zwischenzug: capturing the knight on d4 while attacking White\u2019s queen on e3. If White takes the queen, Black recaptures White\u2019s queen.\n\nFinal Answer: Bxd4"
+        },
+        "info": {
+          "actionApplied": 1431,
+          "actionSubmitted": 1431,
+          "actionSubmittedToString": "Bxd4",
+          "agentSelfReportedStatus": "OK",
+          "timeTaken": 84.066
+        },
+        "observation": {
+          "currentPlayer": 1,
+          "isTerminal": false,
+          "observationString": "rnb1k2r/1p1n1pp1/p3p2p/4q3/3bN3/4Q1B1/2P1B1PP/3RK2R w Kkq - 0 18",
+          "playerId": 0,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n1258\n3572\n1841\n1842\n1431\n3132\n3572\n656\n89\n1215\n2425\n3010\n1808\n1768\n749\n30\n1065\n2571\n1942\n3196\n3131\n1384\n4177\n3854\n381\n615\n498\n1869\n2001\n2977\n2975\n4350\n1431\n\n",
+          "step": 35
+        },
+        "reward": null,
+        "status": "INACTIVE"
+      },
+      {
+        "action": {
+          "submission": -1
+        },
+        "info": {},
+        "observation": {
+          "currentPlayer": 1,
+          "isTerminal": false,
+          "observationString": "rnb1k2r/1p1n1pp1/p3p2p/4q3/3bN3/4Q1B1/2P1B1PP/3RK2R w Kkq - 0 18",
+          "playerId": 1,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n1258\n3572\n1841\n1842\n1431\n3132\n3572\n656\n89\n1215\n2425\n3010\n1808\n1768\n749\n30\n1065\n2571\n1942\n3196\n3131\n1384\n4177\n3854\n381\n615\n498\n1869\n2001\n2977\n2975\n4350\n1431\n\n"
+        },
+        "reward": null,
+        "status": "ACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "submission": -1
+        },
+        "info": {},
+        "observation": {
+          "currentPlayer": 0,
+          "isTerminal": false,
+          "observationString": "rnb1k2r/1p1n1pp1/p3p2p/4q3/3RN3/4Q1B1/2P1B1PP/4K2R b Kkq - 0 18",
+          "playerId": 0,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n1258\n3572\n1841\n1842\n1431\n3132\n3572\n656\n89\n1215\n2425\n3010\n1808\n1768\n749\n30\n1065\n2571\n1942\n3196\n3131\n1384\n4177\n3854\n381\n615\n498\n1869\n2001\n2977\n2975\n4350\n1431\n1770\n\n",
+          "step": 36
+        },
+        "reward": null,
+        "status": "ACTIVE"
+      },
+      {
+        "action": {
+          "actionString": "Rxd4",
+          "generate_returns": [
+            "{\n  \"main_response\": \"To determine the best move, let's analyze the current position and the material balance. \\n\\n**Step 1: Understand the Material and Threats**\\nBlack has just played `17... Bxd4`, capturing your knight on d4. Currently, White is down a full piece (a knight). Additionally, Black's queen on e5 is sitting on the same open e-file as your queen on e3, meaning they are mutually attacking each other. However, your bishop on g3 is also eyeing the black queen on e5. \\n\\n**Step 2: Analyze Candidate Moves**\\nIf you try to resolve the queen tension directly with `18. Bxe5`, Black will simply respond with `18... Bxe3`. After the dust settles with a sequence like `19. Nd6+ Ke7 20. Nxc8+ Raxc8`, White remains down a piece and is losing the endgame. \\n\\nIf you try the intermediate check `18. Nd6+`, Black can simply sacrifice their queen for two pieces with `18... Qxd6! 19. Bxd6 Bxe3 20. Rd3`. Once again, White is still down a minor piece overall and lacking enough compensation.\\n\\n**Step 3: The Winning Move - 18. Rxd4!**\\nThe strongest and most natural continuation is to immediately recapture the piece with your rook: `18. Rxd4`.\\nBy doing this, you restore material equality (in terms of minor/major pieces) and present Black with a massive problem: their queen on e5 is still hanging to your bishop on g3 and your queen on e3. \\n\\nLet's look at how Black can respond:\\n- If Black plays `18... Qxd4` (taking the rook), you simply recapture with `19. Qxd4`. You have effectively traded a rook for a queen, leaving you with a huge material advantage (+4) and a completely winning position.\\n- If Black tries to save their queen with a move like `18... Qc5`, they fall into a devastating positional trap. You can follow up with moves like `19. Bd6!`, completely dominating the center, locking Black's king in, and putting overwhelming pressure on their cramped setup. (Also `19. Nd6+` leads to devastating forks). \\n- If Black tries `18... Qa5+`, you simply play `19. c3` (which is safely defended by your e4-knight) or `19. Qd2` leading into an endgame where you are fully consolidated, materially equal in pieces, and enjoying the pair of bishops. \\n\\nBy playing `18. Rxd4`, White regains the lost piece while keeping a vice-like grip on the initiative. \\n\\nFinal Answer: Rxd4\",\n  \"main_response_and_thoughts\": \"\",\n  \"request_for_logging\": {\n    \"model\": \"google/gemini-3.1-pro-preview\",\n    \"messages\": [\n      {\n        \"role\": \"user\",\n        \"content\": [\n          {\n            \"type\": \"text\",\n            \"text\": \"Let's play chess. The current game state in Forsyth-Edwards Notation (FEN) notation is:\\nrnb1k2r/1p1n1pp1/p3p2p/4q3/3bN3/4Q1B1/2P1B1PP/3RK2R w Kkq - 0 18\\nThe moves played so far are:\\n1. e4 c5 2. Nf3 d6 3. d4 cxd4 4. Nxd4 Nf6 5. Nc3 a6 6. Bg5 e6 7. f4 Qb6 8. Qd2 Qxb2 9. Rb1 Qa3 10. e5 dxe5 11. fxe5 Nfd7 12. Ne4 h6 13. Bh4 Qxa2 14. Rd1 Qd5 15. Qe3 Qxe5 16. Be2 Bc5 17. Bg3 Bxd4 18.\\nYou are playing as player White.\\nIt is now your turn. Play your strongest move. The move MUST be legal. Reason step by step to come up with your move, then output your final answer in the format \\\"Final Answer: X\\\" where X is your chosen move in standard algebraic notation (SAN).\\n\"\n          }\n        ]\n      }\n    ],\n    \"config\": {\n      \"temperature\": \"NOT_GIVEN\",\n      \"top_p\": \"NOT_GIVEN\",\n      \"max_completion_tokens\": \"NOT_GIVEN\"\n    },\n    \"stream_options\": {\n      \"include_usage\": true\n    }\n  },\n  \"response_for_logging\": {\n    \"response_chunks\": [\n      {\n        \"id\": \"IJX6afP2OsudmecPmbT14Qk\",\n        \"choices\": [\n          {\n            \"delta\": {\n              \"content\": \"-like grip on the initiative. \\n\\nFinal Answer: Rxd4\",\n              \"role\": \"assistant\"\n            },\n            \"finish_reason\": \"stop\",\n            \"index\": 0\n          }\n        ],\n        \"created\": 1778029856,\n        \"model\": \"google/gemini-3.1-pro-preview\",\n        \"object\": \"chat.completion.chunk\",\n        \"usage\": {\n          \"completion_tokens\": 592,\n          \"prompt_tokens\": 283,\n          \"total_tokens\": 21183,\n          \"cost\": {\n            \"input_tokens_cost_nanodollars\": 566000,\n            \"output_tokens_cost_nanodollars\": 250800000\n          },\n          \"total_backend_latency_ms\": 193155\n        }\n      }\n    ]\n  },\n  \"generation_tokens\": 592,\n  \"prompt_tokens\": 283,\n  \"reasoning_tokens\": null,\n  \"total_tokens\": 21183,\n  \"duration_success_only_secs\": 193.68276038699878\n}"
+          ],
+          "status": "OK",
+          "submission": 1770,
+          "thoughts": "To determine the best move, let's analyze the current position and the material balance. \n\n**Step 1: Understand the Material and Threats**\nBlack has just played `17... Bxd4`, capturing your knight on d4. Currently, White is down a full piece (a knight). Additionally, Black's queen on e5 is sitting on the same open e-file as your queen on e3, meaning they are mutually attacking each other. However, your bishop on g3 is also eyeing the black queen on e5. \n\n**Step 2: Analyze Candidate Moves**\nIf you try to resolve the queen tension directly with `18. Bxe5`, Black will simply respond with `18... Bxe3`. After the dust settles with a sequence like `19. Nd6+ Ke7 20. Nxc8+ Raxc8`, White remains down a piece and is losing the endgame. \n\nIf you try the intermediate check `18. Nd6+`, Black can simply sacrifice their queen for two pieces with `18... Qxd6! 19. Bxd6 Bxe3 20. Rd3`. Once again, White is still down a minor piece overall and lacking enough compensation.\n\n**Step 3: The Winning Move - 18. Rxd4!**\nThe strongest and most natural continuation is to immediately recapture the piece with your rook: `18. Rxd4`.\nBy doing this, you restore material equality (in terms of minor/major pieces) and present Black with a massive problem: their queen on e5 is still hanging to your bishop on g3 and your queen on e3. \n\nLet's look at how Black can respond:\n- If Black plays `18... Qxd4` (taking the rook), you simply recapture with `19. Qxd4`. You have effectively traded a rook for a queen, leaving you with a huge material advantage (+4) and a completely winning position.\n- If Black tries to save their queen with a move like `18... Qc5`, they fall into a devastating positional trap. You can follow up with moves like `19. Bd6!`, completely dominating the center, locking Black's king in, and putting overwhelming pressure on their cramped setup. (Also `19. Nd6+` leads to devastating forks). \n- If Black tries `18... Qa5+`, you simply play `19. c3` (which is safely defended by your e4-knight) or `19. Qd2` leading into an endgame where you are fully consolidated, materially equal in pieces, and enjoying the pair of bishops. \n\nBy playing `18. Rxd4`, White regains the lost piece while keeping a vice-like grip on the initiative. \n\nFinal Answer: Rxd4"
+        },
+        "info": {
+          "actionApplied": 1770,
+          "actionSubmitted": 1770,
+          "actionSubmittedToString": "Rxd4",
+          "agentSelfReportedStatus": "OK",
+          "timeTaken": 195.418
+        },
+        "observation": {
+          "currentPlayer": 0,
+          "isTerminal": false,
+          "observationString": "rnb1k2r/1p1n1pp1/p3p2p/4q3/3RN3/4Q1B1/2P1B1PP/4K2R b Kkq - 0 18",
+          "playerId": 1,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n1258\n3572\n1841\n1842\n1431\n3132\n3572\n656\n89\n1215\n2425\n3010\n1808\n1768\n749\n30\n1065\n2571\n1942\n3196\n3131\n1384\n4177\n3854\n381\n615\n498\n1869\n2001\n2977\n2975\n4350\n1431\n1770\n\n"
+        },
+        "reward": null,
+        "status": "INACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "actionString": "Qa5+",
+          "generate_returns": [
+            "{\n  \"main_response\": \"Final Answer: Qa5+\",\n  \"main_response_and_thoughts\": \"\",\n  \"request_for_logging\": {\n    \"model\": \"openai/gpt-5.5-2026-04-23\",\n    \"messages\": [\n      {\n        \"role\": \"user\",\n        \"content\": [\n          {\n            \"type\": \"text\",\n            \"text\": \"Let's play chess. The current game state in Forsyth-Edwards Notation (FEN) notation is:\\nrnb1k2r/1p1n1pp1/p3p2p/4q3/3RN3/4Q1B1/2P1B1PP/4K2R b Kkq - 0 18\\nThe moves played so far are:\\n1. e4 c5 2. Nf3 d6 3. d4 cxd4 4. Nxd4 Nf6 5. Nc3 a6 6. Bg5 e6 7. f4 Qb6 8. Qd2 Qxb2 9. Rb1 Qa3 10. e5 dxe5 11. fxe5 Nfd7 12. Ne4 h6 13. Bh4 Qxa2 14. Rd1 Qd5 15. Qe3 Qxe5 16. Be2 Bc5 17. Bg3 Bxd4 18. Rxd4\\nYou are playing as player Black.\\nIt is now your turn. Play your strongest move. The move MUST be legal. Reason step by step to come up with your move, then output your final answer in the format \\\"Final Answer: X\\\" where X is your chosen move in standard algebraic notation (SAN).\\n\"\n          }\n        ]\n      }\n    ],\n    \"config\": {\n      \"temperature\": \"NOT_GIVEN\",\n      \"top_p\": \"NOT_GIVEN\",\n      \"max_completion_tokens\": \"NOT_GIVEN\",\n      \"reasoning_effort\": \"high\"\n    },\n    \"stream_options\": {\n      \"include_usage\": true\n    }\n  },\n  \"response_for_logging\": {\n    \"response_chunks\": [\n      {\n        \"id\": \"chatcmpl-DcL80JEFjroDLaMWmMZxTko3j5XQh\",\n        \"created\": 1778030052,\n        \"model\": \"openai/gpt-5.5-2026-04-23\",\n        \"object\": \"chat.completion.chunk\",\n        \"usage\": {\n          \"completion_tokens\": 10369,\n          \"prompt_tokens\": 296,\n          \"total_tokens\": 10665,\n          \"cost\": {\n            \"input_tokens_cost_nanodollars\": 1480000,\n            \"output_tokens_cost_nanodollars\": 311070000\n          },\n          \"total_backend_latency_ms\": 200029\n        }\n      }\n    ]\n  },\n  \"generation_tokens\": 10369,\n  \"prompt_tokens\": 296,\n  \"reasoning_tokens\": null,\n  \"total_tokens\": 10665,\n  \"duration_success_only_secs\": 200.50849423100044\n}"
+          ],
+          "status": "OK",
+          "submission": 2581,
+          "thoughts": "Final Answer: Qa5+"
+        },
+        "info": {
+          "actionApplied": 2581,
+          "actionSubmitted": 2581,
+          "actionSubmittedToString": "Qa5+",
+          "agentSelfReportedStatus": "OK",
+          "timeTaken": 202.767
+        },
+        "observation": {
+          "currentPlayer": 1,
+          "isTerminal": false,
+          "observationString": "rnb1k2r/1p1n1pp1/p3p2p/q7/3RN3/4Q1B1/2P1B1PP/4K2R w Kkq - 1 19",
+          "playerId": 0,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n1258\n3572\n1841\n1842\n1431\n3132\n3572\n656\n89\n1215\n2425\n3010\n1808\n1768\n749\n30\n1065\n2571\n1942\n3196\n3131\n1384\n4177\n3854\n381\n615\n498\n1869\n2001\n2977\n2975\n4350\n1431\n1770\n2581\n\n",
+          "step": 37
+        },
+        "reward": null,
+        "status": "INACTIVE"
+      },
+      {
+        "action": {
+          "submission": -1
+        },
+        "info": {},
+        "observation": {
+          "currentPlayer": 1,
+          "isTerminal": false,
+          "observationString": "rnb1k2r/1p1n1pp1/p3p2p/q7/3RN3/4Q1B1/2P1B1PP/4K2R w Kkq - 1 19",
+          "playerId": 1,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n1258\n3572\n1841\n1842\n1431\n3132\n3572\n656\n89\n1215\n2425\n3010\n1808\n1768\n749\n30\n1065\n2571\n1942\n3196\n3131\n1384\n4177\n3854\n381\n615\n498\n1869\n2001\n2977\n2975\n4350\n1431\n1770\n2581\n\n"
+        },
+        "reward": null,
+        "status": "ACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "submission": -1
+        },
+        "info": {},
+        "observation": {
+          "currentPlayer": 0,
+          "isTerminal": false,
+          "observationString": "rnb1k2r/1p1n1pp1/p3p2p/q7/3RN3/2P1Q1B1/4B1PP/4K2R b Kkq - 0 19",
+          "playerId": 0,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n1258\n3572\n1841\n1842\n1431\n3132\n3572\n656\n89\n1215\n2425\n3010\n1808\n1768\n749\n30\n1065\n2571\n1942\n3196\n3131\n1384\n4177\n3854\n381\n615\n498\n1869\n2001\n2977\n2975\n4350\n1431\n1770\n2581\n1257\n\n",
+          "step": 38
+        },
+        "reward": null,
+        "status": "ACTIVE"
+      },
+      {
+        "action": {
+          "actionString": "c3",
+          "generate_returns": [
+            "{\n  \"main_response\": \"The current position is a sharp and highly theoretical line of the Sicilian Defense, Najdorf Variation (Poisoned Pawn). White has sacrificed substantial material (three pawns) in the opening and middlegame to gain a massive lead in development, control the center, and launch a dangerous attack against Black's uncastled king. \\n\\nBlack has just played 18... Qa5+, checking the White king. White must resolve the check while keeping the momentum of the attack going. \\n\\nLet's look at White's options:\\n- 19. Qd2: Offering a queen trade with `19... Qxd2+` is counter-productive. Entering an endgame down three pawns completely kills White's attacking compensation. White needs the queens on the board to target Black's vulnerable king.\\n- 19. Nd2 or 19. Rd2: These moves temporarily block the check but misplace active pieces. Retreating the aggressive e4 knight allows Black to breathe, and pinning the d4 rook with 19. Rd2 is clunky and limits White's own flexibility.\\n- 19. Kf1: Moving the king directly loses the right to castle and disconnects the rooks, slowing White down. \\n\\nThe most precise and standard move is **19. c3**. \\nBy playing this, White calmly blocks the check using a pawn while keeping all attacking pieces on their optimal squares (the queen on e3, the rook centralized on d4, and the knight powerfully posted on e4). Most importantly, `19. c3` prepares for White to safely castle kingside (O-O) on the very next turn, bringing the h1 rook into the attack and tucking the king to safety.\\n\\nIf Black responds by continuing development (for instance, 19... Nc6), White will follow up with aggressive ideas such as 20. Nd6+ (forcing the king to remain in the center) or dropping the rook back to d2 while preparing to castle. The initiative remains firmly in White's hands.\\n\\nFinal Answer: c3\",\n  \"main_response_and_thoughts\": \"\",\n  \"request_for_logging\": {\n    \"model\": \"google/gemini-3.1-pro-preview\",\n    \"messages\": [\n      {\n        \"role\": \"user\",\n        \"content\": [\n          {\n            \"type\": \"text\",\n            \"text\": \"Let's play chess. The current game state in Forsyth-Edwards Notation (FEN) notation is:\\nrnb1k2r/1p1n1pp1/p3p2p/q7/3RN3/4Q1B1/2P1B1PP/4K2R w Kkq - 1 19\\nThe moves played so far are:\\n1. e4 c5 2. Nf3 d6 3. d4 cxd4 4. Nxd4 Nf6 5. Nc3 a6 6. Bg5 e6 7. f4 Qb6 8. Qd2 Qxb2 9. Rb1 Qa3 10. e5 dxe5 11. fxe5 Nfd7 12. Ne4 h6 13. Bh4 Qxa2 14. Rd1 Qd5 15. Qe3 Qxe5 16. Be2 Bc5 17. Bg3 Bxd4 18. Rxd4 Qa5+ 19.\\nYou are playing as player White.\\nIt is now your turn. Play your strongest move. The move MUST be legal. Reason step by step to come up with your move, then output your final answer in the format \\\"Final Answer: X\\\" where X is your chosen move in standard algebraic notation (SAN).\\n\"\n          }\n        ]\n      }\n    ],\n    \"config\": {\n      \"temperature\": \"NOT_GIVEN\",\n      \"top_p\": \"NOT_GIVEN\",\n      \"max_completion_tokens\": \"NOT_GIVEN\"\n    },\n    \"stream_options\": {\n      \"include_usage\": true\n    }\n  },\n  \"response_for_logging\": {\n    \"response_chunks\": [\n      {\n        \"id\": \"r5b6abKVDcudmecPmbT14Qk\",\n        \"choices\": [\n          {\n            \"delta\": {\n              \"content\": \" hands.\\n\\nFinal Answer: c3\",\n              \"role\": \"assistant\"\n            },\n            \"finish_reason\": \"stop\",\n            \"index\": 0\n          }\n        ],\n        \"created\": 1778030255,\n        \"model\": \"google/gemini-3.1-pro-preview\",\n        \"object\": \"chat.completion.chunk\",\n        \"usage\": {\n          \"completion_tokens\": 441,\n          \"prompt_tokens\": 290,\n          \"total_tokens\": 5428,\n          \"cost\": {\n            \"input_tokens_cost_nanodollars\": 580000,\n            \"output_tokens_cost_nanodollars\": 61656000\n          },\n          \"total_backend_latency_ms\": 41540\n        }\n      }\n    ]\n  },\n  \"generation_tokens\": 441,\n  \"prompt_tokens\": 290,\n  \"reasoning_tokens\": null,\n  \"total_tokens\": 5428,\n  \"duration_success_only_secs\": 42.51878041600139\n}"
+          ],
+          "status": "OK",
+          "submission": 1257,
+          "thoughts": "The current position is a sharp and highly theoretical line of the Sicilian Defense, Najdorf Variation (Poisoned Pawn). White has sacrificed substantial material (three pawns) in the opening and middlegame to gain a massive lead in development, control the center, and launch a dangerous attack against Black's uncastled king. \n\nBlack has just played 18... Qa5+, checking the White king. White must resolve the check while keeping the momentum of the attack going. \n\nLet's look at White's options:\n- 19. Qd2: Offering a queen trade with `19... Qxd2+` is counter-productive. Entering an endgame down three pawns completely kills White's attacking compensation. White needs the queens on the board to target Black's vulnerable king.\n- 19. Nd2 or 19. Rd2: These moves temporarily block the check but misplace active pieces. Retreating the aggressive e4 knight allows Black to breathe, and pinning the d4 rook with 19. Rd2 is clunky and limits White's own flexibility.\n- 19. Kf1: Moving the king directly loses the right to castle and disconnects the rooks, slowing White down. \n\nThe most precise and standard move is **19. c3**. \nBy playing this, White calmly blocks the check using a pawn while keeping all attacking pieces on their optimal squares (the queen on e3, the rook centralized on d4, and the knight powerfully posted on e4). Most importantly, `19. c3` prepares for White to safely castle kingside (O-O) on the very next turn, bringing the h1 rook into the attack and tucking the king to safety.\n\nIf Black responds by continuing development (for instance, 19... Nc6), White will follow up with aggressive ideas such as 20. Nd6+ (forcing the king to remain in the center) or dropping the rook back to d2 while preparing to castle. The initiative remains firmly in White's hands.\n\nFinal Answer: c3"
+        },
+        "info": {
+          "actionApplied": 1257,
+          "actionSubmitted": 1257,
+          "actionSubmittedToString": "c3",
+          "agentSelfReportedStatus": "OK",
+          "timeTaken": 43.712
+        },
+        "observation": {
+          "currentPlayer": 0,
+          "isTerminal": false,
+          "observationString": "rnb1k2r/1p1n1pp1/p3p2p/q7/3RN3/2P1Q1B1/4B1PP/4K2R b Kkq - 0 19",
+          "playerId": 1,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n1258\n3572\n1841\n1842\n1431\n3132\n3572\n656\n89\n1215\n2425\n3010\n1808\n1768\n749\n30\n1065\n2571\n1942\n3196\n3131\n1384\n4177\n3854\n381\n615\n498\n1869\n2001\n2977\n2975\n4350\n1431\n1770\n2581\n1257\n\n"
+        },
+        "reward": null,
+        "status": "INACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "actionString": "O-O",
+          "generate_returns": [
+            "{\n  \"main_response\": \"Final Answer: O-O\",\n  \"main_response_and_thoughts\": \"\",\n  \"request_for_logging\": {\n    \"model\": \"openai/gpt-5.5-2026-04-23\",\n    \"messages\": [\n      {\n        \"role\": \"user\",\n        \"content\": [\n          {\n            \"type\": \"text\",\n            \"text\": \"Let's play chess. The current game state in Forsyth-Edwards Notation (FEN) notation is:\\nrnb1k2r/1p1n1pp1/p3p2p/q7/3RN3/2P1Q1B1/4B1PP/4K2R b Kkq - 0 19\\nThe moves played so far are:\\n1. e4 c5 2. Nf3 d6 3. d4 cxd4 4. Nxd4 Nf6 5. Nc3 a6 6. Bg5 e6 7. f4 Qb6 8. Qd2 Qxb2 9. Rb1 Qa3 10. e5 dxe5 11. fxe5 Nfd7 12. Ne4 h6 13. Bh4 Qxa2 14. Rd1 Qd5 15. Qe3 Qxe5 16. Be2 Bc5 17. Bg3 Bxd4 18. Rxd4 Qa5+ 19. c3\\nYou are playing as player Black.\\nIt is now your turn. Play your strongest move. The move MUST be legal. Reason step by step to come up with your move, then output your final answer in the format \\\"Final Answer: X\\\" where X is your chosen move in standard algebraic notation (SAN).\\n\"\n          }\n        ]\n      }\n    ],\n    \"config\": {\n      \"temperature\": \"NOT_GIVEN\",\n      \"top_p\": \"NOT_GIVEN\",\n      \"max_completion_tokens\": \"NOT_GIVEN\",\n      \"reasoning_effort\": \"high\"\n    },\n    \"stream_options\": {\n      \"include_usage\": true\n    }\n  },\n  \"response_for_logging\": {\n    \"response_chunks\": [\n      {\n        \"id\": \"chatcmpl-DcLByNgg9gXBhdS2sXJ5TqnY0nZap\",\n        \"created\": 1778030298,\n        \"model\": \"openai/gpt-5.5-2026-04-23\",\n        \"object\": \"chat.completion.chunk\",\n        \"usage\": {\n          \"completion_tokens\": 9850,\n          \"prompt_tokens\": 302,\n          \"total_tokens\": 10152,\n          \"cost\": {\n            \"input_tokens_cost_nanodollars\": 1510000,\n            \"output_tokens_cost_nanodollars\": 295500000\n          },\n          \"total_backend_latency_ms\": 183147\n        }\n      }\n    ]\n  },\n  \"generation_tokens\": 9850,\n  \"prompt_tokens\": 302,\n  \"reasoning_tokens\": null,\n  \"total_tokens\": 10152,\n  \"duration_success_only_secs\": 183.60193537600026\n}"
+          ],
+          "status": "OK",
+          "submission": 4673,
+          "thoughts": "Final Answer: O-O"
+        },
+        "info": {
+          "actionApplied": 4673,
+          "actionSubmitted": 4673,
+          "actionSubmittedToString": "O-O",
+          "agentSelfReportedStatus": "OK",
+          "timeTaken": 184.822
+        },
+        "observation": {
+          "currentPlayer": 1,
+          "isTerminal": false,
+          "observationString": "rnb2rk1/1p1n1pp1/p3p2p/q7/3RN3/2P1Q1B1/4B1PP/4K2R w K - 1 20",
+          "playerId": 0,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n1258\n3572\n1841\n1842\n1431\n3132\n3572\n656\n89\n1215\n2425\n3010\n1808\n1768\n749\n30\n1065\n2571\n1942\n3196\n3131\n1384\n4177\n3854\n381\n615\n498\n1869\n2001\n2977\n2975\n4350\n1431\n1770\n2581\n1257\n4673\n\n",
+          "step": 39
+        },
+        "reward": null,
+        "status": "INACTIVE"
+      },
+      {
+        "action": {
+          "submission": -1
+        },
+        "info": {},
+        "observation": {
+          "currentPlayer": 1,
+          "isTerminal": false,
+          "observationString": "rnb2rk1/1p1n1pp1/p3p2p/q7/3RN3/2P1Q1B1/4B1PP/4K2R w K - 1 20",
+          "playerId": 1,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n1258\n3572\n1841\n1842\n1431\n3132\n3572\n656\n89\n1215\n2425\n3010\n1808\n1768\n749\n30\n1065\n2571\n1942\n3196\n3131\n1384\n4177\n3854\n381\n615\n498\n1869\n2001\n2977\n2975\n4350\n1431\n1770\n2581\n1257\n4673\n\n"
+        },
+        "reward": null,
+        "status": "ACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "submission": -1
+        },
+        "info": {},
+        "observation": {
+          "currentPlayer": 0,
+          "isTerminal": false,
+          "observationString": "rnb2rk1/1p1n1pp1/p3p2p/q7/3RN3/2P1Q1B1/4B1PP/5RK1 b - - 2 20",
+          "playerId": 0,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n1258\n3572\n1841\n1842\n1431\n3132\n3572\n656\n89\n1215\n2425\n3010\n1808\n1768\n749\n30\n1065\n2571\n1942\n3196\n3131\n1384\n4177\n3854\n381\n615\n498\n1869\n2001\n2977\n2975\n4350\n1431\n1770\n2581\n1257\n4673\n4673\n\n",
+          "step": 40
+        },
+        "reward": null,
+        "status": "ACTIVE"
+      },
+      {
+        "action": {
+          "actionString": "O-O",
+          "generate_returns": [
+            "{\n  \"main_response\": \"In this complex position arising from the Poisoned Pawn variation of the Najdorf Sicilian, White is down three pawns but has tremendous compensation in the form of a massive lead in development, piece activity, and central control. Black's queenside pieces are still entirely undeveloped, and their coordination is poor.\\n\\nTo fully capitalize on this advantage and maintain the initiative, White's top priority should be completing development and securing king safety. The white king on e1 is currently slightly vulnerable, and the h1 rook is completely out of the game. \\n\\nThe most natural, standard, and strongest move here is to castle kingside. \\n\\nBy playing **20. O-O**, White protects the king and prepares to bring the remaining rook into the fray (such as defending along the f-file or getting ready to retreat the d4-rook to d1 when Black eventually challenges it with ...Nc6). Any immediate aggressive lunge without castling allows Black to develop with tempo and exploit White's exposed king. After O-O, White's position is fully mobilized, and they can calmly proceed with pressing their long-term positional and attacking advantages.\\n\\nFinal Answer: O-O\",\n  \"main_response_and_thoughts\": \"\",\n  \"request_for_logging\": {\n    \"model\": \"google/gemini-3.1-pro-preview\",\n    \"messages\": [\n      {\n        \"role\": \"user\",\n        \"content\": [\n          {\n            \"type\": \"text\",\n            \"text\": \"Let's play chess. The current game state in Forsyth-Edwards Notation (FEN) notation is:\\nrnb2rk1/1p1n1pp1/p3p2p/q7/3RN3/2P1Q1B1/4B1PP/4K2R w K - 1 20\\nThe moves played so far are:\\n1. e4 c5 2. Nf3 d6 3. d4 cxd4 4. Nxd4 Nf6 5. Nc3 a6 6. Bg5 e6 7. f4 Qb6 8. Qd2 Qxb2 9. Rb1 Qa3 10. e5 dxe5 11. fxe5 Nfd7 12. Ne4 h6 13. Bh4 Qxa2 14. Rd1 Qd5 15. Qe3 Qxe5 16. Be2 Bc5 17. Bg3 Bxd4 18. Rxd4 Qa5+ 19. c3 O-O 20.\\nYou are playing as player White.\\nIt is now your turn. Play your strongest move. The move MUST be legal. Reason step by step to come up with your move, then output your final answer in the format \\\"Final Answer: X\\\" where X is your chosen move in standard algebraic notation (SAN).\\n\"\n          }\n        ]\n      }\n    ],\n    \"config\": {\n      \"temperature\": \"NOT_GIVEN\",\n      \"top_p\": \"NOT_GIVEN\",\n      \"max_completion_tokens\": \"NOT_GIVEN\"\n    },\n    \"stream_options\": {\n      \"include_usage\": true\n    }\n  },\n  \"response_for_logging\": {\n    \"response_chunks\": [\n      {\n        \"id\": \"k5f6aa27DPiMmecPq_Dk8QQ\",\n        \"choices\": [\n          {\n            \"delta\": {\n              \"content\": \" long-term positional and attacking advantages.\\n\\nFinal Answer: O-O\",\n              \"role\": \"assistant\"\n            },\n            \"finish_reason\": \"stop\",\n            \"index\": 0\n          }\n        ],\n        \"created\": 1778030483,\n        \"model\": \"google/gemini-3.1-pro-preview\",\n        \"object\": \"chat.completion.chunk\",\n        \"usage\": {\n          \"completion_tokens\": 244,\n          \"prompt_tokens\": 297,\n          \"total_tokens\": 5714,\n          \"cost\": {\n            \"input_tokens_cost_nanodollars\": 594000,\n            \"output_tokens_cost_nanodollars\": 65004000\n          },\n          \"total_backend_latency_ms\": 47287\n        }\n      }\n    ]\n  },\n  \"generation_tokens\": 244,\n  \"prompt_tokens\": 297,\n  \"reasoning_tokens\": null,\n  \"total_tokens\": 5714,\n  \"duration_success_only_secs\": 47.77353322199997\n}"
+          ],
+          "status": "OK",
+          "submission": 4673,
+          "thoughts": "In this complex position arising from the Poisoned Pawn variation of the Najdorf Sicilian, White is down three pawns but has tremendous compensation in the form of a massive lead in development, piece activity, and central control. Black's queenside pieces are still entirely undeveloped, and their coordination is poor.\n\nTo fully capitalize on this advantage and maintain the initiative, White's top priority should be completing development and securing king safety. The white king on e1 is currently slightly vulnerable, and the h1 rook is completely out of the game. \n\nThe most natural, standard, and strongest move here is to castle kingside. \n\nBy playing **20. O-O**, White protects the king and prepares to bring the remaining rook into the fray (such as defending along the f-file or getting ready to retreat the d4-rook to d1 when Black eventually challenges it with ...Nc6). Any immediate aggressive lunge without castling allows Black to develop with tempo and exploit White's exposed king. After O-O, White's position is fully mobilized, and they can calmly proceed with pressing their long-term positional and attacking advantages.\n\nFinal Answer: O-O"
+        },
+        "info": {
+          "actionApplied": 4673,
+          "actionSubmitted": 4673,
+          "actionSubmittedToString": "O-O",
+          "agentSelfReportedStatus": "OK",
+          "timeTaken": 48.975
+        },
+        "observation": {
+          "currentPlayer": 0,
+          "isTerminal": false,
+          "observationString": "rnb2rk1/1p1n1pp1/p3p2p/q7/3RN3/2P1Q1B1/4B1PP/5RK1 b - - 2 20",
+          "playerId": 1,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n1258\n3572\n1841\n1842\n1431\n3132\n3572\n656\n89\n1215\n2425\n3010\n1808\n1768\n749\n30\n1065\n2571\n1942\n3196\n3131\n1384\n4177\n3854\n381\n615\n498\n1869\n2001\n2977\n2975\n4350\n1431\n1770\n2581\n1257\n4673\n4673\n\n"
+        },
+        "reward": null,
+        "status": "INACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "actionString": "Nc6",
+          "generate_returns": [
+            "{\n  \"main_response\": \"Final Answer: Nc6\",\n  \"main_response_and_thoughts\": \"\",\n  \"request_for_logging\": {\n    \"model\": \"openai/gpt-5.5-2026-04-23\",\n    \"messages\": [\n      {\n        \"role\": \"user\",\n        \"content\": [\n          {\n            \"type\": \"text\",\n            \"text\": \"Let's play chess. The current game state in Forsyth-Edwards Notation (FEN) notation is:\\nrnb2rk1/1p1n1pp1/p3p2p/q7/3RN3/2P1Q1B1/4B1PP/5RK1 b - - 2 20\\nThe moves played so far are:\\n1. e4 c5 2. Nf3 d6 3. d4 cxd4 4. Nxd4 Nf6 5. Nc3 a6 6. Bg5 e6 7. f4 Qb6 8. Qd2 Qxb2 9. Rb1 Qa3 10. e5 dxe5 11. fxe5 Nfd7 12. Ne4 h6 13. Bh4 Qxa2 14. Rd1 Qd5 15. Qe3 Qxe5 16. Be2 Bc5 17. Bg3 Bxd4 18. Rxd4 Qa5+ 19. c3 O-O 20. O-O\\nYou are playing as player Black.\\nIt is now your turn. Play your strongest move. The move MUST be legal. Reason step by step to come up with your move, then output your final answer in the format \\\"Final Answer: X\\\" where X is your chosen move in standard algebraic notation (SAN).\\n\"\n          }\n        ]\n      }\n    ],\n    \"config\": {\n      \"temperature\": \"NOT_GIVEN\",\n      \"top_p\": \"NOT_GIVEN\",\n      \"max_completion_tokens\": \"NOT_GIVEN\",\n      \"reasoning_effort\": \"high\"\n    },\n    \"stream_options\": {\n      \"include_usage\": true\n    }\n  },\n  \"response_for_logging\": {\n    \"response_chunks\": [\n      {\n        \"id\": \"chatcmpl-DcLFlTQLgcyumMy1gG3UjHTKMAyll\",\n        \"created\": 1778030533,\n        \"model\": \"openai/gpt-5.5-2026-04-23\",\n        \"object\": \"chat.completion.chunk\",\n        \"usage\": {\n          \"completion_tokens\": 9850,\n          \"prompt_tokens\": 305,\n          \"total_tokens\": 10155,\n          \"cost\": {\n            \"input_tokens_cost_nanodollars\": 1525000,\n            \"output_tokens_cost_nanodollars\": 295500000\n          },\n          \"total_backend_latency_ms\": 181375\n        }\n      }\n    ]\n  },\n  \"generation_tokens\": 9850,\n  \"prompt_tokens\": 305,\n  \"reasoning_tokens\": null,\n  \"total_tokens\": 10155,\n  \"duration_success_only_secs\": 182.33066160999988\n}"
+          ],
+          "status": "OK",
+          "submission": 656,
+          "thoughts": "Final Answer: Nc6"
+        },
+        "info": {
+          "actionApplied": 656,
+          "actionSubmitted": 656,
+          "actionSubmittedToString": "Nc6",
+          "agentSelfReportedStatus": "OK",
+          "timeTaken": 184.581
+        },
+        "observation": {
+          "currentPlayer": 1,
+          "isTerminal": false,
+          "observationString": "r1b2rk1/1p1n1pp1/p1n1p2p/q7/3RN3/2P1Q1B1/4B1PP/5RK1 w - - 3 21",
+          "playerId": 0,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n1258\n3572\n1841\n1842\n1431\n3132\n3572\n656\n89\n1215\n2425\n3010\n1808\n1768\n749\n30\n1065\n2571\n1942\n3196\n3131\n1384\n4177\n3854\n381\n615\n498\n1869\n2001\n2977\n2975\n4350\n1431\n1770\n2581\n1257\n4673\n4673\n656\n\n",
+          "step": 41
+        },
+        "reward": null,
+        "status": "INACTIVE"
+      },
+      {
+        "action": {
+          "submission": -1
+        },
+        "info": {},
+        "observation": {
+          "currentPlayer": 1,
+          "isTerminal": false,
+          "observationString": "r1b2rk1/1p1n1pp1/p1n1p2p/q7/3RN3/2P1Q1B1/4B1PP/5RK1 w - - 3 21",
+          "playerId": 1,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n1258\n3572\n1841\n1842\n1431\n3132\n3572\n656\n89\n1215\n2425\n3010\n1808\n1768\n749\n30\n1065\n2571\n1942\n3196\n3131\n1384\n4177\n3854\n381\n615\n498\n1869\n2001\n2977\n2975\n4350\n1431\n1770\n2581\n1257\n4673\n4673\n656\n\n"
+        },
+        "reward": null,
+        "status": "ACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "submission": -1
+        },
+        "info": {},
+        "observation": {
+          "currentPlayer": 0,
+          "isTerminal": false,
+          "observationString": "r1b2rk1/1p1n1pp1/p1n1pN1p/q7/3R4/2P1Q1B1/4B1PP/5RK1 b - - 4 21",
+          "playerId": 0,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n1258\n3572\n1841\n1842\n1431\n3132\n3572\n656\n89\n1215\n2425\n3010\n1808\n1768\n749\n30\n1065\n2571\n1942\n3196\n3131\n1384\n4177\n3854\n381\n615\n498\n1869\n2001\n2977\n2975\n4350\n1431\n1770\n2581\n1257\n4673\n4673\n656\n2627\n\n",
+          "step": 42
+        },
+        "reward": null,
+        "status": "ACTIVE"
+      },
+      {
+        "action": {
+          "actionString": "Nf6+",
+          "generate_returns": [
+            "{\n  \"main_response\": \"To determine the best move, we must evaluate the current position, which arises from the wildly complex Poisoned Pawn variation of the Sicilian Najdorf (1. e4 c5 2. Nf3 d6 3. d4 cxd4 4. Nxd4 Nf6 5. Nc3 a6 6. Bg5 e6 7. f4 Qb6 8. Qd2 Qxb2...). \\n\\nWhite has sacrificed no less than three pawns to achieve a massive lead in development and attacking potential. However, Black is solidifying, and White's d4-rook is currently under attack by the knight on c6. Passive moves like retreating the rook to d1 (21. Rdd1) would allow Black to consolidate (e.g., 21... Nde5) and easily convert their material advantage. White must act forcefully and immediately.\\n\\nThe position calls for a famous and spectacular theoretical forcing sequence that leads to a draw by perpetual check, which is the best practical outcome for White given the material deficit:\\n**21. Nf6+!**\\n\\nLet's look at the critical continuation:\\nIf Black plays **21... Nxf6**, White continues with the brilliant double-rook sacrifice:\\n**22. Rxf6!** \\nAccepting the first rook sacrifice with **22... gxf6** is forced if Black wants to survive the crushing mating threats. White follows up with:\\n**23. Qxh6** \\nNow Black must take the second rook to eliminate White's heavy artillery:\\n**23... Nxd4**\\nWith both rooks gone, White seemingly lacks the pieces to deliver checkmate, but White plays the quiet yet deadly:\\n**24. Bd3!**\\nThreatening 25. Bh7+ Kh8 26. Bg6+ Kg8 27. Qh7#. Black's only defense to stave off the mate and cover the dark squares is to return some material and force a sequence with:\\n**24... Qg5**\\nNow White forces the draw:\\n**25. Bh7+ Kh8 26. Qxf8+! Kxh7 27. Qxf7+ Qg7 28. Qh5+ Qh6** (If 28... Kg8 29. cxd4 leaves White with enough compensation, but the draw is safest). **29. Qf7+ Qg7 30. Qh5+** \\n\\nWith a beautifully forced perpetual check, White escapes the materially lost endgame and secures half a point. (Note: If Black tries to decline the initial knight sacrifice with 21... Kh8, White has 22. Rh4! Nxf6 23. Rxf6 and Black's kingside collapses entirely).\\n\\nFinal Answer: Nf6+\",\n  \"main_response_and_thoughts\": \"\",\n  \"request_for_logging\": {\n    \"model\": \"google/gemini-3.1-pro-preview\",\n    \"messages\": [\n      {\n        \"role\": \"user\",\n        \"content\": [\n          {\n            \"type\": \"text\",\n            \"text\": \"Let's play chess. The current game state in Forsyth-Edwards Notation (FEN) notation is:\\nr1b2rk1/1p1n1pp1/p1n1p2p/q7/3RN3/2P1Q1B1/4B1PP/5RK1 w - - 3 21\\nThe moves played so far are:\\n1. e4 c5 2. Nf3 d6 3. d4 cxd4 4. Nxd4 Nf6 5. Nc3 a6 6. Bg5 e6 7. f4 Qb6 8. Qd2 Qxb2 9. Rb1 Qa3 10. e5 dxe5 11. fxe5 Nfd7 12. Ne4 h6 13. Bh4 Qxa2 14. Rd1 Qd5 15. Qe3 Qxe5 16. Be2 Bc5 17. Bg3 Bxd4 18. Rxd4 Qa5+ 19. c3 O-O 20. O-O Nc6 21.\\nYou are playing as player White.\\nIt is now your turn. Play your strongest move. The move MUST be legal. Reason step by step to come up with your move, then output your final answer in the format \\\"Final Answer: X\\\" where X is your chosen move in standard algebraic notation (SAN).\\n\"\n          }\n        ]\n      }\n    ],\n    \"config\": {\n      \"temperature\": \"NOT_GIVEN\",\n      \"top_p\": \"NOT_GIVEN\",\n      \"max_completion_tokens\": \"NOT_GIVEN\"\n    },\n    \"stream_options\": {\n      \"include_usage\": true\n    }\n  },\n  \"response_for_logging\": {\n    \"response_chunks\": [\n      {\n        \"id\": \"fJj6aZaSL4-SmecPifn04Ak\",\n        \"choices\": [\n          {\n            \"delta\": {\n              \"content\": \". Rxf6 and Black's kingside collapses entirely).\\n\\nFinal Answer: Nf6+\",\n              \"role\": \"assistant\"\n            },\n            \"finish_reason\": \"stop\",\n            \"index\": 0\n          }\n        ],\n        \"created\": 1778030716,\n        \"model\": \"google/gemini-3.1-pro-preview\",\n        \"object\": \"chat.completion.chunk\",\n        \"usage\": {\n          \"completion_tokens\": 591,\n          \"prompt_tokens\": 308,\n          \"total_tokens\": 25459,\n          \"cost\": {\n            \"input_tokens_cost_nanodollars\": 616000,\n            \"output_tokens_cost_nanodollars\": 301812000\n          },\n          \"total_backend_latency_ms\": 211964\n        }\n      }\n    ]\n  },\n  \"generation_tokens\": 591,\n  \"prompt_tokens\": 308,\n  \"reasoning_tokens\": null,\n  \"total_tokens\": 25459,\n  \"duration_success_only_secs\": 212.53422468900135\n}"
+          ],
+          "status": "OK",
+          "submission": 2627,
+          "thoughts": "To determine the best move, we must evaluate the current position, which arises from the wildly complex Poisoned Pawn variation of the Sicilian Najdorf (1. e4 c5 2. Nf3 d6 3. d4 cxd4 4. Nxd4 Nf6 5. Nc3 a6 6. Bg5 e6 7. f4 Qb6 8. Qd2 Qxb2...). \n\nWhite has sacrificed no less than three pawns to achieve a massive lead in development and attacking potential. However, Black is solidifying, and White's d4-rook is currently under attack by the knight on c6. Passive moves like retreating the rook to d1 (21. Rdd1) would allow Black to consolidate (e.g., 21... Nde5) and easily convert their material advantage. White must act forcefully and immediately.\n\nThe position calls for a famous and spectacular theoretical forcing sequence that leads to a draw by perpetual check, which is the best practical outcome for White given the material deficit:\n**21. Nf6+!**\n\nLet's look at the critical continuation:\nIf Black plays **21... Nxf6**, White continues with the brilliant double-rook sacrifice:\n**22. Rxf6!** \nAccepting the first rook sacrifice with **22... gxf6** is forced if Black wants to survive the crushing mating threats. White follows up with:\n**23. Qxh6** \nNow Black must take the second rook to eliminate White's heavy artillery:\n**23... Nxd4**\nWith both rooks gone, White seemingly lacks the pieces to deliver checkmate, but White plays the quiet yet deadly:\n**24. Bd3!**\nThreatening 25. Bh7+ Kh8 26. Bg6+ Kg8 27. Qh7#. Black's only defense to stave off the mate and cover the dark squares is to return some material and force a sequence with:\n**24... Qg5**\nNow White forces the draw:\n**25. Bh7+ Kh8 26. Qxf8+! Kxh7 27. Qxf7+ Qg7 28. Qh5+ Qh6** (If 28... Kg8 29. cxd4 leaves White with enough compensation, but the draw is safest). **29. Qf7+ Qg7 30. Qh5+** \n\nWith a beautifully forced perpetual check, White escapes the materially lost endgame and secures half a point. (Note: If Black tries to decline the initial knight sacrifice with 21... Kh8, White has 22. Rh4! Nxf6 23. Rxf6 and Black's kingside collapses entirely).\n\nFinal Answer: Nf6+"
+        },
+        "info": {
+          "actionApplied": 2627,
+          "actionSubmitted": 2627,
+          "actionSubmittedToString": "Nf6+",
+          "agentSelfReportedStatus": "OK",
+          "timeTaken": 214.164
+        },
+        "observation": {
+          "currentPlayer": 0,
+          "isTerminal": false,
+          "observationString": "r1b2rk1/1p1n1pp1/p1n1pN1p/q7/3R4/2P1Q1B1/4B1PP/5RK1 b - - 4 21",
+          "playerId": 1,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n1258\n3572\n1841\n1842\n1431\n3132\n3572\n656\n89\n1215\n2425\n3010\n1808\n1768\n749\n30\n1065\n2571\n1942\n3196\n3131\n1384\n4177\n3854\n381\n615\n498\n1869\n2001\n2977\n2975\n4350\n1431\n1770\n2581\n1257\n4673\n4673\n656\n2627\n\n"
+        },
+        "reward": null,
+        "status": "INACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "actionString": "Nxf6",
+          "generate_returns": [
+            "{\n  \"main_response\": \"Black can meet the knight check by capturing the attacking knight with the d7-knight. This also avoids immediately opening the g-file and sets up a favorable exchange if White plays Rxf6.\\n\\nFinal Answer: Nxf6\",\n  \"main_response_and_thoughts\": \"\",\n  \"request_for_logging\": {\n    \"model\": \"openai/gpt-5.5-2026-04-23\",\n    \"messages\": [\n      {\n        \"role\": \"user\",\n        \"content\": [\n          {\n            \"type\": \"text\",\n            \"text\": \"Let's play chess. The current game state in Forsyth-Edwards Notation (FEN) notation is:\\nr1b2rk1/1p1n1pp1/p1n1pN1p/q7/3R4/2P1Q1B1/4B1PP/5RK1 b - - 4 21\\nThe moves played so far are:\\n1. e4 c5 2. Nf3 d6 3. d4 cxd4 4. Nxd4 Nf6 5. Nc3 a6 6. Bg5 e6 7. f4 Qb6 8. Qd2 Qxb2 9. Rb1 Qa3 10. e5 dxe5 11. fxe5 Nfd7 12. Ne4 h6 13. Bh4 Qxa2 14. Rd1 Qd5 15. Qe3 Qxe5 16. Be2 Bc5 17. Bg3 Bxd4 18. Rxd4 Qa5+ 19. c3 O-O 20. O-O Nc6 21. Nf6+\\nYou are playing as player Black.\\nIt is now your turn. Play your strongest move. The move MUST be legal. Reason step by step to come up with your move, then output your final answer in the format \\\"Final Answer: X\\\" where X is your chosen move in standard algebraic notation (SAN).\\n\"\n          }\n        ]\n      }\n    ],\n    \"config\": {\n      \"temperature\": \"NOT_GIVEN\",\n      \"top_p\": \"NOT_GIVEN\",\n      \"max_completion_tokens\": \"NOT_GIVEN\",\n      \"reasoning_effort\": \"high\"\n    },\n    \"stream_options\": {\n      \"include_usage\": true\n    }\n  },\n  \"response_for_logging\": {\n    \"response_chunks\": [\n      {\n        \"id\": \"chatcmpl-DcLMCqkVbSp8LIdYnuLSUXEZet2w8\",\n        \"created\": 1778030932,\n        \"model\": \"openai/gpt-5.5-2026-04-23\",\n        \"object\": \"chat.completion.chunk\",\n        \"usage\": {\n          \"completion_tokens\": 19214,\n          \"prompt_tokens\": 317,\n          \"total_tokens\": 19531,\n          \"cost\": {\n            \"input_tokens_cost_nanodollars\": 1585000,\n            \"output_tokens_cost_nanodollars\": 576420000\n          },\n          \"total_backend_latency_ms\": 351712\n        }\n      }\n    ]\n  },\n  \"generation_tokens\": 19214,\n  \"prompt_tokens\": 317,\n  \"reasoning_tokens\": null,\n  \"total_tokens\": 19531,\n  \"duration_success_only_secs\": 352.70504442699894\n}"
+          ],
+          "status": "OK",
+          "submission": 1895,
+          "thoughts": "Black can meet the knight check by capturing the attacking knight with the d7-knight. This also avoids immediately opening the g-file and sets up a favorable exchange if White plays Rxf6.\n\nFinal Answer: Nxf6"
+        },
+        "info": {
+          "actionApplied": 1895,
+          "actionSubmitted": 1895,
+          "actionSubmittedToString": "Nxf6",
+          "agentSelfReportedStatus": "OK",
+          "timeTaken": 354.426
+        },
+        "observation": {
+          "currentPlayer": 1,
+          "isTerminal": false,
+          "observationString": "r1b2rk1/1p3pp1/p1n1pn1p/q7/3R4/2P1Q1B1/4B1PP/5RK1 w - - 0 22",
+          "playerId": 0,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n1258\n3572\n1841\n1842\n1431\n3132\n3572\n656\n89\n1215\n2425\n3010\n1808\n1768\n749\n30\n1065\n2571\n1942\n3196\n3131\n1384\n4177\n3854\n381\n615\n498\n1869\n2001\n2977\n2975\n4350\n1431\n1770\n2581\n1257\n4673\n4673\n656\n2627\n1895\n\n",
+          "step": 43
+        },
+        "reward": null,
+        "status": "INACTIVE"
+      },
+      {
+        "action": {
+          "submission": -1
+        },
+        "info": {},
+        "observation": {
+          "currentPlayer": 1,
+          "isTerminal": false,
+          "observationString": "r1b2rk1/1p3pp1/p1n1pn1p/q7/3R4/2P1Q1B1/4B1PP/5RK1 w - - 0 22",
+          "playerId": 1,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n1258\n3572\n1841\n1842\n1431\n3132\n3572\n656\n89\n1215\n2425\n3010\n1808\n1768\n749\n30\n1065\n2571\n1942\n3196\n3131\n1384\n4177\n3854\n381\n615\n498\n1869\n2001\n2977\n2975\n4350\n1431\n1770\n2581\n1257\n4673\n4673\n656\n2627\n1895\n\n"
+        },
+        "reward": null,
+        "status": "ACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "submission": -1
+        },
+        "info": {},
+        "observation": {
+          "currentPlayer": 0,
+          "isTerminal": false,
+          "observationString": "r1b2rk1/1p3pp1/p1n1pR1p/q7/3R4/2P1Q1B1/4B1PP/6K1 b - - 0 22",
+          "playerId": 0,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n1258\n3572\n1841\n1842\n1431\n3132\n3572\n656\n89\n1215\n2425\n3010\n1808\n1768\n749\n30\n1065\n2571\n1942\n3196\n3131\n1384\n4177\n3854\n381\n615\n498\n1869\n2001\n2977\n2975\n4350\n1431\n1770\n2581\n1257\n4673\n4673\n656\n2627\n1895\n2940\n\n",
+          "step": 44
+        },
+        "reward": null,
+        "status": "ACTIVE"
+      },
+      {
+        "action": {
+          "actionString": "Rxf6",
+          "generate_returns": [
+            "{\n  \"main_response\": \"To find the strongest continuation, we must evaluate the attacking potential White has built up on the Kingside. White previously sacrificed a knight (21. Nf6+ Nxf6) to drag the Black knight to f6, preparing a devastating follow-up.\\n\\n**Step-by-step reasoning:**\\n\\n1. **Identify the Target:** Black's Kingside is defended primarily by the f6-knight and the pawn shield. The h6-pawn is a specific weakness, and White's Queen on e3 is perfectly placed to target it. White's Rooks on f1 and d4 are primed for action.\\n2. **The Brilliant Sacrifice:** We can remove the key defender and blow open the King's shelter with **22. Rxf6!**\\n3. **Calculating Black's Responses:**\\n   - **If 22... gxf6:** White\\u2019s d4-rook swings with a deadly check: `23. Rg4+ Kh7` (If `23... Qg5`, White plays `24. Rxg5+ hxg5 25. Qxg5+ Kh7 26. Bd3+ f5 27. Bf4!` and mates soon). After `24. Bd3+ f5`, White follows up with the crushing `25. Rh4!`. There is no way for Black to stop the impending mate on h6 or h7 (e.g., `25... Kg7 26. Qxh6+ Kg8 27. Qh8#` or `25... h5 26. Rxh5+ Kg6 27. Rh6+ Kg7 28. Qg5#`).\\n   - **If 22... Nxd4 (ignoring the rook to take White's d4-rook):** White continues the assault with `23. Rxh6!`. If Black accepts the second rook with `23... gxh6`, White plays `24. Qxh6`. The threat of bringing the bishop to d3 or checking the King is lethal. For example, if Black tries `24... Nxe2+ 25. Kh1 f5`, White plays `26. Qg6+ Kh8 27. Be5+ Rf6 28. Bxf6#`. \\n   - **If 22... Qg5 (offering a Queen trade to blunt the attack):** White plays `23. Bf4!`. Now if `23... Qxf6`, White plays `24. Be5!` attacking the Queen. If Black plays `24... Qg5`, White unleashes `25. Rg4!`. After `25... f6 26. Rxg5 hxg5 27. Bxf6!`, White achieves a completely winning endgame advantage (e.g., `27... gxf6 28. Qe4!` setting up massive threats against the exposed Black King and winning heavy material). \\n\\nEvery line after 22. Rxf6 leads to either a forced checkmate or a completely winning material/positional advantage for White.\\n\\nFinal Answer: Rxf6\",\n  \"main_response_and_thoughts\": \"\",\n  \"request_for_logging\": {\n    \"model\": \"google/gemini-3.1-pro-preview\",\n    \"messages\": [\n      {\n        \"role\": \"user\",\n        \"content\": [\n          {\n            \"type\": \"text\",\n            \"text\": \"Let's play chess. The current game state in Forsyth-Edwards Notation (FEN) notation is:\\nr1b2rk1/1p3pp1/p1n1pn1p/q7/3R4/2P1Q1B1/4B1PP/5RK1 w - - 0 22\\nThe moves played so far are:\\n1. e4 c5 2. Nf3 d6 3. d4 cxd4 4. Nxd4 Nf6 5. Nc3 a6 6. Bg5 e6 7. f4 Qb6 8. Qd2 Qxb2 9. Rb1 Qa3 10. e5 dxe5 11. fxe5 Nfd7 12. Ne4 h6 13. Bh4 Qxa2 14. Rd1 Qd5 15. Qe3 Qxe5 16. Be2 Bc5 17. Bg3 Bxd4 18. Rxd4 Qa5+ 19. c3 O-O 20. O-O Nc6 21. Nf6+ Nxf6 22.\\nYou are playing as player White.\\nIt is now your turn. Play your strongest move. The move MUST be legal. Reason step by step to come up with your move, then output your final answer in the format \\\"Final Answer: X\\\" where X is your chosen move in standard algebraic notation (SAN).\\n\"\n          }\n        ]\n      }\n    ],\n    \"config\": {\n      \"temperature\": \"NOT_GIVEN\",\n      \"top_p\": \"NOT_GIVEN\",\n      \"max_completion_tokens\": \"NOT_GIVEN\"\n    },\n    \"stream_options\": {\n      \"include_usage\": true\n    }\n  },\n  \"response_for_logging\": {\n    \"response_chunks\": [\n      {\n        \"id\": \"tZr6ad_9OauEm9IP2rm86QE\",\n        \"choices\": [\n          {\n            \"delta\": {\n              \"content\": \" Rxf6 leads to either a forced checkmate or a completely winning material/positional advantage for White.\\n\\nFinal Answer: Rxf6\",\n              \"role\": \"assistant\"\n            },\n            \"finish_reason\": \"stop\",\n            \"index\": 0\n          }\n        ],\n        \"created\": 1778031285,\n        \"model\": \"google/gemini-3.1-pro-preview\",\n        \"object\": \"chat.completion.chunk\",\n        \"usage\": {\n          \"completion_tokens\": 662,\n          \"prompt_tokens\": 315,\n          \"total_tokens\": 20315,\n          \"cost\": {\n            \"input_tokens_cost_nanodollars\": 630000,\n            \"output_tokens_cost_nanodollars\": 240000000\n          },\n          \"total_backend_latency_ms\": 167682\n        }\n      }\n    ]\n  },\n  \"generation_tokens\": 662,\n  \"prompt_tokens\": 315,\n  \"reasoning_tokens\": null,\n  \"total_tokens\": 20315,\n  \"duration_success_only_secs\": 168.248505724001\n}"
+          ],
+          "status": "OK",
+          "submission": 2940,
+          "thoughts": "To find the strongest continuation, we must evaluate the attacking potential White has built up on the Kingside. White previously sacrificed a knight (21. Nf6+ Nxf6) to drag the Black knight to f6, preparing a devastating follow-up.\n\n**Step-by-step reasoning:**\n\n1. **Identify the Target:** Black's Kingside is defended primarily by the f6-knight and the pawn shield. The h6-pawn is a specific weakness, and White's Queen on e3 is perfectly placed to target it. White's Rooks on f1 and d4 are primed for action.\n2. **The Brilliant Sacrifice:** We can remove the key defender and blow open the King's shelter with **22. Rxf6!**\n3. **Calculating Black's Responses:**\n   - **If 22... gxf6:** White\u2019s d4-rook swings with a deadly check: `23. Rg4+ Kh7` (If `23... Qg5`, White plays `24. Rxg5+ hxg5 25. Qxg5+ Kh7 26. Bd3+ f5 27. Bf4!` and mates soon). After `24. Bd3+ f5`, White follows up with the crushing `25. Rh4!`. There is no way for Black to stop the impending mate on h6 or h7 (e.g., `25... Kg7 26. Qxh6+ Kg8 27. Qh8#` or `25... h5 26. Rxh5+ Kg6 27. Rh6+ Kg7 28. Qg5#`).\n   - **If 22... Nxd4 (ignoring the rook to take White's d4-rook):** White continues the assault with `23. Rxh6!`. If Black accepts the second rook with `23... gxh6`, White plays `24. Qxh6`. The threat of bringing the bishop to d3 or checking the King is lethal. For example, if Black tries `24... Nxe2+ 25. Kh1 f5`, White plays `26. Qg6+ Kh8 27. Be5+ Rf6 28. Bxf6#`. \n   - **If 22... Qg5 (offering a Queen trade to blunt the attack):** White plays `23. Bf4!`. Now if `23... Qxf6`, White plays `24. Be5!` attacking the Queen. If Black plays `24... Qg5`, White unleashes `25. Rg4!`. After `25... f6 26. Rxg5 hxg5 27. Bxf6!`, White achieves a completely winning endgame advantage (e.g., `27... gxf6 28. Qe4!` setting up massive threats against the exposed Black King and winning heavy material). \n\nEvery line after 22. Rxf6 leads to either a forced checkmate or a completely winning material/positional advantage for White.\n\nFinal Answer: Rxf6"
+        },
+        "info": {
+          "actionApplied": 2940,
+          "actionSubmitted": 2940,
+          "actionSubmittedToString": "Rxf6",
+          "agentSelfReportedStatus": "OK",
+          "timeTaken": 170.547
+        },
+        "observation": {
+          "currentPlayer": 0,
+          "isTerminal": false,
+          "observationString": "r1b2rk1/1p3pp1/p1n1pR1p/q7/3R4/2P1Q1B1/4B1PP/6K1 b - - 0 22",
+          "playerId": 1,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n1258\n3572\n1841\n1842\n1431\n3132\n3572\n656\n89\n1215\n2425\n3010\n1808\n1768\n749\n30\n1065\n2571\n1942\n3196\n3131\n1384\n4177\n3854\n381\n615\n498\n1869\n2001\n2977\n2975\n4350\n1431\n1770\n2581\n1257\n4673\n4673\n656\n2627\n1895\n2940\n\n"
+        },
+        "reward": null,
+        "status": "INACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "actionString": "Nxd4",
+          "generate_returns": [
+            "{\n  \"main_response\": \"The key is to capture the other hanging rook first: the knight on c6 attacks the rook on d4, while the g-pawn can still take the rook on f6 later.\\n\\nFinal Answer: Nxd4\",\n  \"main_response_and_thoughts\": \"\",\n  \"request_for_logging\": {\n    \"model\": \"openai/gpt-5.5-2026-04-23\",\n    \"messages\": [\n      {\n        \"role\": \"user\",\n        \"content\": [\n          {\n            \"type\": \"text\",\n            \"text\": \"Let's play chess. The current game state in Forsyth-Edwards Notation (FEN) notation is:\\nr1b2rk1/1p3pp1/p1n1pR1p/q7/3R4/2P1Q1B1/4B1PP/6K1 b - - 0 22\\nThe moves played so far are:\\n1. e4 c5 2. Nf3 d6 3. d4 cxd4 4. Nxd4 Nf6 5. Nc3 a6 6. Bg5 e6 7. f4 Qb6 8. Qd2 Qxb2 9. Rb1 Qa3 10. e5 dxe5 11. fxe5 Nfd7 12. Ne4 h6 13. Bh4 Qxa2 14. Rd1 Qd5 15. Qe3 Qxe5 16. Be2 Bc5 17. Bg3 Bxd4 18. Rxd4 Qa5+ 19. c3 O-O 20. O-O Nc6 21. Nf6+ Nxf6 22. Rxf6\\nYou are playing as player Black.\\nIt is now your turn. Play your strongest move. The move MUST be legal. Reason step by step to come up with your move, then output your final answer in the format \\\"Final Answer: X\\\" where X is your chosen move in standard algebraic notation (SAN).\\n\"\n          }\n        ]\n      }\n    ],\n    \"config\": {\n      \"temperature\": \"NOT_GIVEN\",\n      \"top_p\": \"NOT_GIVEN\",\n      \"max_completion_tokens\": \"NOT_GIVEN\",\n      \"reasoning_effort\": \"high\"\n    },\n    \"stream_options\": {\n      \"include_usage\": true\n    }\n  },\n  \"response_for_logging\": {\n    \"response_chunks\": [\n      {\n        \"id\": \"chatcmpl-DcLUe3FiTqFnnO82TDceWlcYt6ViK\",\n        \"created\": 1778031456,\n        \"model\": \"openai/gpt-5.5-2026-04-23\",\n        \"object\": \"chat.completion.chunk\",\n        \"usage\": {\n          \"completion_tokens\": 13315,\n          \"prompt_tokens\": 325,\n          \"total_tokens\": 13640,\n          \"cost\": {\n            \"input_tokens_cost_nanodollars\": 1625000,\n            \"output_tokens_cost_nanodollars\": 399450000\n          },\n          \"total_backend_latency_ms\": 241844\n        }\n      }\n    ]\n  },\n  \"generation_tokens\": 13315,\n  \"prompt_tokens\": 325,\n  \"reasoning_tokens\": null,\n  \"total_tokens\": 13640,\n  \"duration_success_only_secs\": 242.34314863500003\n}"
+          ],
+          "status": "OK",
+          "submission": 1386,
+          "thoughts": "The key is to capture the other hanging rook first: the knight on c6 attacks the rook on d4, while the g-pawn can still take the rook on f6 later.\n\nFinal Answer: Nxd4"
+        },
+        "info": {
+          "actionApplied": 1386,
+          "actionSubmitted": 1386,
+          "actionSubmittedToString": "Nxd4",
+          "agentSelfReportedStatus": "OK",
+          "timeTaken": 244.092
+        },
+        "observation": {
+          "currentPlayer": 1,
+          "isTerminal": false,
+          "observationString": "r1b2rk1/1p3pp1/p3pR1p/q7/3n4/2P1Q1B1/4B1PP/6K1 w - - 0 23",
+          "playerId": 0,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n1258\n3572\n1841\n1842\n1431\n3132\n3572\n656\n89\n1215\n2425\n3010\n1808\n1768\n749\n30\n1065\n2571\n1942\n3196\n3131\n1384\n4177\n3854\n381\n615\n498\n1869\n2001\n2977\n2975\n4350\n1431\n1770\n2581\n1257\n4673\n4673\n656\n2627\n1895\n2940\n1386\n\n",
+          "step": 45
+        },
+        "reward": null,
+        "status": "INACTIVE"
+      },
+      {
+        "action": {
+          "submission": -1
+        },
+        "info": {},
+        "observation": {
+          "currentPlayer": 1,
+          "isTerminal": false,
+          "observationString": "r1b2rk1/1p3pp1/p3pR1p/q7/3n4/2P1Q1B1/4B1PP/6K1 w - - 0 23",
+          "playerId": 1,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n1258\n3572\n1841\n1842\n1431\n3132\n3572\n656\n89\n1215\n2425\n3010\n1808\n1768\n749\n30\n1065\n2571\n1942\n3196\n3131\n1384\n4177\n3854\n381\n615\n498\n1869\n2001\n2977\n2975\n4350\n1431\n1770\n2581\n1257\n4673\n4673\n656\n2627\n1895\n2940\n1386\n\n"
+        },
+        "reward": null,
+        "status": "ACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "submission": -1
+        },
+        "info": {},
+        "observation": {
+          "currentPlayer": 0,
+          "isTerminal": false,
+          "observationString": "r1b2rk1/1p3pp1/p3pR1p/q7/3P4/4Q1B1/4B1PP/6K1 b - - 0 23",
+          "playerId": 0,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n1258\n3572\n1841\n1842\n1431\n3132\n3572\n656\n89\n1215\n2425\n3010\n1808\n1768\n749\n30\n1065\n2571\n1942\n3196\n3131\n1384\n4177\n3854\n381\n615\n498\n1869\n2001\n2977\n2975\n4350\n1431\n1770\n2581\n1257\n4673\n4673\n656\n2627\n1895\n2940\n1386\n1358\n\n",
+          "step": 46
+        },
+        "reward": null,
+        "status": "ACTIVE"
+      },
+      {
+        "action": {
+          "actionString": "cxd4",
+          "generate_returns": [
+            "{\n  \"main_response\": \"To determine the best move, we need to analyze the current position, which arises from a heavily theoretical and incredibly sharp line of the Sicilian Defense, Najdorf Variation (Poisoned Pawn). \\n\\nWhite has sacrificed a massive amount of material (currently down a Rook and a Knight, not to mention pawns) in exchange for a ferocious attack on the Black king. Black's last move, **22... Nxd4**, just captured a Rook on d4 while simultaneously ignoring the hanging Rook on f6. \\n\\nWhite is faced with an immediate decision on how to deal with the powerful centralized Knight on d4. \\nThe two candidates to recapture the piece are 23. Qxd4 and 23. cxd4. \\n\\n1. If White plays **23. Qxd4**, the Queen moves to a vulnerable square. Black can respond with a developing and tempo-gaining move like 23... Rd8!, immediately putting the Queen under fire. Having to move the Queen again will break White's attacking coordination and give Black the time needed to consolidate and win with their extra material. \\n2. Therefore, White's strongest and only viable move is **23. cxd4!**. \\n\\nHere is what happens after **23. cxd4**:\\n- If Black finally accepts the Rook sacrifice with **23... gxf6**, White unleashes a terrifying attack with **24. Qxh6!**. Black is practically forced to offer a Queen trade to stave off checkmate with **24... Qg5**. White will follow up with the brilliant **25. Bf4!**, ignoring the Queen trade temporarily. After **25... Qxh6 26. Bxh6**, White wins back the Exchange (attacking the f8 Rook) and maintains a massive positional bind with the two bishops and dark square control.\\n- If Black tries to counterattack White's hanging f6-Rook while getting the Queen back in the defense with **23... Qg5**, White plays **24. Bf4!**, attacking the Queen. Black captures the Rook with **24... Qxf6**, which allows White to play **25. Be5**. Black's Queen is under attack again. If Black returns to g5 (**25... Qg5**), White plays **26. Bf4!** forcing a draw by repetition, an excellent result considering White's material deficit! If Black tries to avoid the draw and plays on with something like **25... Qe7**, White plays **26. Qg3** aiming at g7, and following up with Bd6, launching a devastating, nearly unstoppable attack.\\n\\nRecapturing with the pawn keeps the Queen ideally placed on e3 to swing to the kingside and keeps the tension at its maximum.\\n\\nFinal Answer: cxd4\",\n  \"main_response_and_thoughts\": \"\",\n  \"request_for_logging\": {\n    \"model\": \"google/gemini-3.1-pro-preview\",\n    \"messages\": [\n      {\n        \"role\": \"user\",\n        \"content\": [\n          {\n            \"type\": \"text\",\n            \"text\": \"Let's play chess. The current game state in Forsyth-Edwards Notation (FEN) notation is:\\nr1b2rk1/1p3pp1/p3pR1p/q7/3n4/2P1Q1B1/4B1PP/6K1 w - - 0 23\\nThe moves played so far are:\\n1. e4 c5 2. Nf3 d6 3. d4 cxd4 4. Nxd4 Nf6 5. Nc3 a6 6. Bg5 e6 7. f4 Qb6 8. Qd2 Qxb2 9. Rb1 Qa3 10. e5 dxe5 11. fxe5 Nfd7 12. Ne4 h6 13. Bh4 Qxa2 14. Rd1 Qd5 15. Qe3 Qxe5 16. Be2 Bc5 17. Bg3 Bxd4 18. Rxd4 Qa5+ 19. c3 O-O 20. O-O Nc6 21. Nf6+ Nxf6 22. Rxf6 Nxd4 23.\\nYou are playing as player White.\\nIt is now your turn. Play your strongest move. The move MUST be legal. Reason step by step to come up with your move, then output your final answer in the format \\\"Final Answer: X\\\" where X is your chosen move in standard algebraic notation (SAN).\\n\"\n          }\n        ]\n      }\n    ],\n    \"config\": {\n      \"temperature\": \"NOT_GIVEN\",\n      \"top_p\": \"NOT_GIVEN\",\n      \"max_completion_tokens\": \"NOT_GIVEN\"\n    },\n    \"stream_options\": {\n      \"include_usage\": true\n    }\n  },\n  \"response_for_logging\": {\n    \"response_chunks\": [\n      {\n        \"id\": \"VJz6abZkq4Sb0g_aubzpAQ\",\n        \"choices\": [\n          {\n            \"delta\": {\n              \"content\": \" its maximum.\\n\\nFinal Answer: cxd4\",\n              \"role\": \"assistant\"\n            },\n            \"finish_reason\": \"stop\",\n            \"index\": 0\n          }\n        ],\n        \"created\": 1778031700,\n        \"model\": \"google/gemini-3.1-pro-preview\",\n        \"object\": \"chat.completion.chunk\",\n        \"usage\": {\n          \"completion_tokens\": 584,\n          \"prompt_tokens\": 321,\n          \"total_tokens\": 9942,\n          \"cost\": {\n            \"input_tokens_cost_nanodollars\": 642000,\n            \"output_tokens_cost_nanodollars\": 115452000\n          },\n          \"total_backend_latency_ms\": 82670\n        }\n      }\n    ]\n  },\n  \"generation_tokens\": 584,\n  \"prompt_tokens\": 321,\n  \"reasoning_tokens\": null,\n  \"total_tokens\": 9942,\n  \"duration_success_only_secs\": 83.20518686200012\n}"
+          ],
+          "status": "OK",
+          "submission": 1358,
+          "thoughts": "To determine the best move, we need to analyze the current position, which arises from a heavily theoretical and incredibly sharp line of the Sicilian Defense, Najdorf Variation (Poisoned Pawn). \n\nWhite has sacrificed a massive amount of material (currently down a Rook and a Knight, not to mention pawns) in exchange for a ferocious attack on the Black king. Black's last move, **22... Nxd4**, just captured a Rook on d4 while simultaneously ignoring the hanging Rook on f6. \n\nWhite is faced with an immediate decision on how to deal with the powerful centralized Knight on d4. \nThe two candidates to recapture the piece are 23. Qxd4 and 23. cxd4. \n\n1. If White plays **23. Qxd4**, the Queen moves to a vulnerable square. Black can respond with a developing and tempo-gaining move like 23... Rd8!, immediately putting the Queen under fire. Having to move the Queen again will break White's attacking coordination and give Black the time needed to consolidate and win with their extra material. \n2. Therefore, White's strongest and only viable move is **23. cxd4!**. \n\nHere is what happens after **23. cxd4**:\n- If Black finally accepts the Rook sacrifice with **23... gxf6**, White unleashes a terrifying attack with **24. Qxh6!**. Black is practically forced to offer a Queen trade to stave off checkmate with **24... Qg5**. White will follow up with the brilliant **25. Bf4!**, ignoring the Queen trade temporarily. After **25... Qxh6 26. Bxh6**, White wins back the Exchange (attacking the f8 Rook) and maintains a massive positional bind with the two bishops and dark square control.\n- If Black tries to counterattack White's hanging f6-Rook while getting the Queen back in the defense with **23... Qg5**, White plays **24. Bf4!**, attacking the Queen. Black captures the Rook with **24... Qxf6**, which allows White to play **25. Be5**. Black's Queen is under attack again. If Black returns to g5 (**25... Qg5**), White plays **26. Bf4!** forcing a draw by repetition, an excellent result considering White's material deficit! If Black tries to avoid the draw and plays on with something like **25... Qe7**, White plays **26. Qg3** aiming at g7, and following up with Bd6, launching a devastating, nearly unstoppable attack.\n\nRecapturing with the pawn keeps the Queen ideally placed on e3 to swing to the kingside and keeps the tension at its maximum.\n\nFinal Answer: cxd4"
+        },
+        "info": {
+          "actionApplied": 1358,
+          "actionSubmitted": 1358,
+          "actionSubmittedToString": "cxd4",
+          "agentSelfReportedStatus": "OK",
+          "timeTaken": 84.378
+        },
+        "observation": {
+          "currentPlayer": 0,
+          "isTerminal": false,
+          "observationString": "r1b2rk1/1p3pp1/p3pR1p/q7/3P4/4Q1B1/4B1PP/6K1 b - - 0 23",
+          "playerId": 1,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n1258\n3572\n1841\n1842\n1431\n3132\n3572\n656\n89\n1215\n2425\n3010\n1808\n1768\n749\n30\n1065\n2571\n1942\n3196\n3131\n1384\n4177\n3854\n381\n615\n498\n1869\n2001\n2977\n2975\n4350\n1431\n1770\n2581\n1257\n4673\n4673\n656\n2627\n1895\n2940\n1386\n1358\n\n"
+        },
+        "reward": null,
+        "status": "INACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "actionString": "gxf6",
+          "generate_returns": [
+            "{\n  \"main_response\": \"Black can simply capture White\\u2019s rook on f6 with the g-pawn. The pawn is not pinned, and this wins White\\u2019s last rook while leaving Black with overwhelming material.\\n\\nFinal Answer: gxf6\",\n  \"main_response_and_thoughts\": \"\",\n  \"request_for_logging\": {\n    \"model\": \"openai/gpt-5.5-2026-04-23\",\n    \"messages\": [\n      {\n        \"role\": \"user\",\n        \"content\": [\n          {\n            \"type\": \"text\",\n            \"text\": \"Let's play chess. The current game state in Forsyth-Edwards Notation (FEN) notation is:\\nr1b2rk1/1p3pp1/p3pR1p/q7/3P4/4Q1B1/4B1PP/6K1 b - - 0 23\\nThe moves played so far are:\\n1. e4 c5 2. Nf3 d6 3. d4 cxd4 4. Nxd4 Nf6 5. Nc3 a6 6. Bg5 e6 7. f4 Qb6 8. Qd2 Qxb2 9. Rb1 Qa3 10. e5 dxe5 11. fxe5 Nfd7 12. Ne4 h6 13. Bh4 Qxa2 14. Rd1 Qd5 15. Qe3 Qxe5 16. Be2 Bc5 17. Bg3 Bxd4 18. Rxd4 Qa5+ 19. c3 O-O 20. O-O Nc6 21. Nf6+ Nxf6 22. Rxf6 Nxd4 23. cxd4\\nYou are playing as player Black.\\nIt is now your turn. Play your strongest move. The move MUST be legal. Reason step by step to come up with your move, then output your final answer in the format \\\"Final Answer: X\\\" where X is your chosen move in standard algebraic notation (SAN).\\n\"\n          }\n        ]\n      }\n    ],\n    \"config\": {\n      \"temperature\": \"NOT_GIVEN\",\n      \"top_p\": \"NOT_GIVEN\",\n      \"max_completion_tokens\": \"NOT_GIVEN\",\n      \"reasoning_effort\": \"high\"\n    },\n    \"stream_options\": {\n      \"include_usage\": true\n    }\n  },\n  \"response_for_logging\": {\n    \"response_chunks\": [\n      {\n        \"id\": \"chatcmpl-DcLZwzNBE2Nhyck1du3JoepKvAVXU\",\n        \"created\": 1778031784,\n        \"model\": \"openai/gpt-5.5-2026-04-23\",\n        \"object\": \"chat.completion.chunk\",\n        \"usage\": {\n          \"completion_tokens\": 31101,\n          \"prompt_tokens\": 330,\n          \"total_tokens\": 31431,\n          \"cost\": {\n            \"input_tokens_cost_nanodollars\": 1650000,\n            \"output_tokens_cost_nanodollars\": 933030000\n          },\n          \"total_backend_latency_ms\": 565964\n        }\n      }\n    ]\n  },\n  \"generation_tokens\": 31101,\n  \"prompt_tokens\": 330,\n  \"reasoning_tokens\": null,\n  \"total_tokens\": 31431,\n  \"duration_success_only_secs\": 566.3841239140002\n}"
+          ],
+          "status": "OK",
+          "submission": 3634,
+          "thoughts": "Black can simply capture White\u2019s rook on f6 with the g-pawn. The pawn is not pinned, and this wins White\u2019s last rook while leaving Black with overwhelming material.\n\nFinal Answer: gxf6"
+        },
+        "info": {
+          "actionApplied": 3634,
+          "actionSubmitted": 3634,
+          "actionSubmittedToString": "gxf6",
+          "agentSelfReportedStatus": "OK",
+          "timeTaken": 568.132
+        },
+        "observation": {
+          "currentPlayer": 1,
+          "isTerminal": false,
+          "observationString": "r1b2rk1/1p3p2/p3pp1p/q7/3P4/4Q1B1/4B1PP/6K1 w - - 0 24",
+          "playerId": 0,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n1258\n3572\n1841\n1842\n1431\n3132\n3572\n656\n89\n1215\n2425\n3010\n1808\n1768\n749\n30\n1065\n2571\n1942\n3196\n3131\n1384\n4177\n3854\n381\n615\n498\n1869\n2001\n2977\n2975\n4350\n1431\n1770\n2581\n1257\n4673\n4673\n656\n2627\n1895\n2940\n1386\n1358\n3634\n\n",
+          "step": 47
+        },
+        "reward": null,
+        "status": "INACTIVE"
+      },
+      {
+        "action": {
+          "submission": -1
+        },
+        "info": {},
+        "observation": {
+          "currentPlayer": 1,
+          "isTerminal": false,
+          "observationString": "r1b2rk1/1p3p2/p3pp1p/q7/3P4/4Q1B1/4B1PP/6K1 w - - 0 24",
+          "playerId": 1,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n1258\n3572\n1841\n1842\n1431\n3132\n3572\n656\n89\n1215\n2425\n3010\n1808\n1768\n749\n30\n1065\n2571\n1942\n3196\n3131\n1384\n4177\n3854\n381\n615\n498\n1869\n2001\n2977\n2975\n4350\n1431\n1770\n2581\n1257\n4673\n4673\n656\n2627\n1895\n2940\n1386\n1358\n3634\n\n"
+        },
+        "reward": null,
+        "status": "ACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "submission": -1
+        },
+        "info": {},
+        "observation": {
+          "currentPlayer": 0,
+          "isTerminal": false,
+          "observationString": "r1b2rk1/1p3p2/p3pp1Q/q7/3P4/6B1/4B1PP/6K1 b - - 0 24",
+          "playerId": 0,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n1258\n3572\n1841\n1842\n1431\n3132\n3572\n656\n89\n1215\n2425\n3010\n1808\n1768\n749\n30\n1065\n2571\n1942\n3196\n3131\n1384\n4177\n3854\n381\n615\n498\n1869\n2001\n2977\n2975\n4350\n1431\n1770\n2581\n1257\n4673\n4673\n656\n2627\n1895\n2940\n1386\n1358\n3634\n2528\n\n",
+          "step": 48
+        },
+        "reward": null,
+        "status": "ACTIVE"
+      },
+      {
+        "action": {
+          "actionString": "Qxh6",
+          "generate_returns": [
+            "{\n  \"main_response\": \"To find the strongest move in this highly complex and heavily analyzed position from the Najdorf Poisoned Pawn variation, we must first take stock of the material and positional imbalances. \\n\\n**Step-by-step reasoning:**\\n1. **Material Evaluation:** Over the course of the opening and middlegame, White has sacrificed a massive amount of material\\u2014two rooks and a knight in exchange for Black's two knights, leaving White down effectively two rooks for a bishop and some pawns. However, White's compensation lies entirely in Black's shattered kingside (missing the g-pawn, with weaknesses on f6 and h6) and the severely exposed Black king on g8.\\n2. **Identifying the Goal:** Because White is down so much material, passive or purely positional play will lead to a swift defeat. White must play the most forcing move to sustain the initiative, attack the weak dark squares, and either deliver mate or force a drawing fortress. \\n3. **Candidate Move - 24. Qxh6:** Capturing the h6-pawn is the only way to capitalize on Black's compromised king. It instantly creates lethal threats by eyeing the f6 pawn and preparing to bring the bishops into the attack (for example, Bd3 and Be5).\\n4. **Analyzing Black's Responses:**\\n   - If Black tries to close the position with **24... f5**, White has a crushing continuation: 25. Be5 f6 26. Qg6+ Kh8 27. Bxf6+ Rxf6 28. Qxf6+ Kg8 29. Bh5, leading to a swift mating net or decisive material gain.\\n   - If Black tries to generate counterplay with **24... Qa1+**, White simply walks the king to safety: 25. Kf2 Qxd4+ 26. Kf1 Qa1+ 27. Be1. Black runs out of meaningful checks, and White's attack rages on (e.g., 27... f5 28. Qg5+ Kh7 29. Qh4+ Kg8 30. Qg3+ Qg7 31. Qc7), where White's minor pieces completely paralyze Black's rooks.\\n   - Black's best and most resilient defense is to force a queen trade to blunt the attack with **24... Qg5**. Here, White has the brilliant follow-up **25. Bf4!**. Black is practically forced into 25... Qxh6 26. Bxh6 Rd8, and White plays the incredible **27. d5!**. In this famous endgame setup, despite Black being up a full rook, White's bishop pair and central control create an unbreakable blockade that completely dominates Black's pieces, securing a theoretical draw (0.00 evaluation) and saving the game. \\n\\nOther moves like 24. Bd6 or 24. Bc7 either allow Black to untangle and consolidate their massive material advantage or fail to put enough immediate pressure on the vulnerable king. \\n\\nFinal Answer: Qxh6\",\n  \"main_response_and_thoughts\": \"\",\n  \"request_for_logging\": {\n    \"model\": \"google/gemini-3.1-pro-preview\",\n    \"messages\": [\n      {\n        \"role\": \"user\",\n        \"content\": [\n          {\n            \"type\": \"text\",\n            \"text\": \"Let's play chess. The current game state in Forsyth-Edwards Notation (FEN) notation is:\\nr1b2rk1/1p3p2/p3pp1p/q7/3P4/4Q1B1/4B1PP/6K1 w - - 0 24\\nThe moves played so far are:\\n1. e4 c5 2. Nf3 d6 3. d4 cxd4 4. Nxd4 Nf6 5. Nc3 a6 6. Bg5 e6 7. f4 Qb6 8. Qd2 Qxb2 9. Rb1 Qa3 10. e5 dxe5 11. fxe5 Nfd7 12. Ne4 h6 13. Bh4 Qxa2 14. Rd1 Qd5 15. Qe3 Qxe5 16. Be2 Bc5 17. Bg3 Bxd4 18. Rxd4 Qa5+ 19. c3 O-O 20. O-O Nc6 21. Nf6+ Nxf6 22. Rxf6 Nxd4 23. cxd4 gxf6 24.\\nYou are playing as player White.\\nIt is now your turn. Play your strongest move. The move MUST be legal. Reason step by step to come up with your move, then output your final answer in the format \\\"Final Answer: X\\\" where X is your chosen move in standard algebraic notation (SAN).\\n\"\n          }\n        ]\n      }\n    ],\n    \"config\": {\n      \"temperature\": \"NOT_GIVEN\",\n      \"top_p\": \"NOT_GIVEN\",\n      \"max_completion_tokens\": \"NOT_GIVEN\"\n    },\n    \"stream_options\": {\n      \"include_usage\": true\n    }\n  },\n  \"response_for_logging\": {\n    \"response_chunks\": [\n      {\n        \"id\": \"4p76aeSZBrWKmecPxOar6Aw\",\n        \"choices\": [\n          {\n            \"delta\": {\n              \"content\": \" enough immediate pressure on the vulnerable king. \\n\\nFinal Answer: Qxh6\",\n              \"role\": \"assistant\"\n            },\n            \"finish_reason\": \"stop\",\n            \"index\": 0\n          }\n        ],\n        \"created\": 1778032354,\n        \"model\": \"google/gemini-3.1-pro-preview\",\n        \"object\": \"chat.completion.chunk\",\n        \"usage\": {\n          \"completion_tokens\": 657,\n          \"prompt_tokens\": 327,\n          \"total_tokens\": 17845,\n          \"cost\": {\n            \"input_tokens_cost_nanodollars\": 654000,\n            \"output_tokens_cost_nanodollars\": 210216000\n          },\n          \"total_backend_latency_ms\": 138529\n        }\n      }\n    ]\n  },\n  \"generation_tokens\": 657,\n  \"prompt_tokens\": 327,\n  \"reasoning_tokens\": null,\n  \"total_tokens\": 17845,\n  \"duration_success_only_secs\": 139.49046863799958\n}"
+          ],
+          "status": "OK",
+          "submission": 2528,
+          "thoughts": "To find the strongest move in this highly complex and heavily analyzed position from the Najdorf Poisoned Pawn variation, we must first take stock of the material and positional imbalances. \n\n**Step-by-step reasoning:**\n1. **Material Evaluation:** Over the course of the opening and middlegame, White has sacrificed a massive amount of material\u2014two rooks and a knight in exchange for Black's two knights, leaving White down effectively two rooks for a bishop and some pawns. However, White's compensation lies entirely in Black's shattered kingside (missing the g-pawn, with weaknesses on f6 and h6) and the severely exposed Black king on g8.\n2. **Identifying the Goal:** Because White is down so much material, passive or purely positional play will lead to a swift defeat. White must play the most forcing move to sustain the initiative, attack the weak dark squares, and either deliver mate or force a drawing fortress. \n3. **Candidate Move - 24. Qxh6:** Capturing the h6-pawn is the only way to capitalize on Black's compromised king. It instantly creates lethal threats by eyeing the f6 pawn and preparing to bring the bishops into the attack (for example, Bd3 and Be5).\n4. **Analyzing Black's Responses:**\n   - If Black tries to close the position with **24... f5**, White has a crushing continuation: 25. Be5 f6 26. Qg6+ Kh8 27. Bxf6+ Rxf6 28. Qxf6+ Kg8 29. Bh5, leading to a swift mating net or decisive material gain.\n   - If Black tries to generate counterplay with **24... Qa1+**, White simply walks the king to safety: 25. Kf2 Qxd4+ 26. Kf1 Qa1+ 27. Be1. Black runs out of meaningful checks, and White's attack rages on (e.g., 27... f5 28. Qg5+ Kh7 29. Qh4+ Kg8 30. Qg3+ Qg7 31. Qc7), where White's minor pieces completely paralyze Black's rooks.\n   - Black's best and most resilient defense is to force a queen trade to blunt the attack with **24... Qg5**. Here, White has the brilliant follow-up **25. Bf4!**. Black is practically forced into 25... Qxh6 26. Bxh6 Rd8, and White plays the incredible **27. d5!**. In this famous endgame setup, despite Black being up a full rook, White's bishop pair and central control create an unbreakable blockade that completely dominates Black's pieces, securing a theoretical draw (0.00 evaluation) and saving the game. \n\nOther moves like 24. Bd6 or 24. Bc7 either allow Black to untangle and consolidate their massive material advantage or fail to put enough immediate pressure on the vulnerable king. \n\nFinal Answer: Qxh6"
+        },
+        "info": {
+          "actionApplied": 2528,
+          "actionSubmitted": 2528,
+          "actionSubmittedToString": "Qxh6",
+          "agentSelfReportedStatus": "OK",
+          "timeTaken": 142.327
+        },
+        "observation": {
+          "currentPlayer": 0,
+          "isTerminal": false,
+          "observationString": "r1b2rk1/1p3p2/p3pp1Q/q7/3P4/6B1/4B1PP/6K1 b - - 0 24",
+          "playerId": 1,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n1258\n3572\n1841\n1842\n1431\n3132\n3572\n656\n89\n1215\n2425\n3010\n1808\n1768\n749\n30\n1065\n2571\n1942\n3196\n3131\n1384\n4177\n3854\n381\n615\n498\n1869\n2001\n2977\n2975\n4350\n1431\n1770\n2581\n1257\n4673\n4673\n656\n2627\n1895\n2940\n1386\n1358\n3634\n2528\n\n"
+        },
+        "reward": null,
+        "status": "INACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "actionString": "Qg5",
+          "generate_returns": [
+            "{\n  \"main_response\": \"Final Answer: Qg5\",\n  \"main_response_and_thoughts\": \"\",\n  \"request_for_logging\": {\n    \"model\": \"openai/gpt-5.5-2026-04-23\",\n    \"messages\": [\n      {\n        \"role\": \"user\",\n        \"content\": [\n          {\n            \"type\": \"text\",\n            \"text\": \"Let's play chess. The current game state in Forsyth-Edwards Notation (FEN) notation is:\\nr1b2rk1/1p3p2/p3pp1Q/q7/3P4/6B1/4B1PP/6K1 b - - 0 24\\nThe moves played so far are:\\n1. e4 c5 2. Nf3 d6 3. d4 cxd4 4. Nxd4 Nf6 5. Nc3 a6 6. Bg5 e6 7. f4 Qb6 8. Qd2 Qxb2 9. Rb1 Qa3 10. e5 dxe5 11. fxe5 Nfd7 12. Ne4 h6 13. Bh4 Qxa2 14. Rd1 Qd5 15. Qe3 Qxe5 16. Be2 Bc5 17. Bg3 Bxd4 18. Rxd4 Qa5+ 19. c3 O-O 20. O-O Nc6 21. Nf6+ Nxf6 22. Rxf6 Nxd4 23. cxd4 gxf6 24. Qxh6\\nYou are playing as player Black.\\nIt is now your turn. Play your strongest move. The move MUST be legal. Reason step by step to come up with your move, then output your final answer in the format \\\"Final Answer: X\\\" where X is your chosen move in standard algebraic notation (SAN).\\n\"\n          }\n        ]\n      }\n    ],\n    \"config\": {\n      \"temperature\": \"NOT_GIVEN\",\n      \"top_p\": \"NOT_GIVEN\",\n      \"max_completion_tokens\": \"NOT_GIVEN\",\n      \"reasoning_effort\": \"high\"\n    },\n    \"stream_options\": {\n      \"include_usage\": true\n    }\n  },\n  \"response_for_logging\": {\n    \"response_chunks\": [\n      {\n        \"id\": \"chatcmpl-DcLlOH9skycTllBGJKbZYTsY6CCTX\",\n        \"created\": 1778032494,\n        \"model\": \"openai/gpt-5.5-2026-04-23\",\n        \"object\": \"chat.completion.chunk\",\n        \"usage\": {\n          \"completion_tokens\": 10887,\n          \"prompt_tokens\": 336,\n          \"total_tokens\": 11223,\n          \"cost\": {\n            \"input_tokens_cost_nanodollars\": 1680000,\n            \"output_tokens_cost_nanodollars\": 326610000\n          },\n          \"total_backend_latency_ms\": 200477\n        }\n      }\n    ]\n  },\n  \"generation_tokens\": 10887,\n  \"prompt_tokens\": 336,\n  \"reasoning_tokens\": null,\n  \"total_tokens\": 11223,\n  \"duration_success_only_secs\": 200.94798133399854\n}"
+          ],
+          "status": "OK",
+          "submission": 254,
+          "thoughts": "Final Answer: Qg5"
+        },
+        "info": {
+          "actionApplied": 254,
+          "actionSubmitted": 254,
+          "actionSubmittedToString": "Qg5",
+          "agentSelfReportedStatus": "OK",
+          "timeTaken": 202.138
+        },
+        "observation": {
+          "currentPlayer": 1,
+          "isTerminal": false,
+          "observationString": "r1b2rk1/1p3p2/p3pp1Q/6q1/3P4/6B1/4B1PP/6K1 w - - 1 25",
+          "playerId": 0,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n1258\n3572\n1841\n1842\n1431\n3132\n3572\n656\n89\n1215\n2425\n3010\n1808\n1768\n749\n30\n1065\n2571\n1942\n3196\n3131\n1384\n4177\n3854\n381\n615\n498\n1869\n2001\n2977\n2975\n4350\n1431\n1770\n2581\n1257\n4673\n4673\n656\n2627\n1895\n2940\n1386\n1358\n3634\n2528\n254\n\n",
+          "step": 49
+        },
+        "reward": null,
+        "status": "INACTIVE"
+      },
+      {
+        "action": {
+          "submission": -1
+        },
+        "info": {},
+        "observation": {
+          "currentPlayer": 1,
+          "isTerminal": false,
+          "observationString": "r1b2rk1/1p3p2/p3pp1Q/6q1/3P4/6B1/4B1PP/6K1 w - - 1 25",
+          "playerId": 1,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n1258\n3572\n1841\n1842\n1431\n3132\n3572\n656\n89\n1215\n2425\n3010\n1808\n1768\n749\n30\n1065\n2571\n1942\n3196\n3131\n1384\n4177\n3854\n381\n615\n498\n1869\n2001\n2977\n2975\n4350\n1431\n1770\n2581\n1257\n4673\n4673\n656\n2627\n1895\n2940\n1386\n1358\n3634\n2528\n254\n\n"
+        },
+        "reward": null,
+        "status": "ACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "submission": -1
+        },
+        "info": {},
+        "observation": {
+          "currentPlayer": 0,
+          "isTerminal": false,
+          "observationString": "r1b2rk1/1p3p2/p3pp2/6Q1/3P4/6B1/4B1PP/6K1 b - - 0 25",
+          "playerId": 0,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n1258\n3572\n1841\n1842\n1431\n3132\n3572\n656\n89\n1215\n2425\n3010\n1808\n1768\n749\n30\n1065\n2571\n1942\n3196\n3131\n1384\n4177\n3854\n381\n615\n498\n1869\n2001\n2977\n2975\n4350\n1431\n1770\n2581\n1257\n4673\n4673\n656\n2627\n1895\n2940\n1386\n1358\n3634\n2528\n254\n4496\n\n",
+          "step": 50
+        },
+        "reward": null,
+        "status": "ACTIVE"
+      },
+      {
+        "action": {
+          "actionString": "Qxg5+",
+          "generate_returns": [
+            "{\n  \"main_response\": \"The position you've reached is a tough one for White, having sacrificed a significant amount of material in the prior moves for an attack that has now unfortunately fizzled out. \\n\\nWith Black playing 24... Qg5, your Queen on h6 is under direct attack, and Black is offering a Queen trade. When down this much material, a Queen trade usually favors the side that is ahead (Black). However, keeping the Queens on the board doesn't offer White any practical swindling chances here because Black's King is perfectly safe, and moving the Queen away (for example, 25. Qh3) just drops the initiative and allows Black to consolidate their massive material advantage (e.g., 25... e5!).\\n\\nSince retreating the Queen loses even faster and there are no tactical tricks to save the game, the only logical and best move in this lost position is to accept the trade. \\n\\nFinal Answer: Qxg5+\",\n  \"main_response_and_thoughts\": \"\",\n  \"request_for_logging\": {\n    \"model\": \"google/gemini-3.1-pro-preview\",\n    \"messages\": [\n      {\n        \"role\": \"user\",\n        \"content\": [\n          {\n            \"type\": \"text\",\n            \"text\": \"Let's play chess. The current game state in Forsyth-Edwards Notation (FEN) notation is:\\nr1b2rk1/1p3p2/p3pp1Q/6q1/3P4/6B1/4B1PP/6K1 w - - 1 25\\nThe moves played so far are:\\n1. e4 c5 2. Nf3 d6 3. d4 cxd4 4. Nxd4 Nf6 5. Nc3 a6 6. Bg5 e6 7. f4 Qb6 8. Qd2 Qxb2 9. Rb1 Qa3 10. e5 dxe5 11. fxe5 Nfd7 12. Ne4 h6 13. Bh4 Qxa2 14. Rd1 Qd5 15. Qe3 Qxe5 16. Be2 Bc5 17. Bg3 Bxd4 18. Rxd4 Qa5+ 19. c3 O-O 20. O-O Nc6 21. Nf6+ Nxf6 22. Rxf6 Nxd4 23. cxd4 gxf6 24. Qxh6 Qg5 25.\\nYou are playing as player White.\\nIt is now your turn. Play your strongest move. The move MUST be legal. Reason step by step to come up with your move, then output your final answer in the format \\\"Final Answer: X\\\" where X is your chosen move in standard algebraic notation (SAN).\\n\"\n          }\n        ]\n      }\n    ],\n    \"config\": {\n      \"temperature\": \"NOT_GIVEN\",\n      \"top_p\": \"NOT_GIVEN\",\n      \"max_completion_tokens\": \"NOT_GIVEN\"\n    },\n    \"stream_options\": {\n      \"include_usage\": true\n    }\n  },\n  \"response_for_logging\": {\n    \"response_chunks\": [\n      {\n        \"id\": \"OaD6aeGpAauEm9IP2rm86QE\",\n        \"choices\": [\n          {\n            \"delta\": {\n              \"content\": \" Qxg5+\",\n              \"role\": \"assistant\"\n            },\n            \"finish_reason\": \"stop\",\n            \"index\": 0\n          }\n        ],\n        \"created\": 1778032697,\n        \"model\": \"google/gemini-3.1-pro-preview\",\n        \"object\": \"chat.completion.chunk\",\n        \"usage\": {\n          \"completion_tokens\": 197,\n          \"prompt_tokens\": 334,\n          \"total_tokens\": 2949,\n          \"cost\": {\n            \"input_tokens_cost_nanodollars\": 668000,\n            \"output_tokens_cost_nanodollars\": 31380000\n          },\n          \"total_backend_latency_ms\": 23624\n        }\n      }\n    ]\n  },\n  \"generation_tokens\": 197,\n  \"prompt_tokens\": 334,\n  \"reasoning_tokens\": null,\n  \"total_tokens\": 2949,\n  \"duration_success_only_secs\": 24.151003529001173\n}"
+          ],
+          "status": "OK",
+          "submission": 4496,
+          "thoughts": "The position you've reached is a tough one for White, having sacrificed a significant amount of material in the prior moves for an attack that has now unfortunately fizzled out. \n\nWith Black playing 24... Qg5, your Queen on h6 is under direct attack, and Black is offering a Queen trade. When down this much material, a Queen trade usually favors the side that is ahead (Black). However, keeping the Queens on the board doesn't offer White any practical swindling chances here because Black's King is perfectly safe, and moving the Queen away (for example, 25. Qh3) just drops the initiative and allows Black to consolidate their massive material advantage (e.g., 25... e5!).\n\nSince retreating the Queen loses even faster and there are no tactical tricks to save the game, the only logical and best move in this lost position is to accept the trade. \n\nFinal Answer: Qxg5+"
+        },
+        "info": {
+          "actionApplied": 4496,
+          "actionSubmitted": 4496,
+          "actionSubmittedToString": "Qxg5+",
+          "agentSelfReportedStatus": "OK",
+          "timeTaken": 25.871
+        },
+        "observation": {
+          "currentPlayer": 0,
+          "isTerminal": false,
+          "observationString": "r1b2rk1/1p3p2/p3pp2/6Q1/3P4/6B1/4B1PP/6K1 b - - 0 25",
+          "playerId": 1,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n1258\n3572\n1841\n1842\n1431\n3132\n3572\n656\n89\n1215\n2425\n3010\n1808\n1768\n749\n30\n1065\n2571\n1942\n3196\n3131\n1384\n4177\n3854\n381\n615\n498\n1869\n2001\n2977\n2975\n4350\n1431\n1770\n2581\n1257\n4673\n4673\n656\n2627\n1895\n2940\n1386\n1358\n3634\n2528\n254\n4496\n\n"
+        },
+        "reward": null,
+        "status": "INACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "actionString": "fxg5",
+          "generate_returns": [
+            "{\n  \"main_response\": \"Final Answer: fxg5\",\n  \"main_response_and_thoughts\": \"\",\n  \"request_for_logging\": {\n    \"model\": \"openai/gpt-5.5-2026-04-23\",\n    \"messages\": [\n      {\n        \"role\": \"user\",\n        \"content\": [\n          {\n            \"type\": \"text\",\n            \"text\": \"Let's play chess. The current game state in Forsyth-Edwards Notation (FEN) notation is:\\nr1b2rk1/1p3p2/p3pp2/6Q1/3P4/6B1/4B1PP/6K1 b - - 0 25\\nThe moves played so far are:\\n1. e4 c5 2. Nf3 d6 3. d4 cxd4 4. Nxd4 Nf6 5. Nc3 a6 6. Bg5 e6 7. f4 Qb6 8. Qd2 Qxb2 9. Rb1 Qa3 10. e5 dxe5 11. fxe5 Nfd7 12. Ne4 h6 13. Bh4 Qxa2 14. Rd1 Qd5 15. Qe3 Qxe5 16. Be2 Bc5 17. Bg3 Bxd4 18. Rxd4 Qa5+ 19. c3 O-O 20. O-O Nc6 21. Nf6+ Nxf6 22. Rxf6 Nxd4 23. cxd4 gxf6 24. Qxh6 Qg5 25. Qxg5+\\nYou are playing as player Black.\\nIt is now your turn. Play your strongest move. The move MUST be legal. Reason step by step to come up with your move, then output your final answer in the format \\\"Final Answer: X\\\" where X is your chosen move in standard algebraic notation (SAN).\\n\"\n          }\n        ]\n      }\n    ],\n    \"config\": {\n      \"temperature\": \"NOT_GIVEN\",\n      \"top_p\": \"NOT_GIVEN\",\n      \"max_completion_tokens\": \"NOT_GIVEN\",\n      \"reasoning_effort\": \"high\"\n    },\n    \"stream_options\": {\n      \"include_usage\": true\n    }\n  },\n  \"response_for_logging\": {\n    \"response_chunks\": [\n      {\n        \"id\": \"chatcmpl-DcLp5FW2TEkAsapuh9tDZ0MCOoME6\",\n        \"created\": 1778032723,\n        \"model\": \"openai/gpt-5.5-2026-04-23\",\n        \"object\": \"chat.completion.chunk\",\n        \"usage\": {\n          \"completion_tokens\": 2599,\n          \"prompt_tokens\": 347,\n          \"total_tokens\": 2946,\n          \"cost\": {\n            \"input_tokens_cost_nanodollars\": 1735000,\n            \"output_tokens_cost_nanodollars\": 77970000\n          },\n          \"total_backend_latency_ms\": 47099\n        }\n      }\n    ]\n  },\n  \"generation_tokens\": 2599,\n  \"prompt_tokens\": 347,\n  \"reasoning_tokens\": null,\n  \"total_tokens\": 2946,\n  \"duration_success_only_secs\": 47.67669344500064\n}"
+          ],
+          "status": "OK",
+          "submission": 3110,
+          "thoughts": "Final Answer: fxg5"
+        },
+        "info": {
+          "actionApplied": 3110,
+          "actionSubmitted": 3110,
+          "actionSubmittedToString": "fxg5",
+          "agentSelfReportedStatus": "OK",
+          "timeTaken": 49.439
+        },
+        "observation": {
+          "currentPlayer": 1,
+          "isTerminal": false,
+          "observationString": "r1b2rk1/1p3p2/p3p3/6p1/3P4/6B1/4B1PP/6K1 w - - 0 26",
+          "playerId": 0,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n1258\n3572\n1841\n1842\n1431\n3132\n3572\n656\n89\n1215\n2425\n3010\n1808\n1768\n749\n30\n1065\n2571\n1942\n3196\n3131\n1384\n4177\n3854\n381\n615\n498\n1869\n2001\n2977\n2975\n4350\n1431\n1770\n2581\n1257\n4673\n4673\n656\n2627\n1895\n2940\n1386\n1358\n3634\n2528\n254\n4496\n3110\n\n",
+          "step": 51
+        },
+        "reward": null,
+        "status": "INACTIVE"
+      },
+      {
+        "action": {
+          "submission": -1
+        },
+        "info": {},
+        "observation": {
+          "currentPlayer": 1,
+          "isTerminal": false,
+          "observationString": "r1b2rk1/1p3p2/p3p3/6p1/3P4/6B1/4B1PP/6K1 w - - 0 26",
+          "playerId": 1,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n1258\n3572\n1841\n1842\n1431\n3132\n3572\n656\n89\n1215\n2425\n3010\n1808\n1768\n749\n30\n1065\n2571\n1942\n3196\n3131\n1384\n4177\n3854\n381\n615\n498\n1869\n2001\n2977\n2975\n4350\n1431\n1770\n2581\n1257\n4673\n4673\n656\n2627\n1895\n2940\n1386\n1358\n3634\n2528\n254\n4496\n3110\n\n"
+        },
+        "reward": null,
+        "status": "ACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "submission": -1
+        },
+        "info": {},
+        "observation": {
+          "currentPlayer": 0,
+          "isTerminal": false,
+          "observationString": "r1b2rk1/1p3p2/p2Bp3/6p1/3P4/8/4B1PP/6K1 b - - 1 26",
+          "playerId": 0,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n1258\n3572\n1841\n1842\n1431\n3132\n3572\n656\n89\n1215\n2425\n3010\n1808\n1768\n749\n30\n1065\n2571\n1942\n3196\n3131\n1384\n4177\n3854\n381\n615\n498\n1869\n2001\n2977\n2975\n4350\n1431\n1770\n2581\n1257\n4673\n4673\n656\n2627\n1895\n2940\n1386\n1358\n3634\n2528\n254\n4496\n3110\n3705\n\n",
+          "step": 52
+        },
+        "reward": null,
+        "status": "ACTIVE"
+      },
+      {
+        "action": {
+          "actionString": "Bd6",
+          "generate_returns": [
+            "{\n  \"main_response\": \"To determine the best move, we should look for ways to maximize the activity of White's pieces and create practical problems for Black, despite the material disadvantage. \\n\\n1. **26. Bd6!** is the most forcing and active choice. It immediately attacks the rook on f8 and demands a response. \\n2. If Black plays **26... Rd8**, you can follow up with **27. Be7**, attacking the rook again. If Black replies with **27... Rd7**, you can play **28. Bxg5**, winning a pawn and creating an incredibly annoying dark-squared bishop on f6 if Black plays **28... Rxd4 29. Bf6**. This clamps down on the Black king and gives White a lot of annoying pressure.\\n3. Alternatively, if Black tries to step aside with **26... Re8**, you can launch an attack on the f7-pawn with **27. Bh5!** (e.g., 27... Rd8 28. Bxf7+ Kg7 29. Be7 Rd7 30. Bf6+ Kh6 31. Bxe6), scooping up pawns and severely exposing the Black king.\\n\\nBy centralizing the bishop on d6, you restrict Black's setup and provoke weaknesses.\\n\\nFinal Answer: Bd6\",\n  \"main_response_and_thoughts\": \"\",\n  \"request_for_logging\": {\n    \"model\": \"google/gemini-3.1-pro-preview\",\n    \"messages\": [\n      {\n        \"role\": \"user\",\n        \"content\": [\n          {\n            \"type\": \"text\",\n            \"text\": \"Let's play chess. The current game state in Forsyth-Edwards Notation (FEN) notation is:\\nr1b2rk1/1p3p2/p3p3/6p1/3P4/6B1/4B1PP/6K1 w - - 0 26\\nThe moves played so far are:\\n1. e4 c5 2. Nf3 d6 3. d4 cxd4 4. Nxd4 Nf6 5. Nc3 a6 6. Bg5 e6 7. f4 Qb6 8. Qd2 Qxb2 9. Rb1 Qa3 10. e5 dxe5 11. fxe5 Nfd7 12. Ne4 h6 13. Bh4 Qxa2 14. Rd1 Qd5 15. Qe3 Qxe5 16. Be2 Bc5 17. Bg3 Bxd4 18. Rxd4 Qa5+ 19. c3 O-O 20. O-O Nc6 21. Nf6+ Nxf6 22. Rxf6 Nxd4 23. cxd4 gxf6 24. Qxh6 Qg5 25. Qxg5+ fxg5 26.\\nYou are playing as player White.\\nIt is now your turn. Play your strongest move. The move MUST be legal. Reason step by step to come up with your move, then output your final answer in the format \\\"Final Answer: X\\\" where X is your chosen move in standard algebraic notation (SAN).\\n\"\n          }\n        ]\n      }\n    ],\n    \"config\": {\n      \"temperature\": \"NOT_GIVEN\",\n      \"top_p\": \"NOT_GIVEN\",\n      \"max_completion_tokens\": \"NOT_GIVEN\"\n    },\n    \"stream_options\": {\n      \"include_usage\": true\n    }\n  },\n  \"response_for_logging\": {\n    \"response_chunks\": [\n      {\n        \"id\": \"hKD6ad68FNCfmecP0erHwQ0\",\n        \"choices\": [\n          {\n            \"delta\": {\n              \"content\": \" d6, you restrict Black's setup and provoke weaknesses.\\n\\nFinal Answer: Bd6\",\n              \"role\": \"assistant\"\n            },\n            \"finish_reason\": \"stop\",\n            \"index\": 0\n          }\n        ],\n        \"created\": 1778032772,\n        \"model\": \"google/gemini-3.1-pro-preview\",\n        \"object\": \"chat.completion.chunk\",\n        \"usage\": {\n          \"completion_tokens\": 286,\n          \"prompt_tokens\": 342,\n          \"total_tokens\": 4948,\n          \"cost\": {\n            \"input_tokens_cost_nanodollars\": 684000,\n            \"output_tokens_cost_nanodollars\": 55272000\n          },\n          \"total_backend_latency_ms\": 38150\n        }\n      }\n    ]\n  },\n  \"generation_tokens\": 286,\n  \"prompt_tokens\": 342,\n  \"reasoning_tokens\": null,\n  \"total_tokens\": 4948,\n  \"duration_success_only_secs\": 38.74078674200064\n}"
+          ],
+          "status": "OK",
+          "submission": 3705,
+          "thoughts": "To determine the best move, we should look for ways to maximize the activity of White's pieces and create practical problems for Black, despite the material disadvantage. \n\n1. **26. Bd6!** is the most forcing and active choice. It immediately attacks the rook on f8 and demands a response. \n2. If Black plays **26... Rd8**, you can follow up with **27. Be7**, attacking the rook again. If Black replies with **27... Rd7**, you can play **28. Bxg5**, winning a pawn and creating an incredibly annoying dark-squared bishop on f6 if Black plays **28... Rxd4 29. Bf6**. This clamps down on the Black king and gives White a lot of annoying pressure.\n3. Alternatively, if Black tries to step aside with **26... Re8**, you can launch an attack on the f7-pawn with **27. Bh5!** (e.g., 27... Rd8 28. Bxf7+ Kg7 29. Be7 Rd7 30. Bf6+ Kh6 31. Bxe6), scooping up pawns and severely exposing the Black king.\n\nBy centralizing the bishop on d6, you restrict Black's setup and provoke weaknesses.\n\nFinal Answer: Bd6"
+        },
+        "info": {
+          "actionApplied": 3705,
+          "actionSubmitted": 3705,
+          "actionSubmittedToString": "Bd6",
+          "agentSelfReportedStatus": "OK",
+          "timeTaken": 39.959
+        },
+        "observation": {
+          "currentPlayer": 0,
+          "isTerminal": false,
+          "observationString": "r1b2rk1/1p3p2/p2Bp3/6p1/3P4/8/4B1PP/6K1 b - - 1 26",
+          "playerId": 1,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n1258\n3572\n1841\n1842\n1431\n3132\n3572\n656\n89\n1215\n2425\n3010\n1808\n1768\n749\n30\n1065\n2571\n1942\n3196\n3131\n1384\n4177\n3854\n381\n615\n498\n1869\n2001\n2977\n2975\n4350\n1431\n1770\n2581\n1257\n4673\n4673\n656\n2627\n1895\n2940\n1386\n1358\n3634\n2528\n254\n4496\n3110\n3705\n\n"
+        },
+        "reward": null,
+        "status": "INACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "actionString": "Rd8",
+          "generate_returns": [
+            "{\n  \"main_response\": \"The rook on f8 is attacked by White\\u2019s bishop on d6. Moving it to d8 not only saves it, but also attacks that bishop and centralizes the rook on the open d-file.\\n\\nFinal Answer: Rd8\",\n  \"main_response_and_thoughts\": \"\",\n  \"request_for_logging\": {\n    \"model\": \"openai/gpt-5.5-2026-04-23\",\n    \"messages\": [\n      {\n        \"role\": \"user\",\n        \"content\": [\n          {\n            \"type\": \"text\",\n            \"text\": \"Let's play chess. The current game state in Forsyth-Edwards Notation (FEN) notation is:\\nr1b2rk1/1p3p2/p2Bp3/6p1/3P4/8/4B1PP/6K1 b - - 1 26\\nThe moves played so far are:\\n1. e4 c5 2. Nf3 d6 3. d4 cxd4 4. Nxd4 Nf6 5. Nc3 a6 6. Bg5 e6 7. f4 Qb6 8. Qd2 Qxb2 9. Rb1 Qa3 10. e5 dxe5 11. fxe5 Nfd7 12. Ne4 h6 13. Bh4 Qxa2 14. Rd1 Qd5 15. Qe3 Qxe5 16. Be2 Bc5 17. Bg3 Bxd4 18. Rxd4 Qa5+ 19. c3 O-O 20. O-O Nc6 21. Nf6+ Nxf6 22. Rxf6 Nxd4 23. cxd4 gxf6 24. Qxh6 Qg5 25. Qxg5+ fxg5 26. Bd6\\nYou are playing as player Black.\\nIt is now your turn. Play your strongest move. The move MUST be legal. Reason step by step to come up with your move, then output your final answer in the format \\\"Final Answer: X\\\" where X is your chosen move in standard algebraic notation (SAN).\\n\"\n          }\n        ]\n      }\n    ],\n    \"config\": {\n      \"temperature\": \"NOT_GIVEN\",\n      \"top_p\": \"NOT_GIVEN\",\n      \"max_completion_tokens\": \"NOT_GIVEN\",\n      \"reasoning_effort\": \"high\"\n    },\n    \"stream_options\": {\n      \"include_usage\": true\n    }\n  },\n  \"response_for_logging\": {\n    \"response_chunks\": [\n      {\n        \"id\": \"chatcmpl-DcLqWVACw7ux6kezYxDceEqFlMLM4\",\n        \"created\": 1778032812,\n        \"model\": \"openai/gpt-5.5-2026-04-23\",\n        \"object\": \"chat.completion.chunk\",\n        \"usage\": {\n          \"completion_tokens\": 5229,\n          \"prompt_tokens\": 354,\n          \"total_tokens\": 5583,\n          \"cost\": {\n            \"input_tokens_cost_nanodollars\": 1770000,\n            \"output_tokens_cost_nanodollars\": 156870000\n          },\n          \"total_backend_latency_ms\": 96849\n        }\n      }\n    ]\n  },\n  \"generation_tokens\": 5229,\n  \"prompt_tokens\": 354,\n  \"reasoning_tokens\": null,\n  \"total_tokens\": 5583,\n  \"duration_success_only_secs\": 97.33828207699844\n}"
+          ],
+          "status": "OK",
+          "submission": 2948,
+          "thoughts": "The rook on f8 is attacked by White\u2019s bishop on d6. Moving it to d8 not only saves it, but also attacks that bishop and centralizes the rook on the open d-file.\n\nFinal Answer: Rd8"
+        },
+        "info": {
+          "actionApplied": 2948,
+          "actionSubmitted": 2948,
+          "actionSubmittedToString": "Rd8",
+          "agentSelfReportedStatus": "OK",
+          "timeTaken": 99.049
+        },
+        "observation": {
+          "currentPlayer": 1,
+          "isTerminal": false,
+          "observationString": "r1br2k1/1p3p2/p2Bp3/6p1/3P4/8/4B1PP/6K1 w - - 2 27",
+          "playerId": 0,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n1258\n3572\n1841\n1842\n1431\n3132\n3572\n656\n89\n1215\n2425\n3010\n1808\n1768\n749\n30\n1065\n2571\n1942\n3196\n3131\n1384\n4177\n3854\n381\n615\n498\n1869\n2001\n2977\n2975\n4350\n1431\n1770\n2581\n1257\n4673\n4673\n656\n2627\n1895\n2940\n1386\n1358\n3634\n2528\n254\n4496\n3110\n3705\n2948\n\n",
+          "step": 53
+        },
+        "reward": null,
+        "status": "INACTIVE"
+      },
+      {
+        "action": {
+          "submission": -1
+        },
+        "info": {},
+        "observation": {
+          "currentPlayer": 1,
+          "isTerminal": false,
+          "observationString": "r1br2k1/1p3p2/p2Bp3/6p1/3P4/8/4B1PP/6K1 w - - 2 27",
+          "playerId": 1,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n1258\n3572\n1841\n1842\n1431\n3132\n3572\n656\n89\n1215\n2425\n3010\n1808\n1768\n749\n30\n1065\n2571\n1942\n3196\n3131\n1384\n4177\n3854\n381\n615\n498\n1869\n2001\n2977\n2975\n4350\n1431\n1770\n2581\n1257\n4673\n4673\n656\n2627\n1895\n2940\n1386\n1358\n3634\n2528\n254\n4496\n3110\n3705\n2948\n\n"
+        },
+        "reward": null,
+        "status": "ACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "submission": -1
+        },
+        "info": {},
+        "observation": {
+          "currentPlayer": 0,
+          "isTerminal": false,
+          "observationString": "r1br2k1/1p2Bp2/p3p3/6p1/3P4/8/4B1PP/6K1 b - - 3 27",
+          "playerId": 0,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n1258\n3572\n1841\n1842\n1431\n3132\n3572\n656\n89\n1215\n2425\n3010\n1808\n1768\n749\n30\n1065\n2571\n1942\n3196\n3131\n1384\n4177\n3854\n381\n615\n498\n1869\n2001\n2977\n2975\n4350\n1431\n1770\n2581\n1257\n4673\n4673\n656\n2627\n1895\n2940\n1386\n1358\n3634\n2528\n254\n4496\n3110\n3705\n2948\n2161\n\n",
+          "step": 54
+        },
+        "reward": null,
+        "status": "ACTIVE"
+      },
+      {
+        "action": {
+          "actionString": "Be7",
+          "generate_returns": [
+            "{\n  \"main_response\": \"To determine the best move, we should evaluate the threats and hanging pieces in the current position. \\n\\nRight now, White's dark-squared bishop on d6 is under direct attack by Black's rook on d8. Moving this bishop to safety is a top priority, but we also want to place it as actively as possible. \\n\\nLet's look at the available squares for the bishop on d6:\\nIf we play **27. Be7**, we accomplish several things simultaneously:\\n1. We move the bishop out of danger.\\n2. We counter-attack Black's rook on d8.\\n3. We eye the undefended Black pawn on g5 on the same diagonal.\\n\\nIf Black responds by moving the attacked rook (for instance, 27... Rd7 or 27... Rxd4), White can simply follow up with 28. Bxg5, cleanly winning a pawn and placing the bishop on a very active square. If Black plays 27... Rd7, after 28. Bxg5 Rxd4, White can even follow up with 29. Bf6, placing the bishop on a powerful outpost that eyes the king and restricts Black's movement.\\n\\nOther bishop moves like Bc7 or Be5 are less forcing and do not win material or create as many problems for Black. Be7 is the most active and resilient choice in a difficult endgame.\\n\\nFinal Answer: Be7\",\n  \"main_response_and_thoughts\": \"\",\n  \"request_for_logging\": {\n    \"model\": \"google/gemini-3.1-pro-preview\",\n    \"messages\": [\n      {\n        \"role\": \"user\",\n        \"content\": [\n          {\n            \"type\": \"text\",\n            \"text\": \"Let's play chess. The current game state in Forsyth-Edwards Notation (FEN) notation is:\\nr1br2k1/1p3p2/p2Bp3/6p1/3P4/8/4B1PP/6K1 w - - 2 27\\nThe moves played so far are:\\n1. e4 c5 2. Nf3 d6 3. d4 cxd4 4. Nxd4 Nf6 5. Nc3 a6 6. Bg5 e6 7. f4 Qb6 8. Qd2 Qxb2 9. Rb1 Qa3 10. e5 dxe5 11. fxe5 Nfd7 12. Ne4 h6 13. Bh4 Qxa2 14. Rd1 Qd5 15. Qe3 Qxe5 16. Be2 Bc5 17. Bg3 Bxd4 18. Rxd4 Qa5+ 19. c3 O-O 20. O-O Nc6 21. Nf6+ Nxf6 22. Rxf6 Nxd4 23. cxd4 gxf6 24. Qxh6 Qg5 25. Qxg5+ fxg5 26. Bd6 Rd8 27.\\nYou are playing as player White.\\nIt is now your turn. Play your strongest move. The move MUST be legal. Reason step by step to come up with your move, then output your final answer in the format \\\"Final Answer: X\\\" where X is your chosen move in standard algebraic notation (SAN).\\n\"\n          }\n        ]\n      }\n    ],\n    \"config\": {\n      \"temperature\": \"NOT_GIVEN\",\n      \"top_p\": \"NOT_GIVEN\",\n      \"max_completion_tokens\": \"NOT_GIVEN\"\n    },\n    \"stream_options\": {\n      \"include_usage\": true\n    }\n  },\n  \"response_for_logging\": {\n    \"response_chunks\": [\n      {\n        \"id\": \"D6H6adeHN8udmecPmbT14Qk\",\n        \"choices\": [\n          {\n            \"delta\": {\n              \"content\": \" Be7\",\n              \"role\": \"assistant\"\n            },\n            \"finish_reason\": \"stop\",\n            \"index\": 0\n          }\n        ],\n        \"created\": 1778032911,\n        \"model\": \"google/gemini-3.1-pro-preview\",\n        \"object\": \"chat.completion.chunk\",\n        \"usage\": {\n          \"completion_tokens\": 298,\n          \"prompt_tokens\": 348,\n          \"total_tokens\": 7056,\n          \"cost\": {\n            \"input_tokens_cost_nanodollars\": 696000,\n            \"output_tokens_cost_nanodollars\": 80496000\n          },\n          \"total_backend_latency_ms\": 47498\n        }\n      }\n    ]\n  },\n  \"generation_tokens\": 298,\n  \"prompt_tokens\": 348,\n  \"reasoning_tokens\": null,\n  \"total_tokens\": 7056,\n  \"duration_success_only_secs\": 48.51741342300011\n}"
+          ],
+          "status": "OK",
+          "submission": 2161,
+          "thoughts": "To determine the best move, we should evaluate the threats and hanging pieces in the current position. \n\nRight now, White's dark-squared bishop on d6 is under direct attack by Black's rook on d8. Moving this bishop to safety is a top priority, but we also want to place it as actively as possible. \n\nLet's look at the available squares for the bishop on d6:\nIf we play **27. Be7**, we accomplish several things simultaneously:\n1. We move the bishop out of danger.\n2. We counter-attack Black's rook on d8.\n3. We eye the undefended Black pawn on g5 on the same diagonal.\n\nIf Black responds by moving the attacked rook (for instance, 27... Rd7 or 27... Rxd4), White can simply follow up with 28. Bxg5, cleanly winning a pawn and placing the bishop on a very active square. If Black plays 27... Rd7, after 28. Bxg5 Rxd4, White can even follow up with 29. Bf6, placing the bishop on a powerful outpost that eyes the king and restricts Black's movement.\n\nOther bishop moves like Bc7 or Be5 are less forcing and do not win material or create as many problems for Black. Be7 is the most active and resilient choice in a difficult endgame.\n\nFinal Answer: Be7"
+        },
+        "info": {
+          "actionApplied": 2161,
+          "actionSubmitted": 2161,
+          "actionSubmittedToString": "Be7",
+          "agentSelfReportedStatus": "OK",
+          "timeTaken": 49.757
+        },
+        "observation": {
+          "currentPlayer": 0,
+          "isTerminal": false,
+          "observationString": "r1br2k1/1p2Bp2/p3p3/6p1/3P4/8/4B1PP/6K1 b - - 3 27",
+          "playerId": 1,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n1258\n3572\n1841\n1842\n1431\n3132\n3572\n656\n89\n1215\n2425\n3010\n1808\n1768\n749\n30\n1065\n2571\n1942\n3196\n3131\n1384\n4177\n3854\n381\n615\n498\n1869\n2001\n2977\n2975\n4350\n1431\n1770\n2581\n1257\n4673\n4673\n656\n2627\n1895\n2940\n1386\n1358\n3634\n2528\n254\n4496\n3110\n3705\n2948\n2161\n\n"
+        },
+        "reward": null,
+        "status": "INACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "actionString": "Rxd4",
+          "generate_returns": [
+            "{\n  \"main_response\": \"White is attacking the rook on d8, and Black can move it with gain: the d-file is clear down to d4, so capturing the white pawn is legal and strong.\\n\\nFinal Answer: Rxd4\",\n  \"main_response_and_thoughts\": \"\",\n  \"request_for_logging\": {\n    \"model\": \"openai/gpt-5.5-2026-04-23\",\n    \"messages\": [\n      {\n        \"role\": \"user\",\n        \"content\": [\n          {\n            \"type\": \"text\",\n            \"text\": \"Let's play chess. The current game state in Forsyth-Edwards Notation (FEN) notation is:\\nr1br2k1/1p2Bp2/p3p3/6p1/3P4/8/4B1PP/6K1 b - - 3 27\\nThe moves played so far are:\\n1. e4 c5 2. Nf3 d6 3. d4 cxd4 4. Nxd4 Nf6 5. Nc3 a6 6. Bg5 e6 7. f4 Qb6 8. Qd2 Qxb2 9. Rb1 Qa3 10. e5 dxe5 11. fxe5 Nfd7 12. Ne4 h6 13. Bh4 Qxa2 14. Rd1 Qd5 15. Qe3 Qxe5 16. Be2 Bc5 17. Bg3 Bxd4 18. Rxd4 Qa5+ 19. c3 O-O 20. O-O Nc6 21. Nf6+ Nxf6 22. Rxf6 Nxd4 23. cxd4 gxf6 24. Qxh6 Qg5 25. Qxg5+ fxg5 26. Bd6 Rd8 27. Be7\\nYou are playing as player Black.\\nIt is now your turn. Play your strongest move. The move MUST be legal. Reason step by step to come up with your move, then output your final answer in the format \\\"Final Answer: X\\\" where X is your chosen move in standard algebraic notation (SAN).\\n\"\n          }\n        ]\n      }\n    ],\n    \"config\": {\n      \"temperature\": \"NOT_GIVEN\",\n      \"top_p\": \"NOT_GIVEN\",\n      \"max_completion_tokens\": \"NOT_GIVEN\",\n      \"reasoning_effort\": \"high\"\n    },\n    \"stream_options\": {\n      \"include_usage\": true\n    }\n  },\n  \"response_for_logging\": {\n    \"response_chunks\": [\n      {\n        \"id\": \"chatcmpl-DcLsvEos0PhuPHJE2BdKTZahoz4lj\",\n        \"created\": 1778032961,\n        \"model\": \"openai/gpt-5.5-2026-04-23\",\n        \"object\": \"chat.completion.chunk\",\n        \"usage\": {\n          \"completion_tokens\": 9370,\n          \"prompt_tokens\": 361,\n          \"total_tokens\": 9731,\n          \"cost\": {\n            \"input_tokens_cost_nanodollars\": 1805000,\n            \"output_tokens_cost_nanodollars\": 281100000\n          },\n          \"total_backend_latency_ms\": 177423\n        }\n      }\n    ]\n  },\n  \"generation_tokens\": 9370,\n  \"prompt_tokens\": 361,\n  \"reasoning_tokens\": null,\n  \"total_tokens\": 9731,\n  \"duration_success_only_secs\": 177.85772418499982\n}"
+          ],
+          "status": "OK",
+          "submission": 1771,
+          "thoughts": "White is attacking the rook on d8, and Black can move it with gain: the d-file is clear down to d4, so capturing the white pawn is legal and strong.\n\nFinal Answer: Rxd4"
+        },
+        "info": {
+          "actionApplied": 1771,
+          "actionSubmitted": 1771,
+          "actionSubmittedToString": "Rxd4",
+          "agentSelfReportedStatus": "OK",
+          "timeTaken": 179.029
+        },
+        "observation": {
+          "currentPlayer": 1,
+          "isTerminal": false,
+          "observationString": "r1b3k1/1p2Bp2/p3p3/6p1/3r4/8/4B1PP/6K1 w - - 0 28",
+          "playerId": 0,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n1258\n3572\n1841\n1842\n1431\n3132\n3572\n656\n89\n1215\n2425\n3010\n1808\n1768\n749\n30\n1065\n2571\n1942\n3196\n3131\n1384\n4177\n3854\n381\n615\n498\n1869\n2001\n2977\n2975\n4350\n1431\n1770\n2581\n1257\n4673\n4673\n656\n2627\n1895\n2940\n1386\n1358\n3634\n2528\n254\n4496\n3110\n3705\n2948\n2161\n1771\n\n",
+          "step": 55
+        },
+        "reward": null,
+        "status": "INACTIVE"
+      },
+      {
+        "action": {
+          "submission": -1
+        },
+        "info": {},
+        "observation": {
+          "currentPlayer": 1,
+          "isTerminal": false,
+          "observationString": "r1b3k1/1p2Bp2/p3p3/6p1/3r4/8/4B1PP/6K1 w - - 0 28",
+          "playerId": 1,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n1258\n3572\n1841\n1842\n1431\n3132\n3572\n656\n89\n1215\n2425\n3010\n1808\n1768\n749\n30\n1065\n2571\n1942\n3196\n3131\n1384\n4177\n3854\n381\n615\n498\n1869\n2001\n2977\n2975\n4350\n1431\n1770\n2581\n1257\n4673\n4673\n656\n2627\n1895\n2940\n1386\n1358\n3634\n2528\n254\n4496\n3110\n3705\n2948\n2161\n1771\n\n"
+        },
+        "reward": null,
+        "status": "ACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "submission": -1
+        },
+        "info": {},
+        "observation": {
+          "currentPlayer": 0,
+          "isTerminal": false,
+          "observationString": "r1b3k1/1p3p2/p3p3/6B1/3r4/8/4B1PP/6K1 b - - 0 28",
+          "playerId": 0,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n1258\n3572\n1841\n1842\n1431\n3132\n3572\n656\n89\n1215\n2425\n3010\n1808\n1768\n749\n30\n1065\n2571\n1942\n3196\n3131\n1384\n4177\n3854\n381\n615\n498\n1869\n2001\n2977\n2975\n4350\n1431\n1770\n2581\n1257\n4673\n4673\n656\n2627\n1895\n2940\n1386\n1358\n3634\n2528\n254\n4496\n3110\n3705\n2948\n2161\n1771\n2833\n\n",
+          "step": 56
+        },
+        "reward": null,
+        "status": "ACTIVE"
+      },
+      {
+        "action": {
+          "actionString": "Bxg5",
+          "generate_returns": [
+            "{\n  \"main_response\": \"To determine the best move, we must evaluate the current position. White is down a significant amount of material (down a full rook for essentially nothing in return after the series of simplifications), so our primary focus should be to eliminate Black's remaining threats and generate as much practical resistance as possible. \\n\\nLooking at the board, Black has a pawn on g5 which is loose and can be safely captured by our dark-squared bishop. \\n\\nCapturing this pawn with **28. Bxg5** is the strongest choice. It accomplishes a few things:\\n1. It wins material and eliminates a dangerous kingside pawn that could otherwise be used as a passed pawn or to create weaknesses around our King.\\n2. It improves the placement of the bishop, putting it on a more active diagonal where it helps control the center and keep an eye on Black's rooks.\\n3. It limits Black's rook on d4, which could otherwise swing along the 4th rank without much resistance.\\n\\nAfter 28. Bxg5, White is still objectively lost due to the heavy material deficit, but it remains the most resilient and principled move on the board to prolong the game and test Black's technique.\\n\\nFinal Answer: Bxg5\",\n  \"main_response_and_thoughts\": \"\",\n  \"request_for_logging\": {\n    \"model\": \"google/gemini-3.1-pro-preview\",\n    \"messages\": [\n      {\n        \"role\": \"user\",\n        \"content\": [\n          {\n            \"type\": \"text\",\n            \"text\": \"Let's play chess. The current game state in Forsyth-Edwards Notation (FEN) notation is:\\nr1b3k1/1p2Bp2/p3p3/6p1/3r4/8/4B1PP/6K1 w - - 0 28\\nThe moves played so far are:\\n1. e4 c5 2. Nf3 d6 3. d4 cxd4 4. Nxd4 Nf6 5. Nc3 a6 6. Bg5 e6 7. f4 Qb6 8. Qd2 Qxb2 9. Rb1 Qa3 10. e5 dxe5 11. fxe5 Nfd7 12. Ne4 h6 13. Bh4 Qxa2 14. Rd1 Qd5 15. Qe3 Qxe5 16. Be2 Bc5 17. Bg3 Bxd4 18. Rxd4 Qa5+ 19. c3 O-O 20. O-O Nc6 21. Nf6+ Nxf6 22. Rxf6 Nxd4 23. cxd4 gxf6 24. Qxh6 Qg5 25. Qxg5+ fxg5 26. Bd6 Rd8 27. Be7 Rxd4 28.\\nYou are playing as player White.\\nIt is now your turn. Play your strongest move. The move MUST be legal. Reason step by step to come up with your move, then output your final answer in the format \\\"Final Answer: X\\\" where X is your chosen move in standard algebraic notation (SAN).\\n\"\n          }\n        ]\n      }\n    ],\n    \"config\": {\n      \"temperature\": \"NOT_GIVEN\",\n      \"top_p\": \"NOT_GIVEN\",\n      \"max_completion_tokens\": \"NOT_GIVEN\"\n    },\n    \"stream_options\": {\n      \"include_usage\": true\n    }\n  },\n  \"response_for_logging\": {\n    \"response_chunks\": [\n      {\n        \"id\": \"9KH6aeuDCquEm9IP2rm86QE\",\n        \"choices\": [\n          {\n            \"delta\": {\n              \"content\": \" the board to prolong the game and test Black's technique.\\n\\nFinal Answer: Bxg5\",\n              \"role\": \"assistant\"\n            },\n            \"finish_reason\": \"stop\",\n            \"index\": 0\n          }\n        ],\n        \"created\": 1778033140,\n        \"model\": \"google/gemini-3.1-pro-preview\",\n        \"object\": \"chat.completion.chunk\",\n        \"usage\": {\n          \"completion_tokens\": 256,\n          \"prompt_tokens\": 356,\n          \"total_tokens\": 2604,\n          \"cost\": {\n            \"input_tokens_cost_nanodollars\": 712000,\n            \"output_tokens_cost_nanodollars\": 26976000\n          },\n          \"total_backend_latency_ms\": 22430\n        }\n      }\n    ]\n  },\n  \"generation_tokens\": 256,\n  \"prompt_tokens\": 356,\n  \"reasoning_tokens\": null,\n  \"total_tokens\": 2604,\n  \"duration_success_only_secs\": 22.921926453000196\n}"
+          ],
+          "status": "OK",
+          "submission": 2833,
+          "thoughts": "To determine the best move, we must evaluate the current position. White is down a significant amount of material (down a full rook for essentially nothing in return after the series of simplifications), so our primary focus should be to eliminate Black's remaining threats and generate as much practical resistance as possible. \n\nLooking at the board, Black has a pawn on g5 which is loose and can be safely captured by our dark-squared bishop. \n\nCapturing this pawn with **28. Bxg5** is the strongest choice. It accomplishes a few things:\n1. It wins material and eliminates a dangerous kingside pawn that could otherwise be used as a passed pawn or to create weaknesses around our King.\n2. It improves the placement of the bishop, putting it on a more active diagonal where it helps control the center and keep an eye on Black's rooks.\n3. It limits Black's rook on d4, which could otherwise swing along the 4th rank without much resistance.\n\nAfter 28. Bxg5, White is still objectively lost due to the heavy material deficit, but it remains the most resilient and principled move on the board to prolong the game and test Black's technique.\n\nFinal Answer: Bxg5"
+        },
+        "info": {
+          "actionApplied": 2833,
+          "actionSubmitted": 2833,
+          "actionSubmittedToString": "Bxg5",
+          "agentSelfReportedStatus": "OK",
+          "timeTaken": 24.17
+        },
+        "observation": {
+          "currentPlayer": 0,
+          "isTerminal": false,
+          "observationString": "r1b3k1/1p3p2/p3p3/6B1/3r4/8/4B1PP/6K1 b - - 0 28",
+          "playerId": 1,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n1258\n3572\n1841\n1842\n1431\n3132\n3572\n656\n89\n1215\n2425\n3010\n1808\n1768\n749\n30\n1065\n2571\n1942\n3196\n3131\n1384\n4177\n3854\n381\n615\n498\n1869\n2001\n2977\n2975\n4350\n1431\n1770\n2581\n1257\n4673\n4673\n656\n2627\n1895\n2940\n1386\n1358\n3634\n2528\n254\n4496\n3110\n3705\n2948\n2161\n1771\n2833\n\n"
+        },
+        "reward": null,
+        "status": "INACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "actionString": "Rd5",
+          "generate_returns": [
+            "{\n  \"main_response\": \"Final Answer: Rd5\",\n  \"main_response_and_thoughts\": \"\",\n  \"request_for_logging\": {\n    \"model\": \"openai/gpt-5.5-2026-04-23\",\n    \"messages\": [\n      {\n        \"role\": \"user\",\n        \"content\": [\n          {\n            \"type\": \"text\",\n            \"text\": \"Let's play chess. The current game state in Forsyth-Edwards Notation (FEN) notation is:\\nr1b3k1/1p3p2/p3p3/6B1/3r4/8/4B1PP/6K1 b - - 0 28\\nThe moves played so far are:\\n1. e4 c5 2. Nf3 d6 3. d4 cxd4 4. Nxd4 Nf6 5. Nc3 a6 6. Bg5 e6 7. f4 Qb6 8. Qd2 Qxb2 9. Rb1 Qa3 10. e5 dxe5 11. fxe5 Nfd7 12. Ne4 h6 13. Bh4 Qxa2 14. Rd1 Qd5 15. Qe3 Qxe5 16. Be2 Bc5 17. Bg3 Bxd4 18. Rxd4 Qa5+ 19. c3 O-O 20. O-O Nc6 21. Nf6+ Nxf6 22. Rxf6 Nxd4 23. cxd4 gxf6 24. Qxh6 Qg5 25. Qxg5+ fxg5 26. Bd6 Rd8 27. Be7 Rxd4 28. Bxg5\\nYou are playing as player Black.\\nIt is now your turn. Play your strongest move. The move MUST be legal. Reason step by step to come up with your move, then output your final answer in the format \\\"Final Answer: X\\\" where X is your chosen move in standard algebraic notation (SAN).\\n\"\n          }\n        ]\n      }\n    ],\n    \"config\": {\n      \"temperature\": \"NOT_GIVEN\",\n      \"top_p\": \"NOT_GIVEN\",\n      \"max_completion_tokens\": \"NOT_GIVEN\",\n      \"reasoning_effort\": \"high\"\n    },\n    \"stream_options\": {\n      \"include_usage\": true\n    }\n  },\n  \"response_for_logging\": {\n    \"response_chunks\": [\n      {\n        \"id\": \"chatcmpl-DcLwCvXax7gJ3TKEV99vdbrOPLc9I\",\n        \"created\": 1778033164,\n        \"model\": \"openai/gpt-5.5-2026-04-23\",\n        \"object\": \"chat.completion.chunk\",\n        \"usage\": {\n          \"completion_tokens\": 29016,\n          \"prompt_tokens\": 371,\n          \"total_tokens\": 29387,\n          \"cost\": {\n            \"input_tokens_cost_nanodollars\": 1855000,\n            \"output_tokens_cost_nanodollars\": 870480000\n          },\n          \"total_backend_latency_ms\": 550856\n        }\n      }\n    ]\n  },\n  \"generation_tokens\": 29016,\n  \"prompt_tokens\": 371,\n  \"reasoning_tokens\": null,\n  \"total_tokens\": 29387,\n  \"duration_success_only_secs\": 551.3201849249999\n}"
+          ],
+          "status": "OK",
+          "submission": 2059,
+          "thoughts": "Final Answer: Rd5"
+        },
+        "info": {
+          "actionApplied": 2059,
+          "actionSubmitted": 2059,
+          "actionSubmittedToString": "Rd5",
+          "agentSelfReportedStatus": "OK",
+          "timeTaken": 552.532
+        },
+        "observation": {
+          "currentPlayer": 1,
+          "isTerminal": false,
+          "observationString": "r1b3k1/1p3p2/p3p3/3r2B1/8/8/4B1PP/6K1 w - - 1 29",
+          "playerId": 0,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n1258\n3572\n1841\n1842\n1431\n3132\n3572\n656\n89\n1215\n2425\n3010\n1808\n1768\n749\n30\n1065\n2571\n1942\n3196\n3131\n1384\n4177\n3854\n381\n615\n498\n1869\n2001\n2977\n2975\n4350\n1431\n1770\n2581\n1257\n4673\n4673\n656\n2627\n1895\n2940\n1386\n1358\n3634\n2528\n254\n4496\n3110\n3705\n2948\n2161\n1771\n2833\n2059\n\n",
+          "step": 57
+        },
+        "reward": null,
+        "status": "INACTIVE"
+      },
+      {
+        "action": {
+          "submission": -1
+        },
+        "info": {},
+        "observation": {
+          "currentPlayer": 1,
+          "isTerminal": false,
+          "observationString": "r1b3k1/1p3p2/p3p3/3r2B1/8/8/4B1PP/6K1 w - - 1 29",
+          "playerId": 1,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n1258\n3572\n1841\n1842\n1431\n3132\n3572\n656\n89\n1215\n2425\n3010\n1808\n1768\n749\n30\n1065\n2571\n1942\n3196\n3131\n1384\n4177\n3854\n381\n615\n498\n1869\n2001\n2977\n2975\n4350\n1431\n1770\n2581\n1257\n4673\n4673\n656\n2627\n1895\n2940\n1386\n1358\n3634\n2528\n254\n4496\n3110\n3705\n2948\n2161\n1771\n2833\n2059\n\n"
+        },
+        "reward": null,
+        "status": "ACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "submission": -1
+        },
+        "info": {},
+        "observation": {
+          "currentPlayer": 0,
+          "isTerminal": false,
+          "observationString": "r1b3k1/1p3p2/p3pB2/3r4/8/8/4B1PP/6K1 b - - 2 29",
+          "playerId": 0,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n1258\n3572\n1841\n1842\n1431\n3132\n3572\n656\n89\n1215\n2425\n3010\n1808\n1768\n749\n30\n1065\n2571\n1942\n3196\n3131\n1384\n4177\n3854\n381\n615\n498\n1869\n2001\n2977\n2975\n4350\n1431\n1770\n2581\n1257\n4673\n4673\n656\n2627\n1895\n2940\n1386\n1358\n3634\n2528\n254\n4496\n3110\n3705\n2948\n2161\n1771\n2833\n2059\n3853\n\n",
+          "step": 58
+        },
+        "reward": null,
+        "status": "ACTIVE"
+      },
+      {
+        "action": {
+          "actionString": "Bf6",
+          "generate_returns": [
+            "{\n  \"main_response\": \"To find the best move in this position, we must evaluate the material imbalance and the safety of White's pieces. \\n\\nCurrently, White is down a massive amount of material (two whole Rooks for two Pawns), a consequence of previous sacrifices that did not result in a checkmate. However, it is White's turn, and the dark-squared Bishop on g5 is currently under attack by Black's Rook on d5. \\n\\nSince sacrificing the Bishop (e.g., with 29. h4 Rxg5) would only worsen the situation and simplify the game into an easily won endgame for Black, the Bishop must move to safety.\\n\\nLooking at the available squares for the Bishop:\\n- `29. Bc1` or `29. Bd2` are far too passive.\\n- `29. Bh4` leaves the Bishop somewhat out of play and easily targeted if Black continues expanding on the queenside. \\n- `29. Be3` is solid, but it allows Black's Rook to immediately swing to e5 or f5 with tempo.\\n- `29. Bf6!` is the most active and resilient choice. \\n\\nBy placing the Bishop on f6, White anchors it on a powerful diagonal deep within Black's camp. This move creates significant positional annoyance:\\n1. It completely cuts off the Black King on g8, denying it access to f7 and g7.\\n2. It eyes the d8 square, taking away ideal files and squares from Black's rooks. \\n3. Because Black no longer has a g-pawn, the Bishop on f6 is remarkably stable and cannot be easily chased away by pawn pushes. \\n4. It seamlessly prepares the follow-up `30. Bf3`, where White's light-squared Bishop can join the fight, challenge the central Rook on d5, and try to create maximum resistance on the long light-squared diagonal.\\n\\nEven though the position remains objectively lost, `29. Bf6` offers the most stubborn defense and requires Black to play accurately to convert the advantage.\\n\\nFinal Answer: Bf6\",\n  \"main_response_and_thoughts\": \"\",\n  \"request_for_logging\": {\n    \"model\": \"google/gemini-3.1-pro-preview\",\n    \"messages\": [\n      {\n        \"role\": \"user\",\n        \"content\": [\n          {\n            \"type\": \"text\",\n            \"text\": \"Let's play chess. The current game state in Forsyth-Edwards Notation (FEN) notation is:\\nr1b3k1/1p3p2/p3p3/3r2B1/8/8/4B1PP/6K1 w - - 1 29\\nThe moves played so far are:\\n1. e4 c5 2. Nf3 d6 3. d4 cxd4 4. Nxd4 Nf6 5. Nc3 a6 6. Bg5 e6 7. f4 Qb6 8. Qd2 Qxb2 9. Rb1 Qa3 10. e5 dxe5 11. fxe5 Nfd7 12. Ne4 h6 13. Bh4 Qxa2 14. Rd1 Qd5 15. Qe3 Qxe5 16. Be2 Bc5 17. Bg3 Bxd4 18. Rxd4 Qa5+ 19. c3 O-O 20. O-O Nc6 21. Nf6+ Nxf6 22. Rxf6 Nxd4 23. cxd4 gxf6 24. Qxh6 Qg5 25. Qxg5+ fxg5 26. Bd6 Rd8 27. Be7 Rxd4 28. Bxg5 Rd5 29.\\nYou are playing as player White.\\nIt is now your turn. Play your strongest move. The move MUST be legal. Reason step by step to come up with your move, then output your final answer in the format \\\"Final Answer: X\\\" where X is your chosen move in standard algebraic notation (SAN).\\n\"\n          }\n        ]\n      }\n    ],\n    \"config\": {\n      \"temperature\": \"NOT_GIVEN\",\n      \"top_p\": \"NOT_GIVEN\",\n      \"max_completion_tokens\": \"NOT_GIVEN\"\n    },\n    \"stream_options\": {\n      \"include_usage\": true\n    }\n  },\n  \"response_for_logging\": {\n    \"response_chunks\": [\n      {\n        \"id\": \"NKT6ab20MauEm9IP2rm86QE\",\n        \"choices\": [\n          {\n            \"delta\": {\n              \"content\": \"6\",\n              \"role\": \"assistant\"\n            },\n            \"finish_reason\": \"stop\",\n            \"index\": 0\n          }\n        ],\n        \"created\": 1778033716,\n        \"model\": \"google/gemini-3.1-pro-preview\",\n        \"object\": \"chat.completion.chunk\",\n        \"usage\": {\n          \"completion_tokens\": 447,\n          \"prompt_tokens\": 364,\n          \"total_tokens\": 5577,\n          \"cost\": {\n            \"input_tokens_cost_nanodollars\": 728000,\n            \"output_tokens_cost_nanodollars\": 62556000\n          },\n          \"total_backend_latency_ms\": 46429\n        }\n      }\n    ]\n  },\n  \"generation_tokens\": 447,\n  \"prompt_tokens\": 364,\n  \"reasoning_tokens\": null,\n  \"total_tokens\": 5577,\n  \"duration_success_only_secs\": 46.94133810600033\n}"
+          ],
+          "status": "OK",
+          "submission": 3853,
+          "thoughts": "To find the best move in this position, we must evaluate the material imbalance and the safety of White's pieces. \n\nCurrently, White is down a massive amount of material (two whole Rooks for two Pawns), a consequence of previous sacrifices that did not result in a checkmate. However, it is White's turn, and the dark-squared Bishop on g5 is currently under attack by Black's Rook on d5. \n\nSince sacrificing the Bishop (e.g., with 29. h4 Rxg5) would only worsen the situation and simplify the game into an easily won endgame for Black, the Bishop must move to safety.\n\nLooking at the available squares for the Bishop:\n- `29. Bc1` or `29. Bd2` are far too passive.\n- `29. Bh4` leaves the Bishop somewhat out of play and easily targeted if Black continues expanding on the queenside. \n- `29. Be3` is solid, but it allows Black's Rook to immediately swing to e5 or f5 with tempo.\n- `29. Bf6!` is the most active and resilient choice. \n\nBy placing the Bishop on f6, White anchors it on a powerful diagonal deep within Black's camp. This move creates significant positional annoyance:\n1. It completely cuts off the Black King on g8, denying it access to f7 and g7.\n2. It eyes the d8 square, taking away ideal files and squares from Black's rooks. \n3. Because Black no longer has a g-pawn, the Bishop on f6 is remarkably stable and cannot be easily chased away by pawn pushes. \n4. It seamlessly prepares the follow-up `30. Bf3`, where White's light-squared Bishop can join the fight, challenge the central Rook on d5, and try to create maximum resistance on the long light-squared diagonal.\n\nEven though the position remains objectively lost, `29. Bf6` offers the most stubborn defense and requires Black to play accurately to convert the advantage.\n\nFinal Answer: Bf6"
+        },
+        "info": {
+          "actionApplied": 3853,
+          "actionSubmitted": 3853,
+          "actionSubmittedToString": "Bf6",
+          "agentSelfReportedStatus": "OK",
+          "timeTaken": 48.161
+        },
+        "observation": {
+          "currentPlayer": 0,
+          "isTerminal": false,
+          "observationString": "r1b3k1/1p3p2/p3pB2/3r4/8/8/4B1PP/6K1 b - - 2 29",
+          "playerId": 1,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n1258\n3572\n1841\n1842\n1431\n3132\n3572\n656\n89\n1215\n2425\n3010\n1808\n1768\n749\n30\n1065\n2571\n1942\n3196\n3131\n1384\n4177\n3854\n381\n615\n498\n1869\n2001\n2977\n2975\n4350\n1431\n1770\n2581\n1257\n4673\n4673\n656\n2627\n1895\n2940\n1386\n1358\n3634\n2528\n254\n4496\n3110\n3705\n2948\n2161\n1771\n2833\n2059\n3853\n\n"
+        },
+        "reward": null,
+        "status": "INACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "actionString": "Rf5",
+          "generate_returns": [
+            "{\n  \"main_response\": \"The strongest move is to activate the rook with tempo, attacking the bishop on f6 and avoiding White\\u2019s potential Bf3 attack on the d5-rook.\\n\\nFinal Answer: Rf5\",\n  \"main_response_and_thoughts\": \"\",\n  \"request_for_logging\": {\n    \"model\": \"openai/gpt-5.5-2026-04-23\",\n    \"messages\": [\n      {\n        \"role\": \"user\",\n        \"content\": [\n          {\n            \"type\": \"text\",\n            \"text\": \"Let's play chess. The current game state in Forsyth-Edwards Notation (FEN) notation is:\\nr1b3k1/1p3p2/p3pB2/3r4/8/8/4B1PP/6K1 b - - 2 29\\nThe moves played so far are:\\n1. e4 c5 2. Nf3 d6 3. d4 cxd4 4. Nxd4 Nf6 5. Nc3 a6 6. Bg5 e6 7. f4 Qb6 8. Qd2 Qxb2 9. Rb1 Qa3 10. e5 dxe5 11. fxe5 Nfd7 12. Ne4 h6 13. Bh4 Qxa2 14. Rd1 Qd5 15. Qe3 Qxe5 16. Be2 Bc5 17. Bg3 Bxd4 18. Rxd4 Qa5+ 19. c3 O-O 20. O-O Nc6 21. Nf6+ Nxf6 22. Rxf6 Nxd4 23. cxd4 gxf6 24. Qxh6 Qg5 25. Qxg5+ fxg5 26. Bd6 Rd8 27. Be7 Rxd4 28. Bxg5 Rd5 29. Bf6\\nYou are playing as player Black.\\nIt is now your turn. Play your strongest move. The move MUST be legal. Reason step by step to come up with your move, then output your final answer in the format \\\"Final Answer: X\\\" where X is your chosen move in standard algebraic notation (SAN).\\n\"\n          }\n        ]\n      }\n    ],\n    \"config\": {\n      \"temperature\": \"NOT_GIVEN\",\n      \"top_p\": \"NOT_GIVEN\",\n      \"max_completion_tokens\": \"NOT_GIVEN\",\n      \"reasoning_effort\": \"high\"\n    },\n    \"stream_options\": {\n      \"include_usage\": true\n    }\n  },\n  \"response_for_logging\": {\n    \"response_chunks\": [\n      {\n        \"id\": \"chatcmpl-DcM5thE3aXhhN8HVEvoMOa55LcHAf\",\n        \"created\": 1778033765,\n        \"model\": \"openai/gpt-5.5-2026-04-23\",\n        \"object\": \"chat.completion.chunk\",\n        \"usage\": {\n          \"completion_tokens\": 14028,\n          \"prompt_tokens\": 378,\n          \"total_tokens\": 14406,\n          \"cost\": {\n            \"input_tokens_cost_nanodollars\": 1890000,\n            \"output_tokens_cost_nanodollars\": 420840000\n          },\n          \"total_backend_latency_ms\": 267764\n        }\n      }\n    ]\n  },\n  \"generation_tokens\": 14028,\n  \"prompt_tokens\": 378,\n  \"reasoning_tokens\": null,\n  \"total_tokens\": 14406,\n  \"duration_success_only_secs\": 268.22433800199906\n}"
+          ],
+          "status": "OK",
+          "submission": 2002,
+          "thoughts": "The strongest move is to activate the rook with tempo, attacking the bishop on f6 and avoiding White\u2019s potential Bf3 attack on the d5-rook.\n\nFinal Answer: Rf5"
+        },
+        "info": {
+          "actionApplied": 2002,
+          "actionSubmitted": 2002,
+          "actionSubmittedToString": "Rf5",
+          "agentSelfReportedStatus": "OK",
+          "timeTaken": 269.889
+        },
+        "observation": {
+          "currentPlayer": 1,
+          "isTerminal": false,
+          "observationString": "r1b3k1/1p3p2/p3pB2/5r2/8/8/4B1PP/6K1 w - - 3 30",
+          "playerId": 0,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n1258\n3572\n1841\n1842\n1431\n3132\n3572\n656\n89\n1215\n2425\n3010\n1808\n1768\n749\n30\n1065\n2571\n1942\n3196\n3131\n1384\n4177\n3854\n381\n615\n498\n1869\n2001\n2977\n2975\n4350\n1431\n1770\n2581\n1257\n4673\n4673\n656\n2627\n1895\n2940\n1386\n1358\n3634\n2528\n254\n4496\n3110\n3705\n2948\n2161\n1771\n2833\n2059\n3853\n2002\n\n",
+          "step": 59
+        },
+        "reward": null,
+        "status": "INACTIVE"
+      },
+      {
+        "action": {
+          "submission": -1
+        },
+        "info": {},
+        "observation": {
+          "currentPlayer": 1,
+          "isTerminal": false,
+          "observationString": "r1b3k1/1p3p2/p3pB2/5r2/8/8/4B1PP/6K1 w - - 3 30",
+          "playerId": 1,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n1258\n3572\n1841\n1842\n1431\n3132\n3572\n656\n89\n1215\n2425\n3010\n1808\n1768\n749\n30\n1065\n2571\n1942\n3196\n3131\n1384\n4177\n3854\n381\n615\n498\n1869\n2001\n2977\n2975\n4350\n1431\n1770\n2581\n1257\n4673\n4673\n656\n2627\n1895\n2940\n1386\n1358\n3634\n2528\n254\n4496\n3110\n3705\n2948\n2161\n1771\n2833\n2059\n3853\n2002\n\n"
+        },
+        "reward": null,
+        "status": "ACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "submission": -1
+        },
+        "info": {},
+        "observation": {
+          "currentPlayer": 0,
+          "isTerminal": false,
+          "observationString": "r1b3k1/1p3p2/p3p3/5r2/8/2B5/4B1PP/6K1 b - - 4 30",
+          "playerId": 0,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n1258\n3572\n1841\n1842\n1431\n3132\n3572\n656\n89\n1215\n2425\n3010\n1808\n1768\n749\n30\n1065\n2571\n1942\n3196\n3131\n1384\n4177\n3854\n381\n615\n498\n1869\n2001\n2977\n2975\n4350\n1431\n1770\n2581\n1257\n4673\n4673\n656\n2627\n1895\n2940\n1386\n1358\n3634\n2528\n254\n4496\n3110\n3705\n2948\n2161\n1771\n2833\n2059\n3853\n2002\n3326\n\n",
+          "step": 60
+        },
+        "reward": null,
+        "status": "ACTIVE"
+      },
+      {
+        "action": {
+          "actionString": "Bc3",
+          "generate_returns": [
+            "{\n  \"main_response\": \"The position shows that White is significantly behind in material, so it is crucial to avoid giving away any more pieces for free. Black's last move, `29... Rf5`, directly attacks your bishop on f6. \\n\\nIf you try to defend the bishop or counter-attack the rook with a move like `30. g4` or `30. Bd3`, Black will simply play `30... Rxf6`, capturing the bishop. While you can then attack the rook on f6 (e.g., with `31. g5`), the rook will just move away to safety, leaving you having lost a full bishop for nothing.\\n\\nTherefore, the only sensible choice is to retreat the attacked bishop to a safe and active square. \\n\\nThe most natural and powerful retreat is **30. Bc3**.\\n- It safely secures the bishop.\\n- It places the bishop on the excellent, unobstructed long diagonal (a1-h8), maximizing its scope.\\n- It stays centralized while preparing to cover key squares, preventing Black's pawns and pieces from easily advancing without contest. \\n\\nMoves like `30. Bd4` are less accurate because they invite Black to gain a free tempo with `30... e5`, forcing your bishop to move yet again. `30. Bc3` avoids this and keeps your bishop robustly active in a difficult endgame.\\n\\nFinal Answer: Bc3\",\n  \"main_response_and_thoughts\": \"\",\n  \"request_for_logging\": {\n    \"model\": \"google/gemini-3.1-pro-preview\",\n    \"messages\": [\n      {\n        \"role\": \"user\",\n        \"content\": [\n          {\n            \"type\": \"text\",\n            \"text\": \"Let's play chess. The current game state in Forsyth-Edwards Notation (FEN) notation is:\\nr1b3k1/1p3p2/p3pB2/5r2/8/8/4B1PP/6K1 w - - 3 30\\nThe moves played so far are:\\n1. e4 c5 2. Nf3 d6 3. d4 cxd4 4. Nxd4 Nf6 5. Nc3 a6 6. Bg5 e6 7. f4 Qb6 8. Qd2 Qxb2 9. Rb1 Qa3 10. e5 dxe5 11. fxe5 Nfd7 12. Ne4 h6 13. Bh4 Qxa2 14. Rd1 Qd5 15. Qe3 Qxe5 16. Be2 Bc5 17. Bg3 Bxd4 18. Rxd4 Qa5+ 19. c3 O-O 20. O-O Nc6 21. Nf6+ Nxf6 22. Rxf6 Nxd4 23. cxd4 gxf6 24. Qxh6 Qg5 25. Qxg5+ fxg5 26. Bd6 Rd8 27. Be7 Rxd4 28. Bxg5 Rd5 29. Bf6 Rf5 30.\\nYou are playing as player White.\\nIt is now your turn. Play your strongest move. The move MUST be legal. Reason step by step to come up with your move, then output your final answer in the format \\\"Final Answer: X\\\" where X is your chosen move in standard algebraic notation (SAN).\\n\"\n          }\n        ]\n      }\n    ],\n    \"config\": {\n      \"temperature\": \"NOT_GIVEN\",\n      \"top_p\": \"NOT_GIVEN\",\n      \"max_completion_tokens\": \"NOT_GIVEN\"\n    },\n    \"stream_options\": {\n      \"include_usage\": true\n    }\n  },\n  \"response_for_logging\": {\n    \"response_chunks\": [\n      {\n        \"id\": \"c6X6aeWSF_iMmecPq_Dk8QQ\",\n        \"choices\": [\n          {\n            \"delta\": {\n              \"content\": \" and keeps your bishop robustly active in a difficult endgame.\\n\\nFinal Answer: Bc3\",\n              \"role\": \"assistant\"\n            },\n            \"finish_reason\": \"stop\",\n            \"index\": 0\n          }\n        ],\n        \"created\": 1778034035,\n        \"model\": \"google/gemini-3.1-pro-preview\",\n        \"object\": \"chat.completion.chunk\",\n        \"usage\": {\n          \"completion_tokens\": 297,\n          \"prompt_tokens\": 371,\n          \"total_tokens\": 13852,\n          \"cost\": {\n            \"input_tokens_cost_nanodollars\": 742000,\n            \"output_tokens_cost_nanodollars\": 161772000\n          },\n          \"total_backend_latency_ms\": 110857\n        }\n      }\n    ]\n  },\n  \"generation_tokens\": 297,\n  \"prompt_tokens\": 371,\n  \"reasoning_tokens\": null,\n  \"total_tokens\": 13852,\n  \"duration_success_only_secs\": 111.84804276500108\n}"
+          ],
+          "status": "OK",
+          "submission": 3326,
+          "thoughts": "The position shows that White is significantly behind in material, so it is crucial to avoid giving away any more pieces for free. Black's last move, `29... Rf5`, directly attacks your bishop on f6. \n\nIf you try to defend the bishop or counter-attack the rook with a move like `30. g4` or `30. Bd3`, Black will simply play `30... Rxf6`, capturing the bishop. While you can then attack the rook on f6 (e.g., with `31. g5`), the rook will just move away to safety, leaving you having lost a full bishop for nothing.\n\nTherefore, the only sensible choice is to retreat the attacked bishop to a safe and active square. \n\nThe most natural and powerful retreat is **30. Bc3**.\n- It safely secures the bishop.\n- It places the bishop on the excellent, unobstructed long diagonal (a1-h8), maximizing its scope.\n- It stays centralized while preparing to cover key squares, preventing Black's pawns and pieces from easily advancing without contest. \n\nMoves like `30. Bd4` are less accurate because they invite Black to gain a free tempo with `30... e5`, forcing your bishop to move yet again. `30. Bc3` avoids this and keeps your bishop robustly active in a difficult endgame.\n\nFinal Answer: Bc3"
+        },
+        "info": {
+          "actionApplied": 3326,
+          "actionSubmitted": 3326,
+          "actionSubmittedToString": "Bc3",
+          "agentSelfReportedStatus": "OK",
+          "timeTaken": 113.07
+        },
+        "observation": {
+          "currentPlayer": 0,
+          "isTerminal": false,
+          "observationString": "r1b3k1/1p3p2/p3p3/5r2/8/2B5/4B1PP/6K1 b - - 4 30",
+          "playerId": 1,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n1258\n3572\n1841\n1842\n1431\n3132\n3572\n656\n89\n1215\n2425\n3010\n1808\n1768\n749\n30\n1065\n2571\n1942\n3196\n3131\n1384\n4177\n3854\n381\n615\n498\n1869\n2001\n2977\n2975\n4350\n1431\n1770\n2581\n1257\n4673\n4673\n656\n2627\n1895\n2940\n1386\n1358\n3634\n2528\n254\n4496\n3110\n3705\n2948\n2161\n1771\n2833\n2059\n3853\n2002\n3326\n\n"
+        },
+        "reward": null,
+        "status": "INACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "actionString": "Rc5",
+          "generate_returns": [
+            "{\n  \"main_response\": \"Final Answer: Rc5\",\n  \"main_response_and_thoughts\": \"\",\n  \"request_for_logging\": {\n    \"model\": \"openai/gpt-5.5-2026-04-23\",\n    \"messages\": [\n      {\n        \"role\": \"user\",\n        \"content\": [\n          {\n            \"type\": \"text\",\n            \"text\": \"Let's play chess. The current game state in Forsyth-Edwards Notation (FEN) notation is:\\nr1b3k1/1p3p2/p3p3/5r2/8/2B5/4B1PP/6K1 b - - 4 30\\nThe moves played so far are:\\n1. e4 c5 2. Nf3 d6 3. d4 cxd4 4. Nxd4 Nf6 5. Nc3 a6 6. Bg5 e6 7. f4 Qb6 8. Qd2 Qxb2 9. Rb1 Qa3 10. e5 dxe5 11. fxe5 Nfd7 12. Ne4 h6 13. Bh4 Qxa2 14. Rd1 Qd5 15. Qe3 Qxe5 16. Be2 Bc5 17. Bg3 Bxd4 18. Rxd4 Qa5+ 19. c3 O-O 20. O-O Nc6 21. Nf6+ Nxf6 22. Rxf6 Nxd4 23. cxd4 gxf6 24. Qxh6 Qg5 25. Qxg5+ fxg5 26. Bd6 Rd8 27. Be7 Rxd4 28. Bxg5 Rd5 29. Bf6 Rf5 30. Bc3\\nYou are playing as player Black.\\nIt is now your turn. Play your strongest move. The move MUST be legal. Reason step by step to come up with your move, then output your final answer in the format \\\"Final Answer: X\\\" where X is your chosen move in standard algebraic notation (SAN).\\n\"\n          }\n        ]\n      }\n    ],\n    \"config\": {\n      \"temperature\": \"NOT_GIVEN\",\n      \"top_p\": \"NOT_GIVEN\",\n      \"max_completion_tokens\": \"NOT_GIVEN\",\n      \"reasoning_effort\": \"high\"\n    },\n    \"stream_options\": {\n      \"include_usage\": true\n    }\n  },\n  \"response_for_logging\": {\n    \"response_chunks\": [\n      {\n        \"id\": \"chatcmpl-DcMC4mpnkBghghEc6FOviyEuvzS7G\",\n        \"created\": 1778034148,\n        \"model\": \"openai/gpt-5.5-2026-04-23\",\n        \"object\": \"chat.completion.chunk\",\n        \"usage\": {\n          \"completion_tokens\": 5706,\n          \"prompt_tokens\": 388,\n          \"total_tokens\": 6094,\n          \"cost\": {\n            \"input_tokens_cost_nanodollars\": 1940000,\n            \"output_tokens_cost_nanodollars\": 171180000\n          },\n          \"total_backend_latency_ms\": 114830\n        }\n      }\n    ]\n  },\n  \"generation_tokens\": 5706,\n  \"prompt_tokens\": 388,\n  \"reasoning_tokens\": null,\n  \"total_tokens\": 6094,\n  \"duration_success_only_secs\": 115.25647073800064\n}"
+          ],
+          "status": "OK",
+          "submission": 3166,
+          "thoughts": "Final Answer: Rc5"
+        },
+        "info": {
+          "actionApplied": 3166,
+          "actionSubmitted": 3166,
+          "actionSubmittedToString": "Rc5",
+          "agentSelfReportedStatus": "OK",
+          "timeTaken": 116.526
+        },
+        "observation": {
+          "currentPlayer": 1,
+          "isTerminal": false,
+          "observationString": "r1b3k1/1p3p2/p3p3/2r5/8/2B5/4B1PP/6K1 w - - 5 31",
+          "playerId": 0,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n1258\n3572\n1841\n1842\n1431\n3132\n3572\n656\n89\n1215\n2425\n3010\n1808\n1768\n749\n30\n1065\n2571\n1942\n3196\n3131\n1384\n4177\n3854\n381\n615\n498\n1869\n2001\n2977\n2975\n4350\n1431\n1770\n2581\n1257\n4673\n4673\n656\n2627\n1895\n2940\n1386\n1358\n3634\n2528\n254\n4496\n3110\n3705\n2948\n2161\n1771\n2833\n2059\n3853\n2002\n3326\n3166\n\n",
+          "step": 61
+        },
+        "reward": null,
+        "status": "INACTIVE"
+      },
+      {
+        "action": {
+          "submission": -1
+        },
+        "info": {},
+        "observation": {
+          "currentPlayer": 1,
+          "isTerminal": false,
+          "observationString": "r1b3k1/1p3p2/p3p3/2r5/8/2B5/4B1PP/6K1 w - - 5 31",
+          "playerId": 1,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n1258\n3572\n1841\n1842\n1431\n3132\n3572\n656\n89\n1215\n2425\n3010\n1808\n1768\n749\n30\n1065\n2571\n1942\n3196\n3131\n1384\n4177\n3854\n381\n615\n498\n1869\n2001\n2977\n2975\n4350\n1431\n1770\n2581\n1257\n4673\n4673\n656\n2627\n1895\n2940\n1386\n1358\n3634\n2528\n254\n4496\n3110\n3705\n2948\n2161\n1771\n2833\n2059\n3853\n2002\n3326\n3166\n\n"
+        },
+        "reward": null,
+        "status": "ACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "submission": -1
+        },
+        "info": {},
+        "observation": {
+          "currentPlayer": 0,
+          "isTerminal": false,
+          "observationString": "r1b3k1/1p3p2/p3p3/2r5/3B4/8/4B1PP/6K1 b - - 6 31",
+          "playerId": 0,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n1258\n3572\n1841\n1842\n1431\n3132\n3572\n656\n89\n1215\n2425\n3010\n1808\n1768\n749\n30\n1065\n2571\n1942\n3196\n3131\n1384\n4177\n3854\n381\n615\n498\n1869\n2001\n2977\n2975\n4350\n1431\n1770\n2581\n1257\n4673\n4673\n656\n2627\n1895\n2940\n1386\n1358\n3634\n2528\n254\n4496\n3110\n3705\n2948\n2161\n1771\n2833\n2059\n3853\n2002\n3326\n3166\n1358\n\n",
+          "step": 62
+        },
+        "reward": null,
+        "status": "ACTIVE"
+      },
+      {
+        "action": {
+          "actionString": "Bd4",
+          "generate_returns": [
+            "{\n  \"main_response\": \"The bishop on c3 is under attack by the black rook on c5. Moving it to safety while simultaneously challenging the position of the black rook is the best practical decision here, especially in an endgame where White is down significant material and must attempt to create as much resistance as possible. \\n\\nBy playing the bishop to d4, you centralize the piece, eye important squares, and gain a tempo by immediately attacking the rook on c5, forcing Black to respond.\\n\\nFinal Answer: Bd4\",\n  \"main_response_and_thoughts\": \"\",\n  \"request_for_logging\": {\n    \"model\": \"google/gemini-3.1-pro-preview\",\n    \"messages\": [\n      {\n        \"role\": \"user\",\n        \"content\": [\n          {\n            \"type\": \"text\",\n            \"text\": \"Let's play chess. The current game state in Forsyth-Edwards Notation (FEN) notation is:\\nr1b3k1/1p3p2/p3p3/2r5/8/2B5/4B1PP/6K1 w - - 5 31\\nThe moves played so far are:\\n1. e4 c5 2. Nf3 d6 3. d4 cxd4 4. Nxd4 Nf6 5. Nc3 a6 6. Bg5 e6 7. f4 Qb6 8. Qd2 Qxb2 9. Rb1 Qa3 10. e5 dxe5 11. fxe5 Nfd7 12. Ne4 h6 13. Bh4 Qxa2 14. Rd1 Qd5 15. Qe3 Qxe5 16. Be2 Bc5 17. Bg3 Bxd4 18. Rxd4 Qa5+ 19. c3 O-O 20. O-O Nc6 21. Nf6+ Nxf6 22. Rxf6 Nxd4 23. cxd4 gxf6 24. Qxh6 Qg5 25. Qxg5+ fxg5 26. Bd6 Rd8 27. Be7 Rxd4 28. Bxg5 Rd5 29. Bf6 Rf5 30. Bc3 Rc5 31.\\nYou are playing as player White.\\nIt is now your turn. Play your strongest move. The move MUST be legal. Reason step by step to come up with your move, then output your final answer in the format \\\"Final Answer: X\\\" where X is your chosen move in standard algebraic notation (SAN).\\n\"\n          }\n        ]\n      }\n    ],\n    \"config\": {\n      \"temperature\": \"NOT_GIVEN\",\n      \"top_p\": \"NOT_GIVEN\",\n      \"max_completion_tokens\": \"NOT_GIVEN\"\n    },\n    \"stream_options\": {\n      \"include_usage\": true\n    }\n  },\n  \"response_for_logging\": {\n    \"response_chunks\": [\n      {\n        \"id\": \"WKb6aautHMudmecPmbT14Qk\",\n        \"choices\": [\n          {\n            \"delta\": {\n              \"content\": \" immediately attacking the rook on c5, forcing Black to respond.\\n\\nFinal Answer: Bd4\",\n              \"role\": \"assistant\"\n            },\n            \"finish_reason\": \"stop\",\n            \"index\": 0\n          }\n        ],\n        \"created\": 1778034264,\n        \"model\": \"google/gemini-3.1-pro-preview\",\n        \"object\": \"chat.completion.chunk\",\n        \"usage\": {\n          \"completion_tokens\": 101,\n          \"prompt_tokens\": 380,\n          \"total_tokens\": 3609,\n          \"cost\": {\n            \"input_tokens_cost_nanodollars\": 760000,\n            \"output_tokens_cost_nanodollars\": 38748000\n          },\n          \"total_backend_latency_ms\": 29017\n        }\n      }\n    ]\n  },\n  \"generation_tokens\": 101,\n  \"prompt_tokens\": 380,\n  \"reasoning_tokens\": null,\n  \"total_tokens\": 3609,\n  \"duration_success_only_secs\": 29.521809337002196\n}"
+          ],
+          "status": "OK",
+          "submission": 1358,
+          "thoughts": "The bishop on c3 is under attack by the black rook on c5. Moving it to safety while simultaneously challenging the position of the black rook is the best practical decision here, especially in an endgame where White is down significant material and must attempt to create as much resistance as possible. \n\nBy playing the bishop to d4, you centralize the piece, eye important squares, and gain a tempo by immediately attacking the rook on c5, forcing Black to respond.\n\nFinal Answer: Bd4"
+        },
+        "info": {
+          "actionApplied": 1358,
+          "actionSubmitted": 1358,
+          "actionSubmittedToString": "Bd4",
+          "agentSelfReportedStatus": "OK",
+          "timeTaken": 31.208
+        },
+        "observation": {
+          "currentPlayer": 0,
+          "isTerminal": false,
+          "observationString": "r1b3k1/1p3p2/p3p3/2r5/3B4/8/4B1PP/6K1 b - - 6 31",
+          "playerId": 1,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n1258\n3572\n1841\n1842\n1431\n3132\n3572\n656\n89\n1215\n2425\n3010\n1808\n1768\n749\n30\n1065\n2571\n1942\n3196\n3131\n1384\n4177\n3854\n381\n615\n498\n1869\n2001\n2977\n2975\n4350\n1431\n1770\n2581\n1257\n4673\n4673\n656\n2627\n1895\n2940\n1386\n1358\n3634\n2528\n254\n4496\n3110\n3705\n2948\n2161\n1771\n2833\n2059\n3853\n2002\n3326\n3166\n1358\n\n"
+        },
+        "reward": null,
+        "status": "INACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "actionString": "Rc1+",
+          "generate_returns": [
+            "{\n  \"main_response\": \"Final Answer: Rc1+\",\n  \"main_response_and_thoughts\": \"\",\n  \"request_for_logging\": {\n    \"model\": \"openai/gpt-5.5-2026-04-23\",\n    \"messages\": [\n      {\n        \"role\": \"user\",\n        \"content\": [\n          {\n            \"type\": \"text\",\n            \"text\": \"Let's play chess. The current game state in Forsyth-Edwards Notation (FEN) notation is:\\nr1b3k1/1p3p2/p3p3/2r5/3B4/8/4B1PP/6K1 b - - 6 31\\nThe moves played so far are:\\n1. e4 c5 2. Nf3 d6 3. d4 cxd4 4. Nxd4 Nf6 5. Nc3 a6 6. Bg5 e6 7. f4 Qb6 8. Qd2 Qxb2 9. Rb1 Qa3 10. e5 dxe5 11. fxe5 Nfd7 12. Ne4 h6 13. Bh4 Qxa2 14. Rd1 Qd5 15. Qe3 Qxe5 16. Be2 Bc5 17. Bg3 Bxd4 18. Rxd4 Qa5+ 19. c3 O-O 20. O-O Nc6 21. Nf6+ Nxf6 22. Rxf6 Nxd4 23. cxd4 gxf6 24. Qxh6 Qg5 25. Qxg5+ fxg5 26. Bd6 Rd8 27. Be7 Rxd4 28. Bxg5 Rd5 29. Bf6 Rf5 30. Bc3 Rc5 31. Bd4\\nYou are playing as player Black.\\nIt is now your turn. Play your strongest move. The move MUST be legal. Reason step by step to come up with your move, then output your final answer in the format \\\"Final Answer: X\\\" where X is your chosen move in standard algebraic notation (SAN).\\n\"\n          }\n        ]\n      }\n    ],\n    \"config\": {\n      \"temperature\": \"NOT_GIVEN\",\n      \"top_p\": \"NOT_GIVEN\",\n      \"max_completion_tokens\": \"NOT_GIVEN\",\n      \"reasoning_effort\": \"high\"\n    },\n    \"stream_options\": {\n      \"include_usage\": true\n    }\n  },\n  \"response_for_logging\": {\n    \"response_chunks\": [\n      {\n        \"id\": \"chatcmpl-DcMESd96wG4l18xVhLcdq19pPmqRE\",\n        \"created\": 1778034296,\n        \"model\": \"openai/gpt-5.5-2026-04-23\",\n        \"object\": \"chat.completion.chunk\",\n        \"usage\": {\n          \"completion_tokens\": 9740,\n          \"prompt_tokens\": 395,\n          \"total_tokens\": 10135,\n          \"cost\": {\n            \"input_tokens_cost_nanodollars\": 1975000,\n            \"output_tokens_cost_nanodollars\": 292200000\n          },\n          \"total_backend_latency_ms\": 193252\n        }\n      }\n    ]\n  },\n  \"generation_tokens\": 9740,\n  \"prompt_tokens\": 395,\n  \"reasoning_tokens\": null,\n  \"total_tokens\": 10135,\n  \"duration_success_only_secs\": 193.7471615359973\n}"
+          ],
+          "status": "OK",
+          "submission": 1406,
+          "thoughts": "Final Answer: Rc1+"
+        },
+        "info": {
+          "actionApplied": 1406,
+          "actionSubmitted": 1406,
+          "actionSubmittedToString": "Rc1+",
+          "agentSelfReportedStatus": "OK",
+          "timeTaken": 195.892
+        },
+        "observation": {
+          "currentPlayer": 1,
+          "isTerminal": false,
+          "observationString": "r1b3k1/1p3p2/p3p3/8/3B4/8/4B1PP/2r3K1 w - - 7 32",
+          "playerId": 0,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n1258\n3572\n1841\n1842\n1431\n3132\n3572\n656\n89\n1215\n2425\n3010\n1808\n1768\n749\n30\n1065\n2571\n1942\n3196\n3131\n1384\n4177\n3854\n381\n615\n498\n1869\n2001\n2977\n2975\n4350\n1431\n1770\n2581\n1257\n4673\n4673\n656\n2627\n1895\n2940\n1386\n1358\n3634\n2528\n254\n4496\n3110\n3705\n2948\n2161\n1771\n2833\n2059\n3853\n2002\n3326\n3166\n1358\n1406\n\n",
+          "step": 63
+        },
+        "reward": null,
+        "status": "INACTIVE"
+      },
+      {
+        "action": {
+          "submission": -1
+        },
+        "info": {},
+        "observation": {
+          "currentPlayer": 1,
+          "isTerminal": false,
+          "observationString": "r1b3k1/1p3p2/p3p3/8/3B4/8/4B1PP/2r3K1 w - - 7 32",
+          "playerId": 1,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n1258\n3572\n1841\n1842\n1431\n3132\n3572\n656\n89\n1215\n2425\n3010\n1808\n1768\n749\n30\n1065\n2571\n1942\n3196\n3131\n1384\n4177\n3854\n381\n615\n498\n1869\n2001\n2977\n2975\n4350\n1431\n1770\n2581\n1257\n4673\n4673\n656\n2627\n1895\n2940\n1386\n1358\n3634\n2528\n254\n4496\n3110\n3705\n2948\n2161\n1771\n2833\n2059\n3853\n2002\n3326\n3166\n1358\n1406\n\n"
+        },
+        "reward": null,
+        "status": "ACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "submission": -1
+        },
+        "info": {},
+        "observation": {
+          "currentPlayer": 0,
+          "isTerminal": false,
+          "observationString": "r1b3k1/1p3p2/p3p3/8/3B4/8/4BKPP/2r5 b - - 8 32",
+          "playerId": 0,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n1258\n3572\n1841\n1842\n1431\n3132\n3572\n656\n89\n1215\n2425\n3010\n1808\n1768\n749\n30\n1065\n2571\n1942\n3196\n3131\n1384\n4177\n3854\n381\n615\n498\n1869\n2001\n2977\n2975\n4350\n1431\n1770\n2581\n1257\n4673\n4673\n656\n2627\n1895\n2940\n1386\n1358\n3634\n2528\n254\n4496\n3110\n3705\n2948\n2161\n1771\n2833\n2059\n3853\n2002\n3326\n3166\n1358\n1406\n3561\n\n",
+          "step": 64
+        },
+        "reward": null,
+        "status": "ACTIVE"
+      },
+      {
+        "action": {
+          "actionString": "Kf2",
+          "generate_returns": [
+            "{\n  \"main_response\": \"The king is currently in check from the black rook on c1. You have two legal ways to respond to this check: playing `Bf1` to block the check, or stepping out of the check with `Kf2`. \\n\\nBlocking with `1. Bf1` is highly undesirable because it voluntarily pins the bishop to the king, paralyzing one of your few remaining active pieces. Your bishops are your best assets in this endgame, and hiding the king behind the bishop severely limits your activity.\\n\\nTherefore, moving the king up the board to safety with `Kf2` is by far the strongest move. Your king becomes active, steps out of the pin, and you keep your bishop pair coordinated. \\n\\nFinal Answer: Kf2\",\n  \"main_response_and_thoughts\": \"\",\n  \"request_for_logging\": {\n    \"model\": \"google/gemini-3.1-pro-preview\",\n    \"messages\": [\n      {\n        \"role\": \"user\",\n        \"content\": [\n          {\n            \"type\": \"text\",\n            \"text\": \"Let's play chess. The current game state in Forsyth-Edwards Notation (FEN) notation is:\\nr1b3k1/1p3p2/p3p3/8/3B4/8/4B1PP/2r3K1 w - - 7 32\\nThe moves played so far are:\\n1. e4 c5 2. Nf3 d6 3. d4 cxd4 4. Nxd4 Nf6 5. Nc3 a6 6. Bg5 e6 7. f4 Qb6 8. Qd2 Qxb2 9. Rb1 Qa3 10. e5 dxe5 11. fxe5 Nfd7 12. Ne4 h6 13. Bh4 Qxa2 14. Rd1 Qd5 15. Qe3 Qxe5 16. Be2 Bc5 17. Bg3 Bxd4 18. Rxd4 Qa5+ 19. c3 O-O 20. O-O Nc6 21. Nf6+ Nxf6 22. Rxf6 Nxd4 23. cxd4 gxf6 24. Qxh6 Qg5 25. Qxg5+ fxg5 26. Bd6 Rd8 27. Be7 Rxd4 28. Bxg5 Rd5 29. Bf6 Rf5 30. Bc3 Rc5 31. Bd4 Rc1+ 32.\\nYou are playing as player White.\\nIt is now your turn. Play your strongest move. The move MUST be legal. Reason step by step to come up with your move, then output your final answer in the format \\\"Final Answer: X\\\" where X is your chosen move in standard algebraic notation (SAN).\\n\"\n          }\n        ]\n      }\n    ],\n    \"config\": {\n      \"temperature\": \"NOT_GIVEN\",\n      \"top_p\": \"NOT_GIVEN\",\n      \"max_completion_tokens\": \"NOT_GIVEN\"\n    },\n    \"stream_options\": {\n      \"include_usage\": true\n    }\n  },\n  \"response_for_logging\": {\n    \"response_chunks\": [\n      {\n        \"id\": \"O6f6adXAJdCfmecP0erHwQ0\",\n        \"choices\": [\n          {\n            \"delta\": {\n              \"content\": \"Final Answer: Kf2\",\n              \"role\": \"assistant\"\n            },\n            \"finish_reason\": \"stop\",\n            \"index\": 0\n          }\n        ],\n        \"created\": 1778034491,\n        \"model\": \"google/gemini-3.1-pro-preview\",\n        \"object\": \"chat.completion.chunk\",\n        \"usage\": {\n          \"completion_tokens\": 151,\n          \"prompt_tokens\": 389,\n          \"total_tokens\": 1816,\n          \"cost\": {\n            \"input_tokens_cost_nanodollars\": 778000,\n            \"output_tokens_cost_nanodollars\": 17124000\n          },\n          \"total_backend_latency_ms\": 13979\n        }\n      }\n    ]\n  },\n  \"generation_tokens\": 151,\n  \"prompt_tokens\": 389,\n  \"reasoning_tokens\": null,\n  \"total_tokens\": 1816,\n  \"duration_success_only_secs\": 14.490493290999439\n}"
+          ],
+          "status": "OK",
+          "submission": 3561,
+          "thoughts": "The king is currently in check from the black rook on c1. You have two legal ways to respond to this check: playing `Bf1` to block the check, or stepping out of the check with `Kf2`. \n\nBlocking with `1. Bf1` is highly undesirable because it voluntarily pins the bishop to the king, paralyzing one of your few remaining active pieces. Your bishops are your best assets in this endgame, and hiding the king behind the bishop severely limits your activity.\n\nTherefore, moving the king up the board to safety with `Kf2` is by far the strongest move. Your king becomes active, steps out of the pin, and you keep your bishop pair coordinated. \n\nFinal Answer: Kf2"
+        },
+        "info": {
+          "actionApplied": 3561,
+          "actionSubmitted": 3561,
+          "actionSubmittedToString": "Kf2",
+          "agentSelfReportedStatus": "OK",
+          "timeTaken": 15.664
+        },
+        "observation": {
+          "currentPlayer": 0,
+          "isTerminal": false,
+          "observationString": "r1b3k1/1p3p2/p3p3/8/3B4/8/4BKPP/2r5 b - - 8 32",
+          "playerId": 1,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n1258\n3572\n1841\n1842\n1431\n3132\n3572\n656\n89\n1215\n2425\n3010\n1808\n1768\n749\n30\n1065\n2571\n1942\n3196\n3131\n1384\n4177\n3854\n381\n615\n498\n1869\n2001\n2977\n2975\n4350\n1431\n1770\n2581\n1257\n4673\n4673\n656\n2627\n1895\n2940\n1386\n1358\n3634\n2528\n254\n4496\n3110\n3705\n2948\n2161\n1771\n2833\n2059\n3853\n2002\n3326\n3166\n1358\n1406\n3561\n\n"
+        },
+        "reward": null,
+        "status": "INACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "actionString": "Rc2",
+          "generate_returns": [
+            "{\n  \"main_response\": \"The strongest move is to penetrate with the rook and pin the bishop on e2 to the king.\\n\\nFinal Answer: Rc2\",\n  \"main_response_and_thoughts\": \"\",\n  \"request_for_logging\": {\n    \"model\": \"openai/gpt-5.5-2026-04-23\",\n    \"messages\": [\n      {\n        \"role\": \"user\",\n        \"content\": [\n          {\n            \"type\": \"text\",\n            \"text\": \"Let's play chess. The current game state in Forsyth-Edwards Notation (FEN) notation is:\\nr1b3k1/1p3p2/p3p3/8/3B4/8/4BKPP/2r5 b - - 8 32\\nThe moves played so far are:\\n1. e4 c5 2. Nf3 d6 3. d4 cxd4 4. Nxd4 Nf6 5. Nc3 a6 6. Bg5 e6 7. f4 Qb6 8. Qd2 Qxb2 9. Rb1 Qa3 10. e5 dxe5 11. fxe5 Nfd7 12. Ne4 h6 13. Bh4 Qxa2 14. Rd1 Qd5 15. Qe3 Qxe5 16. Be2 Bc5 17. Bg3 Bxd4 18. Rxd4 Qa5+ 19. c3 O-O 20. O-O Nc6 21. Nf6+ Nxf6 22. Rxf6 Nxd4 23. cxd4 gxf6 24. Qxh6 Qg5 25. Qxg5+ fxg5 26. Bd6 Rd8 27. Be7 Rxd4 28. Bxg5 Rd5 29. Bf6 Rf5 30. Bc3 Rc5 31. Bd4 Rc1+ 32. Kf2\\nYou are playing as player Black.\\nIt is now your turn. Play your strongest move. The move MUST be legal. Reason step by step to come up with your move, then output your final answer in the format \\\"Final Answer: X\\\" where X is your chosen move in standard algebraic notation (SAN).\\n\"\n          }\n        ]\n      }\n    ],\n    \"config\": {\n      \"temperature\": \"NOT_GIVEN\",\n      \"top_p\": \"NOT_GIVEN\",\n      \"max_completion_tokens\": \"NOT_GIVEN\",\n      \"reasoning_effort\": \"high\"\n    },\n    \"stream_options\": {\n      \"include_usage\": true\n    }\n  },\n  \"response_for_logging\": {\n    \"response_chunks\": [\n      {\n        \"id\": \"chatcmpl-DcMHsPgxBTJi5Fm9Bp7zZy88NlNul\",\n        \"created\": 1778034508,\n        \"model\": \"openai/gpt-5.5-2026-04-23\",\n        \"object\": \"chat.completion.chunk\",\n        \"usage\": {\n          \"completion_tokens\": 21784,\n          \"prompt_tokens\": 401,\n          \"total_tokens\": 22185,\n          \"cost\": {\n            \"input_tokens_cost_nanodollars\": 2005000,\n            \"output_tokens_cost_nanodollars\": 653520000\n          },\n          \"total_backend_latency_ms\": 445301\n        }\n      }\n    ]\n  },\n  \"generation_tokens\": 21784,\n  \"prompt_tokens\": 401,\n  \"reasoning_tokens\": null,\n  \"total_tokens\": 22185,\n  \"duration_success_only_secs\": 446.27107131400044\n}"
+          ],
+          "status": "OK",
+          "submission": 1694,
+          "thoughts": "The strongest move is to penetrate with the rook and pin the bishop on e2 to the king.\n\nFinal Answer: Rc2"
+        },
+        "info": {
+          "actionApplied": 1694,
+          "actionSubmitted": 1694,
+          "actionSubmittedToString": "Rc2",
+          "agentSelfReportedStatus": "OK",
+          "timeTaken": 447.983
+        },
+        "observation": {
+          "currentPlayer": 1,
+          "isTerminal": false,
+          "observationString": "r1b3k1/1p3p2/p3p3/8/3B4/8/2r1BKPP/8 w - - 9 33",
+          "playerId": 0,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n1258\n3572\n1841\n1842\n1431\n3132\n3572\n656\n89\n1215\n2425\n3010\n1808\n1768\n749\n30\n1065\n2571\n1942\n3196\n3131\n1384\n4177\n3854\n381\n615\n498\n1869\n2001\n2977\n2975\n4350\n1431\n1770\n2581\n1257\n4673\n4673\n656\n2627\n1895\n2940\n1386\n1358\n3634\n2528\n254\n4496\n3110\n3705\n2948\n2161\n1771\n2833\n2059\n3853\n2002\n3326\n3166\n1358\n1406\n3561\n1694\n\n",
+          "step": 65
+        },
+        "reward": null,
+        "status": "INACTIVE"
+      },
+      {
+        "action": {
+          "submission": -1
+        },
+        "info": {},
+        "observation": {
+          "currentPlayer": 1,
+          "isTerminal": false,
+          "observationString": "r1b3k1/1p3p2/p3p3/8/3B4/8/2r1BKPP/8 w - - 9 33",
+          "playerId": 1,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n1258\n3572\n1841\n1842\n1431\n3132\n3572\n656\n89\n1215\n2425\n3010\n1808\n1768\n749\n30\n1065\n2571\n1942\n3196\n3131\n1384\n4177\n3854\n381\n615\n498\n1869\n2001\n2977\n2975\n4350\n1431\n1770\n2581\n1257\n4673\n4673\n656\n2627\n1895\n2940\n1386\n1358\n3634\n2528\n254\n4496\n3110\n3705\n2948\n2161\n1771\n2833\n2059\n3853\n2002\n3326\n3166\n1358\n1406\n3561\n1694\n\n"
+        },
+        "reward": null,
+        "status": "ACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "submission": -1
+        },
+        "info": {},
+        "observation": {
+          "currentPlayer": 0,
+          "isTerminal": false,
+          "observationString": "r1b3k1/1p3p2/p3p3/8/3B4/4K3/2r1B1PP/8 b - - 10 33",
+          "playerId": 0,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n1258\n3572\n1841\n1842\n1431\n3132\n3572\n656\n89\n1215\n2425\n3010\n1808\n1768\n749\n30\n1065\n2571\n1942\n3196\n3131\n1384\n4177\n3854\n381\n615\n498\n1869\n2001\n2977\n2975\n4350\n1431\n1770\n2581\n1257\n4673\n4673\n656\n2627\n1895\n2940\n1386\n1358\n3634\n2528\n254\n4496\n3110\n3705\n2948\n2161\n1771\n2833\n2059\n3853\n2002\n3326\n3166\n1358\n1406\n3561\n1694\n3050\n\n",
+          "step": 66
+        },
+        "reward": null,
+        "status": "ACTIVE"
+      },
+      {
+        "action": {
+          "actionString": "Ke3",
+          "generate_returns": [
+            "{\n  \"main_response\": \"To decide on the best move, we must first analyze the current position. Black is significantly ahead in material (with two Rooks and a Bishop against White's two Bishops). Furthermore, White's Bishop on e2 is absolutely pinned to the King on f2 by the Black rook on c2. \\n\\nOur first priority should be to break this pin so that the e2 Bishop can move and participate in the game, allowing White to reorganize the pieces and try to create some resistance. \\n\\nMoving the King is the only way to unpin the Bishop. Let's look at the King moves:\\n- `33. Kf1` breaks the pin, but leaves the King somewhat passive on the back rank.\\n- `33. Ke1` breaks the pin, but also places the King on the passive first rank and temporarily blocks the Bishop from potentially retreating to d1.\\n- `33. Kf3` breaks the pin, but walks into the line of fire of a future ...Bb7+.\\n- `33. Ke3` is the most active and natural choice. It centralizes the King for the endgame, safely steps off the 2nd rank to break the pin, and prepares to aggressively reposition the e2 Bishop (for instance, preparing `34. Bd3` to immediately attack the c2 rook and gain a tempo).\\n\\nIf Black responds with a move like `33... b5` or `33... Bd7`, White can follow up with `34. Bd3`, forcing the rook to move and improving the coordination of White's pieces. If Black tries `33... e5`, White can simply capture with `34. Bxe5`.\\n\\nBy centralizing the King and breaking the pin simultaneously, White maximizes their chances to fight on.\\n\\nFinal Answer: Ke3\",\n  \"main_response_and_thoughts\": \"\",\n  \"request_for_logging\": {\n    \"model\": \"google/gemini-3.1-pro-preview\",\n    \"messages\": [\n      {\n        \"role\": \"user\",\n        \"content\": [\n          {\n            \"type\": \"text\",\n            \"text\": \"Let's play chess. The current game state in Forsyth-Edwards Notation (FEN) notation is:\\nr1b3k1/1p3p2/p3p3/8/3B4/8/2r1BKPP/8 w - - 9 33\\nThe moves played so far are:\\n1. e4 c5 2. Nf3 d6 3. d4 cxd4 4. Nxd4 Nf6 5. Nc3 a6 6. Bg5 e6 7. f4 Qb6 8. Qd2 Qxb2 9. Rb1 Qa3 10. e5 dxe5 11. fxe5 Nfd7 12. Ne4 h6 13. Bh4 Qxa2 14. Rd1 Qd5 15. Qe3 Qxe5 16. Be2 Bc5 17. Bg3 Bxd4 18. Rxd4 Qa5+ 19. c3 O-O 20. O-O Nc6 21. Nf6+ Nxf6 22. Rxf6 Nxd4 23. cxd4 gxf6 24. Qxh6 Qg5 25. Qxg5+ fxg5 26. Bd6 Rd8 27. Be7 Rxd4 28. Bxg5 Rd5 29. Bf6 Rf5 30. Bc3 Rc5 31. Bd4 Rc1+ 32. Kf2 Rc2 33.\\nYou are playing as player White.\\nIt is now your turn. Play your strongest move. The move MUST be legal. Reason step by step to come up with your move, then output your final answer in the format \\\"Final Answer: X\\\" where X is your chosen move in standard algebraic notation (SAN).\\n\"\n          }\n        ]\n      }\n    ],\n    \"config\": {\n      \"temperature\": \"NOT_GIVEN\",\n      \"top_p\": \"NOT_GIVEN\",\n      \"max_completion_tokens\": \"NOT_GIVEN\"\n    },\n    \"stream_options\": {\n      \"include_usage\": true\n    }\n  },\n  \"response_for_logging\": {\n    \"response_chunks\": [\n      {\n        \"id\": \"C6n6aZ2LD_iMmecPq_Dk8QQ\",\n        \"choices\": [\n          {\n            \"delta\": {\n              \"content\": \" chances to fight on.\\n\\nFinal Answer: Ke3\",\n              \"role\": \"assistant\"\n            },\n            \"finish_reason\": \"stop\",\n            \"index\": 0\n          }\n        ],\n        \"created\": 1778034955,\n        \"model\": \"google/gemini-3.1-pro-preview\",\n        \"object\": \"chat.completion.chunk\",\n        \"usage\": {\n          \"completion_tokens\": 380,\n          \"prompt_tokens\": 394,\n          \"total_tokens\": 4206,\n          \"cost\": {\n            \"input_tokens_cost_nanodollars\": 788000,\n            \"output_tokens_cost_nanodollars\": 45744000\n          },\n          \"total_backend_latency_ms\": 34309\n        }\n      }\n    ]\n  },\n  \"generation_tokens\": 380,\n  \"prompt_tokens\": 394,\n  \"reasoning_tokens\": null,\n  \"total_tokens\": 4206,\n  \"duration_success_only_secs\": 34.826816766002594\n}"
+          ],
+          "status": "OK",
+          "submission": 3050,
+          "thoughts": "To decide on the best move, we must first analyze the current position. Black is significantly ahead in material (with two Rooks and a Bishop against White's two Bishops). Furthermore, White's Bishop on e2 is absolutely pinned to the King on f2 by the Black rook on c2. \n\nOur first priority should be to break this pin so that the e2 Bishop can move and participate in the game, allowing White to reorganize the pieces and try to create some resistance. \n\nMoving the King is the only way to unpin the Bishop. Let's look at the King moves:\n- `33. Kf1` breaks the pin, but leaves the King somewhat passive on the back rank.\n- `33. Ke1` breaks the pin, but also places the King on the passive first rank and temporarily blocks the Bishop from potentially retreating to d1.\n- `33. Kf3` breaks the pin, but walks into the line of fire of a future ...Bb7+.\n- `33. Ke3` is the most active and natural choice. It centralizes the King for the endgame, safely steps off the 2nd rank to break the pin, and prepares to aggressively reposition the e2 Bishop (for instance, preparing `34. Bd3` to immediately attack the c2 rook and gain a tempo).\n\nIf Black responds with a move like `33... b5` or `33... Bd7`, White can follow up with `34. Bd3`, forcing the rook to move and improving the coordination of White's pieces. If Black tries `33... e5`, White can simply capture with `34. Bxe5`.\n\nBy centralizing the King and breaking the pin simultaneously, White maximizes their chances to fight on.\n\nFinal Answer: Ke3"
+        },
+        "info": {
+          "actionApplied": 3050,
+          "actionSubmitted": 3050,
+          "actionSubmittedToString": "Ke3",
+          "agentSelfReportedStatus": "OK",
+          "timeTaken": 36.005
+        },
+        "observation": {
+          "currentPlayer": 0,
+          "isTerminal": false,
+          "observationString": "r1b3k1/1p3p2/p3p3/8/3B4/4K3/2r1B1PP/8 b - - 10 33",
+          "playerId": 1,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n1258\n3572\n1841\n1842\n1431\n3132\n3572\n656\n89\n1215\n2425\n3010\n1808\n1768\n749\n30\n1065\n2571\n1942\n3196\n3131\n1384\n4177\n3854\n381\n615\n498\n1869\n2001\n2977\n2975\n4350\n1431\n1770\n2581\n1257\n4673\n4673\n656\n2627\n1895\n2940\n1386\n1358\n3634\n2528\n254\n4496\n3110\n3705\n2948\n2161\n1771\n2833\n2059\n3853\n2002\n3326\n3166\n1358\n1406\n3561\n1694\n3050\n\n"
+        },
+        "reward": null,
+        "status": "INACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "actionString": "Rxe2+",
+          "generate_returns": [
+            "{\n  \"main_response\": \"Black can force a winning simplification by capturing the bishop on e2 with check. Even if White recaptures with the king, Black remains with a decisive material advantage.\\n\\nFinal Answer: Rxe2+\",\n  \"main_response_and_thoughts\": \"\",\n  \"request_for_logging\": {\n    \"model\": \"openai/gpt-5.5-2026-04-23\",\n    \"messages\": [\n      {\n        \"role\": \"user\",\n        \"content\": [\n          {\n            \"type\": \"text\",\n            \"text\": \"Let's play chess. The current game state in Forsyth-Edwards Notation (FEN) notation is:\\nr1b3k1/1p3p2/p3p3/8/3B4/4K3/2r1B1PP/8 b - - 10 33\\nThe moves played so far are:\\n1. e4 c5 2. Nf3 d6 3. d4 cxd4 4. Nxd4 Nf6 5. Nc3 a6 6. Bg5 e6 7. f4 Qb6 8. Qd2 Qxb2 9. Rb1 Qa3 10. e5 dxe5 11. fxe5 Nfd7 12. Ne4 h6 13. Bh4 Qxa2 14. Rd1 Qd5 15. Qe3 Qxe5 16. Be2 Bc5 17. Bg3 Bxd4 18. Rxd4 Qa5+ 19. c3 O-O 20. O-O Nc6 21. Nf6+ Nxf6 22. Rxf6 Nxd4 23. cxd4 gxf6 24. Qxh6 Qg5 25. Qxg5+ fxg5 26. Bd6 Rd8 27. Be7 Rxd4 28. Bxg5 Rd5 29. Bf6 Rf5 30. Bc3 Rc5 31. Bd4 Rc1+ 32. Kf2 Rc2 33. Ke3\\nYou are playing as player Black.\\nIt is now your turn. Play your strongest move. The move MUST be legal. Reason step by step to come up with your move, then output your final answer in the format \\\"Final Answer: X\\\" where X is your chosen move in standard algebraic notation (SAN).\\n\"\n          }\n        ]\n      }\n    ],\n    \"config\": {\n      \"temperature\": \"NOT_GIVEN\",\n      \"top_p\": \"NOT_GIVEN\",\n      \"max_completion_tokens\": \"NOT_GIVEN\",\n      \"reasoning_effort\": \"high\"\n    },\n    \"stream_options\": {\n      \"include_usage\": true\n    }\n  },\n  \"response_for_logging\": {\n    \"response_chunks\": [\n      {\n        \"id\": \"chatcmpl-DcMPfgzLwcLXp4oV0xV6oNDnOb77j\",\n        \"created\": 1778034991,\n        \"model\": \"openai/gpt-5.5-2026-04-23\",\n        \"object\": \"chat.completion.chunk\",\n        \"usage\": {\n          \"completion_tokens\": 20447,\n          \"prompt_tokens\": 411,\n          \"total_tokens\": 20858,\n          \"cost\": {\n            \"input_tokens_cost_nanodollars\": 2055000,\n            \"output_tokens_cost_nanodollars\": 613410000\n          },\n          \"total_backend_latency_ms\": 439490\n        }\n      }\n    ]\n  },\n  \"generation_tokens\": 20447,\n  \"prompt_tokens\": 411,\n  \"reasoning_tokens\": null,\n  \"total_tokens\": 20858,\n  \"duration_success_only_secs\": 440.463348942998\n}"
+          ],
+          "status": "OK",
+          "submission": 1637,
+          "thoughts": "Black can force a winning simplification by capturing the bishop on e2 with check. Even if White recaptures with the king, Black remains with a decisive material advantage.\n\nFinal Answer: Rxe2+"
+        },
+        "info": {
+          "actionApplied": 1637,
+          "actionSubmitted": 1637,
+          "actionSubmittedToString": "Rxe2+",
+          "agentSelfReportedStatus": "OK",
+          "timeTaken": 441.663
+        },
+        "observation": {
+          "currentPlayer": 1,
+          "isTerminal": false,
+          "observationString": "r1b3k1/1p3p2/p3p3/8/3B4/4K3/4r1PP/8 w - - 0 34",
+          "playerId": 0,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n1258\n3572\n1841\n1842\n1431\n3132\n3572\n656\n89\n1215\n2425\n3010\n1808\n1768\n749\n30\n1065\n2571\n1942\n3196\n3131\n1384\n4177\n3854\n381\n615\n498\n1869\n2001\n2977\n2975\n4350\n1431\n1770\n2581\n1257\n4673\n4673\n656\n2627\n1895\n2940\n1386\n1358\n3634\n2528\n254\n4496\n3110\n3705\n2948\n2161\n1771\n2833\n2059\n3853\n2002\n3326\n3166\n1358\n1406\n3561\n1694\n3050\n1637\n\n",
+          "step": 67
+        },
+        "reward": null,
+        "status": "INACTIVE"
+      },
+      {
+        "action": {
+          "submission": -1
+        },
+        "info": {},
+        "observation": {
+          "currentPlayer": 1,
+          "isTerminal": false,
+          "observationString": "r1b3k1/1p3p2/p3p3/8/3B4/4K3/4r1PP/8 w - - 0 34",
+          "playerId": 1,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n1258\n3572\n1841\n1842\n1431\n3132\n3572\n656\n89\n1215\n2425\n3010\n1808\n1768\n749\n30\n1065\n2571\n1942\n3196\n3131\n1384\n4177\n3854\n381\n615\n498\n1869\n2001\n2977\n2975\n4350\n1431\n1770\n2581\n1257\n4673\n4673\n656\n2627\n1895\n2940\n1386\n1358\n3634\n2528\n254\n4496\n3110\n3705\n2948\n2161\n1771\n2833\n2059\n3853\n2002\n3326\n3166\n1358\n1406\n3561\n1694\n3050\n1637\n\n"
+        },
+        "reward": null,
+        "status": "ACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "submission": -1
+        },
+        "info": {},
+        "observation": {
+          "currentPlayer": 0,
+          "isTerminal": false,
+          "observationString": "r1b3k1/1p3p2/p3p3/8/3B4/8/4K1PP/8 b - - 0 34",
+          "playerId": 0,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n1258\n3572\n1841\n1842\n1431\n3132\n3572\n656\n89\n1215\n2425\n3010\n1808\n1768\n749\n30\n1065\n2571\n1942\n3196\n3131\n1384\n4177\n3854\n381\n615\n498\n1869\n2001\n2977\n2975\n4350\n1431\n1770\n2581\n1257\n4673\n4673\n656\n2627\n1895\n2940\n1386\n1358\n3634\n2528\n254\n4496\n3110\n3705\n2948\n2161\n1771\n2833\n2059\n3853\n2002\n3326\n3166\n1358\n1406\n3561\n1694\n3050\n1637\n2497\n\n",
+          "step": 68
+        },
+        "reward": null,
+        "status": "ACTIVE"
+      },
+      {
+        "action": {
+          "actionString": "Kxe2",
+          "generate_returns": [
+            "{\n  \"main_response\": \"The current situation shows that your King on e3 is in check by the Black Rook on e2. \\n\\nTo get out of check, you have three legal moves: moving the King to d3, moving the King to f3, or capturing the undefended Rook on e2. Capturing the Rook is by far the best choice as it eliminates one of Black's most active and dangerous pieces for free, significantly reducing their massive material advantage.\\n\\nFinal Answer: Kxe2\",\n  \"main_response_and_thoughts\": \"\",\n  \"request_for_logging\": {\n    \"model\": \"google/gemini-3.1-pro-preview\",\n    \"messages\": [\n      {\n        \"role\": \"user\",\n        \"content\": [\n          {\n            \"type\": \"text\",\n            \"text\": \"Let's play chess. The current game state in Forsyth-Edwards Notation (FEN) notation is:\\nr1b3k1/1p3p2/p3p3/8/3B4/4K3/4r1PP/8 w - - 0 34\\nThe moves played so far are:\\n1. e4 c5 2. Nf3 d6 3. d4 cxd4 4. Nxd4 Nf6 5. Nc3 a6 6. Bg5 e6 7. f4 Qb6 8. Qd2 Qxb2 9. Rb1 Qa3 10. e5 dxe5 11. fxe5 Nfd7 12. Ne4 h6 13. Bh4 Qxa2 14. Rd1 Qd5 15. Qe3 Qxe5 16. Be2 Bc5 17. Bg3 Bxd4 18. Rxd4 Qa5+ 19. c3 O-O 20. O-O Nc6 21. Nf6+ Nxf6 22. Rxf6 Nxd4 23. cxd4 gxf6 24. Qxh6 Qg5 25. Qxg5+ fxg5 26. Bd6 Rd8 27. Be7 Rxd4 28. Bxg5 Rd5 29. Bf6 Rf5 30. Bc3 Rc5 31. Bd4 Rc1+ 32. Kf2 Rc2 33. Ke3 Rxe2+ 34.\\nYou are playing as player White.\\nIt is now your turn. Play your strongest move. The move MUST be legal. Reason step by step to come up with your move, then output your final answer in the format \\\"Final Answer: X\\\" where X is your chosen move in standard algebraic notation (SAN).\\n\"\n          }\n        ]\n      }\n    ],\n    \"config\": {\n      \"temperature\": \"NOT_GIVEN\",\n      \"top_p\": \"NOT_GIVEN\",\n      \"max_completion_tokens\": \"NOT_GIVEN\"\n    },\n    \"stream_options\": {\n      \"include_usage\": true\n    }\n  },\n  \"response_for_logging\": {\n    \"response_chunks\": [\n      {\n        \"id\": \"6ar6abCtGNCfmecP0erHwQ0\",\n        \"choices\": [\n          {\n            \"delta\": {\n              \"content\": \"s most active and dangerous pieces for free, significantly reducing their massive material advantage.\\n\\nFinal Answer: Kxe2\",\n              \"role\": \"assistant\"\n            },\n            \"finish_reason\": \"stop\",\n            \"index\": 0\n          }\n        ],\n        \"created\": 1778035433,\n        \"model\": \"google/gemini-3.1-pro-preview\",\n        \"object\": \"chat.completion.chunk\",\n        \"usage\": {\n          \"completion_tokens\": 98,\n          \"prompt_tokens\": 404,\n          \"total_tokens\": 1201,\n          \"cost\": {\n            \"input_tokens_cost_nanodollars\": 808000,\n            \"output_tokens_cost_nanodollars\": 9564000\n          },\n          \"total_backend_latency_ms\": 8302\n        }\n      }\n    ]\n  },\n  \"generation_tokens\": 98,\n  \"prompt_tokens\": 404,\n  \"reasoning_tokens\": null,\n  \"total_tokens\": 1201,\n  \"duration_success_only_secs\": 8.800156506000349\n}"
+          ],
+          "status": "OK",
+          "submission": 2497,
+          "thoughts": "The current situation shows that your King on e3 is in check by the Black Rook on e2. \n\nTo get out of check, you have three legal moves: moving the King to d3, moving the King to f3, or capturing the undefended Rook on e2. Capturing the Rook is by far the best choice as it eliminates one of Black's most active and dangerous pieces for free, significantly reducing their massive material advantage.\n\nFinal Answer: Kxe2"
+        },
+        "info": {
+          "actionApplied": 2497,
+          "actionSubmitted": 2497,
+          "actionSubmittedToString": "Kxe2",
+          "agentSelfReportedStatus": "OK",
+          "timeTaken": 10.462
+        },
+        "observation": {
+          "currentPlayer": 0,
+          "isTerminal": false,
+          "observationString": "r1b3k1/1p3p2/p3p3/8/3B4/8/4K1PP/8 b - - 0 34",
+          "playerId": 1,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n1258\n3572\n1841\n1842\n1431\n3132\n3572\n656\n89\n1215\n2425\n3010\n1808\n1768\n749\n30\n1065\n2571\n1942\n3196\n3131\n1384\n4177\n3854\n381\n615\n498\n1869\n2001\n2977\n2975\n4350\n1431\n1770\n2581\n1257\n4673\n4673\n656\n2627\n1895\n2940\n1386\n1358\n3634\n2528\n254\n4496\n3110\n3705\n2948\n2161\n1771\n2833\n2059\n3853\n2002\n3326\n3166\n1358\n1406\n3561\n1694\n3050\n1637\n2497\n\n"
+        },
+        "reward": null,
+        "status": "INACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "actionString": "Bd7",
+          "generate_returns": [
+            "{\n  \"main_response\": \"Final Answer: Bd7\",\n  \"main_response_and_thoughts\": \"\",\n  \"request_for_logging\": {\n    \"model\": \"openai/gpt-5.5-2026-04-23\",\n    \"messages\": [\n      {\n        \"role\": \"user\",\n        \"content\": [\n          {\n            \"type\": \"text\",\n            \"text\": \"Let's play chess. The current game state in Forsyth-Edwards Notation (FEN) notation is:\\nr1b3k1/1p3p2/p3p3/8/3B4/8/4K1PP/8 b - - 0 34\\nThe moves played so far are:\\n1. e4 c5 2. Nf3 d6 3. d4 cxd4 4. Nxd4 Nf6 5. Nc3 a6 6. Bg5 e6 7. f4 Qb6 8. Qd2 Qxb2 9. Rb1 Qa3 10. e5 dxe5 11. fxe5 Nfd7 12. Ne4 h6 13. Bh4 Qxa2 14. Rd1 Qd5 15. Qe3 Qxe5 16. Be2 Bc5 17. Bg3 Bxd4 18. Rxd4 Qa5+ 19. c3 O-O 20. O-O Nc6 21. Nf6+ Nxf6 22. Rxf6 Nxd4 23. cxd4 gxf6 24. Qxh6 Qg5 25. Qxg5+ fxg5 26. Bd6 Rd8 27. Be7 Rxd4 28. Bxg5 Rd5 29. Bf6 Rf5 30. Bc3 Rc5 31. Bd4 Rc1+ 32. Kf2 Rc2 33. Ke3 Rxe2+ 34. Kxe2\\nYou are playing as player Black.\\nIt is now your turn. Play your strongest move. The move MUST be legal. Reason step by step to come up with your move, then output your final answer in the format \\\"Final Answer: X\\\" where X is your chosen move in standard algebraic notation (SAN).\\n\"\n          }\n        ]\n      }\n    ],\n    \"config\": {\n      \"temperature\": \"NOT_GIVEN\",\n      \"top_p\": \"NOT_GIVEN\",\n      \"max_completion_tokens\": \"NOT_GIVEN\",\n      \"reasoning_effort\": \"high\"\n    },\n    \"stream_options\": {\n      \"include_usage\": true\n    }\n  },\n  \"response_for_logging\": {\n    \"response_chunks\": [\n      {\n        \"id\": \"chatcmpl-DcMWxjRjVqgGk866t7JGL3BtH6YSw\",\n        \"created\": 1778035443,\n        \"model\": \"openai/gpt-5.5-2026-04-23\",\n        \"object\": \"chat.completion.chunk\",\n        \"usage\": {\n          \"completion_tokens\": 4670,\n          \"prompt_tokens\": 417,\n          \"total_tokens\": 5087,\n          \"cost\": {\n            \"input_tokens_cost_nanodollars\": 2085000,\n            \"output_tokens_cost_nanodollars\": 140100000\n          },\n          \"total_backend_latency_ms\": 98492\n        }\n      }\n    ]\n  },\n  \"generation_tokens\": 4670,\n  \"prompt_tokens\": 417,\n  \"reasoning_tokens\": null,\n  \"total_tokens\": 5087,\n  \"duration_success_only_secs\": 98.94446432900077\n}"
+          ],
+          "status": "OK",
+          "submission": 1212,
+          "thoughts": "Final Answer: Bd7"
+        },
+        "info": {
+          "actionApplied": 1212,
+          "actionSubmitted": 1212,
+          "actionSubmittedToString": "Bd7",
+          "agentSelfReportedStatus": "OK",
+          "timeTaken": 100.695
+        },
+        "observation": {
+          "currentPlayer": 1,
+          "isTerminal": false,
+          "observationString": "r5k1/1p1b1p2/p3p3/8/3B4/8/4K1PP/8 w - - 1 35",
+          "playerId": 0,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n1258\n3572\n1841\n1842\n1431\n3132\n3572\n656\n89\n1215\n2425\n3010\n1808\n1768\n749\n30\n1065\n2571\n1942\n3196\n3131\n1384\n4177\n3854\n381\n615\n498\n1869\n2001\n2977\n2975\n4350\n1431\n1770\n2581\n1257\n4673\n4673\n656\n2627\n1895\n2940\n1386\n1358\n3634\n2528\n254\n4496\n3110\n3705\n2948\n2161\n1771\n2833\n2059\n3853\n2002\n3326\n3166\n1358\n1406\n3561\n1694\n3050\n1637\n2497\n1212\n\n",
+          "step": 69
+        },
+        "reward": null,
+        "status": "INACTIVE"
+      },
+      {
+        "action": {
+          "submission": -1
+        },
+        "info": {},
+        "observation": {
+          "currentPlayer": 1,
+          "isTerminal": false,
+          "observationString": "r5k1/1p1b1p2/p3p3/8/3B4/8/4K1PP/8 w - - 1 35",
+          "playerId": 1,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n1258\n3572\n1841\n1842\n1431\n3132\n3572\n656\n89\n1215\n2425\n3010\n1808\n1768\n749\n30\n1065\n2571\n1942\n3196\n3131\n1384\n4177\n3854\n381\n615\n498\n1869\n2001\n2977\n2975\n4350\n1431\n1770\n2581\n1257\n4673\n4673\n656\n2627\n1895\n2940\n1386\n1358\n3634\n2528\n254\n4496\n3110\n3705\n2948\n2161\n1771\n2833\n2059\n3853\n2002\n3326\n3166\n1358\n1406\n3561\n1694\n3050\n1637\n2497\n1212\n\n"
+        },
+        "reward": null,
+        "status": "ACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "submission": -1
+        },
+        "info": {},
+        "observation": {
+          "currentPlayer": 0,
+          "isTerminal": false,
+          "observationString": "r5k1/1p1b1p2/p3p3/8/3B4/4K3/6PP/8 b - - 2 35",
+          "playerId": 0,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n1258\n3572\n1841\n1842\n1431\n3132\n3572\n656\n89\n1215\n2425\n3010\n1808\n1768\n749\n30\n1065\n2571\n1942\n3196\n3131\n1384\n4177\n3854\n381\n615\n498\n1869\n2001\n2977\n2975\n4350\n1431\n1770\n2581\n1257\n4673\n4673\n656\n2627\n1895\n2940\n1386\n1358\n3634\n2528\n254\n4496\n3110\n3705\n2948\n2161\n1771\n2833\n2059\n3853\n2002\n3326\n3166\n1358\n1406\n3561\n1694\n3050\n1637\n2497\n1212\n2425\n\n",
+          "step": 70
+        },
+        "reward": null,
+        "status": "ACTIVE"
+      },
+      {
+        "action": {
+          "actionString": "Ke3",
+          "generate_returns": [
+            "{\n  \"main_response\": \"The position is completely winning for Black, as White is down a full Rook and two pawns in this endgame. With no direct tactical resources or saving chances available, White's best practical approach is to centralize the King, prepare to contest the center, and try to create as much resistance as possible. \\n\\nThe King on e2 can step up to e3, a natural centralizing move that supports the position and prepares to respond to Black's impending maneuvers (like the Rook activating or the Bishop moving to an attacking diagonal). \\n\\nFinal Answer: Ke3\",\n  \"main_response_and_thoughts\": \"\",\n  \"request_for_logging\": {\n    \"model\": \"google/gemini-3.1-pro-preview\",\n    \"messages\": [\n      {\n        \"role\": \"user\",\n        \"content\": [\n          {\n            \"type\": \"text\",\n            \"text\": \"Let's play chess. The current game state in Forsyth-Edwards Notation (FEN) notation is:\\nr5k1/1p1b1p2/p3p3/8/3B4/8/4K1PP/8 w - - 1 35\\nThe moves played so far are:\\n1. e4 c5 2. Nf3 d6 3. d4 cxd4 4. Nxd4 Nf6 5. Nc3 a6 6. Bg5 e6 7. f4 Qb6 8. Qd2 Qxb2 9. Rb1 Qa3 10. e5 dxe5 11. fxe5 Nfd7 12. Ne4 h6 13. Bh4 Qxa2 14. Rd1 Qd5 15. Qe3 Qxe5 16. Be2 Bc5 17. Bg3 Bxd4 18. Rxd4 Qa5+ 19. c3 O-O 20. O-O Nc6 21. Nf6+ Nxf6 22. Rxf6 Nxd4 23. cxd4 gxf6 24. Qxh6 Qg5 25. Qxg5+ fxg5 26. Bd6 Rd8 27. Be7 Rxd4 28. Bxg5 Rd5 29. Bf6 Rf5 30. Bc3 Rc5 31. Bd4 Rc1+ 32. Kf2 Rc2 33. Ke3 Rxe2+ 34. Kxe2 Bd7 35.\\nYou are playing as player White.\\nIt is now your turn. Play your strongest move. The move MUST be legal. Reason step by step to come up with your move, then output your final answer in the format \\\"Final Answer: X\\\" where X is your chosen move in standard algebraic notation (SAN).\\n\"\n          }\n        ]\n      }\n    ],\n    \"config\": {\n      \"temperature\": \"NOT_GIVEN\",\n      \"top_p\": \"NOT_GIVEN\",\n      \"max_completion_tokens\": \"NOT_GIVEN\"\n    },\n    \"stream_options\": {\n      \"include_usage\": true\n    }\n  },\n  \"response_for_logging\": {\n    \"response_chunks\": [\n      {\n        \"id\": \"Wav6adL8A9CfmecP0erHwQ0\",\n        \"choices\": [\n          {\n            \"delta\": {\n              \"content\": \" the Rook activating or the Bishop moving to an attacking diagonal). \\n\\nFinal Answer: Ke3\",\n              \"role\": \"assistant\"\n            },\n            \"finish_reason\": \"stop\",\n            \"index\": 0\n          }\n        ],\n        \"created\": 1778035545,\n        \"model\": \"google/gemini-3.1-pro-preview\",\n        \"object\": \"chat.completion.chunk\",\n        \"usage\": {\n          \"completion_tokens\": 116,\n          \"prompt_tokens\": 410,\n          \"total_tokens\": 2504,\n          \"cost\": {\n            \"input_tokens_cost_nanodollars\": 820000,\n            \"output_tokens_cost_nanodollars\": 25128000\n          },\n          \"total_backend_latency_ms\": 20156\n        }\n      }\n    ]\n  },\n  \"generation_tokens\": 116,\n  \"prompt_tokens\": 410,\n  \"reasoning_tokens\": null,\n  \"total_tokens\": 2504,\n  \"duration_success_only_secs\": 21.17356687100255\n}"
+          ],
+          "status": "OK",
+          "submission": 2425,
+          "thoughts": "The position is completely winning for Black, as White is down a full Rook and two pawns in this endgame. With no direct tactical resources or saving chances available, White's best practical approach is to centralize the King, prepare to contest the center, and try to create as much resistance as possible. \n\nThe King on e2 can step up to e3, a natural centralizing move that supports the position and prepares to respond to Black's impending maneuvers (like the Rook activating or the Bishop moving to an attacking diagonal). \n\nFinal Answer: Ke3"
+        },
+        "info": {
+          "actionApplied": 2425,
+          "actionSubmitted": 2425,
+          "actionSubmittedToString": "Ke3",
+          "agentSelfReportedStatus": "OK",
+          "timeTaken": 22.84
+        },
+        "observation": {
+          "currentPlayer": 0,
+          "isTerminal": false,
+          "observationString": "r5k1/1p1b1p2/p3p3/8/3B4/4K3/6PP/8 b - - 2 35",
+          "playerId": 1,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n1258\n3572\n1841\n1842\n1431\n3132\n3572\n656\n89\n1215\n2425\n3010\n1808\n1768\n749\n30\n1065\n2571\n1942\n3196\n3131\n1384\n4177\n3854\n381\n615\n498\n1869\n2001\n2977\n2975\n4350\n1431\n1770\n2581\n1257\n4673\n4673\n656\n2627\n1895\n2940\n1386\n1358\n3634\n2528\n254\n4496\n3110\n3705\n2948\n2161\n1771\n2833\n2059\n3853\n2002\n3326\n3166\n1358\n1406\n3561\n1694\n3050\n1637\n2497\n1212\n2425\n\n"
+        },
+        "reward": null,
+        "status": "INACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "actionString": "Bc6",
+          "generate_returns": [
+            "{\n  \"main_response\": \"Final Answer: Bc6\",\n  \"main_response_and_thoughts\": \"\",\n  \"request_for_logging\": {\n    \"model\": \"openai/gpt-5.5-2026-04-23\",\n    \"messages\": [\n      {\n        \"role\": \"user\",\n        \"content\": [\n          {\n            \"type\": \"text\",\n            \"text\": \"Let's play chess. The current game state in Forsyth-Edwards Notation (FEN) notation is:\\nr5k1/1p1b1p2/p3p3/8/3B4/4K3/6PP/8 b - - 2 35\\nThe moves played so far are:\\n1. e4 c5 2. Nf3 d6 3. d4 cxd4 4. Nxd4 Nf6 5. Nc3 a6 6. Bg5 e6 7. f4 Qb6 8. Qd2 Qxb2 9. Rb1 Qa3 10. e5 dxe5 11. fxe5 Nfd7 12. Ne4 h6 13. Bh4 Qxa2 14. Rd1 Qd5 15. Qe3 Qxe5 16. Be2 Bc5 17. Bg3 Bxd4 18. Rxd4 Qa5+ 19. c3 O-O 20. O-O Nc6 21. Nf6+ Nxf6 22. Rxf6 Nxd4 23. cxd4 gxf6 24. Qxh6 Qg5 25. Qxg5+ fxg5 26. Bd6 Rd8 27. Be7 Rxd4 28. Bxg5 Rd5 29. Bf6 Rf5 30. Bc3 Rc5 31. Bd4 Rc1+ 32. Kf2 Rc2 33. Ke3 Rxe2+ 34. Kxe2 Bd7 35. Ke3\\nYou are playing as player Black.\\nIt is now your turn. Play your strongest move. The move MUST be legal. Reason step by step to come up with your move, then output your final answer in the format \\\"Final Answer: X\\\" where X is your chosen move in standard algebraic notation (SAN).\\n\"\n          }\n        ]\n      }\n    ],\n    \"config\": {\n      \"temperature\": \"NOT_GIVEN\",\n      \"top_p\": \"NOT_GIVEN\",\n      \"max_completion_tokens\": \"NOT_GIVEN\",\n      \"reasoning_effort\": \"high\"\n    },\n    \"stream_options\": {\n      \"include_usage\": true\n    }\n  },\n  \"response_for_logging\": {\n    \"response_chunks\": [\n      {\n        \"id\": \"chatcmpl-DcMYxEqozv53Rg9EZmbc3Y0G2Uwjx\",\n        \"created\": 1778035567,\n        \"model\": \"openai/gpt-5.5-2026-04-23\",\n        \"object\": \"chat.completion.chunk\",\n        \"usage\": {\n          \"completion_tokens\": 6964,\n          \"prompt_tokens\": 424,\n          \"total_tokens\": 7388,\n          \"cost\": {\n            \"input_tokens_cost_nanodollars\": 2120000,\n            \"output_tokens_cost_nanodollars\": 208920000\n          },\n          \"total_backend_latency_ms\": 135331\n        }\n      }\n    ]\n  },\n  \"generation_tokens\": 6964,\n  \"prompt_tokens\": 424,\n  \"reasoning_tokens\": null,\n  \"total_tokens\": 7388,\n  \"duration_success_only_secs\": 135.76228350900055\n}"
+          ],
+          "status": "OK",
+          "submission": 1882,
+          "thoughts": "Final Answer: Bc6"
+        },
+        "info": {
+          "actionApplied": 1882,
+          "actionSubmitted": 1882,
+          "actionSubmittedToString": "Bc6",
+          "agentSelfReportedStatus": "OK",
+          "timeTaken": 137.446
+        },
+        "observation": {
+          "currentPlayer": 1,
+          "isTerminal": false,
+          "observationString": "r5k1/1p3p2/p1b1p3/8/3B4/4K3/6PP/8 w - - 3 36",
+          "playerId": 0,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n1258\n3572\n1841\n1842\n1431\n3132\n3572\n656\n89\n1215\n2425\n3010\n1808\n1768\n749\n30\n1065\n2571\n1942\n3196\n3131\n1384\n4177\n3854\n381\n615\n498\n1869\n2001\n2977\n2975\n4350\n1431\n1770\n2581\n1257\n4673\n4673\n656\n2627\n1895\n2940\n1386\n1358\n3634\n2528\n254\n4496\n3110\n3705\n2948\n2161\n1771\n2833\n2059\n3853\n2002\n3326\n3166\n1358\n1406\n3561\n1694\n3050\n1637\n2497\n1212\n2425\n1882\n\n",
+          "step": 71
+        },
+        "reward": null,
+        "status": "INACTIVE"
+      },
+      {
+        "action": {
+          "submission": -1
+        },
+        "info": {},
+        "observation": {
+          "currentPlayer": 1,
+          "isTerminal": false,
+          "observationString": "r5k1/1p3p2/p1b1p3/8/3B4/4K3/6PP/8 w - - 3 36",
+          "playerId": 1,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n1258\n3572\n1841\n1842\n1431\n3132\n3572\n656\n89\n1215\n2425\n3010\n1808\n1768\n749\n30\n1065\n2571\n1942\n3196\n3131\n1384\n4177\n3854\n381\n615\n498\n1869\n2001\n2977\n2975\n4350\n1431\n1770\n2581\n1257\n4673\n4673\n656\n2627\n1895\n2940\n1386\n1358\n3634\n2528\n254\n4496\n3110\n3705\n2948\n2161\n1771\n2833\n2059\n3853\n2002\n3326\n3166\n1358\n1406\n3561\n1694\n3050\n1637\n2497\n1212\n2425\n1882\n\n"
+        },
+        "reward": null,
+        "status": "ACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "submission": -1
+        },
+        "info": {},
+        "observation": {
+          "currentPlayer": 0,
+          "isTerminal": false,
+          "observationString": "r5k1/1p3p2/p1b1p3/8/3B4/4K1P1/7P/8 b - - 0 36",
+          "playerId": 0,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n1258\n3572\n1841\n1842\n1431\n3132\n3572\n656\n89\n1215\n2425\n3010\n1808\n1768\n749\n30\n1065\n2571\n1942\n3196\n3131\n1384\n4177\n3854\n381\n615\n498\n1869\n2001\n2977\n2975\n4350\n1431\n1770\n2581\n1257\n4673\n4673\n656\n2627\n1895\n2940\n1386\n1358\n3634\n2528\n254\n4496\n3110\n3705\n2948\n2161\n1771\n2833\n2059\n3853\n2002\n3326\n3166\n1358\n1406\n3561\n1694\n3050\n1637\n2497\n1212\n2425\n1882\n3593\n\n",
+          "step": 72
+        },
+        "reward": null,
+        "status": "ACTIVE"
+      },
+      {
+        "action": {
+          "actionString": "g3",
+          "generate_returns": [
+            "{\n  \"main_response\": \"The position is completely lost for White, being down a Rook and two pawns for nothing. However, we still have to find the best practical continuation. \\n\\nCurrently, your pawn on g2 is hanging as it is being attacked by Black's bishop on c6. The most logical and resilient choice is to move the pawn out of danger to g3, placing it on a dark square where the light-squared bishop cannot easily harass it, while also maintaining a solid pawn structure with h2. \\n\\nStep-by-step derivation:\\n1. Identify the threats: Black's light-squared bishop has just moved to c6, eyeing the undefended g2-pawn.\\n2. Evaluate options to handle the threat: \\n   - Moving the king (36. Kf2) defends it, but subjects the king to a more passive role.\\n   - Pushing the pawn to g4 weakens the h2 pawn and leaves g4 somewhat loose. \\n   - Pushing the pawn to g3 (36. g3) stops the attack immediately and sets up a nice dark-square defense (since Black lacks a dark-squared bishop, g3 is very safe).\\n3. Confirm legality: The g3 square is empty and moving the pawn one step forward is perfectly legal. \\n\\nFinal Answer: g3\",\n  \"main_response_and_thoughts\": \"\",\n  \"request_for_logging\": {\n    \"model\": \"google/gemini-3.1-pro-preview\",\n    \"messages\": [\n      {\n        \"role\": \"user\",\n        \"content\": [\n          {\n            \"type\": \"text\",\n            \"text\": \"Let's play chess. The current game state in Forsyth-Edwards Notation (FEN) notation is:\\nr5k1/1p3p2/p1b1p3/8/3B4/4K3/6PP/8 w - - 3 36\\nThe moves played so far are:\\n1. e4 c5 2. Nf3 d6 3. d4 cxd4 4. Nxd4 Nf6 5. Nc3 a6 6. Bg5 e6 7. f4 Qb6 8. Qd2 Qxb2 9. Rb1 Qa3 10. e5 dxe5 11. fxe5 Nfd7 12. Ne4 h6 13. Bh4 Qxa2 14. Rd1 Qd5 15. Qe3 Qxe5 16. Be2 Bc5 17. Bg3 Bxd4 18. Rxd4 Qa5+ 19. c3 O-O 20. O-O Nc6 21. Nf6+ Nxf6 22. Rxf6 Nxd4 23. cxd4 gxf6 24. Qxh6 Qg5 25. Qxg5+ fxg5 26. Bd6 Rd8 27. Be7 Rxd4 28. Bxg5 Rd5 29. Bf6 Rf5 30. Bc3 Rc5 31. Bd4 Rc1+ 32. Kf2 Rc2 33. Ke3 Rxe2+ 34. Kxe2 Bd7 35. Ke3 Bc6 36.\\nYou are playing as player White.\\nIt is now your turn. Play your strongest move. The move MUST be legal. Reason step by step to come up with your move, then output your final answer in the format \\\"Final Answer: X\\\" where X is your chosen move in standard algebraic notation (SAN).\\n\"\n          }\n        ]\n      }\n    ],\n    \"config\": {\n      \"temperature\": \"NOT_GIVEN\",\n      \"top_p\": \"NOT_GIVEN\",\n      \"max_completion_tokens\": \"NOT_GIVEN\"\n    },\n    \"stream_options\": {\n      \"include_usage\": true\n    }\n  },\n  \"response_for_logging\": {\n    \"response_chunks\": [\n      {\n        \"id\": \"-Kv6acmiF9CfmecP0erHwQ0\",\n        \"choices\": [\n          {\n            \"delta\": {\n              \"content\": \"3\",\n              \"role\": \"assistant\"\n            },\n            \"finish_reason\": \"stop\",\n            \"index\": 0\n          }\n        ],\n        \"created\": 1778035704,\n        \"model\": \"google/gemini-3.1-pro-preview\",\n        \"object\": \"chat.completion.chunk\",\n        \"usage\": {\n          \"completion_tokens\": 278,\n          \"prompt_tokens\": 418,\n          \"total_tokens\": 2192,\n          \"cost\": {\n            \"input_tokens_cost_nanodollars\": 836000,\n            \"output_tokens_cost_nanodollars\": 21288000\n          },\n          \"total_backend_latency_ms\": 17493\n        }\n      }\n    ]\n  },\n  \"generation_tokens\": 278,\n  \"prompt_tokens\": 418,\n  \"reasoning_tokens\": null,\n  \"total_tokens\": 2192,\n  \"duration_success_only_secs\": 17.97360967699933\n}"
+          ],
+          "status": "OK",
+          "submission": 3593,
+          "thoughts": "The position is completely lost for White, being down a Rook and two pawns for nothing. However, we still have to find the best practical continuation. \n\nCurrently, your pawn on g2 is hanging as it is being attacked by Black's bishop on c6. The most logical and resilient choice is to move the pawn out of danger to g3, placing it on a dark square where the light-squared bishop cannot easily harass it, while also maintaining a solid pawn structure with h2. \n\nStep-by-step derivation:\n1. Identify the threats: Black's light-squared bishop has just moved to c6, eyeing the undefended g2-pawn.\n2. Evaluate options to handle the threat: \n   - Moving the king (36. Kf2) defends it, but subjects the king to a more passive role.\n   - Pushing the pawn to g4 weakens the h2 pawn and leaves g4 somewhat loose. \n   - Pushing the pawn to g3 (36. g3) stops the attack immediately and sets up a nice dark-square defense (since Black lacks a dark-squared bishop, g3 is very safe).\n3. Confirm legality: The g3 square is empty and moving the pawn one step forward is perfectly legal. \n\nFinal Answer: g3"
+        },
+        "info": {
+          "actionApplied": 3593,
+          "actionSubmitted": 3593,
+          "actionSubmittedToString": "g3",
+          "agentSelfReportedStatus": "OK",
+          "timeTaken": 19.186
+        },
+        "observation": {
+          "currentPlayer": 0,
+          "isTerminal": false,
+          "observationString": "r5k1/1p3p2/p1b1p3/8/3B4/4K1P1/7P/8 b - - 0 36",
+          "playerId": 1,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n1258\n3572\n1841\n1842\n1431\n3132\n3572\n656\n89\n1215\n2425\n3010\n1808\n1768\n749\n30\n1065\n2571\n1942\n3196\n3131\n1384\n4177\n3854\n381\n615\n498\n1869\n2001\n2977\n2975\n4350\n1431\n1770\n2581\n1257\n4673\n4673\n656\n2627\n1895\n2940\n1386\n1358\n3634\n2528\n254\n4496\n3110\n3705\n2948\n2161\n1771\n2833\n2059\n3853\n2002\n3326\n3166\n1358\n1406\n3561\n1694\n3050\n1637\n2497\n1212\n2425\n1882\n3593\n\n"
+        },
+        "reward": null,
+        "status": "INACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "actionString": "Rd8",
+          "generate_returns": [
+            "{\n  \"main_response\": \"Final Answer: Rd8\",\n  \"main_response_and_thoughts\": \"\",\n  \"request_for_logging\": {\n    \"model\": \"openai/gpt-5.5-2026-04-23\",\n    \"messages\": [\n      {\n        \"role\": \"user\",\n        \"content\": [\n          {\n            \"type\": \"text\",\n            \"text\": \"Let's play chess. The current game state in Forsyth-Edwards Notation (FEN) notation is:\\nr5k1/1p3p2/p1b1p3/8/3B4/4K1P1/7P/8 b - - 0 36\\nThe moves played so far are:\\n1. e4 c5 2. Nf3 d6 3. d4 cxd4 4. Nxd4 Nf6 5. Nc3 a6 6. Bg5 e6 7. f4 Qb6 8. Qd2 Qxb2 9. Rb1 Qa3 10. e5 dxe5 11. fxe5 Nfd7 12. Ne4 h6 13. Bh4 Qxa2 14. Rd1 Qd5 15. Qe3 Qxe5 16. Be2 Bc5 17. Bg3 Bxd4 18. Rxd4 Qa5+ 19. c3 O-O 20. O-O Nc6 21. Nf6+ Nxf6 22. Rxf6 Nxd4 23. cxd4 gxf6 24. Qxh6 Qg5 25. Qxg5+ fxg5 26. Bd6 Rd8 27. Be7 Rxd4 28. Bxg5 Rd5 29. Bf6 Rf5 30. Bc3 Rc5 31. Bd4 Rc1+ 32. Kf2 Rc2 33. Ke3 Rxe2+ 34. Kxe2 Bd7 35. Ke3 Bc6 36. g3\\nYou are playing as player Black.\\nIt is now your turn. Play your strongest move. The move MUST be legal. Reason step by step to come up with your move, then output your final answer in the format \\\"Final Answer: X\\\" where X is your chosen move in standard algebraic notation (SAN).\\n\"\n          }\n        ]\n      }\n    ],\n    \"config\": {\n      \"temperature\": \"NOT_GIVEN\",\n      \"top_p\": \"NOT_GIVEN\",\n      \"max_completion_tokens\": \"NOT_GIVEN\",\n      \"reasoning_effort\": \"high\"\n    },\n    \"stream_options\": {\n      \"include_usage\": true\n    }\n  },\n  \"response_for_logging\": {\n    \"response_chunks\": [\n      {\n        \"id\": \"chatcmpl-DcMbUyrrnLDuJqKuiUFkQ4Jk6dt42\",\n        \"created\": 1778035724,\n        \"model\": \"openai/gpt-5.5-2026-04-23\",\n        \"object\": \"chat.completion.chunk\",\n        \"usage\": {\n          \"completion_tokens\": 33678,\n          \"prompt_tokens\": 434,\n          \"total_tokens\": 34112,\n          \"cost\": {\n            \"input_tokens_cost_nanodollars\": 2170000,\n            \"output_tokens_cost_nanodollars\": 1010340000\n          },\n          \"total_backend_latency_ms\": 678932\n        }\n      }\n    ]\n  },\n  \"generation_tokens\": 33678,\n  \"prompt_tokens\": 434,\n  \"reasoning_tokens\": null,\n  \"total_tokens\": 34112,\n  \"duration_success_only_secs\": 679.3958816129998\n}"
+          ],
+          "status": "OK",
+          "submission": 32,
+          "thoughts": "Final Answer: Rd8"
+        },
+        "info": {
+          "actionApplied": 32,
+          "actionSubmitted": 32,
+          "actionSubmittedToString": "Rd8",
+          "agentSelfReportedStatus": "OK",
+          "timeTaken": 681.104
+        },
+        "observation": {
+          "currentPlayer": 1,
+          "isTerminal": false,
+          "observationString": "3r2k1/1p3p2/p1b1p3/8/3B4/4K1P1/7P/8 w - - 1 37",
+          "playerId": 0,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n1258\n3572\n1841\n1842\n1431\n3132\n3572\n656\n89\n1215\n2425\n3010\n1808\n1768\n749\n30\n1065\n2571\n1942\n3196\n3131\n1384\n4177\n3854\n381\n615\n498\n1869\n2001\n2977\n2975\n4350\n1431\n1770\n2581\n1257\n4673\n4673\n656\n2627\n1895\n2940\n1386\n1358\n3634\n2528\n254\n4496\n3110\n3705\n2948\n2161\n1771\n2833\n2059\n3853\n2002\n3326\n3166\n1358\n1406\n3561\n1694\n3050\n1637\n2497\n1212\n2425\n1882\n3593\n32\n\n",
+          "step": 73
+        },
+        "reward": null,
+        "status": "INACTIVE"
+      },
+      {
+        "action": {
+          "submission": -1
+        },
+        "info": {},
+        "observation": {
+          "currentPlayer": 1,
+          "isTerminal": false,
+          "observationString": "3r2k1/1p3p2/p1b1p3/8/3B4/4K1P1/7P/8 w - - 1 37",
+          "playerId": 1,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n1258\n3572\n1841\n1842\n1431\n3132\n3572\n656\n89\n1215\n2425\n3010\n1808\n1768\n749\n30\n1065\n2571\n1942\n3196\n3131\n1384\n4177\n3854\n381\n615\n498\n1869\n2001\n2977\n2975\n4350\n1431\n1770\n2581\n1257\n4673\n4673\n656\n2627\n1895\n2940\n1386\n1358\n3634\n2528\n254\n4496\n3110\n3705\n2948\n2161\n1771\n2833\n2059\n3853\n2002\n3326\n3166\n1358\n1406\n3561\n1694\n3050\n1637\n2497\n1212\n2425\n1882\n3593\n32\n\n"
+        },
+        "reward": null,
+        "status": "ACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "submission": -1
+        },
+        "info": {},
+        "observation": {
+          "currentPlayer": 0,
+          "isTerminal": false,
+          "observationString": "3r2k1/1p3p2/p1b1pB2/8/8/4K1P1/7P/8 b - - 2 37",
+          "playerId": 0,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n1258\n3572\n1841\n1842\n1431\n3132\n3572\n656\n89\n1215\n2425\n3010\n1808\n1768\n749\n30\n1065\n2571\n1942\n3196\n3131\n1384\n4177\n3854\n381\n615\n498\n1869\n2001\n2977\n2975\n4350\n1431\n1770\n2581\n1257\n4673\n4673\n656\n2627\n1895\n2940\n1386\n1358\n3634\n2528\n254\n4496\n3110\n3705\n2948\n2161\n1771\n2833\n2059\n3853\n2002\n3326\n3166\n1358\n1406\n3561\n1694\n3050\n1637\n2497\n1212\n2425\n1882\n3593\n32\n2016\n\n",
+          "step": 74
+        },
+        "reward": null,
+        "status": "ACTIVE"
+      },
+      {
+        "action": {
+          "actionString": "Bf6",
+          "generate_returns": [
+            "{\n  \"main_response\": \"The position is completely lost for White, as Black is up a full exchange and two pawns in the endgame (Rook, Bishop, and four pawns against a Bishop and two pawns). White's main goal here is to offer as much resistance as possible and stay active. \\n\\nThe Bishop on d4 is well-placed but currently doing little to restrict Black. Playing the active move **Bf6** improves the Bishop's position, takes control of key dark squares, and importantly attacks Black's Rook on d8, forcing it to immediately respond and slightly disrupting Black's coordination.\\n\\nStep-by-step derivation:\\n1. Identify the material imbalance: White is down an exchange and two pawns. The position is objectively lost.\\n2. Look for active piece play to create any practical difficulties. \\n3. The move Bf6 attacks the undefended rook on d8. \\n4. The f6 square is not attacked by any of Black's pawns or pieces (Black pawns are on e6, f7, a6, b7). \\n5. The move is legal and forces a response from the opponent.\\n\\nFinal Answer: Bf6\",\n  \"main_response_and_thoughts\": \"\",\n  \"request_for_logging\": {\n    \"model\": \"google/gemini-3.1-pro-preview\",\n    \"messages\": [\n      {\n        \"role\": \"user\",\n        \"content\": [\n          {\n            \"type\": \"text\",\n            \"text\": \"Let's play chess. The current game state in Forsyth-Edwards Notation (FEN) notation is:\\n3r2k1/1p3p2/p1b1p3/8/3B4/4K1P1/7P/8 w - - 1 37\\nThe moves played so far are:\\n1. e4 c5 2. Nf3 d6 3. d4 cxd4 4. Nxd4 Nf6 5. Nc3 a6 6. Bg5 e6 7. f4 Qb6 8. Qd2 Qxb2 9. Rb1 Qa3 10. e5 dxe5 11. fxe5 Nfd7 12. Ne4 h6 13. Bh4 Qxa2 14. Rd1 Qd5 15. Qe3 Qxe5 16. Be2 Bc5 17. Bg3 Bxd4 18. Rxd4 Qa5+ 19. c3 O-O 20. O-O Nc6 21. Nf6+ Nxf6 22. Rxf6 Nxd4 23. cxd4 gxf6 24. Qxh6 Qg5 25. Qxg5+ fxg5 26. Bd6 Rd8 27. Be7 Rxd4 28. Bxg5 Rd5 29. Bf6 Rf5 30. Bc3 Rc5 31. Bd4 Rc1+ 32. Kf2 Rc2 33. Ke3 Rxe2+ 34. Kxe2 Bd7 35. Ke3 Bc6 36. g3 Rd8 37.\\nYou are playing as player White.\\nIt is now your turn. Play your strongest move. The move MUST be legal. Reason step by step to come up with your move, then output your final answer in the format \\\"Final Answer: X\\\" where X is your chosen move in standard algebraic notation (SAN).\\n\"\n          }\n        ]\n      }\n    ],\n    \"config\": {\n      \"temperature\": \"NOT_GIVEN\",\n      \"top_p\": \"NOT_GIVEN\",\n      \"max_completion_tokens\": \"NOT_GIVEN\"\n    },\n    \"stream_options\": {\n      \"include_usage\": true\n    }\n  },\n  \"response_for_logging\": {\n    \"response_chunks\": [\n      {\n        \"id\": \"tK76acagLNCfmecP0erHwQ0\",\n        \"choices\": [\n          {\n            \"delta\": {\n              \"content\": \" legal and forces a response from the opponent.\\n\\nFinal Answer: Bf6\",\n              \"role\": \"assistant\"\n            },\n            \"finish_reason\": \"stop\",\n            \"index\": 0\n          }\n        ],\n        \"created\": 1778036404,\n        \"model\": \"google/gemini-3.1-pro-preview\",\n        \"object\": \"chat.completion.chunk\",\n        \"usage\": {\n          \"completion_tokens\": 248,\n          \"prompt_tokens\": 429,\n          \"total_tokens\": 1730,\n          \"cost\": {\n            \"input_tokens_cost_nanodollars\": 858000,\n            \"output_tokens_cost_nanodollars\": 15612000\n          },\n          \"total_backend_latency_ms\": 13831\n        }\n      }\n    ]\n  },\n  \"generation_tokens\": 248,\n  \"prompt_tokens\": 429,\n  \"reasoning_tokens\": null,\n  \"total_tokens\": 1730,\n  \"duration_success_only_secs\": 14.315617288000794\n}"
+          ],
+          "status": "OK",
+          "submission": 2016,
+          "thoughts": "The position is completely lost for White, as Black is up a full exchange and two pawns in the endgame (Rook, Bishop, and four pawns against a Bishop and two pawns). White's main goal here is to offer as much resistance as possible and stay active. \n\nThe Bishop on d4 is well-placed but currently doing little to restrict Black. Playing the active move **Bf6** improves the Bishop's position, takes control of key dark squares, and importantly attacks Black's Rook on d8, forcing it to immediately respond and slightly disrupting Black's coordination.\n\nStep-by-step derivation:\n1. Identify the material imbalance: White is down an exchange and two pawns. The position is objectively lost.\n2. Look for active piece play to create any practical difficulties. \n3. The move Bf6 attacks the undefended rook on d8. \n4. The f6 square is not attacked by any of Black's pawns or pieces (Black pawns are on e6, f7, a6, b7). \n5. The move is legal and forces a response from the opponent.\n\nFinal Answer: Bf6"
+        },
+        "info": {
+          "actionApplied": 2016,
+          "actionSubmitted": 2016,
+          "actionSubmittedToString": "Bf6",
+          "agentSelfReportedStatus": "OK",
+          "timeTaken": 15.545
+        },
+        "observation": {
+          "currentPlayer": 0,
+          "isTerminal": false,
+          "observationString": "3r2k1/1p3p2/p1b1pB2/8/8/4K1P1/7P/8 b - - 2 37",
+          "playerId": 1,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n1258\n3572\n1841\n1842\n1431\n3132\n3572\n656\n89\n1215\n2425\n3010\n1808\n1768\n749\n30\n1065\n2571\n1942\n3196\n3131\n1384\n4177\n3854\n381\n615\n498\n1869\n2001\n2977\n2975\n4350\n1431\n1770\n2581\n1257\n4673\n4673\n656\n2627\n1895\n2940\n1386\n1358\n3634\n2528\n254\n4496\n3110\n3705\n2948\n2161\n1771\n2833\n2059\n3853\n2002\n3326\n3166\n1358\n1406\n3561\n1694\n3050\n1637\n2497\n1212\n2425\n1882\n3593\n32\n2016\n\n"
+        },
+        "reward": null,
+        "status": "INACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "actionString": "Rd5",
+          "generate_returns": [
+            "{\n  \"main_response\": \"The rook on d8 is attacked by White\\u2019s bishop on f6, so Black must move it. The most active and strong choice is to centralize it on a protected square, cutting off the white king and keeping winning chances clear.\\n\\nFinal Answer: Rd5\",\n  \"main_response_and_thoughts\": \"\",\n  \"request_for_logging\": {\n    \"model\": \"openai/gpt-5.5-2026-04-23\",\n    \"messages\": [\n      {\n        \"role\": \"user\",\n        \"content\": [\n          {\n            \"type\": \"text\",\n            \"text\": \"Let's play chess. The current game state in Forsyth-Edwards Notation (FEN) notation is:\\n3r2k1/1p3p2/p1b1pB2/8/8/4K1P1/7P/8 b - - 2 37\\nThe moves played so far are:\\n1. e4 c5 2. Nf3 d6 3. d4 cxd4 4. Nxd4 Nf6 5. Nc3 a6 6. Bg5 e6 7. f4 Qb6 8. Qd2 Qxb2 9. Rb1 Qa3 10. e5 dxe5 11. fxe5 Nfd7 12. Ne4 h6 13. Bh4 Qxa2 14. Rd1 Qd5 15. Qe3 Qxe5 16. Be2 Bc5 17. Bg3 Bxd4 18. Rxd4 Qa5+ 19. c3 O-O 20. O-O Nc6 21. Nf6+ Nxf6 22. Rxf6 Nxd4 23. cxd4 gxf6 24. Qxh6 Qg5 25. Qxg5+ fxg5 26. Bd6 Rd8 27. Be7 Rxd4 28. Bxg5 Rd5 29. Bf6 Rf5 30. Bc3 Rc5 31. Bd4 Rc1+ 32. Kf2 Rc2 33. Ke3 Rxe2+ 34. Kxe2 Bd7 35. Ke3 Bc6 36. g3 Rd8 37. Bf6\\nYou are playing as player Black.\\nIt is now your turn. Play your strongest move. The move MUST be legal. Reason step by step to come up with your move, then output your final answer in the format \\\"Final Answer: X\\\" where X is your chosen move in standard algebraic notation (SAN).\\n\"\n          }\n        ]\n      }\n    ],\n    \"config\": {\n      \"temperature\": \"NOT_GIVEN\",\n      \"top_p\": \"NOT_GIVEN\",\n      \"max_completion_tokens\": \"NOT_GIVEN\",\n      \"reasoning_effort\": \"high\"\n    },\n    \"stream_options\": {\n      \"include_usage\": true\n    }\n  },\n  \"response_for_logging\": {\n    \"response_chunks\": [\n      {\n        \"id\": \"chatcmpl-DcMmiwAIbsdWmuNeFkuPkub8xPbkV\",\n        \"created\": 1778036420,\n        \"model\": \"openai/gpt-5.5-2026-04-23\",\n        \"object\": \"chat.completion.chunk\",\n        \"usage\": {\n          \"completion_tokens\": 12488,\n          \"prompt_tokens\": 442,\n          \"total_tokens\": 12930,\n          \"cost\": {\n            \"input_tokens_cost_nanodollars\": 2210000,\n            \"output_tokens_cost_nanodollars\": 374640000\n          },\n          \"total_backend_latency_ms\": 256713\n        }\n      }\n    ]\n  },\n  \"generation_tokens\": 12488,\n  \"prompt_tokens\": 442,\n  \"reasoning_tokens\": null,\n  \"total_tokens\": 12930,\n  \"duration_success_only_secs\": 257.2139678639978\n}"
+          ],
+          "status": "OK",
+          "submission": 1770,
+          "thoughts": "The rook on d8 is attacked by White\u2019s bishop on f6, so Black must move it. The most active and strong choice is to centralize it on a protected square, cutting off the white king and keeping winning chances clear.\n\nFinal Answer: Rd5"
+        },
+        "info": {
+          "actionApplied": 1770,
+          "actionSubmitted": 1770,
+          "actionSubmittedToString": "Rd5",
+          "agentSelfReportedStatus": "OK",
+          "timeTaken": 258.435
+        },
+        "observation": {
+          "currentPlayer": 1,
+          "isTerminal": false,
+          "observationString": "6k1/1p3p2/p1b1pB2/3r4/8/4K1P1/7P/8 w - - 3 38",
+          "playerId": 0,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n1258\n3572\n1841\n1842\n1431\n3132\n3572\n656\n89\n1215\n2425\n3010\n1808\n1768\n749\n30\n1065\n2571\n1942\n3196\n3131\n1384\n4177\n3854\n381\n615\n498\n1869\n2001\n2977\n2975\n4350\n1431\n1770\n2581\n1257\n4673\n4673\n656\n2627\n1895\n2940\n1386\n1358\n3634\n2528\n254\n4496\n3110\n3705\n2948\n2161\n1771\n2833\n2059\n3853\n2002\n3326\n3166\n1358\n1406\n3561\n1694\n3050\n1637\n2497\n1212\n2425\n1882\n3593\n32\n2016\n1770\n\n",
+          "step": 75
+        },
+        "reward": null,
+        "status": "INACTIVE"
+      },
+      {
+        "action": {
+          "submission": -1
+        },
+        "info": {},
+        "observation": {
+          "currentPlayer": 1,
+          "isTerminal": false,
+          "observationString": "6k1/1p3p2/p1b1pB2/3r4/8/4K1P1/7P/8 w - - 3 38",
+          "playerId": 1,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n1258\n3572\n1841\n1842\n1431\n3132\n3572\n656\n89\n1215\n2425\n3010\n1808\n1768\n749\n30\n1065\n2571\n1942\n3196\n3131\n1384\n4177\n3854\n381\n615\n498\n1869\n2001\n2977\n2975\n4350\n1431\n1770\n2581\n1257\n4673\n4673\n656\n2627\n1895\n2940\n1386\n1358\n3634\n2528\n254\n4496\n3110\n3705\n2948\n2161\n1771\n2833\n2059\n3853\n2002\n3326\n3166\n1358\n1406\n3561\n1694\n3050\n1637\n2497\n1212\n2425\n1882\n3593\n32\n2016\n1770\n\n"
+        },
+        "reward": null,
+        "status": "ACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "submission": -1
+        },
+        "info": {},
+        "observation": {
+          "currentPlayer": 0,
+          "isTerminal": false,
+          "observationString": "6k1/1p3p2/p1b1pB2/3r4/6P1/4K3/7P/8 b - - 0 38",
+          "playerId": 0,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n1258\n3572\n1841\n1842\n1431\n3132\n3572\n656\n89\n1215\n2425\n3010\n1808\n1768\n749\n30\n1065\n2571\n1942\n3196\n3131\n1384\n4177\n3854\n381\n615\n498\n1869\n2001\n2977\n2975\n4350\n1431\n1770\n2581\n1257\n4673\n4673\n656\n2627\n1895\n2940\n1386\n1358\n3634\n2528\n254\n4496\n3110\n3705\n2948\n2161\n1771\n2833\n2059\n3853\n2002\n3326\n3166\n1358\n1406\n3561\n1694\n3050\n1637\n2497\n1212\n2425\n1882\n3593\n32\n2016\n1770\n3666\n\n",
+          "step": 76
+        },
+        "reward": null,
+        "status": "ACTIVE"
+      },
+      {
+        "action": {
+          "actionString": "g4",
+          "generate_returns": [
+            "{\n  \"main_response\": \"To determine the best move, we should evaluate the current position. White is at a significant material disadvantage (down a Rook and two pawns), so the objective is to put up the maximum possible resistance by keeping our remaining pieces as active and annoying as possible.\\n\\n1. **Assess White's strongest asset:** White's dark-squared Bishop is exceptionally placed on the f6 outpost. It completely restricts the Black King to the corner and controls crucial dark squares in Black's territory. \\n2. **Identify Black's plans to untangle:** The most natural and straightforward way for Black to dislodge White's powerful Bishop and activate their own King is to play the Rook to f5 (`...Rf5`), attacking the f6 Bishop and forcing it to retreat to a less active square.\\n3. **Find the best preventative measure:** By pushing the pawn to **g4**, White permanently controls the f5 square, completely stopping Black from playing `...Rf5`. \\n4. **Secondary benefits:** The move `g4` anchors the kingside structure and prepares the way to push the h-pawn (`h4-h5`), which is White's only realistic source of generating counterplay or trying to create a passed pawn on the kingside. \\n\\nOther King or Bishop moves would surrender the f6 outpost and passively allow Black to consolidate their massive advantage without a fight.\\n\\nFinal Answer: g4\",\n  \"main_response_and_thoughts\": \"\",\n  \"request_for_logging\": {\n    \"model\": \"google/gemini-3.1-pro-preview\",\n    \"messages\": [\n      {\n        \"role\": \"user\",\n        \"content\": [\n          {\n            \"type\": \"text\",\n            \"text\": \"Let's play chess. The current game state in Forsyth-Edwards Notation (FEN) notation is:\\n6k1/1p3p2/p1b1pB2/3r4/8/4K1P1/7P/8 w - - 3 38\\nThe moves played so far are:\\n1. e4 c5 2. Nf3 d6 3. d4 cxd4 4. Nxd4 Nf6 5. Nc3 a6 6. Bg5 e6 7. f4 Qb6 8. Qd2 Qxb2 9. Rb1 Qa3 10. e5 dxe5 11. fxe5 Nfd7 12. Ne4 h6 13. Bh4 Qxa2 14. Rd1 Qd5 15. Qe3 Qxe5 16. Be2 Bc5 17. Bg3 Bxd4 18. Rxd4 Qa5+ 19. c3 O-O 20. O-O Nc6 21. Nf6+ Nxf6 22. Rxf6 Nxd4 23. cxd4 gxf6 24. Qxh6 Qg5 25. Qxg5+ fxg5 26. Bd6 Rd8 27. Be7 Rxd4 28. Bxg5 Rd5 29. Bf6 Rf5 30. Bc3 Rc5 31. Bd4 Rc1+ 32. Kf2 Rc2 33. Ke3 Rxe2+ 34. Kxe2 Bd7 35. Ke3 Bc6 36. g3 Rd8 37. Bf6 Rd5 38.\\nYou are playing as player White.\\nIt is now your turn. Play your strongest move. The move MUST be legal. Reason step by step to come up with your move, then output your final answer in the format \\\"Final Answer: X\\\" where X is your chosen move in standard algebraic notation (SAN).\\n\"\n          }\n        ]\n      }\n    ],\n    \"config\": {\n      \"temperature\": \"NOT_GIVEN\",\n      \"top_p\": \"NOT_GIVEN\",\n      \"max_completion_tokens\": \"NOT_GIVEN\"\n    },\n    \"stream_options\": {\n      \"include_usage\": true\n    }\n  },\n  \"response_for_logging\": {\n    \"response_chunks\": [\n      {\n        \"id\": \"xq_6acuCKo-SmecPifn04Ak\",\n        \"choices\": [\n          {\n            \"delta\": {\n              \"content\": \" would surrender the f6 outpost and passively allow Black to consolidate their massive advantage without a fight.\\n\\nFinal Answer: g4\",\n              \"role\": \"assistant\"\n            },\n            \"finish_reason\": \"stop\",\n            \"index\": 0\n          }\n        ],\n        \"created\": 1778036678,\n        \"model\": \"google/gemini-3.1-pro-preview\",\n        \"object\": \"chat.completion.chunk\",\n        \"usage\": {\n          \"completion_tokens\": 293,\n          \"prompt_tokens\": 436,\n          \"total_tokens\": 5216,\n          \"cost\": {\n            \"input_tokens_cost_nanodollars\": 872000,\n            \"output_tokens_cost_nanodollars\": 57360000\n          },\n          \"total_backend_latency_ms\": 40729\n        }\n      }\n    ]\n  },\n  \"generation_tokens\": 293,\n  \"prompt_tokens\": 436,\n  \"reasoning_tokens\": null,\n  \"total_tokens\": 5216,\n  \"duration_success_only_secs\": 41.269276672999695\n}"
+          ],
+          "status": "OK",
+          "submission": 3666,
+          "thoughts": "To determine the best move, we should evaluate the current position. White is at a significant material disadvantage (down a Rook and two pawns), so the objective is to put up the maximum possible resistance by keeping our remaining pieces as active and annoying as possible.\n\n1. **Assess White's strongest asset:** White's dark-squared Bishop is exceptionally placed on the f6 outpost. It completely restricts the Black King to the corner and controls crucial dark squares in Black's territory. \n2. **Identify Black's plans to untangle:** The most natural and straightforward way for Black to dislodge White's powerful Bishop and activate their own King is to play the Rook to f5 (`...Rf5`), attacking the f6 Bishop and forcing it to retreat to a less active square.\n3. **Find the best preventative measure:** By pushing the pawn to **g4**, White permanently controls the f5 square, completely stopping Black from playing `...Rf5`. \n4. **Secondary benefits:** The move `g4` anchors the kingside structure and prepares the way to push the h-pawn (`h4-h5`), which is White's only realistic source of generating counterplay or trying to create a passed pawn on the kingside. \n\nOther King or Bishop moves would surrender the f6 outpost and passively allow Black to consolidate their massive advantage without a fight.\n\nFinal Answer: g4"
+        },
+        "info": {
+          "actionApplied": 3666,
+          "actionSubmitted": 3666,
+          "actionSubmittedToString": "g4",
+          "agentSelfReportedStatus": "OK",
+          "timeTaken": 42.505
+        },
+        "observation": {
+          "currentPlayer": 0,
+          "isTerminal": false,
+          "observationString": "6k1/1p3p2/p1b1pB2/3r4/6P1/4K3/7P/8 b - - 0 38",
+          "playerId": 1,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n1258\n3572\n1841\n1842\n1431\n3132\n3572\n656\n89\n1215\n2425\n3010\n1808\n1768\n749\n30\n1065\n2571\n1942\n3196\n3131\n1384\n4177\n3854\n381\n615\n498\n1869\n2001\n2977\n2975\n4350\n1431\n1770\n2581\n1257\n4673\n4673\n656\n2627\n1895\n2940\n1386\n1358\n3634\n2528\n254\n4496\n3110\n3705\n2948\n2161\n1771\n2833\n2059\n3853\n2002\n3326\n3166\n1358\n1406\n3561\n1694\n3050\n1637\n2497\n1212\n2425\n1882\n3593\n32\n2016\n1770\n3666\n\n"
+        },
+        "reward": null,
+        "status": "INACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "actionString": "e5",
+          "generate_returns": [
+            "{\n  \"main_response\": \"The strongest move is to advance the e-pawn, clamping the white king and making the pawn tactically protected: if White plays Bxe5, Black can reply Rxe5+ and win the bishop.\\n\\nFinal Answer: e5\",\n  \"main_response_and_thoughts\": \"\",\n  \"request_for_logging\": {\n    \"model\": \"openai/gpt-5.5-2026-04-23\",\n    \"messages\": [\n      {\n        \"role\": \"user\",\n        \"content\": [\n          {\n            \"type\": \"text\",\n            \"text\": \"Let's play chess. The current game state in Forsyth-Edwards Notation (FEN) notation is:\\n6k1/1p3p2/p1b1pB2/3r4/6P1/4K3/7P/8 b - - 0 38\\nThe moves played so far are:\\n1. e4 c5 2. Nf3 d6 3. d4 cxd4 4. Nxd4 Nf6 5. Nc3 a6 6. Bg5 e6 7. f4 Qb6 8. Qd2 Qxb2 9. Rb1 Qa3 10. e5 dxe5 11. fxe5 Nfd7 12. Ne4 h6 13. Bh4 Qxa2 14. Rd1 Qd5 15. Qe3 Qxe5 16. Be2 Bc5 17. Bg3 Bxd4 18. Rxd4 Qa5+ 19. c3 O-O 20. O-O Nc6 21. Nf6+ Nxf6 22. Rxf6 Nxd4 23. cxd4 gxf6 24. Qxh6 Qg5 25. Qxg5+ fxg5 26. Bd6 Rd8 27. Be7 Rxd4 28. Bxg5 Rd5 29. Bf6 Rf5 30. Bc3 Rc5 31. Bd4 Rc1+ 32. Kf2 Rc2 33. Ke3 Rxe2+ 34. Kxe2 Bd7 35. Ke3 Bc6 36. g3 Rd8 37. Bf6 Rd5 38. g4\\nYou are playing as player Black.\\nIt is now your turn. Play your strongest move. The move MUST be legal. Reason step by step to come up with your move, then output your final answer in the format \\\"Final Answer: X\\\" where X is your chosen move in standard algebraic notation (SAN).\\n\"\n          }\n        ]\n      }\n    ],\n    \"config\": {\n      \"temperature\": \"NOT_GIVEN\",\n      \"top_p\": \"NOT_GIVEN\",\n      \"max_completion_tokens\": \"NOT_GIVEN\",\n      \"reasoning_effort\": \"high\"\n    },\n    \"stream_options\": {\n      \"include_usage\": true\n    }\n  },\n  \"response_for_logging\": {\n    \"response_chunks\": [\n      {\n        \"id\": \"chatcmpl-DcMrZTWxizZbNPpCI4oa5c0TFKuqS\",\n        \"created\": 1778036721,\n        \"model\": \"openai/gpt-5.5-2026-04-23\",\n        \"object\": \"chat.completion.chunk\",\n        \"usage\": {\n          \"completion_tokens\": 16627,\n          \"prompt_tokens\": 449,\n          \"total_tokens\": 17076,\n          \"cost\": {\n            \"input_tokens_cost_nanodollars\": 2245000,\n            \"output_tokens_cost_nanodollars\": 498810000\n          },\n          \"total_backend_latency_ms\": 324776\n        }\n      }\n    ]\n  },\n  \"generation_tokens\": 16627,\n  \"prompt_tokens\": 449,\n  \"reasoning_tokens\": null,\n  \"total_tokens\": 17076,\n  \"duration_success_only_secs\": 325.2703152110007\n}"
+          ],
+          "status": "OK",
+          "submission": 2498,
+          "thoughts": "The strongest move is to advance the e-pawn, clamping the white king and making the pawn tactically protected: if White plays Bxe5, Black can reply Rxe5+ and win the bishop.\n\nFinal Answer: e5"
+        },
+        "info": {
+          "actionApplied": 2498,
+          "actionSubmitted": 2498,
+          "actionSubmittedToString": "e5",
+          "agentSelfReportedStatus": "OK",
+          "timeTaken": 326.443
+        },
+        "observation": {
+          "currentPlayer": 1,
+          "isTerminal": false,
+          "observationString": "6k1/1p3p2/p1b2B2/3rp3/6P1/4K3/7P/8 w - - 0 39",
+          "playerId": 0,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n1258\n3572\n1841\n1842\n1431\n3132\n3572\n656\n89\n1215\n2425\n3010\n1808\n1768\n749\n30\n1065\n2571\n1942\n3196\n3131\n1384\n4177\n3854\n381\n615\n498\n1869\n2001\n2977\n2975\n4350\n1431\n1770\n2581\n1257\n4673\n4673\n656\n2627\n1895\n2940\n1386\n1358\n3634\n2528\n254\n4496\n3110\n3705\n2948\n2161\n1771\n2833\n2059\n3853\n2002\n3326\n3166\n1358\n1406\n3561\n1694\n3050\n1637\n2497\n1212\n2425\n1882\n3593\n32\n2016\n1770\n3666\n2498\n\n",
+          "step": 77
+        },
+        "reward": null,
+        "status": "INACTIVE"
+      },
+      {
+        "action": {
+          "submission": -1
+        },
+        "info": {},
+        "observation": {
+          "currentPlayer": 1,
+          "isTerminal": false,
+          "observationString": "6k1/1p3p2/p1b2B2/3rp3/6P1/4K3/7P/8 w - - 0 39",
+          "playerId": 1,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n1258\n3572\n1841\n1842\n1431\n3132\n3572\n656\n89\n1215\n2425\n3010\n1808\n1768\n749\n30\n1065\n2571\n1942\n3196\n3131\n1384\n4177\n3854\n381\n615\n498\n1869\n2001\n2977\n2975\n4350\n1431\n1770\n2581\n1257\n4673\n4673\n656\n2627\n1895\n2940\n1386\n1358\n3634\n2528\n254\n4496\n3110\n3705\n2948\n2161\n1771\n2833\n2059\n3853\n2002\n3326\n3166\n1358\n1406\n3561\n1694\n3050\n1637\n2497\n1212\n2425\n1882\n3593\n32\n2016\n1770\n3666\n2498\n\n"
+        },
+        "reward": null,
+        "status": "ACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "submission": -1
+        },
+        "info": {},
+        "observation": {
+          "currentPlayer": 0,
+          "isTerminal": false,
+          "observationString": "6k1/1p3p2/p1b2B2/3rp3/6PP/4K3/8/8 b - - 0 39",
+          "playerId": 0,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n1258\n3572\n1841\n1842\n1431\n3132\n3572\n656\n89\n1215\n2425\n3010\n1808\n1768\n749\n30\n1065\n2571\n1942\n3196\n3131\n1384\n4177\n3854\n381\n615\n498\n1869\n2001\n2977\n2975\n4350\n1431\n1770\n2581\n1257\n4673\n4673\n656\n2627\n1895\n2940\n1386\n1358\n3634\n2528\n254\n4496\n3110\n3705\n2948\n2161\n1771\n2833\n2059\n3853\n2002\n3326\n3166\n1358\n1406\n3561\n1694\n3050\n1637\n2497\n1212\n2425\n1882\n3593\n32\n2016\n1770\n3666\n2498\n4178\n\n",
+          "step": 78
+        },
+        "reward": null,
+        "status": "ACTIVE"
+      },
+      {
+        "action": {
+          "actionString": "h4",
+          "generate_returns": [
+            "{\n  \"main_response\": \"To find the best move, we should evaluate the position and formulate a plan to maximize White's resistance in this endgame. White is currently down a full exchange (Rook for a Bishop) and several pawns, making the position objectively lost, but White must strive to create as much practical difficulty for Black as possible by coordinating the remaining pieces and pawns.\\n\\n1. **Evaluate the Pawn Structure**: White's only remaining pawns are on g4 and h2. To prevent them from being easily picked off by Black's rook, White needs to coordinate them so they can defend each other or control important squares. \\n2. **Comparing Options**: \\n   - If White plays `1. g5` immediately to defend the Bishop on f6, Black can respond with an attack on the undefended h2 pawn via `1... Rd3+ 2. Ke2 Rh3`. If White then tries to push `3. h4`, the pawn on h4 is completely undefended and falls to `3... Rxh4`. \\n   - Instead, pushing `1. h4` is significantly more flexible and resilient. It supports the g4 pawn and prepares to meet Black's threats appropriately. \\n\\n3. **Reacting to Black's Plans**: \\n   - If Black attacks the f6 Bishop with `1... Rd6`, White can then comfortably push `2. g5`. The pawn on g5 will defend the Bishop on f6, and simultaneously, the g5 pawn will be defended by the pawn on h4. \\n   - If Black tries to attack the pawns from behind with `1... Rd3+ 2. Ke2 Rh3`, White has the excellent resource `3. h5!`. In this setup, the pawn on h5 is perfectly defended by the pawn on g4, effectively creating a miniature fortress on the kingside that is difficult for Black to break through without giving up their positional advantages. \\n\\nPushing the h-pawn is the most principled way to secure White's kingside structure and prolong the game.\\n\\nFinal Answer: h4\",\n  \"main_response_and_thoughts\": \"\",\n  \"request_for_logging\": {\n    \"model\": \"google/gemini-3.1-pro-preview\",\n    \"messages\": [\n      {\n        \"role\": \"user\",\n        \"content\": [\n          {\n            \"type\": \"text\",\n            \"text\": \"Let's play chess. The current game state in Forsyth-Edwards Notation (FEN) notation is:\\n6k1/1p3p2/p1b2B2/3rp3/6P1/4K3/7P/8 w - - 0 39\\nThe moves played so far are:\\n1. e4 c5 2. Nf3 d6 3. d4 cxd4 4. Nxd4 Nf6 5. Nc3 a6 6. Bg5 e6 7. f4 Qb6 8. Qd2 Qxb2 9. Rb1 Qa3 10. e5 dxe5 11. fxe5 Nfd7 12. Ne4 h6 13. Bh4 Qxa2 14. Rd1 Qd5 15. Qe3 Qxe5 16. Be2 Bc5 17. Bg3 Bxd4 18. Rxd4 Qa5+ 19. c3 O-O 20. O-O Nc6 21. Nf6+ Nxf6 22. Rxf6 Nxd4 23. cxd4 gxf6 24. Qxh6 Qg5 25. Qxg5+ fxg5 26. Bd6 Rd8 27. Be7 Rxd4 28. Bxg5 Rd5 29. Bf6 Rf5 30. Bc3 Rc5 31. Bd4 Rc1+ 32. Kf2 Rc2 33. Ke3 Rxe2+ 34. Kxe2 Bd7 35. Ke3 Bc6 36. g3 Rd8 37. Bf6 Rd5 38. g4 e5 39.\\nYou are playing as player White.\\nIt is now your turn. Play your strongest move. The move MUST be legal. Reason step by step to come up with your move, then output your final answer in the format \\\"Final Answer: X\\\" where X is your chosen move in standard algebraic notation (SAN).\\n\"\n          }\n        ]\n      }\n    ],\n    \"config\": {\n      \"temperature\": \"NOT_GIVEN\",\n      \"top_p\": \"NOT_GIVEN\",\n      \"max_completion_tokens\": \"NOT_GIVEN\"\n    },\n    \"stream_options\": {\n      \"include_usage\": true\n    }\n  },\n  \"response_for_logging\": {\n    \"response_chunks\": [\n      {\n        \"id\": \"N7H6abT0JrWKmecPxOar6Aw\",\n        \"choices\": [\n          {\n            \"delta\": {\n              \"content\": \"4\",\n              \"role\": \"assistant\"\n            },\n            \"finish_reason\": \"stop\",\n            \"index\": 0\n          }\n        ],\n        \"created\": 1778037047,\n        \"model\": \"google/gemini-3.1-pro-preview\",\n        \"object\": \"chat.completion.chunk\",\n        \"usage\": {\n          \"completion_tokens\": 440,\n          \"prompt_tokens\": 443,\n          \"total_tokens\": 6016,\n          \"cost\": {\n            \"input_tokens_cost_nanodollars\": 886000,\n            \"output_tokens_cost_nanodollars\": 66876000\n          },\n          \"total_backend_latency_ms\": 51811\n        }\n      }\n    ]\n  },\n  \"generation_tokens\": 440,\n  \"prompt_tokens\": 443,\n  \"reasoning_tokens\": null,\n  \"total_tokens\": 6016,\n  \"duration_success_only_secs\": 52.314407023997774\n}"
+          ],
+          "status": "OK",
+          "submission": 4178,
+          "thoughts": "To find the best move, we should evaluate the position and formulate a plan to maximize White's resistance in this endgame. White is currently down a full exchange (Rook for a Bishop) and several pawns, making the position objectively lost, but White must strive to create as much practical difficulty for Black as possible by coordinating the remaining pieces and pawns.\n\n1. **Evaluate the Pawn Structure**: White's only remaining pawns are on g4 and h2. To prevent them from being easily picked off by Black's rook, White needs to coordinate them so they can defend each other or control important squares. \n2. **Comparing Options**: \n   - If White plays `1. g5` immediately to defend the Bishop on f6, Black can respond with an attack on the undefended h2 pawn via `1... Rd3+ 2. Ke2 Rh3`. If White then tries to push `3. h4`, the pawn on h4 is completely undefended and falls to `3... Rxh4`. \n   - Instead, pushing `1. h4` is significantly more flexible and resilient. It supports the g4 pawn and prepares to meet Black's threats appropriately. \n\n3. **Reacting to Black's Plans**: \n   - If Black attacks the f6 Bishop with `1... Rd6`, White can then comfortably push `2. g5`. The pawn on g5 will defend the Bishop on f6, and simultaneously, the g5 pawn will be defended by the pawn on h4. \n   - If Black tries to attack the pawns from behind with `1... Rd3+ 2. Ke2 Rh3`, White has the excellent resource `3. h5!`. In this setup, the pawn on h5 is perfectly defended by the pawn on g4, effectively creating a miniature fortress on the kingside that is difficult for Black to break through without giving up their positional advantages. \n\nPushing the h-pawn is the most principled way to secure White's kingside structure and prolong the game.\n\nFinal Answer: h4"
+        },
+        "info": {
+          "actionApplied": 4178,
+          "actionSubmitted": 4178,
+          "actionSubmittedToString": "h4",
+          "agentSelfReportedStatus": "OK",
+          "timeTaken": 53.545
+        },
+        "observation": {
+          "currentPlayer": 0,
+          "isTerminal": false,
+          "observationString": "6k1/1p3p2/p1b2B2/3rp3/6PP/4K3/8/8 b - - 0 39",
+          "playerId": 1,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n1258\n3572\n1841\n1842\n1431\n3132\n3572\n656\n89\n1215\n2425\n3010\n1808\n1768\n749\n30\n1065\n2571\n1942\n3196\n3131\n1384\n4177\n3854\n381\n615\n498\n1869\n2001\n2977\n2975\n4350\n1431\n1770\n2581\n1257\n4673\n4673\n656\n2627\n1895\n2940\n1386\n1358\n3634\n2528\n254\n4496\n3110\n3705\n2948\n2161\n1771\n2833\n2059\n3853\n2002\n3326\n3166\n1358\n1406\n3561\n1694\n3050\n1637\n2497\n1212\n2425\n1882\n3593\n32\n2016\n1770\n3666\n2498\n4178\n\n"
+        },
+        "reward": null,
+        "status": "INACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "actionString": "e4",
+          "generate_returns": [
+            "{\n  \"main_response\": \"Final Answer: e4\",\n  \"main_response_and_thoughts\": \"\",\n  \"request_for_logging\": {\n    \"model\": \"openai/gpt-5.5-2026-04-23\",\n    \"messages\": [\n      {\n        \"role\": \"user\",\n        \"content\": [\n          {\n            \"type\": \"text\",\n            \"text\": \"Let's play chess. The current game state in Forsyth-Edwards Notation (FEN) notation is:\\n6k1/1p3p2/p1b2B2/3rp3/6PP/4K3/8/8 b - - 0 39\\nThe moves played so far are:\\n1. e4 c5 2. Nf3 d6 3. d4 cxd4 4. Nxd4 Nf6 5. Nc3 a6 6. Bg5 e6 7. f4 Qb6 8. Qd2 Qxb2 9. Rb1 Qa3 10. e5 dxe5 11. fxe5 Nfd7 12. Ne4 h6 13. Bh4 Qxa2 14. Rd1 Qd5 15. Qe3 Qxe5 16. Be2 Bc5 17. Bg3 Bxd4 18. Rxd4 Qa5+ 19. c3 O-O 20. O-O Nc6 21. Nf6+ Nxf6 22. Rxf6 Nxd4 23. cxd4 gxf6 24. Qxh6 Qg5 25. Qxg5+ fxg5 26. Bd6 Rd8 27. Be7 Rxd4 28. Bxg5 Rd5 29. Bf6 Rf5 30. Bc3 Rc5 31. Bd4 Rc1+ 32. Kf2 Rc2 33. Ke3 Rxe2+ 34. Kxe2 Bd7 35. Ke3 Bc6 36. g3 Rd8 37. Bf6 Rd5 38. g4 e5 39. h4\\nYou are playing as player Black.\\nIt is now your turn. Play your strongest move. The move MUST be legal. Reason step by step to come up with your move, then output your final answer in the format \\\"Final Answer: X\\\" where X is your chosen move in standard algebraic notation (SAN).\\n\"\n          }\n        ]\n      }\n    ],\n    \"config\": {\n      \"temperature\": \"NOT_GIVEN\",\n      \"top_p\": \"NOT_GIVEN\",\n      \"max_completion_tokens\": \"NOT_GIVEN\",\n      \"reasoning_effort\": \"high\"\n    },\n    \"stream_options\": {\n      \"include_usage\": true\n    }\n  },\n  \"response_for_logging\": {\n    \"response_chunks\": [\n      {\n        \"id\": \"chatcmpl-DcMy8Mb2bNgU4bnSBbUQay7sAg4e3\",\n        \"created\": 1778037128,\n        \"model\": \"openai/gpt-5.5-2026-04-23\",\n        \"object\": \"chat.completion.chunk\",\n        \"usage\": {\n          \"completion_tokens\": 4152,\n          \"prompt_tokens\": 453,\n          \"total_tokens\": 4605,\n          \"cost\": {\n            \"input_tokens_cost_nanodollars\": 2265000,\n            \"output_tokens_cost_nanodollars\": 124560000\n          },\n          \"total_backend_latency_ms\": 82933\n        }\n      }\n    ]\n  },\n  \"generation_tokens\": 4152,\n  \"prompt_tokens\": 453,\n  \"reasoning_tokens\": null,\n  \"total_tokens\": 4605,\n  \"duration_success_only_secs\": 110.115834420998\n}"
+          ],
+          "status": "OK",
+          "submission": 2571,
+          "thoughts": "Final Answer: e4"
+        },
+        "info": {
+          "actionApplied": 2571,
+          "actionSubmitted": 2571,
+          "actionSubmittedToString": "e4",
+          "agentSelfReportedStatus": "OK",
+          "timeTaken": 111.328
+        },
+        "observation": {
+          "currentPlayer": 1,
+          "isTerminal": false,
+          "observationString": "6k1/1p3p2/p1b2B2/3r4/4p1PP/4K3/8/8 w - - 0 40",
+          "playerId": 0,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n1258\n3572\n1841\n1842\n1431\n3132\n3572\n656\n89\n1215\n2425\n3010\n1808\n1768\n749\n30\n1065\n2571\n1942\n3196\n3131\n1384\n4177\n3854\n381\n615\n498\n1869\n2001\n2977\n2975\n4350\n1431\n1770\n2581\n1257\n4673\n4673\n656\n2627\n1895\n2940\n1386\n1358\n3634\n2528\n254\n4496\n3110\n3705\n2948\n2161\n1771\n2833\n2059\n3853\n2002\n3326\n3166\n1358\n1406\n3561\n1694\n3050\n1637\n2497\n1212\n2425\n1882\n3593\n32\n2016\n1770\n3666\n2498\n4178\n2571\n\n",
+          "step": 79
+        },
+        "reward": null,
+        "status": "INACTIVE"
+      },
+      {
+        "action": {
+          "submission": -1
+        },
+        "info": {},
+        "observation": {
+          "currentPlayer": 1,
+          "isTerminal": false,
+          "observationString": "6k1/1p3p2/p1b2B2/3r4/4p1PP/4K3/8/8 w - - 0 40",
+          "playerId": 1,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n1258\n3572\n1841\n1842\n1431\n3132\n3572\n656\n89\n1215\n2425\n3010\n1808\n1768\n749\n30\n1065\n2571\n1942\n3196\n3131\n1384\n4177\n3854\n381\n615\n498\n1869\n2001\n2977\n2975\n4350\n1431\n1770\n2581\n1257\n4673\n4673\n656\n2627\n1895\n2940\n1386\n1358\n3634\n2528\n254\n4496\n3110\n3705\n2948\n2161\n1771\n2833\n2059\n3853\n2002\n3326\n3166\n1358\n1406\n3561\n1694\n3050\n1637\n2497\n1212\n2425\n1882\n3593\n32\n2016\n1770\n3666\n2498\n4178\n2571\n\n"
+        },
+        "reward": null,
+        "status": "ACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "submission": -1
+        },
+        "info": {},
+        "observation": {
+          "currentPlayer": 0,
+          "isTerminal": false,
+          "observationString": "6k1/1p3p2/p1b2B2/3r4/4K1PP/8/8/8 b - - 0 40",
+          "playerId": 0,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n1258\n3572\n1841\n1842\n1431\n3132\n3572\n656\n89\n1215\n2425\n3010\n1808\n1768\n749\n30\n1065\n2571\n1942\n3196\n3131\n1384\n4177\n3854\n381\n615\n498\n1869\n2001\n2977\n2975\n4350\n1431\n1770\n2581\n1257\n4673\n4673\n656\n2627\n1895\n2940\n1386\n1358\n3634\n2528\n254\n4496\n3110\n3705\n2948\n2161\n1771\n2833\n2059\n3853\n2002\n3326\n3166\n1358\n1406\n3561\n1694\n3050\n1637\n2497\n1212\n2425\n1882\n3593\n32\n2016\n1770\n3666\n2498\n4178\n2571\n2498\n\n",
+          "step": 80
+        },
+        "reward": null,
+        "status": "ACTIVE"
+      },
+      {
+        "action": {
+          "actionString": "Kxe4",
+          "generate_returns": [
+            "{\n  \"main_response\": \"To determine the best move, let's analyze the current position and the consequences of the last move played by Black (39... e4). \\n\\nBlack pushed their pawn to e4, likely assuming that it was protected by their light-squared bishop on c6. However, if we look closely at the a8-h1 diagonal (which the c6 bishop controls), the squares are c6, d5, e4, f3, g2, and h1. Black's own rook is currently sitting on the d5 square, completely blocking the bishop's line of sight to the e4 pawn! \\n\\nAdditionally, a rook moves in straight files and ranks, meaning the d5 rook controls the 5th rank and the d-file, but it does not protect the e4 square (which is a diagonal knight-step away). \\n\\nSince there are no other pieces defending this pawn, the e4 pawn is completely hanging. \\n\\nAs White, you are in a tough endgame where Black has a massive material advantage. Black's most dangerous immediate threat was this rolling passed e-pawn that was marching towards promotion. By playing **Kxe4**, you not only take a free pawn and eliminate Black's most dangerous asset, but you also force Black to reposition. \\n\\nWhile taking the pawn aligns your King with Black's c6 Bishop (allowing a discovered check when the d5 Rook moves), it is perfectly safe. Your King will have safe squares to escape to once the check is delivered (e.g., if 1... Rd6+, you can simply reply with 2. Kf4).\\n\\nFinal Answer: Kxe4\",\n  \"main_response_and_thoughts\": \"\",\n  \"request_for_logging\": {\n    \"model\": \"google/gemini-3.1-pro-preview\",\n    \"messages\": [\n      {\n        \"role\": \"user\",\n        \"content\": [\n          {\n            \"type\": \"text\",\n            \"text\": \"Let's play chess. The current game state in Forsyth-Edwards Notation (FEN) notation is:\\n6k1/1p3p2/p1b2B2/3r4/4p1PP/4K3/8/8 w - - 0 40\\nThe moves played so far are:\\n1. e4 c5 2. Nf3 d6 3. d4 cxd4 4. Nxd4 Nf6 5. Nc3 a6 6. Bg5 e6 7. f4 Qb6 8. Qd2 Qxb2 9. Rb1 Qa3 10. e5 dxe5 11. fxe5 Nfd7 12. Ne4 h6 13. Bh4 Qxa2 14. Rd1 Qd5 15. Qe3 Qxe5 16. Be2 Bc5 17. Bg3 Bxd4 18. Rxd4 Qa5+ 19. c3 O-O 20. O-O Nc6 21. Nf6+ Nxf6 22. Rxf6 Nxd4 23. cxd4 gxf6 24. Qxh6 Qg5 25. Qxg5+ fxg5 26. Bd6 Rd8 27. Be7 Rxd4 28. Bxg5 Rd5 29. Bf6 Rf5 30. Bc3 Rc5 31. Bd4 Rc1+ 32. Kf2 Rc2 33. Ke3 Rxe2+ 34. Kxe2 Bd7 35. Ke3 Bc6 36. g3 Rd8 37. Bf6 Rd5 38. g4 e5 39. h4 e4 40.\\nYou are playing as player White.\\nIt is now your turn. Play your strongest move. The move MUST be legal. Reason step by step to come up with your move, then output your final answer in the format \\\"Final Answer: X\\\" where X is your chosen move in standard algebraic notation (SAN).\\n\"\n          }\n        ]\n      }\n    ],\n    \"config\": {\n      \"temperature\": \"NOT_GIVEN\",\n      \"top_p\": \"NOT_GIVEN\",\n      \"max_completion_tokens\": \"NOT_GIVEN\"\n    },\n    \"stream_options\": {\n      \"include_usage\": true\n    }\n  },\n  \"response_for_logging\": {\n    \"response_chunks\": [\n      {\n        \"id\": \"3LH6abCZIY-SmecPifn04Ak\",\n        \"choices\": [\n          {\n            \"delta\": {\n              \"content\": \" reply with 2. Kf4).\\n\\nFinal Answer: Kxe4\",\n              \"role\": \"assistant\"\n            },\n            \"finish_reason\": \"stop\",\n            \"index\": 0\n          }\n        ],\n        \"created\": 1778037212,\n        \"model\": \"google/gemini-3.1-pro-preview\",\n        \"object\": \"chat.completion.chunk\",\n        \"usage\": {\n          \"completion_tokens\": 345,\n          \"prompt_tokens\": 451,\n          \"total_tokens\": 7341,\n          \"cost\": {\n            \"input_tokens_cost_nanodollars\": 902000,\n            \"output_tokens_cost_nanodollars\": 82680000\n          },\n          \"total_backend_latency_ms\": 61229\n        }\n      }\n    ]\n  },\n  \"generation_tokens\": 345,\n  \"prompt_tokens\": 451,\n  \"reasoning_tokens\": null,\n  \"total_tokens\": 7341,\n  \"duration_success_only_secs\": 61.722015979998105\n}"
+          ],
+          "status": "OK",
+          "submission": 2498,
+          "thoughts": "To determine the best move, let's analyze the current position and the consequences of the last move played by Black (39... e4). \n\nBlack pushed their pawn to e4, likely assuming that it was protected by their light-squared bishop on c6. However, if we look closely at the a8-h1 diagonal (which the c6 bishop controls), the squares are c6, d5, e4, f3, g2, and h1. Black's own rook is currently sitting on the d5 square, completely blocking the bishop's line of sight to the e4 pawn! \n\nAdditionally, a rook moves in straight files and ranks, meaning the d5 rook controls the 5th rank and the d-file, but it does not protect the e4 square (which is a diagonal knight-step away). \n\nSince there are no other pieces defending this pawn, the e4 pawn is completely hanging. \n\nAs White, you are in a tough endgame where Black has a massive material advantage. Black's most dangerous immediate threat was this rolling passed e-pawn that was marching towards promotion. By playing **Kxe4**, you not only take a free pawn and eliminate Black's most dangerous asset, but you also force Black to reposition. \n\nWhile taking the pawn aligns your King with Black's c6 Bishop (allowing a discovered check when the d5 Rook moves), it is perfectly safe. Your King will have safe squares to escape to once the check is delivered (e.g., if 1... Rd6+, you can simply reply with 2. Kf4).\n\nFinal Answer: Kxe4"
+        },
+        "info": {
+          "actionApplied": 2498,
+          "actionSubmitted": 2498,
+          "actionSubmittedToString": "Kxe4",
+          "agentSelfReportedStatus": "OK",
+          "timeTaken": 62.973
+        },
+        "observation": {
+          "currentPlayer": 0,
+          "isTerminal": false,
+          "observationString": "6k1/1p3p2/p1b2B2/3r4/4K1PP/8/8/8 b - - 0 40",
+          "playerId": 1,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n1258\n3572\n1841\n1842\n1431\n3132\n3572\n656\n89\n1215\n2425\n3010\n1808\n1768\n749\n30\n1065\n2571\n1942\n3196\n3131\n1384\n4177\n3854\n381\n615\n498\n1869\n2001\n2977\n2975\n4350\n1431\n1770\n2581\n1257\n4673\n4673\n656\n2627\n1895\n2940\n1386\n1358\n3634\n2528\n254\n4496\n3110\n3705\n2948\n2161\n1771\n2833\n2059\n3853\n2002\n3326\n3166\n1358\n1406\n3561\n1694\n3050\n1637\n2497\n1212\n2425\n1882\n3593\n32\n2016\n1770\n3666\n2498\n4178\n2571\n2498\n\n"
+        },
+        "reward": null,
+        "status": "INACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "actionString": "Rd6+",
+          "generate_returns": [
+            "{\n  \"main_response\": \"I look for a forcing move, since White\\u2019s king is exposed and the bishop on f6 is loose.\\n\\nMoving the rook off d5 opens the diagonal from the bishop on c6 to the white king on e4, giving a discovered check. The strongest square is d6: it gives check and simultaneously attacks the white bishop on f6.\\n\\nFinal Answer: Rd6+\",\n  \"main_response_and_thoughts\": \"\",\n  \"request_for_logging\": {\n    \"model\": \"openai/gpt-5.5-2026-04-23\",\n    \"messages\": [\n      {\n        \"role\": \"user\",\n        \"content\": [\n          {\n            \"type\": \"text\",\n            \"text\": \"Let's play chess. The current game state in Forsyth-Edwards Notation (FEN) notation is:\\n6k1/1p3p2/p1b2B2/3r4/4K1PP/8/8/8 b - - 0 40\\nThe moves played so far are:\\n1. e4 c5 2. Nf3 d6 3. d4 cxd4 4. Nxd4 Nf6 5. Nc3 a6 6. Bg5 e6 7. f4 Qb6 8. Qd2 Qxb2 9. Rb1 Qa3 10. e5 dxe5 11. fxe5 Nfd7 12. Ne4 h6 13. Bh4 Qxa2 14. Rd1 Qd5 15. Qe3 Qxe5 16. Be2 Bc5 17. Bg3 Bxd4 18. Rxd4 Qa5+ 19. c3 O-O 20. O-O Nc6 21. Nf6+ Nxf6 22. Rxf6 Nxd4 23. cxd4 gxf6 24. Qxh6 Qg5 25. Qxg5+ fxg5 26. Bd6 Rd8 27. Be7 Rxd4 28. Bxg5 Rd5 29. Bf6 Rf5 30. Bc3 Rc5 31. Bd4 Rc1+ 32. Kf2 Rc2 33. Ke3 Rxe2+ 34. Kxe2 Bd7 35. Ke3 Bc6 36. g3 Rd8 37. Bf6 Rd5 38. g4 e5 39. h4 e4 40. Kxe4\\nYou are playing as player Black.\\nIt is now your turn. Play your strongest move. The move MUST be legal. Reason step by step to come up with your move, then output your final answer in the format \\\"Final Answer: X\\\" where X is your chosen move in standard algebraic notation (SAN).\\n\"\n          }\n        ]\n      }\n    ],\n    \"config\": {\n      \"temperature\": \"NOT_GIVEN\",\n      \"top_p\": \"NOT_GIVEN\",\n      \"max_completion_tokens\": \"NOT_GIVEN\",\n      \"reasoning_effort\": \"high\"\n    },\n    \"stream_options\": {\n      \"include_usage\": true\n    }\n  },\n  \"response_for_logging\": {\n    \"response_chunks\": [\n      {\n        \"id\": \"chatcmpl-DcN0VDZ4ZuuSPTxx6AudHTBORfrIE\",\n        \"created\": 1778037275,\n        \"model\": \"openai/gpt-5.5-2026-04-23\",\n        \"object\": \"chat.completion.chunk\",\n        \"usage\": {\n          \"completion_tokens\": 24943,\n          \"prompt_tokens\": 461,\n          \"total_tokens\": 25404,\n          \"cost\": {\n            \"input_tokens_cost_nanodollars\": 2305000,\n            \"output_tokens_cost_nanodollars\": 748290000\n          },\n          \"total_backend_latency_ms\": 510831\n        }\n      }\n    ]\n  },\n  \"generation_tokens\": 24943,\n  \"prompt_tokens\": 461,\n  \"reasoning_tokens\": null,\n  \"total_tokens\": 25404,\n  \"duration_success_only_secs\": 511.31215249399975\n}"
+          ],
+          "status": "OK",
+          "submission": 1986,
+          "thoughts": "I look for a forcing move, since White\u2019s king is exposed and the bishop on f6 is loose.\n\nMoving the rook off d5 opens the diagonal from the bishop on c6 to the white king on e4, giving a discovered check. The strongest square is d6: it gives check and simultaneously attacks the white bishop on f6.\n\nFinal Answer: Rd6+"
+        },
+        "info": {
+          "actionApplied": 1986,
+          "actionSubmitted": 1986,
+          "actionSubmittedToString": "Rd6+",
+          "agentSelfReportedStatus": "OK",
+          "timeTaken": 512.531
+        },
+        "observation": {
+          "currentPlayer": 1,
+          "isTerminal": false,
+          "observationString": "6k1/1p3p2/p1br1B2/8/4K1PP/8/8/8 w - - 1 41",
+          "playerId": 0,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n1258\n3572\n1841\n1842\n1431\n3132\n3572\n656\n89\n1215\n2425\n3010\n1808\n1768\n749\n30\n1065\n2571\n1942\n3196\n3131\n1384\n4177\n3854\n381\n615\n498\n1869\n2001\n2977\n2975\n4350\n1431\n1770\n2581\n1257\n4673\n4673\n656\n2627\n1895\n2940\n1386\n1358\n3634\n2528\n254\n4496\n3110\n3705\n2948\n2161\n1771\n2833\n2059\n3853\n2002\n3326\n3166\n1358\n1406\n3561\n1694\n3050\n1637\n2497\n1212\n2425\n1882\n3593\n32\n2016\n1770\n3666\n2498\n4178\n2571\n2498\n1986\n\n",
+          "step": 81
+        },
+        "reward": null,
+        "status": "INACTIVE"
+      },
+      {
+        "action": {
+          "submission": -1
+        },
+        "info": {},
+        "observation": {
+          "currentPlayer": 1,
+          "isTerminal": false,
+          "observationString": "6k1/1p3p2/p1br1B2/8/4K1PP/8/8/8 w - - 1 41",
+          "playerId": 1,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n1258\n3572\n1841\n1842\n1431\n3132\n3572\n656\n89\n1215\n2425\n3010\n1808\n1768\n749\n30\n1065\n2571\n1942\n3196\n3131\n1384\n4177\n3854\n381\n615\n498\n1869\n2001\n2977\n2975\n4350\n1431\n1770\n2581\n1257\n4673\n4673\n656\n2627\n1895\n2940\n1386\n1358\n3634\n2528\n254\n4496\n3110\n3705\n2948\n2161\n1771\n2833\n2059\n3853\n2002\n3326\n3166\n1358\n1406\n3561\n1694\n3050\n1637\n2497\n1212\n2425\n1882\n3593\n32\n2016\n1770\n3666\n2498\n4178\n2571\n2498\n1986\n\n"
+        },
+        "reward": null,
+        "status": "ACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "submission": -1
+        },
+        "info": {},
+        "observation": {
+          "currentPlayer": 0,
+          "isTerminal": false,
+          "observationString": "6k1/1p3p2/p1br1B2/4K3/6PP/8/8/8 b - - 2 41",
+          "playerId": 0,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n1258\n3572\n1841\n1842\n1431\n3132\n3572\n656\n89\n1215\n2425\n3010\n1808\n1768\n749\n30\n1065\n2571\n1942\n3196\n3131\n1384\n4177\n3854\n381\n615\n498\n1869\n2001\n2977\n2975\n4350\n1431\n1770\n2581\n1257\n4673\n4673\n656\n2627\n1895\n2940\n1386\n1358\n3634\n2528\n254\n4496\n3110\n3705\n2948\n2161\n1771\n2833\n2059\n3853\n2002\n3326\n3166\n1358\n1406\n3561\n1694\n3050\n1637\n2497\n1212\n2425\n1882\n3593\n32\n2016\n1770\n3666\n2498\n4178\n2571\n2498\n1986\n2571\n\n",
+          "step": 82
+        },
+        "reward": null,
+        "status": "ACTIVE"
+      },
+      {
+        "action": {
+          "actionString": "Ke5",
+          "generate_returns": [
+            "{\n  \"main_response\": \"The current position shows that White's King on e4 is in check from Black's Bishop on c6 (discovered check after Black played 40... Rd6+). \\n\\nWhite is forced to move the King out of check. Let's look at the available squares for the King:\\n- `d3`, `d4`, and `d5` are all covered by Black's rook on d6 (and `d5` is additionally covered by the c6 bishop).\\n- `f3` is covered by Black's bishop on c6.\\n- This leaves `e3`, `e5`, `f4`, and `f5` as the only legal squares. \\n\\nLooking closely at the position, Black's rook on d6 is simultaneously attacking White's bishop on f6. \\nIf White plays `Ke3`, `Kf4`, or `Kf5`, Black will simply capture the bishop for free (and with check in the case of `Kf4` or `Kf5`): 41... Rxf6.\\n\\nHowever, moving the King to `e5` comes with a massive double-purpose. By playing `Ke5`:\\n1. You step out of the check from the c6 bishop safely.\\n2. You directly attack the unprotected Black rook on d6.\\n3. You provide defense for your own attacked bishop on f6. \\n\\nThis forces Black to either trade their Rook for your Bishop (e.g. 41... Rxf6 42. Kxf6) or move their Rook away with a check (41... Re6+), preventing them from simply picking up your piece for free. It is by far White's most resilient and best move.\\n\\nFinal Answer: Ke5\",\n  \"main_response_and_thoughts\": \"\",\n  \"request_for_logging\": {\n    \"model\": \"google/gemini-3.1-pro-preview\",\n    \"messages\": [\n      {\n        \"role\": \"user\",\n        \"content\": [\n          {\n            \"type\": \"text\",\n            \"text\": \"Let's play chess. The current game state in Forsyth-Edwards Notation (FEN) notation is:\\n6k1/1p3p2/p1br1B2/8/4K1PP/8/8/8 w - - 1 41\\nThe moves played so far are:\\n1. e4 c5 2. Nf3 d6 3. d4 cxd4 4. Nxd4 Nf6 5. Nc3 a6 6. Bg5 e6 7. f4 Qb6 8. Qd2 Qxb2 9. Rb1 Qa3 10. e5 dxe5 11. fxe5 Nfd7 12. Ne4 h6 13. Bh4 Qxa2 14. Rd1 Qd5 15. Qe3 Qxe5 16. Be2 Bc5 17. Bg3 Bxd4 18. Rxd4 Qa5+ 19. c3 O-O 20. O-O Nc6 21. Nf6+ Nxf6 22. Rxf6 Nxd4 23. cxd4 gxf6 24. Qxh6 Qg5 25. Qxg5+ fxg5 26. Bd6 Rd8 27. Be7 Rxd4 28. Bxg5 Rd5 29. Bf6 Rf5 30. Bc3 Rc5 31. Bd4 Rc1+ 32. Kf2 Rc2 33. Ke3 Rxe2+ 34. Kxe2 Bd7 35. Ke3 Bc6 36. g3 Rd8 37. Bf6 Rd5 38. g4 e5 39. h4 e4 40. Kxe4 Rd6+ 41.\\nYou are playing as player White.\\nIt is now your turn. Play your strongest move. The move MUST be legal. Reason step by step to come up with your move, then output your final answer in the format \\\"Final Answer: X\\\" where X is your chosen move in standard algebraic notation (SAN).\\n\"\n          }\n        ]\n      }\n    ],\n    \"config\": {\n      \"temperature\": \"NOT_GIVEN\",\n      \"top_p\": \"NOT_GIVEN\",\n      \"max_completion_tokens\": \"NOT_GIVEN\"\n    },\n    \"stream_options\": {\n      \"include_usage\": true\n    }\n  },\n  \"response_for_logging\": {\n    \"response_chunks\": [\n      {\n        \"id\": \"HLT6aeLnA4-SmecPifn04Ak\",\n        \"choices\": [\n          {\n            \"delta\": {\n              \"content\": \": Ke5\",\n              \"role\": \"assistant\"\n            },\n            \"finish_reason\": \"stop\",\n            \"index\": 0\n          }\n        ],\n        \"created\": 1778037788,\n        \"model\": \"google/gemini-3.1-pro-preview\",\n        \"object\": \"chat.completion.chunk\",\n        \"usage\": {\n          \"completion_tokens\": 371,\n          \"prompt_tokens\": 456,\n          \"total_tokens\": 4864,\n          \"cost\": {\n            \"input_tokens_cost_nanodollars\": 912000,\n            \"output_tokens_cost_nanodollars\": 52896000\n          },\n          \"total_backend_latency_ms\": 40341\n        }\n      }\n    ]\n  },\n  \"generation_tokens\": 371,\n  \"prompt_tokens\": 456,\n  \"reasoning_tokens\": null,\n  \"total_tokens\": 4864,\n  \"duration_success_only_secs\": 40.8496517900021\n}"
+          ],
+          "status": "OK",
+          "submission": 2571,
+          "thoughts": "The current position shows that White's King on e4 is in check from Black's Bishop on c6 (discovered check after Black played 40... Rd6+). \n\nWhite is forced to move the King out of check. Let's look at the available squares for the King:\n- `d3`, `d4`, and `d5` are all covered by Black's rook on d6 (and `d5` is additionally covered by the c6 bishop).\n- `f3` is covered by Black's bishop on c6.\n- This leaves `e3`, `e5`, `f4`, and `f5` as the only legal squares. \n\nLooking closely at the position, Black's rook on d6 is simultaneously attacking White's bishop on f6. \nIf White plays `Ke3`, `Kf4`, or `Kf5`, Black will simply capture the bishop for free (and with check in the case of `Kf4` or `Kf5`): 41... Rxf6.\n\nHowever, moving the King to `e5` comes with a massive double-purpose. By playing `Ke5`:\n1. You step out of the check from the c6 bishop safely.\n2. You directly attack the unprotected Black rook on d6.\n3. You provide defense for your own attacked bishop on f6. \n\nThis forces Black to either trade their Rook for your Bishop (e.g. 41... Rxf6 42. Kxf6) or move their Rook away with a check (41... Re6+), preventing them from simply picking up your piece for free. It is by far White's most resilient and best move.\n\nFinal Answer: Ke5"
+        },
+        "info": {
+          "actionApplied": 2571,
+          "actionSubmitted": 2571,
+          "actionSubmittedToString": "Ke5",
+          "agentSelfReportedStatus": "OK",
+          "timeTaken": 42.113
+        },
+        "observation": {
+          "currentPlayer": 0,
+          "isTerminal": false,
+          "observationString": "6k1/1p3p2/p1br1B2/4K3/6PP/8/8/8 b - - 2 41",
+          "playerId": 1,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n1258\n3572\n1841\n1842\n1431\n3132\n3572\n656\n89\n1215\n2425\n3010\n1808\n1768\n749\n30\n1065\n2571\n1942\n3196\n3131\n1384\n4177\n3854\n381\n615\n498\n1869\n2001\n2977\n2975\n4350\n1431\n1770\n2581\n1257\n4673\n4673\n656\n2627\n1895\n2940\n1386\n1358\n3634\n2528\n254\n4496\n3110\n3705\n2948\n2161\n1771\n2833\n2059\n3853\n2002\n3326\n3166\n1358\n1406\n3561\n1694\n3050\n1637\n2497\n1212\n2425\n1882\n3593\n32\n2016\n1770\n3666\n2498\n4178\n2571\n2498\n1986\n2571\n\n"
+        },
+        "reward": null,
+        "status": "INACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "actionString": "Rd5+",
+          "generate_returns": [
+            "{\n  \"main_response\": \"Final Answer: Rd5+\",\n  \"main_response_and_thoughts\": \"\",\n  \"request_for_logging\": {\n    \"model\": \"openai/gpt-5.5-2026-04-23\",\n    \"messages\": [\n      {\n        \"role\": \"user\",\n        \"content\": [\n          {\n            \"type\": \"text\",\n            \"text\": \"Let's play chess. The current game state in Forsyth-Edwards Notation (FEN) notation is:\\n6k1/1p3p2/p1br1B2/4K3/6PP/8/8/8 b - - 2 41\\nThe moves played so far are:\\n1. e4 c5 2. Nf3 d6 3. d4 cxd4 4. Nxd4 Nf6 5. Nc3 a6 6. Bg5 e6 7. f4 Qb6 8. Qd2 Qxb2 9. Rb1 Qa3 10. e5 dxe5 11. fxe5 Nfd7 12. Ne4 h6 13. Bh4 Qxa2 14. Rd1 Qd5 15. Qe3 Qxe5 16. Be2 Bc5 17. Bg3 Bxd4 18. Rxd4 Qa5+ 19. c3 O-O 20. O-O Nc6 21. Nf6+ Nxf6 22. Rxf6 Nxd4 23. cxd4 gxf6 24. Qxh6 Qg5 25. Qxg5+ fxg5 26. Bd6 Rd8 27. Be7 Rxd4 28. Bxg5 Rd5 29. Bf6 Rf5 30. Bc3 Rc5 31. Bd4 Rc1+ 32. Kf2 Rc2 33. Ke3 Rxe2+ 34. Kxe2 Bd7 35. Ke3 Bc6 36. g3 Rd8 37. Bf6 Rd5 38. g4 e5 39. h4 e4 40. Kxe4 Rd6+ 41. Ke5\\nYou are playing as player Black.\\nIt is now your turn. Play your strongest move. The move MUST be legal. Reason step by step to come up with your move, then output your final answer in the format \\\"Final Answer: X\\\" where X is your chosen move in standard algebraic notation (SAN).\\n\"\n          }\n        ]\n      }\n    ],\n    \"config\": {\n      \"temperature\": \"NOT_GIVEN\",\n      \"top_p\": \"NOT_GIVEN\",\n      \"max_completion_tokens\": \"NOT_GIVEN\",\n      \"reasoning_effort\": \"high\"\n    },\n    \"stream_options\": {\n      \"include_usage\": true\n    }\n  },\n  \"response_for_logging\": {\n    \"response_chunks\": [\n      {\n        \"id\": \"chatcmpl-DcNLrzKXCt9StfbLNja0e3g00a8gj\",\n        \"created\": 1778038599,\n        \"model\": \"openai/gpt-5.5-2026-04-23\",\n        \"object\": \"chat.completion.chunk\",\n        \"usage\": {\n          \"completion_tokens\": 20211,\n          \"prompt_tokens\": 467,\n          \"total_tokens\": 20678,\n          \"cost\": {\n            \"input_tokens_cost_nanodollars\": 2335000,\n            \"output_tokens_cost_nanodollars\": 606330000\n          },\n          \"total_backend_latency_ms\": 414864\n        }\n      }\n    ]\n  },\n  \"generation_tokens\": 20211,\n  \"prompt_tokens\": 467,\n  \"reasoning_tokens\": null,\n  \"total_tokens\": 20678,\n  \"duration_success_only_secs\": 415.3308940989991\n}"
+          ],
+          "status": "OK",
+          "submission": 1914,
+          "thoughts": "Final Answer: Rd5+"
+        },
+        "info": {
+          "actionApplied": 1914,
+          "actionSubmitted": 1914,
+          "actionSubmittedToString": "Rd5+",
+          "agentSelfReportedStatus": "OK",
+          "timeTaken": 1185.539
+        },
+        "observation": {
+          "currentPlayer": 1,
+          "isTerminal": false,
+          "observationString": "6k1/1p3p2/p1b2B2/3rK3/6PP/8/8/8 w - - 3 42",
+          "playerId": 0,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n1258\n3572\n1841\n1842\n1431\n3132\n3572\n656\n89\n1215\n2425\n3010\n1808\n1768\n749\n30\n1065\n2571\n1942\n3196\n3131\n1384\n4177\n3854\n381\n615\n498\n1869\n2001\n2977\n2975\n4350\n1431\n1770\n2581\n1257\n4673\n4673\n656\n2627\n1895\n2940\n1386\n1358\n3634\n2528\n254\n4496\n3110\n3705\n2948\n2161\n1771\n2833\n2059\n3853\n2002\n3326\n3166\n1358\n1406\n3561\n1694\n3050\n1637\n2497\n1212\n2425\n1882\n3593\n32\n2016\n1770\n3666\n2498\n4178\n2571\n2498\n1986\n2571\n1914\n\n",
+          "step": 83
+        },
+        "reward": null,
+        "status": "INACTIVE"
+      },
+      {
+        "action": {
+          "submission": -1
+        },
+        "info": {},
+        "observation": {
+          "currentPlayer": 1,
+          "isTerminal": false,
+          "observationString": "6k1/1p3p2/p1b2B2/3rK3/6PP/8/8/8 w - - 3 42",
+          "playerId": 1,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n1258\n3572\n1841\n1842\n1431\n3132\n3572\n656\n89\n1215\n2425\n3010\n1808\n1768\n749\n30\n1065\n2571\n1942\n3196\n3131\n1384\n4177\n3854\n381\n615\n498\n1869\n2001\n2977\n2975\n4350\n1431\n1770\n2581\n1257\n4673\n4673\n656\n2627\n1895\n2940\n1386\n1358\n3634\n2528\n254\n4496\n3110\n3705\n2948\n2161\n1771\n2833\n2059\n3853\n2002\n3326\n3166\n1358\n1406\n3561\n1694\n3050\n1637\n2497\n1212\n2425\n1882\n3593\n32\n2016\n1770\n3666\n2498\n4178\n2571\n2498\n1986\n2571\n1914\n\n"
+        },
+        "reward": null,
+        "status": "ACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "submission": -1
+        },
+        "info": {},
+        "observation": {
+          "currentPlayer": 0,
+          "isTerminal": false,
+          "observationString": "6k1/1p3p2/p1b2B2/3r4/5KPP/8/8/8 b - - 4 42",
+          "playerId": 0,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n1258\n3572\n1841\n1842\n1431\n3132\n3572\n656\n89\n1215\n2425\n3010\n1808\n1768\n749\n30\n1065\n2571\n1942\n3196\n3131\n1384\n4177\n3854\n381\n615\n498\n1869\n2001\n2977\n2975\n4350\n1431\n1770\n2581\n1257\n4673\n4673\n656\n2627\n1895\n2940\n1386\n1358\n3634\n2528\n254\n4496\n3110\n3705\n2948\n2161\n1771\n2833\n2059\n3853\n2002\n3326\n3166\n1358\n1406\n3561\n1694\n3050\n1637\n2497\n1212\n2425\n1882\n3593\n32\n2016\n1770\n3666\n2498\n4178\n2571\n2498\n1986\n2571\n1914\n2686\n\n",
+          "step": 84
+        },
+        "reward": null,
+        "status": "ACTIVE"
+      },
+      {
+        "action": {
+          "actionString": "Kf4",
+          "generate_returns": [
+            "{\n  \"main_response\": \"The game is in a state where your King on e5 is in check by the Black Rook on d5. Let's evaluate all possible ways to respond to this check:\\n\\n1. **Capture the checking piece:** You have a Bishop on f6 and pawns on g4 and h4. None of these pieces can attack and capture the Black Rook on d5.\\n2. **Block the check:** The Black Rook on d5 is directly adjacent to your King on e5. Therefore, there are no squares in between to interpose a piece. \\n3. **Move the King to a safe square:** Let's examine all adjacent squares around the e5 King:\\n- **d4, d6:** Both squares fall on the d-file, which is still controlled by the Black Rook.\\n- **e4:** The Black Bishop on c6 controls the long light-squared diagonal (a8-h1), completely slicing through e4 (c6-d5-e4). \\n- **e6:** The Black pawn on f7 attacks this square, as pawns capture diagonally forward one square (f7 to e6).\\n- **f5:** This square lies on the 5th rank, which is horizontally attacked by the d5 Rook.\\n- **f6:** This square is currently occupied by your own Bishop.\\n- **f4:** This square is empty and perfectly safe. It is a dark square (safe from the c6 Bishop), off the 5th rank and d-file (safe from the d5 Rook), and untouched by Black's pawns or King. \\n\\nSince all other options would illegally leave your King in check or capture it, the King has only one legal forced escape square.\\n\\nFinal Answer: Kf4\",\n  \"main_response_and_thoughts\": \"\",\n  \"request_for_logging\": {\n    \"model\": \"google/gemini-3.1-pro-preview\",\n    \"messages\": [\n      {\n        \"role\": \"user\",\n        \"content\": [\n          {\n            \"type\": \"text\",\n            \"text\": \"Let's play chess. The current game state in Forsyth-Edwards Notation (FEN) notation is:\\n6k1/1p3p2/p1b2B2/3rK3/6PP/8/8/8 w - - 3 42\\nThe moves played so far are:\\n1. e4 c5 2. Nf3 d6 3. d4 cxd4 4. Nxd4 Nf6 5. Nc3 a6 6. Bg5 e6 7. f4 Qb6 8. Qd2 Qxb2 9. Rb1 Qa3 10. e5 dxe5 11. fxe5 Nfd7 12. Ne4 h6 13. Bh4 Qxa2 14. Rd1 Qd5 15. Qe3 Qxe5 16. Be2 Bc5 17. Bg3 Bxd4 18. Rxd4 Qa5+ 19. c3 O-O 20. O-O Nc6 21. Nf6+ Nxf6 22. Rxf6 Nxd4 23. cxd4 gxf6 24. Qxh6 Qg5 25. Qxg5+ fxg5 26. Bd6 Rd8 27. Be7 Rxd4 28. Bxg5 Rd5 29. Bf6 Rf5 30. Bc3 Rc5 31. Bd4 Rc1+ 32. Kf2 Rc2 33. Ke3 Rxe2+ 34. Kxe2 Bd7 35. Ke3 Bc6 36. g3 Rd8 37. Bf6 Rd5 38. g4 e5 39. h4 e4 40. Kxe4 Rd6+ 41. Ke5 Rd5+ 42.\\nYou are playing as player White.\\nIt is now your turn. Play your strongest move. The move MUST be legal. Reason step by step to come up with your move, then output your final answer in the format \\\"Final Answer: X\\\" where X is your chosen move in standard algebraic notation (SAN).\\n\"\n          }\n        ]\n      }\n    ],\n    \"config\": {\n      \"temperature\": \"NOT_GIVEN\",\n      \"top_p\": \"NOT_GIVEN\",\n      \"max_completion_tokens\": \"NOT_GIVEN\"\n    },\n    \"stream_options\": {\n      \"include_usage\": true\n    }\n  },\n  \"response_for_logging\": {\n    \"response_chunks\": [\n      {\n        \"id\": \"57j6aY25KbWKmecPxOar6Aw\",\n        \"choices\": [\n          {\n            \"delta\": {\n              \"content\": \" check or capture it, the King has only one legal forced escape square.\\n\\nFinal Answer: Kf4\",\n              \"role\": \"assistant\"\n            },\n            \"finish_reason\": \"stop\",\n            \"index\": 0\n          }\n        ],\n        \"created\": 1778039015,\n        \"model\": \"google/gemini-3.1-pro-preview\",\n        \"object\": \"chat.completion.chunk\",\n        \"usage\": {\n          \"completion_tokens\": 372,\n          \"prompt_tokens\": 466,\n          \"total_tokens\": 7110,\n          \"cost\": {\n            \"input_tokens_cost_nanodollars\": 932000,\n            \"output_tokens_cost_nanodollars\": 79728000\n          },\n          \"total_backend_latency_ms\": 58109\n        }\n      }\n    ]\n  },\n  \"generation_tokens\": 372,\n  \"prompt_tokens\": 466,\n  \"reasoning_tokens\": null,\n  \"total_tokens\": 7110,\n  \"duration_success_only_secs\": 58.5694960740002\n}"
+          ],
+          "status": "OK",
+          "submission": 2686,
+          "thoughts": "The game is in a state where your King on e5 is in check by the Black Rook on d5. Let's evaluate all possible ways to respond to this check:\n\n1. **Capture the checking piece:** You have a Bishop on f6 and pawns on g4 and h4. None of these pieces can attack and capture the Black Rook on d5.\n2. **Block the check:** The Black Rook on d5 is directly adjacent to your King on e5. Therefore, there are no squares in between to interpose a piece. \n3. **Move the King to a safe square:** Let's examine all adjacent squares around the e5 King:\n- **d4, d6:** Both squares fall on the d-file, which is still controlled by the Black Rook.\n- **e4:** The Black Bishop on c6 controls the long light-squared diagonal (a8-h1), completely slicing through e4 (c6-d5-e4). \n- **e6:** The Black pawn on f7 attacks this square, as pawns capture diagonally forward one square (f7 to e6).\n- **f5:** This square lies on the 5th rank, which is horizontally attacked by the d5 Rook.\n- **f6:** This square is currently occupied by your own Bishop.\n- **f4:** This square is empty and perfectly safe. It is a dark square (safe from the c6 Bishop), off the 5th rank and d-file (safe from the d5 Rook), and untouched by Black's pawns or King. \n\nSince all other options would illegally leave your King in check or capture it, the King has only one legal forced escape square.\n\nFinal Answer: Kf4"
+        },
+        "info": {
+          "actionApplied": 2686,
+          "actionSubmitted": 2686,
+          "actionSubmittedToString": "Kf4",
+          "agentSelfReportedStatus": "OK",
+          "timeTaken": 60.746
+        },
+        "observation": {
+          "currentPlayer": 0,
+          "isTerminal": false,
+          "observationString": "6k1/1p3p2/p1b2B2/3r4/5KPP/8/8/8 b - - 4 42",
+          "playerId": 1,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n1258\n3572\n1841\n1842\n1431\n3132\n3572\n656\n89\n1215\n2425\n3010\n1808\n1768\n749\n30\n1065\n2571\n1942\n3196\n3131\n1384\n4177\n3854\n381\n615\n498\n1869\n2001\n2977\n2975\n4350\n1431\n1770\n2581\n1257\n4673\n4673\n656\n2627\n1895\n2940\n1386\n1358\n3634\n2528\n254\n4496\n3110\n3705\n2948\n2161\n1771\n2833\n2059\n3853\n2002\n3326\n3166\n1358\n1406\n3561\n1694\n3050\n1637\n2497\n1212\n2425\n1882\n3593\n32\n2016\n1770\n3666\n2498\n4178\n2571\n2498\n1986\n2571\n1914\n2686\n\n"
+        },
+        "reward": null,
+        "status": "INACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "actionString": "Rb5",
+          "generate_returns": [
+            "{\n  \"main_response\": \"I\\u2019ll move the rook off d5 while keeping it on the 5th rank. This opens the bishop\\u2019s diagonal from c6 to e4/f3, restricting the white king, while the rook on b5 still controls e5, f5, and g5. It\\u2019s also protected by the bishop on c6.\\n\\nFinal Answer: Rb5\",\n  \"main_response_and_thoughts\": \"\",\n  \"request_for_logging\": {\n    \"model\": \"openai/gpt-5.5-2026-04-23\",\n    \"messages\": [\n      {\n        \"role\": \"user\",\n        \"content\": [\n          {\n            \"type\": \"text\",\n            \"text\": \"Let's play chess. The current game state in Forsyth-Edwards Notation (FEN) notation is:\\n6k1/1p3p2/p1b2B2/3r4/5KPP/8/8/8 b - - 4 42\\nThe moves played so far are:\\n1. e4 c5 2. Nf3 d6 3. d4 cxd4 4. Nxd4 Nf6 5. Nc3 a6 6. Bg5 e6 7. f4 Qb6 8. Qd2 Qxb2 9. Rb1 Qa3 10. e5 dxe5 11. fxe5 Nfd7 12. Ne4 h6 13. Bh4 Qxa2 14. Rd1 Qd5 15. Qe3 Qxe5 16. Be2 Bc5 17. Bg3 Bxd4 18. Rxd4 Qa5+ 19. c3 O-O 20. O-O Nc6 21. Nf6+ Nxf6 22. Rxf6 Nxd4 23. cxd4 gxf6 24. Qxh6 Qg5 25. Qxg5+ fxg5 26. Bd6 Rd8 27. Be7 Rxd4 28. Bxg5 Rd5 29. Bf6 Rf5 30. Bc3 Rc5 31. Bd4 Rc1+ 32. Kf2 Rc2 33. Ke3 Rxe2+ 34. Kxe2 Bd7 35. Ke3 Bc6 36. g3 Rd8 37. Bf6 Rd5 38. g4 e5 39. h4 e4 40. Kxe4 Rd6+ 41. Ke5 Rd5+ 42. Kf4\\nYou are playing as player Black.\\nIt is now your turn. Play your strongest move. The move MUST be legal. Reason step by step to come up with your move, then output your final answer in the format \\\"Final Answer: X\\\" where X is your chosen move in standard algebraic notation (SAN).\\n\"\n          }\n        ]\n      }\n    ],\n    \"config\": {\n      \"temperature\": \"NOT_GIVEN\",\n      \"top_p\": \"NOT_GIVEN\",\n      \"max_completion_tokens\": \"NOT_GIVEN\",\n      \"reasoning_effort\": \"high\"\n    },\n    \"stream_options\": {\n      \"include_usage\": true\n    }\n  },\n  \"response_for_logging\": {\n    \"response_chunks\": [\n      {\n        \"id\": \"chatcmpl-DcNWqofmC3GKaHSg1QitNpruBPcEb\",\n        \"created\": 1778039280,\n        \"model\": \"openai/gpt-5.5-2026-04-23\",\n        \"object\": \"chat.completion.chunk\",\n        \"usage\": {\n          \"completion_tokens\": 33746,\n          \"prompt_tokens\": 477,\n          \"total_tokens\": 34223,\n          \"cost\": {\n            \"input_tokens_cost_nanodollars\": 2385000,\n            \"output_tokens_cost_nanodollars\": 1012380000\n          },\n          \"total_backend_latency_ms\": 680556\n        }\n      }\n    ]\n  },\n  \"generation_tokens\": 33746,\n  \"prompt_tokens\": 477,\n  \"reasoning_tokens\": null,\n  \"total_tokens\": 34223,\n  \"duration_success_only_secs\": 681.0190848710008\n}"
+          ],
+          "status": "OK",
+          "submission": 1999,
+          "thoughts": "I\u2019ll move the rook off d5 while keeping it on the 5th rank. This opens the bishop\u2019s diagonal from c6 to e4/f3, restricting the white king, while the rook on b5 still controls e5, f5, and g5. It\u2019s also protected by the bishop on c6.\n\nFinal Answer: Rb5"
+        },
+        "info": {
+          "actionApplied": 1999,
+          "actionSubmitted": 1999,
+          "actionSubmittedToString": "Rb5",
+          "agentSelfReportedStatus": "OK",
+          "timeTaken": 884.886
+        },
+        "observation": {
+          "currentPlayer": 1,
+          "isTerminal": false,
+          "observationString": "6k1/1p3p2/p1b2B2/1r6/5KPP/8/8/8 w - - 5 43",
+          "playerId": 0,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n1258\n3572\n1841\n1842\n1431\n3132\n3572\n656\n89\n1215\n2425\n3010\n1808\n1768\n749\n30\n1065\n2571\n1942\n3196\n3131\n1384\n4177\n3854\n381\n615\n498\n1869\n2001\n2977\n2975\n4350\n1431\n1770\n2581\n1257\n4673\n4673\n656\n2627\n1895\n2940\n1386\n1358\n3634\n2528\n254\n4496\n3110\n3705\n2948\n2161\n1771\n2833\n2059\n3853\n2002\n3326\n3166\n1358\n1406\n3561\n1694\n3050\n1637\n2497\n1212\n2425\n1882\n3593\n32\n2016\n1770\n3666\n2498\n4178\n2571\n2498\n1986\n2571\n1914\n2686\n1999\n\n",
+          "step": 85
+        },
+        "reward": null,
+        "status": "INACTIVE"
+      },
+      {
+        "action": {
+          "submission": -1
+        },
+        "info": {},
+        "observation": {
+          "currentPlayer": 1,
+          "isTerminal": false,
+          "observationString": "6k1/1p3p2/p1b2B2/1r6/5KPP/8/8/8 w - - 5 43",
+          "playerId": 1,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n1258\n3572\n1841\n1842\n1431\n3132\n3572\n656\n89\n1215\n2425\n3010\n1808\n1768\n749\n30\n1065\n2571\n1942\n3196\n3131\n1384\n4177\n3854\n381\n615\n498\n1869\n2001\n2977\n2975\n4350\n1431\n1770\n2581\n1257\n4673\n4673\n656\n2627\n1895\n2940\n1386\n1358\n3634\n2528\n254\n4496\n3110\n3705\n2948\n2161\n1771\n2833\n2059\n3853\n2002\n3326\n3166\n1358\n1406\n3561\n1694\n3050\n1637\n2497\n1212\n2425\n1882\n3593\n32\n2016\n1770\n3666\n2498\n4178\n2571\n2498\n1986\n2571\n1914\n2686\n1999\n\n"
+        },
+        "reward": null,
+        "status": "ACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "submission": -1
+        },
+        "info": {},
+        "observation": {
+          "currentPlayer": 0,
+          "isTerminal": false,
+          "observationString": "6k1/1p3p2/p1b2B2/1r5P/5KP1/8/8/8 b - - 0 43",
+          "playerId": 0,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n1258\n3572\n1841\n1842\n1431\n3132\n3572\n656\n89\n1215\n2425\n3010\n1808\n1768\n749\n30\n1065\n2571\n1942\n3196\n3131\n1384\n4177\n3854\n381\n615\n498\n1869\n2001\n2977\n2975\n4350\n1431\n1770\n2581\n1257\n4673\n4673\n656\n2627\n1895\n2940\n1386\n1358\n3634\n2528\n254\n4496\n3110\n3705\n2948\n2161\n1771\n2833\n2059\n3853\n2002\n3326\n3166\n1358\n1406\n3561\n1694\n3050\n1637\n2497\n1212\n2425\n1882\n3593\n32\n2016\n1770\n3666\n2498\n4178\n2571\n2498\n1986\n2571\n1914\n2686\n1999\n4323\n\n",
+          "step": 86
+        },
+        "reward": null,
+        "status": "ACTIVE"
+      },
+      {
+        "action": {
+          "actionString": "h5",
+          "generate_returns": [
+            "{\n  \"main_response\": \"The current position is completely winning for Black, as they are up a full Exchange and a pawn with two dangerous passed pawns on the queenside (a6, b7) ready to roll. White's only practical plan is to push their kingside pawns, attempt to create some counterplay, and set up the most resilient defense possible. \\n\\nThe move **h5** is best. It gains space, secures the kingside pawn structure, and fixes Black's pawn on f7 while aiming to prepare g4-g5. Though it will not save the game against perfect play, it is the most stubborn way to resist, restricting the Black king and limiting the scope of Black's pieces on the kingside before they begin their decisive queenside advance.\\n\\nStep-by-step reasoning:\\n1. White has a severe material disadvantage: a bishop and two pawns versus a rook, bishop, and three pawns.\\n2. The f6-bishop is currently optimally placed, restricting the Black king from entering f8/e7/d8 and eyeing the queenside. Moving the king is not productive since f4 is an active square.\\n3. Therefore, advancing the kingside pawns to grab space is the logical approach. Playing 1. h5 limits Black's mobility on the kingside (controlling g6) and supports the g-pawn's future advance to g5. \\n4. If Black tries to immediately organize their queenside pawns with something like ...a5 or ...Rb4+, White can follow up with Kg3 and g5, generating the maximum possible annoyance on the kingside.\\n\\nFinal Answer: h5\",\n  \"main_response_and_thoughts\": \"\",\n  \"request_for_logging\": {\n    \"model\": \"google/gemini-3.1-pro-preview\",\n    \"messages\": [\n      {\n        \"role\": \"user\",\n        \"content\": [\n          {\n            \"type\": \"text\",\n            \"text\": \"Let's play chess. The current game state in Forsyth-Edwards Notation (FEN) notation is:\\n6k1/1p3p2/p1b2B2/1r6/5KPP/8/8/8 w - - 5 43\\nThe moves played so far are:\\n1. e4 c5 2. Nf3 d6 3. d4 cxd4 4. Nxd4 Nf6 5. Nc3 a6 6. Bg5 e6 7. f4 Qb6 8. Qd2 Qxb2 9. Rb1 Qa3 10. e5 dxe5 11. fxe5 Nfd7 12. Ne4 h6 13. Bh4 Qxa2 14. Rd1 Qd5 15. Qe3 Qxe5 16. Be2 Bc5 17. Bg3 Bxd4 18. Rxd4 Qa5+ 19. c3 O-O 20. O-O Nc6 21. Nf6+ Nxf6 22. Rxf6 Nxd4 23. cxd4 gxf6 24. Qxh6 Qg5 25. Qxg5+ fxg5 26. Bd6 Rd8 27. Be7 Rxd4 28. Bxg5 Rd5 29. Bf6 Rf5 30. Bc3 Rc5 31. Bd4 Rc1+ 32. Kf2 Rc2 33. Ke3 Rxe2+ 34. Kxe2 Bd7 35. Ke3 Bc6 36. g3 Rd8 37. Bf6 Rd5 38. g4 e5 39. h4 e4 40. Kxe4 Rd6+ 41. Ke5 Rd5+ 42. Kf4 Rb5 43.\\nYou are playing as player White.\\nIt is now your turn. Play your strongest move. The move MUST be legal. Reason step by step to come up with your move, then output your final answer in the format \\\"Final Answer: X\\\" where X is your chosen move in standard algebraic notation (SAN).\\n\"\n          }\n        ]\n      }\n    ],\n    \"config\": {\n      \"temperature\": \"NOT_GIVEN\",\n      \"top_p\": \"NOT_GIVEN\",\n      \"max_completion_tokens\": \"NOT_GIVEN\"\n    },\n    \"stream_options\": {\n      \"include_usage\": true\n    }\n  },\n  \"response_for_logging\": {\n    \"response_chunks\": [\n      {\n        \"id\": \"mbz6aceCNfiMmecPq_Dk8QQ\",\n        \"choices\": [\n          {\n            \"delta\": {\n              \"content\": \"Final Answer: h5\",\n              \"role\": \"assistant\"\n            },\n            \"finish_reason\": \"stop\",\n            \"index\": 0\n          }\n        ],\n        \"created\": 1778039961,\n        \"model\": \"google/gemini-3.1-pro-preview\",\n        \"object\": \"chat.completion.chunk\",\n        \"usage\": {\n          \"completion_tokens\": 347,\n          \"prompt_tokens\": 474,\n          \"total_tokens\": 2877,\n          \"cost\": {\n            \"input_tokens_cost_nanodollars\": 948000,\n            \"output_tokens_cost_nanodollars\": 28836000\n          },\n          \"total_backend_latency_ms\": 22874\n        }\n      }\n    ]\n  },\n  \"generation_tokens\": 347,\n  \"prompt_tokens\": 474,\n  \"reasoning_tokens\": null,\n  \"total_tokens\": 2877,\n  \"duration_success_only_secs\": 23.376697403000435\n}"
+          ],
+          "status": "OK",
+          "submission": 4323,
+          "thoughts": "The current position is completely winning for Black, as they are up a full Exchange and a pawn with two dangerous passed pawns on the queenside (a6, b7) ready to roll. White's only practical plan is to push their kingside pawns, attempt to create some counterplay, and set up the most resilient defense possible. \n\nThe move **h5** is best. It gains space, secures the kingside pawn structure, and fixes Black's pawn on f7 while aiming to prepare g4-g5. Though it will not save the game against perfect play, it is the most stubborn way to resist, restricting the Black king and limiting the scope of Black's pieces on the kingside before they begin their decisive queenside advance.\n\nStep-by-step reasoning:\n1. White has a severe material disadvantage: a bishop and two pawns versus a rook, bishop, and three pawns.\n2. The f6-bishop is currently optimally placed, restricting the Black king from entering f8/e7/d8 and eyeing the queenside. Moving the king is not productive since f4 is an active square.\n3. Therefore, advancing the kingside pawns to grab space is the logical approach. Playing 1. h5 limits Black's mobility on the kingside (controlling g6) and supports the g-pawn's future advance to g5. \n4. If Black tries to immediately organize their queenside pawns with something like ...a5 or ...Rb4+, White can follow up with Kg3 and g5, generating the maximum possible annoyance on the kingside.\n\nFinal Answer: h5"
+        },
+        "info": {
+          "actionApplied": 4323,
+          "actionSubmitted": 4323,
+          "actionSubmittedToString": "h5",
+          "agentSelfReportedStatus": "OK",
+          "timeTaken": 25.184
+        },
+        "observation": {
+          "currentPlayer": 0,
+          "isTerminal": false,
+          "observationString": "6k1/1p3p2/p1b2B2/1r5P/5KP1/8/8/8 b - - 0 43",
+          "playerId": 1,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n1258\n3572\n1841\n1842\n1431\n3132\n3572\n656\n89\n1215\n2425\n3010\n1808\n1768\n749\n30\n1065\n2571\n1942\n3196\n3131\n1384\n4177\n3854\n381\n615\n498\n1869\n2001\n2977\n2975\n4350\n1431\n1770\n2581\n1257\n4673\n4673\n656\n2627\n1895\n2940\n1386\n1358\n3634\n2528\n254\n4496\n3110\n3705\n2948\n2161\n1771\n2833\n2059\n3853\n2002\n3326\n3166\n1358\n1406\n3561\n1694\n3050\n1637\n2497\n1212\n2425\n1882\n3593\n32\n2016\n1770\n3666\n2498\n4178\n2571\n2498\n1986\n2571\n1914\n2686\n1999\n4323\n\n"
+        },
+        "reward": null,
+        "status": "INACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "actionString": "Kh7",
+          "generate_returns": [
+            "{\n  \"main_response\": \"Black should first neutralize White\\u2019s dangerous h-pawn. Capturing it immediately fails to 43...Rxh5? 44.gxh5, but moving the king to h7 blockades it while keeping the rook active on the 5th rank.\\n\\nAfter 43...Kh7:\\n- 44.h6 is met by 44...Kxh6.\\n- 44.g5 leaves h5 undefended, allowing ...Rxh5.\\n- Black maintains control and should convert the material advantage.\\n\\nFinal Answer: Kh7\",\n  \"main_response_and_thoughts\": \"\",\n  \"request_for_logging\": {\n    \"model\": \"openai/gpt-5.5-2026-04-23\",\n    \"messages\": [\n      {\n        \"role\": \"user\",\n        \"content\": [\n          {\n            \"type\": \"text\",\n            \"text\": \"Let's play chess. The current game state in Forsyth-Edwards Notation (FEN) notation is:\\n6k1/1p3p2/p1b2B2/1r5P/5KP1/8/8/8 b - - 0 43\\nThe moves played so far are:\\n1. e4 c5 2. Nf3 d6 3. d4 cxd4 4. Nxd4 Nf6 5. Nc3 a6 6. Bg5 e6 7. f4 Qb6 8. Qd2 Qxb2 9. Rb1 Qa3 10. e5 dxe5 11. fxe5 Nfd7 12. Ne4 h6 13. Bh4 Qxa2 14. Rd1 Qd5 15. Qe3 Qxe5 16. Be2 Bc5 17. Bg3 Bxd4 18. Rxd4 Qa5+ 19. c3 O-O 20. O-O Nc6 21. Nf6+ Nxf6 22. Rxf6 Nxd4 23. cxd4 gxf6 24. Qxh6 Qg5 25. Qxg5+ fxg5 26. Bd6 Rd8 27. Be7 Rxd4 28. Bxg5 Rd5 29. Bf6 Rf5 30. Bc3 Rc5 31. Bd4 Rc1+ 32. Kf2 Rc2 33. Ke3 Rxe2+ 34. Kxe2 Bd7 35. Ke3 Bc6 36. g3 Rd8 37. Bf6 Rd5 38. g4 e5 39. h4 e4 40. Kxe4 Rd6+ 41. Ke5 Rd5+ 42. Kf4 Rb5 43. h5\\nYou are playing as player Black.\\nIt is now your turn. Play your strongest move. The move MUST be legal. Reason step by step to come up with your move, then output your final answer in the format \\\"Final Answer: X\\\" where X is your chosen move in standard algebraic notation (SAN).\\n\"\n          }\n        ]\n      }\n    ],\n    \"config\": {\n      \"temperature\": \"NOT_GIVEN\",\n      \"top_p\": \"NOT_GIVEN\",\n      \"max_completion_tokens\": \"NOT_GIVEN\",\n      \"reasoning_effort\": \"high\"\n    },\n    \"stream_options\": {\n      \"include_usage\": true\n    }\n  },\n  \"response_for_logging\": {\n    \"response_chunks\": [\n      {\n        \"id\": \"chatcmpl-DcNiES781lB5WvJubkYOkbxAKga5k\",\n        \"created\": 1778039986,\n        \"model\": \"openai/gpt-5.5-2026-04-23\",\n        \"object\": \"chat.completion.chunk\",\n        \"usage\": {\n          \"completion_tokens\": 31191,\n          \"prompt_tokens\": 486,\n          \"total_tokens\": 31677,\n          \"cost\": {\n            \"input_tokens_cost_nanodollars\": 2430000,\n            \"output_tokens_cost_nanodollars\": 935730000\n          },\n          \"total_backend_latency_ms\": 610149\n        }\n      }\n    ]\n  },\n  \"generation_tokens\": 31191,\n  \"prompt_tokens\": 486,\n  \"reasoning_tokens\": null,\n  \"total_tokens\": 31677,\n  \"duration_success_only_secs\": 610.6320848670002\n}"
+          ],
+          "status": "OK",
+          "submission": 3548,
+          "thoughts": "Black should first neutralize White\u2019s dangerous h-pawn. Capturing it immediately fails to 43...Rxh5? 44.gxh5, but moving the king to h7 blockades it while keeping the rook active on the 5th rank.\n\nAfter 43...Kh7:\n- 44.h6 is met by 44...Kxh6.\n- 44.g5 leaves h5 undefended, allowing ...Rxh5.\n- Black maintains control and should convert the material advantage.\n\nFinal Answer: Kh7"
+        },
+        "info": {
+          "actionApplied": 3548,
+          "actionSubmitted": 3548,
+          "actionSubmittedToString": "Kh7",
+          "agentSelfReportedStatus": "OK",
+          "timeTaken": 611.889
+        },
+        "observation": {
+          "currentPlayer": 1,
+          "isTerminal": false,
+          "observationString": "8/1p3p1k/p1b2B2/1r5P/5KP1/8/8/8 w - - 1 44",
+          "playerId": 0,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n1258\n3572\n1841\n1842\n1431\n3132\n3572\n656\n89\n1215\n2425\n3010\n1808\n1768\n749\n30\n1065\n2571\n1942\n3196\n3131\n1384\n4177\n3854\n381\n615\n498\n1869\n2001\n2977\n2975\n4350\n1431\n1770\n2581\n1257\n4673\n4673\n656\n2627\n1895\n2940\n1386\n1358\n3634\n2528\n254\n4496\n3110\n3705\n2948\n2161\n1771\n2833\n2059\n3853\n2002\n3326\n3166\n1358\n1406\n3561\n1694\n3050\n1637\n2497\n1212\n2425\n1882\n3593\n32\n2016\n1770\n3666\n2498\n4178\n2571\n2498\n1986\n2571\n1914\n2686\n1999\n4323\n3548\n\n",
+          "step": 87
+        },
+        "reward": null,
+        "status": "INACTIVE"
+      },
+      {
+        "action": {
+          "submission": -1
+        },
+        "info": {},
+        "observation": {
+          "currentPlayer": 1,
+          "isTerminal": false,
+          "observationString": "8/1p3p1k/p1b2B2/1r5P/5KP1/8/8/8 w - - 1 44",
+          "playerId": 1,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n1258\n3572\n1841\n1842\n1431\n3132\n3572\n656\n89\n1215\n2425\n3010\n1808\n1768\n749\n30\n1065\n2571\n1942\n3196\n3131\n1384\n4177\n3854\n381\n615\n498\n1869\n2001\n2977\n2975\n4350\n1431\n1770\n2581\n1257\n4673\n4673\n656\n2627\n1895\n2940\n1386\n1358\n3634\n2528\n254\n4496\n3110\n3705\n2948\n2161\n1771\n2833\n2059\n3853\n2002\n3326\n3166\n1358\n1406\n3561\n1694\n3050\n1637\n2497\n1212\n2425\n1882\n3593\n32\n2016\n1770\n3666\n2498\n4178\n2571\n2498\n1986\n2571\n1914\n2686\n1999\n4323\n3548\n\n"
+        },
+        "reward": null,
+        "status": "ACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "submission": -1
+        },
+        "info": {},
+        "observation": {
+          "currentPlayer": 0,
+          "isTerminal": false,
+          "observationString": "8/1p3p1k/p1b2B2/1r4PP/5K2/8/8/8 b - - 0 44",
+          "playerId": 0,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n1258\n3572\n1841\n1842\n1431\n3132\n3572\n656\n89\n1215\n2425\n3010\n1808\n1768\n749\n30\n1065\n2571\n1942\n3196\n3131\n1384\n4177\n3854\n381\n615\n498\n1869\n2001\n2977\n2975\n4350\n1431\n1770\n2581\n1257\n4673\n4673\n656\n2627\n1895\n2940\n1386\n1358\n3634\n2528\n254\n4496\n3110\n3705\n2948\n2161\n1771\n2833\n2059\n3853\n2002\n3326\n3166\n1358\n1406\n3561\n1694\n3050\n1637\n2497\n1212\n2425\n1882\n3593\n32\n2016\n1770\n3666\n2498\n4178\n2571\n2498\n1986\n2571\n1914\n2686\n1999\n4323\n3548\n3739\n\n",
+          "step": 88
+        },
+        "reward": null,
+        "status": "ACTIVE"
+      },
+      {
+        "action": {
+          "actionString": "g5",
+          "generate_returns": [
+            "{\n  \"main_response\": \"To determine the best move, let's analyze the position. White is down an exchange and a pawn in an endgame (White has a Bishop and two pawns vs Black's Rook, Bishop, and three pawns), so the position is technically lost with perfect play from Black. However, White must play the most resilient move to create practical difficulties, maximize piece coordination, and limit Black's counterplay.\\n\\nWhite's primary assets are the well-placed dark-squared Bishop on f6 (which severely restricts the Black king on h7) and the connected kingside pawns on g4 and h5. White's King is currently active on f4. \\n\\nThe move **44. g5** is the most active and challenging continuation. By pushing the pawn:\\n1. White gains more space on the kingside and further paralyzes the Black king. \\n2. It sets up the threat of pushing `g6+` at an opportune moment. If Black isn't careful, a future `g6+` could disrupt Black's structure (e.g., ...fxg6 hxg6+ Kxg6) creating chances for White to eliminate Black's remaining kingside pawn and secure a slightly less passive defensive setup.\\n3. The pawn on g5 guards the f6 square, cementing the Bishop's dominant outpost. \\n4. If Black tries to immediately generate side-attacks like 44... Rb4+, the White King can easily step aside to e3 or e5. For instance, if 44... Rb4+ 45. Ke5, the King helps support the center, and Black's rook swinging to h4 (hoping to attack the h5 pawn) would allow White to unleash `g6+!`, shattering Black's coordination. \\n\\nAlternative King moves like 44. Kg3 are also playable but slightly more passive, immediately allowing Black's rook freedom to improve its placement with tempo on the kingside pawns. 44. g5 keeps White's position as tricky and resilient as possible.\\n\\nFinal Answer: g5\",\n  \"main_response_and_thoughts\": \"\",\n  \"request_for_logging\": {\n    \"model\": \"google/gemini-3.1-pro-preview\",\n    \"messages\": [\n      {\n        \"role\": \"user\",\n        \"content\": [\n          {\n            \"type\": \"text\",\n            \"text\": \"Let's play chess. The current game state in Forsyth-Edwards Notation (FEN) notation is:\\n8/1p3p1k/p1b2B2/1r5P/5KP1/8/8/8 w - - 1 44\\nThe moves played so far are:\\n1. e4 c5 2. Nf3 d6 3. d4 cxd4 4. Nxd4 Nf6 5. Nc3 a6 6. Bg5 e6 7. f4 Qb6 8. Qd2 Qxb2 9. Rb1 Qa3 10. e5 dxe5 11. fxe5 Nfd7 12. Ne4 h6 13. Bh4 Qxa2 14. Rd1 Qd5 15. Qe3 Qxe5 16. Be2 Bc5 17. Bg3 Bxd4 18. Rxd4 Qa5+ 19. c3 O-O 20. O-O Nc6 21. Nf6+ Nxf6 22. Rxf6 Nxd4 23. cxd4 gxf6 24. Qxh6 Qg5 25. Qxg5+ fxg5 26. Bd6 Rd8 27. Be7 Rxd4 28. Bxg5 Rd5 29. Bf6 Rf5 30. Bc3 Rc5 31. Bd4 Rc1+ 32. Kf2 Rc2 33. Ke3 Rxe2+ 34. Kxe2 Bd7 35. Ke3 Bc6 36. g3 Rd8 37. Bf6 Rd5 38. g4 e5 39. h4 e4 40. Kxe4 Rd6+ 41. Ke5 Rd5+ 42. Kf4 Rb5 43. h5 Kh7 44.\\nYou are playing as player White.\\nIt is now your turn. Play your strongest move. The move MUST be legal. Reason step by step to come up with your move, then output your final answer in the format \\\"Final Answer: X\\\" where X is your chosen move in standard algebraic notation (SAN).\\n\"\n          }\n        ]\n      }\n    ],\n    \"config\": {\n      \"temperature\": \"NOT_GIVEN\",\n      \"top_p\": \"NOT_GIVEN\",\n      \"max_completion_tokens\": \"NOT_GIVEN\"\n    },\n    \"stream_options\": {\n      \"include_usage\": true\n    }\n  },\n  \"response_for_logging\": {\n    \"response_chunks\": [\n      {\n        \"id\": \"F7_6ab-uHbWKmecPxOar6Aw\",\n        \"choices\": [\n          {\n            \"delta\": {\n              \"content\": \" 44. g5 keeps White's position as tricky and resilient as possible.\\n\\nFinal Answer: g5\",\n              \"role\": \"assistant\"\n            },\n            \"finish_reason\": \"stop\",\n            \"index\": 0\n          }\n        ],\n        \"created\": 1778040599,\n        \"model\": \"google/gemini-3.1-pro-preview\",\n        \"object\": \"chat.completion.chunk\",\n        \"usage\": {\n          \"completion_tokens\": 441,\n          \"prompt_tokens\": 482,\n          \"total_tokens\": 5256,\n          \"cost\": {\n            \"input_tokens_cost_nanodollars\": 964000,\n            \"output_tokens_cost_nanodollars\": 57288000\n          },\n          \"total_backend_latency_ms\": 44444\n        }\n      }\n    ]\n  },\n  \"generation_tokens\": 441,\n  \"prompt_tokens\": 482,\n  \"reasoning_tokens\": null,\n  \"total_tokens\": 5256,\n  \"duration_success_only_secs\": 45.60624108999764\n}"
+          ],
+          "status": "OK",
+          "submission": 3739,
+          "thoughts": "To determine the best move, let's analyze the position. White is down an exchange and a pawn in an endgame (White has a Bishop and two pawns vs Black's Rook, Bishop, and three pawns), so the position is technically lost with perfect play from Black. However, White must play the most resilient move to create practical difficulties, maximize piece coordination, and limit Black's counterplay.\n\nWhite's primary assets are the well-placed dark-squared Bishop on f6 (which severely restricts the Black king on h7) and the connected kingside pawns on g4 and h5. White's King is currently active on f4. \n\nThe move **44. g5** is the most active and challenging continuation. By pushing the pawn:\n1. White gains more space on the kingside and further paralyzes the Black king. \n2. It sets up the threat of pushing `g6+` at an opportune moment. If Black isn't careful, a future `g6+` could disrupt Black's structure (e.g., ...fxg6 hxg6+ Kxg6) creating chances for White to eliminate Black's remaining kingside pawn and secure a slightly less passive defensive setup.\n3. The pawn on g5 guards the f6 square, cementing the Bishop's dominant outpost. \n4. If Black tries to immediately generate side-attacks like 44... Rb4+, the White King can easily step aside to e3 or e5. For instance, if 44... Rb4+ 45. Ke5, the King helps support the center, and Black's rook swinging to h4 (hoping to attack the h5 pawn) would allow White to unleash `g6+!`, shattering Black's coordination. \n\nAlternative King moves like 44. Kg3 are also playable but slightly more passive, immediately allowing Black's rook freedom to improve its placement with tempo on the kingside pawns. 44. g5 keeps White's position as tricky and resilient as possible.\n\nFinal Answer: g5"
+        },
+        "info": {
+          "actionApplied": 3739,
+          "actionSubmitted": 3739,
+          "actionSubmittedToString": "g5",
+          "agentSelfReportedStatus": "OK",
+          "timeTaken": 47.354
+        },
+        "observation": {
+          "currentPlayer": 0,
+          "isTerminal": false,
+          "observationString": "8/1p3p1k/p1b2B2/1r4PP/5K2/8/8/8 b - - 0 44",
+          "playerId": 1,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n1258\n3572\n1841\n1842\n1431\n3132\n3572\n656\n89\n1215\n2425\n3010\n1808\n1768\n749\n30\n1065\n2571\n1942\n3196\n3131\n1384\n4177\n3854\n381\n615\n498\n1869\n2001\n2977\n2975\n4350\n1431\n1770\n2581\n1257\n4673\n4673\n656\n2627\n1895\n2940\n1386\n1358\n3634\n2528\n254\n4496\n3110\n3705\n2948\n2161\n1771\n2833\n2059\n3853\n2002\n3326\n3166\n1358\n1406\n3561\n1694\n3050\n1637\n2497\n1212\n2425\n1882\n3593\n32\n2016\n1770\n3666\n2498\n4178\n2571\n2498\n1986\n2571\n1914\n2686\n1999\n4323\n3548\n3739\n\n"
+        },
+        "reward": null,
+        "status": "INACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "actionString": "Rb4+",
+          "generate_returns": [
+            "{\n  \"main_response\": \"Final Answer: Rb4+\",\n  \"main_response_and_thoughts\": \"\",\n  \"request_for_logging\": {\n    \"model\": \"openai/gpt-5.5-2026-04-23\",\n    \"messages\": [\n      {\n        \"role\": \"user\",\n        \"content\": [\n          {\n            \"type\": \"text\",\n            \"text\": \"Let's play chess. The current game state in Forsyth-Edwards Notation (FEN) notation is:\\n8/1p3p1k/p1b2B2/1r4PP/5K2/8/8/8 b - - 0 44\\nThe moves played so far are:\\n1. e4 c5 2. Nf3 d6 3. d4 cxd4 4. Nxd4 Nf6 5. Nc3 a6 6. Bg5 e6 7. f4 Qb6 8. Qd2 Qxb2 9. Rb1 Qa3 10. e5 dxe5 11. fxe5 Nfd7 12. Ne4 h6 13. Bh4 Qxa2 14. Rd1 Qd5 15. Qe3 Qxe5 16. Be2 Bc5 17. Bg3 Bxd4 18. Rxd4 Qa5+ 19. c3 O-O 20. O-O Nc6 21. Nf6+ Nxf6 22. Rxf6 Nxd4 23. cxd4 gxf6 24. Qxh6 Qg5 25. Qxg5+ fxg5 26. Bd6 Rd8 27. Be7 Rxd4 28. Bxg5 Rd5 29. Bf6 Rf5 30. Bc3 Rc5 31. Bd4 Rc1+ 32. Kf2 Rc2 33. Ke3 Rxe2+ 34. Kxe2 Bd7 35. Ke3 Bc6 36. g3 Rd8 37. Bf6 Rd5 38. g4 e5 39. h4 e4 40. Kxe4 Rd6+ 41. Ke5 Rd5+ 42. Kf4 Rb5 43. h5 Kh7 44. g5\\nYou are playing as player Black.\\nIt is now your turn. Play your strongest move. The move MUST be legal. Reason step by step to come up with your move, then output your final answer in the format \\\"Final Answer: X\\\" where X is your chosen move in standard algebraic notation (SAN).\\n\"\n          }\n        ]\n      }\n    ],\n    \"config\": {\n      \"temperature\": \"NOT_GIVEN\",\n      \"top_p\": \"NOT_GIVEN\",\n      \"max_completion_tokens\": \"NOT_GIVEN\",\n      \"reasoning_effort\": \"high\"\n    },\n    \"stream_options\": {\n      \"include_usage\": true\n    }\n  },\n  \"response_for_logging\": {\n    \"response_chunks\": [\n      {\n        \"id\": \"chatcmpl-DcNsrlALxyo2A8BQRjeawDRdBxz3o\",\n        \"created\": 1778040645,\n        \"model\": \"openai/gpt-5.5-2026-04-23\",\n        \"object\": \"chat.completion.chunk\",\n        \"usage\": {\n          \"completion_tokens\": 29018,\n          \"prompt_tokens\": 492,\n          \"total_tokens\": 29510,\n          \"cost\": {\n            \"input_tokens_cost_nanodollars\": 2460000,\n            \"output_tokens_cost_nanodollars\": 870540000\n          },\n          \"total_backend_latency_ms\": 559168\n        }\n      }\n    ]\n  },\n  \"generation_tokens\": 29018,\n  \"prompt_tokens\": 492,\n  \"reasoning_tokens\": null,\n  \"total_tokens\": 29510,\n  \"duration_success_only_secs\": 559.6062728790021\n}"
+          ],
+          "status": "OK",
+          "submission": 819,
+          "thoughts": "Final Answer: Rb4+"
+        },
+        "info": {
+          "actionApplied": 819,
+          "actionSubmitted": 819,
+          "actionSubmittedToString": "Rb4+",
+          "agentSelfReportedStatus": "OK",
+          "timeTaken": 561.286
+        },
+        "observation": {
+          "currentPlayer": 1,
+          "isTerminal": false,
+          "observationString": "8/1p3p1k/p1b2B2/6PP/1r3K2/8/8/8 w - - 1 45",
+          "playerId": 0,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n1258\n3572\n1841\n1842\n1431\n3132\n3572\n656\n89\n1215\n2425\n3010\n1808\n1768\n749\n30\n1065\n2571\n1942\n3196\n3131\n1384\n4177\n3854\n381\n615\n498\n1869\n2001\n2977\n2975\n4350\n1431\n1770\n2581\n1257\n4673\n4673\n656\n2627\n1895\n2940\n1386\n1358\n3634\n2528\n254\n4496\n3110\n3705\n2948\n2161\n1771\n2833\n2059\n3853\n2002\n3326\n3166\n1358\n1406\n3561\n1694\n3050\n1637\n2497\n1212\n2425\n1882\n3593\n32\n2016\n1770\n3666\n2498\n4178\n2571\n2498\n1986\n2571\n1914\n2686\n1999\n4323\n3548\n3739\n819\n\n",
+          "step": 89
+        },
+        "reward": null,
+        "status": "INACTIVE"
+      },
+      {
+        "action": {
+          "submission": -1
+        },
+        "info": {},
+        "observation": {
+          "currentPlayer": 1,
+          "isTerminal": false,
+          "observationString": "8/1p3p1k/p1b2B2/6PP/1r3K2/8/8/8 w - - 1 45",
+          "playerId": 1,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n1258\n3572\n1841\n1842\n1431\n3132\n3572\n656\n89\n1215\n2425\n3010\n1808\n1768\n749\n30\n1065\n2571\n1942\n3196\n3131\n1384\n4177\n3854\n381\n615\n498\n1869\n2001\n2977\n2975\n4350\n1431\n1770\n2581\n1257\n4673\n4673\n656\n2627\n1895\n2940\n1386\n1358\n3634\n2528\n254\n4496\n3110\n3705\n2948\n2161\n1771\n2833\n2059\n3853\n2002\n3326\n3166\n1358\n1406\n3561\n1694\n3050\n1637\n2497\n1212\n2425\n1882\n3593\n32\n2016\n1770\n3666\n2498\n4178\n2571\n2498\n1986\n2571\n1914\n2686\n1999\n4323\n3548\n3739\n819\n\n"
+        },
+        "reward": null,
+        "status": "ACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "submission": -1
+        },
+        "info": {},
+        "observation": {
+          "currentPlayer": 0,
+          "isTerminal": false,
+          "observationString": "8/1p3p1k/p1b2B2/4K1PP/1r6/8/8/8 b - - 2 45",
+          "playerId": 0,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n1258\n3572\n1841\n1842\n1431\n3132\n3572\n656\n89\n1215\n2425\n3010\n1808\n1768\n749\n30\n1065\n2571\n1942\n3196\n3131\n1384\n4177\n3854\n381\n615\n498\n1869\n2001\n2977\n2975\n4350\n1431\n1770\n2581\n1257\n4673\n4673\n656\n2627\n1895\n2940\n1386\n1358\n3634\n2528\n254\n4496\n3110\n3705\n2948\n2161\n1771\n2833\n2059\n3853\n2002\n3326\n3166\n1358\n1406\n3561\n1694\n3050\n1637\n2497\n1212\n2425\n1882\n3593\n32\n2016\n1770\n3666\n2498\n4178\n2571\n2498\n1986\n2571\n1914\n2686\n1999\n4323\n3548\n3739\n819\n3196\n\n",
+          "step": 90
+        },
+        "reward": null,
+        "status": "ACTIVE"
+      },
+      {
+        "action": {
+          "actionString": "Ke5",
+          "generate_returns": [
+            "{\n  \"main_response\": \"To find the best move, we need to consider how to activate our king and handle Black's passed pawns on the queenside while maintaining the threat of our own passed pawns on the kingside.\\n\\nWhen in an endgame, king activity is paramount. The White king is currently in check.\\nIf White plays 45. Kg3, the king becomes slightly passive, and Black has time to easily push their a-pawn (45... a5). \\nIf White plays 45. Ke3, the king heads toward the queenside to stop the pawns, but leaves the g5 and h5 pawns without support, while potentially running into future checks.\\n\\nThe most active and resilient choice is **45. Ke5**. \\nMoving the King to the center not only keeps it well-placed to support its own passed pawns (g5 and h5) but also sets up a potential journey toward the queenside (via d6 and c5 or d4 and c4) to intercept Black's advancing a-pawn. \\n\\nFor instance, if Black tries to push immediately with 45... a5, White's king aggressively marches with 46. Kd6 a4 47. Kc5, arriving just in time to neutralize the passed pawn. If Black opts for 45... Rb5+, White can adaptably play 46. Kd6 or 46. Kf4, keeping maximum pressure and complicating the position for Black as much as possible to salvage a draw in a difficult endgame.\\n\\nFinal Answer: Ke5\",\n  \"main_response_and_thoughts\": \"\",\n  \"request_for_logging\": {\n    \"model\": \"google/gemini-3.1-pro-preview\",\n    \"messages\": [\n      {\n        \"role\": \"user\",\n        \"content\": [\n          {\n            \"type\": \"text\",\n            \"text\": \"Let's play chess. The current game state in Forsyth-Edwards Notation (FEN) notation is:\\n8/1p3p1k/p1b2B2/6PP/1r3K2/8/8/8 w - - 1 45\\nThe moves played so far are:\\n1. e4 c5 2. Nf3 d6 3. d4 cxd4 4. Nxd4 Nf6 5. Nc3 a6 6. Bg5 e6 7. f4 Qb6 8. Qd2 Qxb2 9. Rb1 Qa3 10. e5 dxe5 11. fxe5 Nfd7 12. Ne4 h6 13. Bh4 Qxa2 14. Rd1 Qd5 15. Qe3 Qxe5 16. Be2 Bc5 17. Bg3 Bxd4 18. Rxd4 Qa5+ 19. c3 O-O 20. O-O Nc6 21. Nf6+ Nxf6 22. Rxf6 Nxd4 23. cxd4 gxf6 24. Qxh6 Qg5 25. Qxg5+ fxg5 26. Bd6 Rd8 27. Be7 Rxd4 28. Bxg5 Rd5 29. Bf6 Rf5 30. Bc3 Rc5 31. Bd4 Rc1+ 32. Kf2 Rc2 33. Ke3 Rxe2+ 34. Kxe2 Bd7 35. Ke3 Bc6 36. g3 Rd8 37. Bf6 Rd5 38. g4 e5 39. h4 e4 40. Kxe4 Rd6+ 41. Ke5 Rd5+ 42. Kf4 Rb5 43. h5 Kh7 44. g5 Rb4+ 45.\\nYou are playing as player White.\\nIt is now your turn. Play your strongest move. The move MUST be legal. Reason step by step to come up with your move, then output your final answer in the format \\\"Final Answer: X\\\" where X is your chosen move in standard algebraic notation (SAN).\\n\"\n          }\n        ]\n      }\n    ],\n    \"config\": {\n      \"temperature\": \"NOT_GIVEN\",\n      \"top_p\": \"NOT_GIVEN\",\n      \"max_completion_tokens\": \"NOT_GIVEN\"\n    },\n    \"stream_options\": {\n      \"include_usage\": true\n    }\n  },\n  \"response_for_logging\": {\n    \"response_chunks\": [\n      {\n        \"id\": \"d8H6acm2IcudmecPmbT14Qk\",\n        \"choices\": [\n          {\n            \"delta\": {\n              \"content\": \"5\",\n              \"role\": \"assistant\"\n            },\n            \"finish_reason\": \"stop\",\n            \"index\": 0\n          }\n        ],\n        \"created\": 1778041207,\n        \"model\": \"google/gemini-3.1-pro-preview\",\n        \"object\": \"chat.completion.chunk\",\n        \"usage\": {\n          \"completion_tokens\": 331,\n          \"prompt_tokens\": 491,\n          \"total_tokens\": 5485,\n          \"cost\": {\n            \"input_tokens_cost_nanodollars\": 982000,\n            \"output_tokens_cost_nanodollars\": 59928000\n          },\n          \"total_backend_latency_ms\": 41540\n        }\n      }\n    ]\n  },\n  \"generation_tokens\": 331,\n  \"prompt_tokens\": 491,\n  \"reasoning_tokens\": null,\n  \"total_tokens\": 5485,\n  \"duration_success_only_secs\": 42.528892676000396\n}"
+          ],
+          "status": "OK",
+          "submission": 3196,
+          "thoughts": "To find the best move, we need to consider how to activate our king and handle Black's passed pawns on the queenside while maintaining the threat of our own passed pawns on the kingside.\n\nWhen in an endgame, king activity is paramount. The White king is currently in check.\nIf White plays 45. Kg3, the king becomes slightly passive, and Black has time to easily push their a-pawn (45... a5). \nIf White plays 45. Ke3, the king heads toward the queenside to stop the pawns, but leaves the g5 and h5 pawns without support, while potentially running into future checks.\n\nThe most active and resilient choice is **45. Ke5**. \nMoving the King to the center not only keeps it well-placed to support its own passed pawns (g5 and h5) but also sets up a potential journey toward the queenside (via d6 and c5 or d4 and c4) to intercept Black's advancing a-pawn. \n\nFor instance, if Black tries to push immediately with 45... a5, White's king aggressively marches with 46. Kd6 a4 47. Kc5, arriving just in time to neutralize the passed pawn. If Black opts for 45... Rb5+, White can adaptably play 46. Kd6 or 46. Kf4, keeping maximum pressure and complicating the position for Black as much as possible to salvage a draw in a difficult endgame.\n\nFinal Answer: Ke5"
+        },
+        "info": {
+          "actionApplied": 3196,
+          "actionSubmitted": 3196,
+          "actionSubmittedToString": "Ke5",
+          "agentSelfReportedStatus": "OK",
+          "timeTaken": 43.759
+        },
+        "observation": {
+          "currentPlayer": 0,
+          "isTerminal": false,
+          "observationString": "8/1p3p1k/p1b2B2/4K1PP/1r6/8/8/8 b - - 2 45",
+          "playerId": 1,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n1258\n3572\n1841\n1842\n1431\n3132\n3572\n656\n89\n1215\n2425\n3010\n1808\n1768\n749\n30\n1065\n2571\n1942\n3196\n3131\n1384\n4177\n3854\n381\n615\n498\n1869\n2001\n2977\n2975\n4350\n1431\n1770\n2581\n1257\n4673\n4673\n656\n2627\n1895\n2940\n1386\n1358\n3634\n2528\n254\n4496\n3110\n3705\n2948\n2161\n1771\n2833\n2059\n3853\n2002\n3326\n3166\n1358\n1406\n3561\n1694\n3050\n1637\n2497\n1212\n2425\n1882\n3593\n32\n2016\n1770\n3666\n2498\n4178\n2571\n2498\n1986\n2571\n1914\n2686\n1999\n4323\n3548\n3739\n819\n3196\n\n"
+        },
+        "reward": null,
+        "status": "INACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "actionString": "Rh4",
+          "generate_returns": [
+            "{\n  \"main_response\": \"The strongest move is to swing the rook to h4, attacking the h-pawn. The g5 pawn blocks White\\u2019s bishop from taking on h4, so the rook is safe. If White tries 46. h6, Black can play 46...Rxh6 and after 47. gxh6 Kxh6, the dangerous pawns are gone.\\n\\nFinal Answer: Rh4\",\n  \"main_response_and_thoughts\": \"\",\n  \"request_for_logging\": {\n    \"model\": \"openai/gpt-5.5-2026-04-23\",\n    \"messages\": [\n      {\n        \"role\": \"user\",\n        \"content\": [\n          {\n            \"type\": \"text\",\n            \"text\": \"Let's play chess. The current game state in Forsyth-Edwards Notation (FEN) notation is:\\n8/1p3p1k/p1b2B2/4K1PP/1r6/8/8/8 b - - 2 45\\nThe moves played so far are:\\n1. e4 c5 2. Nf3 d6 3. d4 cxd4 4. Nxd4 Nf6 5. Nc3 a6 6. Bg5 e6 7. f4 Qb6 8. Qd2 Qxb2 9. Rb1 Qa3 10. e5 dxe5 11. fxe5 Nfd7 12. Ne4 h6 13. Bh4 Qxa2 14. Rd1 Qd5 15. Qe3 Qxe5 16. Be2 Bc5 17. Bg3 Bxd4 18. Rxd4 Qa5+ 19. c3 O-O 20. O-O Nc6 21. Nf6+ Nxf6 22. Rxf6 Nxd4 23. cxd4 gxf6 24. Qxh6 Qg5 25. Qxg5+ fxg5 26. Bd6 Rd8 27. Be7 Rxd4 28. Bxg5 Rd5 29. Bf6 Rf5 30. Bc3 Rc5 31. Bd4 Rc1+ 32. Kf2 Rc2 33. Ke3 Rxe2+ 34. Kxe2 Bd7 35. Ke3 Bc6 36. g3 Rd8 37. Bf6 Rd5 38. g4 e5 39. h4 e4 40. Kxe4 Rd6+ 41. Ke5 Rd5+ 42. Kf4 Rb5 43. h5 Kh7 44. g5 Rb4+ 45. Ke5\\nYou are playing as player Black.\\nIt is now your turn. Play your strongest move. The move MUST be legal. Reason step by step to come up with your move, then output your final answer in the format \\\"Final Answer: X\\\" where X is your chosen move in standard algebraic notation (SAN).\\n\"\n          }\n        ]\n      }\n    ],\n    \"config\": {\n      \"temperature\": \"NOT_GIVEN\",\n      \"top_p\": \"NOT_GIVEN\",\n      \"max_completion_tokens\": \"NOT_GIVEN\",\n      \"reasoning_effort\": \"high\"\n    },\n    \"stream_options\": {\n      \"include_usage\": true\n    }\n  },\n  \"response_for_logging\": {\n    \"response_chunks\": [\n      {\n        \"id\": \"chatcmpl-DcO2caQER39HXnK2C6yUOO0BlV0pK\",\n        \"created\": 1778041250,\n        \"model\": \"openai/gpt-5.5-2026-04-23\",\n        \"object\": \"chat.completion.chunk\",\n        \"usage\": {\n          \"completion_tokens\": 26482,\n          \"prompt_tokens\": 501,\n          \"total_tokens\": 26983,\n          \"cost\": {\n            \"input_tokens_cost_nanodollars\": 2505000,\n            \"output_tokens_cost_nanodollars\": 794460000\n          },\n          \"total_backend_latency_ms\": 498479\n        }\n      }\n    ]\n  },\n  \"generation_tokens\": 26482,\n  \"prompt_tokens\": 501,\n  \"reasoning_tokens\": null,\n  \"total_tokens\": 26983,\n  \"duration_success_only_secs\": 498.9298258310009\n}"
+          ],
+          "status": "OK",
+          "submission": 911,
+          "thoughts": "The strongest move is to swing the rook to h4, attacking the h-pawn. The g5 pawn blocks White\u2019s bishop from taking on h4, so the rook is safe. If White tries 46. h6, Black can play 46...Rxh6 and after 47. gxh6 Kxh6, the dangerous pawns are gone.\n\nFinal Answer: Rh4"
+        },
+        "info": {
+          "actionApplied": 911,
+          "actionSubmitted": 911,
+          "actionSubmittedToString": "Rh4",
+          "agentSelfReportedStatus": "OK",
+          "timeTaken": 500.194
+        },
+        "observation": {
+          "currentPlayer": 1,
+          "isTerminal": false,
+          "observationString": "8/1p3p1k/p1b2B2/4K1PP/7r/8/8/8 w - - 3 46",
+          "playerId": 0,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n1258\n3572\n1841\n1842\n1431\n3132\n3572\n656\n89\n1215\n2425\n3010\n1808\n1768\n749\n30\n1065\n2571\n1942\n3196\n3131\n1384\n4177\n3854\n381\n615\n498\n1869\n2001\n2977\n2975\n4350\n1431\n1770\n2581\n1257\n4673\n4673\n656\n2627\n1895\n2940\n1386\n1358\n3634\n2528\n254\n4496\n3110\n3705\n2948\n2161\n1771\n2833\n2059\n3853\n2002\n3326\n3166\n1358\n1406\n3561\n1694\n3050\n1637\n2497\n1212\n2425\n1882\n3593\n32\n2016\n1770\n3666\n2498\n4178\n2571\n2498\n1986\n2571\n1914\n2686\n1999\n4323\n3548\n3739\n819\n3196\n911\n\n",
+          "step": 91
+        },
+        "reward": null,
+        "status": "INACTIVE"
+      },
+      {
+        "action": {
+          "submission": -1
+        },
+        "info": {},
+        "observation": {
+          "currentPlayer": 1,
+          "isTerminal": false,
+          "observationString": "8/1p3p1k/p1b2B2/4K1PP/7r/8/8/8 w - - 3 46",
+          "playerId": 1,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n1258\n3572\n1841\n1842\n1431\n3132\n3572\n656\n89\n1215\n2425\n3010\n1808\n1768\n749\n30\n1065\n2571\n1942\n3196\n3131\n1384\n4177\n3854\n381\n615\n498\n1869\n2001\n2977\n2975\n4350\n1431\n1770\n2581\n1257\n4673\n4673\n656\n2627\n1895\n2940\n1386\n1358\n3634\n2528\n254\n4496\n3110\n3705\n2948\n2161\n1771\n2833\n2059\n3853\n2002\n3326\n3166\n1358\n1406\n3561\n1694\n3050\n1637\n2497\n1212\n2425\n1882\n3593\n32\n2016\n1770\n3666\n2498\n4178\n2571\n2498\n1986\n2571\n1914\n2686\n1999\n4323\n3548\n3739\n819\n3196\n911\n\n"
+        },
+        "reward": null,
+        "status": "ACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "submission": -1
+        },
+        "info": {},
+        "observation": {
+          "currentPlayer": 0,
+          "isTerminal": false,
+          "observationString": "8/1p3p1k/p1b2BP1/4K2P/7r/8/8/8 b - - 0 46",
+          "playerId": 0,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n1258\n3572\n1841\n1842\n1431\n3132\n3572\n656\n89\n1215\n2425\n3010\n1808\n1768\n749\n30\n1065\n2571\n1942\n3196\n3131\n1384\n4177\n3854\n381\n615\n498\n1869\n2001\n2977\n2975\n4350\n1431\n1770\n2581\n1257\n4673\n4673\n656\n2627\n1895\n2940\n1386\n1358\n3634\n2528\n254\n4496\n3110\n3705\n2948\n2161\n1771\n2833\n2059\n3853\n2002\n3326\n3166\n1358\n1406\n3561\n1694\n3050\n1637\n2497\n1212\n2425\n1882\n3593\n32\n2016\n1770\n3666\n2498\n4178\n2571\n2498\n1986\n2571\n1914\n2686\n1999\n4323\n3548\n3739\n819\n3196\n911\n3812\n\n",
+          "step": 92
+        },
+        "reward": null,
+        "status": "ACTIVE"
+      },
+      {
+        "action": {
+          "actionString": "g6+",
+          "generate_returns": [
+            "{\n  \"main_response\": \"To find the best move, we must carefully analyze the geometric placement of the pieces on the board. \\n\\nCurrently, White is down a substantial amount of material (a full rook and a pawn). However, a tactical opportunity presents itself due to the alignment of the pieces on the kingside.\\n\\n1. **Spot the Alignment**: Notice that the White Bishop on f6 and the Black Rook on h4 share the same dark-squared diagonal (f6 - g5 - h4). \\n2. **Identify the Obstacle**: The only piece blocking the Bishop's vision of the unprotected Black Rook is White's own pawn on g5. If this pawn moves, it will open a \\\"discovered attack\\\" on the rook.\\n3. **Force the Issue**: If White simply moves the pawn, Black might move the rook away. Therefore, White needs to move the pawn with a tempo (a forcing threat) so that Black does not have the time to save their rook.\\n4. **The Execution**: The move **46. g6+!** achieves exactly this. By advancing the pawn, White delivers a direct check to the Black King on h7. \\n\\nBecause Black is in check, they are forced to deal with the threat to their King (either by moving the king to g8/h6 or playing ...fxg6). Whatever Black decides to do, they won't have the time to save their rook on h4, and on the next turn, White will simply capture the rook with the bishop (47. Bxh4), drastically improving the material situation and giving White fighting chances in the endgame.\\n\\nFinal Answer: g6+\",\n  \"main_response_and_thoughts\": \"\",\n  \"request_for_logging\": {\n    \"model\": \"google/gemini-3.1-pro-preview\",\n    \"messages\": [\n      {\n        \"role\": \"user\",\n        \"content\": [\n          {\n            \"type\": \"text\",\n            \"text\": \"Let's play chess. The current game state in Forsyth-Edwards Notation (FEN) notation is:\\n8/1p3p1k/p1b2B2/4K1PP/7r/8/8/8 w - - 3 46\\nThe moves played so far are:\\n1. e4 c5 2. Nf3 d6 3. d4 cxd4 4. Nxd4 Nf6 5. Nc3 a6 6. Bg5 e6 7. f4 Qb6 8. Qd2 Qxb2 9. Rb1 Qa3 10. e5 dxe5 11. fxe5 Nfd7 12. Ne4 h6 13. Bh4 Qxa2 14. Rd1 Qd5 15. Qe3 Qxe5 16. Be2 Bc5 17. Bg3 Bxd4 18. Rxd4 Qa5+ 19. c3 O-O 20. O-O Nc6 21. Nf6+ Nxf6 22. Rxf6 Nxd4 23. cxd4 gxf6 24. Qxh6 Qg5 25. Qxg5+ fxg5 26. Bd6 Rd8 27. Be7 Rxd4 28. Bxg5 Rd5 29. Bf6 Rf5 30. Bc3 Rc5 31. Bd4 Rc1+ 32. Kf2 Rc2 33. Ke3 Rxe2+ 34. Kxe2 Bd7 35. Ke3 Bc6 36. g3 Rd8 37. Bf6 Rd5 38. g4 e5 39. h4 e4 40. Kxe4 Rd6+ 41. Ke5 Rd5+ 42. Kf4 Rb5 43. h5 Kh7 44. g5 Rb4+ 45. Ke5 Rh4 46.\\nYou are playing as player White.\\nIt is now your turn. Play your strongest move. The move MUST be legal. Reason step by step to come up with your move, then output your final answer in the format \\\"Final Answer: X\\\" where X is your chosen move in standard algebraic notation (SAN).\\n\"\n          }\n        ]\n      }\n    ],\n    \"config\": {\n      \"temperature\": \"NOT_GIVEN\",\n      \"top_p\": \"NOT_GIVEN\",\n      \"max_completion_tokens\": \"NOT_GIVEN\"\n    },\n    \"stream_options\": {\n      \"include_usage\": true\n    }\n  },\n  \"response_for_logging\": {\n    \"response_chunks\": [\n      {\n        \"id\": \"lsP6af7tO7WKmecPxOar6Aw\",\n        \"choices\": [\n          {\n            \"delta\": {\n              \"content\": \": g6+\",\n              \"role\": \"assistant\"\n            },\n            \"finish_reason\": \"stop\",\n            \"index\": 0\n          }\n        ],\n        \"created\": 1778041750,\n        \"model\": \"google/gemini-3.1-pro-preview\",\n        \"object\": \"chat.completion.chunk\",\n        \"usage\": {\n          \"completion_tokens\": 343,\n          \"prompt_tokens\": 498,\n          \"total_tokens\": 5347,\n          \"cost\": {\n            \"input_tokens_cost_nanodollars\": 996000,\n            \"output_tokens_cost_nanodollars\": 58188000\n          },\n          \"total_backend_latency_ms\": 41352\n        }\n      }\n    ]\n  },\n  \"generation_tokens\": 343,\n  \"prompt_tokens\": 498,\n  \"reasoning_tokens\": null,\n  \"total_tokens\": 5347,\n  \"duration_success_only_secs\": 41.85865838099926\n}"
+          ],
+          "status": "OK",
+          "submission": 3812,
+          "thoughts": "To find the best move, we must carefully analyze the geometric placement of the pieces on the board. \n\nCurrently, White is down a substantial amount of material (a full rook and a pawn). However, a tactical opportunity presents itself due to the alignment of the pieces on the kingside.\n\n1. **Spot the Alignment**: Notice that the White Bishop on f6 and the Black Rook on h4 share the same dark-squared diagonal (f6 - g5 - h4). \n2. **Identify the Obstacle**: The only piece blocking the Bishop's vision of the unprotected Black Rook is White's own pawn on g5. If this pawn moves, it will open a \"discovered attack\" on the rook.\n3. **Force the Issue**: If White simply moves the pawn, Black might move the rook away. Therefore, White needs to move the pawn with a tempo (a forcing threat) so that Black does not have the time to save their rook.\n4. **The Execution**: The move **46. g6+!** achieves exactly this. By advancing the pawn, White delivers a direct check to the Black King on h7. \n\nBecause Black is in check, they are forced to deal with the threat to their King (either by moving the king to g8/h6 or playing ...fxg6). Whatever Black decides to do, they won't have the time to save their rook on h4, and on the next turn, White will simply capture the rook with the bishop (47. Bxh4), drastically improving the material situation and giving White fighting chances in the endgame.\n\nFinal Answer: g6+"
+        },
+        "info": {
+          "actionApplied": 3812,
+          "actionSubmitted": 3812,
+          "actionSubmittedToString": "g6+",
+          "agentSelfReportedStatus": "OK",
+          "timeTaken": 43.04
+        },
+        "observation": {
+          "currentPlayer": 0,
+          "isTerminal": false,
+          "observationString": "8/1p3p1k/p1b2BP1/4K2P/7r/8/8/8 b - - 0 46",
+          "playerId": 1,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n1258\n3572\n1841\n1842\n1431\n3132\n3572\n656\n89\n1215\n2425\n3010\n1808\n1768\n749\n30\n1065\n2571\n1942\n3196\n3131\n1384\n4177\n3854\n381\n615\n498\n1869\n2001\n2977\n2975\n4350\n1431\n1770\n2581\n1257\n4673\n4673\n656\n2627\n1895\n2940\n1386\n1358\n3634\n2528\n254\n4496\n3110\n3705\n2948\n2161\n1771\n2833\n2059\n3853\n2002\n3326\n3166\n1358\n1406\n3561\n1694\n3050\n1637\n2497\n1212\n2425\n1882\n3593\n32\n2016\n1770\n3666\n2498\n4178\n2571\n2498\n1986\n2571\n1914\n2686\n1999\n4323\n3548\n3739\n819\n3196\n911\n3812\n\n"
+        },
+        "reward": null,
+        "status": "INACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "actionString": "fxg6",
+          "generate_returns": [
+            "{\n  \"main_response\": \"Black should capture the checking pawn and reduce White\\u2019s dangerous kingside pawns.\\n\\nFinal Answer: fxg6\",\n  \"main_response_and_thoughts\": \"\",\n  \"request_for_logging\": {\n    \"model\": \"openai/gpt-5.5-2026-04-23\",\n    \"messages\": [\n      {\n        \"role\": \"user\",\n        \"content\": [\n          {\n            \"type\": \"text\",\n            \"text\": \"Let's play chess. The current game state in Forsyth-Edwards Notation (FEN) notation is:\\n8/1p3p1k/p1b2BP1/4K2P/7r/8/8/8 b - - 0 46\\nThe moves played so far are:\\n1. e4 c5 2. Nf3 d6 3. d4 cxd4 4. Nxd4 Nf6 5. Nc3 a6 6. Bg5 e6 7. f4 Qb6 8. Qd2 Qxb2 9. Rb1 Qa3 10. e5 dxe5 11. fxe5 Nfd7 12. Ne4 h6 13. Bh4 Qxa2 14. Rd1 Qd5 15. Qe3 Qxe5 16. Be2 Bc5 17. Bg3 Bxd4 18. Rxd4 Qa5+ 19. c3 O-O 20. O-O Nc6 21. Nf6+ Nxf6 22. Rxf6 Nxd4 23. cxd4 gxf6 24. Qxh6 Qg5 25. Qxg5+ fxg5 26. Bd6 Rd8 27. Be7 Rxd4 28. Bxg5 Rd5 29. Bf6 Rf5 30. Bc3 Rc5 31. Bd4 Rc1+ 32. Kf2 Rc2 33. Ke3 Rxe2+ 34. Kxe2 Bd7 35. Ke3 Bc6 36. g3 Rd8 37. Bf6 Rd5 38. g4 e5 39. h4 e4 40. Kxe4 Rd6+ 41. Ke5 Rd5+ 42. Kf4 Rb5 43. h5 Kh7 44. g5 Rb4+ 45. Ke5 Rh4 46. g6+\\nYou are playing as player Black.\\nIt is now your turn. Play your strongest move. The move MUST be legal. Reason step by step to come up with your move, then output your final answer in the format \\\"Final Answer: X\\\" where X is your chosen move in standard algebraic notation (SAN).\\n\"\n          }\n        ]\n      }\n    ],\n    \"config\": {\n      \"temperature\": \"NOT_GIVEN\",\n      \"top_p\": \"NOT_GIVEN\",\n      \"max_completion_tokens\": \"NOT_GIVEN\",\n      \"reasoning_effort\": \"high\"\n    },\n    \"stream_options\": {\n      \"include_usage\": true\n    }\n  },\n  \"response_for_logging\": {\n    \"response_chunks\": [\n      {\n        \"id\": \"chatcmpl-DcOBOagKeSU0XDakRkeYw3e6qgWHe\",\n        \"created\": 1778041794,\n        \"model\": \"openai/gpt-5.5-2026-04-23\",\n        \"object\": \"chat.completion.chunk\",\n        \"usage\": {\n          \"completion_tokens\": 16083,\n          \"prompt_tokens\": 507,\n          \"total_tokens\": 16590,\n          \"cost\": {\n            \"input_tokens_cost_nanodollars\": 2535000,\n            \"output_tokens_cost_nanodollars\": 482490000\n          },\n          \"total_backend_latency_ms\": 298984\n        }\n      }\n    ]\n  },\n  \"generation_tokens\": 16083,\n  \"prompt_tokens\": 507,\n  \"reasoning_tokens\": null,\n  \"total_tokens\": 16590,\n  \"duration_success_only_secs\": 300.01238130099955\n}"
+          ],
+          "status": "OK",
+          "submission": 3037,
+          "thoughts": "Black should capture the checking pawn and reduce White\u2019s dangerous kingside pawns.\n\nFinal Answer: fxg6"
+        },
+        "info": {
+          "actionApplied": 3037,
+          "actionSubmitted": 3037,
+          "actionSubmittedToString": "fxg6",
+          "agentSelfReportedStatus": "OK",
+          "timeTaken": 301.268
+        },
+        "observation": {
+          "currentPlayer": 1,
+          "isTerminal": false,
+          "observationString": "8/1p5k/p1b2Bp1/4K2P/7r/8/8/8 w - - 0 47",
+          "playerId": 0,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n1258\n3572\n1841\n1842\n1431\n3132\n3572\n656\n89\n1215\n2425\n3010\n1808\n1768\n749\n30\n1065\n2571\n1942\n3196\n3131\n1384\n4177\n3854\n381\n615\n498\n1869\n2001\n2977\n2975\n4350\n1431\n1770\n2581\n1257\n4673\n4673\n656\n2627\n1895\n2940\n1386\n1358\n3634\n2528\n254\n4496\n3110\n3705\n2948\n2161\n1771\n2833\n2059\n3853\n2002\n3326\n3166\n1358\n1406\n3561\n1694\n3050\n1637\n2497\n1212\n2425\n1882\n3593\n32\n2016\n1770\n3666\n2498\n4178\n2571\n2498\n1986\n2571\n1914\n2686\n1999\n4323\n3548\n3739\n819\n3196\n911\n3812\n3037\n\n",
+          "step": 93
+        },
+        "reward": null,
+        "status": "INACTIVE"
+      },
+      {
+        "action": {
+          "submission": -1
+        },
+        "info": {},
+        "observation": {
+          "currentPlayer": 1,
+          "isTerminal": false,
+          "observationString": "8/1p5k/p1b2Bp1/4K2P/7r/8/8/8 w - - 0 47",
+          "playerId": 1,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n1258\n3572\n1841\n1842\n1431\n3132\n3572\n656\n89\n1215\n2425\n3010\n1808\n1768\n749\n30\n1065\n2571\n1942\n3196\n3131\n1384\n4177\n3854\n381\n615\n498\n1869\n2001\n2977\n2975\n4350\n1431\n1770\n2581\n1257\n4673\n4673\n656\n2627\n1895\n2940\n1386\n1358\n3634\n2528\n254\n4496\n3110\n3705\n2948\n2161\n1771\n2833\n2059\n3853\n2002\n3326\n3166\n1358\n1406\n3561\n1694\n3050\n1637\n2497\n1212\n2425\n1882\n3593\n32\n2016\n1770\n3666\n2498\n4178\n2571\n2498\n1986\n2571\n1914\n2686\n1999\n4323\n3548\n3739\n819\n3196\n911\n3812\n3037\n\n"
+        },
+        "reward": null,
+        "status": "ACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "submission": -1
+        },
+        "info": {},
+        "observation": {
+          "currentPlayer": 0,
+          "isTerminal": false,
+          "observationString": "8/1p5k/p1b2BP1/4K3/7r/8/8/8 b - - 0 47",
+          "playerId": 0,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n1258\n3572\n1841\n1842\n1431\n3132\n3572\n656\n89\n1215\n2425\n3010\n1808\n1768\n749\n30\n1065\n2571\n1942\n3196\n3131\n1384\n4177\n3854\n381\n615\n498\n1869\n2001\n2977\n2975\n4350\n1431\n1770\n2581\n1257\n4673\n4673\n656\n2627\n1895\n2940\n1386\n1358\n3634\n2528\n254\n4496\n3110\n3705\n2948\n2161\n1771\n2833\n2059\n3853\n2002\n3326\n3166\n1358\n1406\n3561\n1694\n3050\n1637\n2497\n1212\n2425\n1882\n3593\n32\n2016\n1770\n3666\n2498\n4178\n2571\n2498\n1986\n2571\n1914\n2686\n1999\n4323\n3548\n3739\n819\n3196\n911\n3812\n3037\n4437\n\n",
+          "step": 94
+        },
+        "reward": null,
+        "status": "ACTIVE"
+      },
+      {
+        "action": {
+          "actionString": "hxg6+",
+          "generate_returns": [
+            "{\n  \"main_response\": \"To determine the best move, let's analyze the current position from the FEN provided. \\n\\n**Board Evaluation:**\\n- **White's pieces:** King on e5, Bishop on f6, and a Pawn on h5.\\n- **Black's pieces:** King on h7, Rook on h4, Bishop on c6, and Pawns on a6, b7, and g6. \\n\\n**Previous Move Context:**\\nLooking at the last few moves, White played `46. g6+` putting Black's king in check. Black responded with `46... fxg6`, capturing the attacking pawn and breaking the check, landing their pawn on the g6-square.\\n\\n**Candidate Moves for White:**\\n1. **47. Bxh4:** White's dark-squared bishop on f6 is currently attacking Black's rook on h4. Taking the rook immediately seems very tempting. However, if White plays `47. Bxh4`, Black will reply with `47... gxh5`. While White wins the exchange, Black is left with a dangerous passed pawn on the h-file in addition to their two queenside pawns (a6 and b7). White would be down 3 pawns to zero in an opposite-colored bishop endgame, making it a difficult defense. \\n \\n2. **47. hxg6+!:** Because Black's pawn is now on g6, White's pawn on h5 can capture it. \\nLet's see what happens if White chooses this intermediate move:\\n- Capturing the pawn comes with a check to Black's king (`47. hxg6+`). \\n- Black is forced to address the check (e.g., `47... Kxg6`). \\n- Crucially, White's Bishop on f6 has not moved and *still* maintains its attack on the Black rook on h4!\\n- After Black's king moves, White simply follows up with `48. Bxh4`. \\n\\n**Conclusion:**\\nBy playing `47. hxg6+`, White not only eliminates Black's g-pawn but also trades off their own h-pawn before capturing the rook. This completely dismantles Black's kingside pawn structure. In the resulting endgame (Bishop + King vs Bishop + King + 2 Queenside pawns), White's drawing chances are significantly better without a passed Black h-pawn on the board. The opposite-colored bishops heavily favor a draw despite the pawn deficit. \\n\\nTherefore, capturing the pawn with check is the most forceful and favorable continuation.\\n\\nFinal Answer: hxg6+\",\n  \"main_response_and_thoughts\": \"\",\n  \"request_for_logging\": {\n    \"model\": \"google/gemini-3.1-pro-preview\",\n    \"messages\": [\n      {\n        \"role\": \"user\",\n        \"content\": [\n          {\n            \"type\": \"text\",\n            \"text\": \"Let's play chess. The current game state in Forsyth-Edwards Notation (FEN) notation is:\\n8/1p5k/p1b2Bp1/4K2P/7r/8/8/8 w - - 0 47\\nThe moves played so far are:\\n1. e4 c5 2. Nf3 d6 3. d4 cxd4 4. Nxd4 Nf6 5. Nc3 a6 6. Bg5 e6 7. f4 Qb6 8. Qd2 Qxb2 9. Rb1 Qa3 10. e5 dxe5 11. fxe5 Nfd7 12. Ne4 h6 13. Bh4 Qxa2 14. Rd1 Qd5 15. Qe3 Qxe5 16. Be2 Bc5 17. Bg3 Bxd4 18. Rxd4 Qa5+ 19. c3 O-O 20. O-O Nc6 21. Nf6+ Nxf6 22. Rxf6 Nxd4 23. cxd4 gxf6 24. Qxh6 Qg5 25. Qxg5+ fxg5 26. Bd6 Rd8 27. Be7 Rxd4 28. Bxg5 Rd5 29. Bf6 Rf5 30. Bc3 Rc5 31. Bd4 Rc1+ 32. Kf2 Rc2 33. Ke3 Rxe2+ 34. Kxe2 Bd7 35. Ke3 Bc6 36. g3 Rd8 37. Bf6 Rd5 38. g4 e5 39. h4 e4 40. Kxe4 Rd6+ 41. Ke5 Rd5+ 42. Kf4 Rb5 43. h5 Kh7 44. g5 Rb4+ 45. Ke5 Rh4 46. g6+ fxg6 47.\\nYou are playing as player White.\\nIt is now your turn. Play your strongest move. The move MUST be legal. Reason step by step to come up with your move, then output your final answer in the format \\\"Final Answer: X\\\" where X is your chosen move in standard algebraic notation (SAN).\\n\"\n          }\n        ]\n      }\n    ],\n    \"config\": {\n      \"temperature\": \"NOT_GIVEN\",\n      \"top_p\": \"NOT_GIVEN\",\n      \"max_completion_tokens\": \"NOT_GIVEN\"\n    },\n    \"stream_options\": {\n      \"include_usage\": true\n    }\n  },\n  \"response_for_logging\": {\n    \"response_chunks\": [\n      {\n        \"id\": \"78T6ae_ZE8udmecPmbT14Qk\",\n        \"choices\": [\n          {\n            \"delta\": {\n              \"content\": \". \\n\\nTherefore, capturing the pawn with check is the most forceful and favorable continuation.\\n\\nFinal Answer: hxg6+\",\n              \"role\": \"assistant\"\n            },\n            \"finish_reason\": \"stop\",\n            \"index\": 0\n          }\n        ],\n        \"created\": 1778042095,\n        \"model\": \"google/gemini-3.1-pro-preview\",\n        \"object\": \"chat.completion.chunk\",\n        \"usage\": {\n          \"completion_tokens\": 558,\n          \"prompt_tokens\": 505,\n          \"total_tokens\": 7916,\n          \"cost\": {\n            \"input_tokens_cost_nanodollars\": 1010000,\n            \"output_tokens_cost_nanodollars\": 88932000\n          },\n          \"total_backend_latency_ms\": 64630\n        }\n      }\n    ]\n  },\n  \"generation_tokens\": 558,\n  \"prompt_tokens\": 505,\n  \"reasoning_tokens\": null,\n  \"total_tokens\": 7916,\n  \"duration_success_only_secs\": 65.09764962400004\n}"
+          ],
+          "status": "OK",
+          "submission": 4437,
+          "thoughts": "To determine the best move, let's analyze the current position from the FEN provided. \n\n**Board Evaluation:**\n- **White's pieces:** King on e5, Bishop on f6, and a Pawn on h5.\n- **Black's pieces:** King on h7, Rook on h4, Bishop on c6, and Pawns on a6, b7, and g6. \n\n**Previous Move Context:**\nLooking at the last few moves, White played `46. g6+` putting Black's king in check. Black responded with `46... fxg6`, capturing the attacking pawn and breaking the check, landing their pawn on the g6-square.\n\n**Candidate Moves for White:**\n1. **47. Bxh4:** White's dark-squared bishop on f6 is currently attacking Black's rook on h4. Taking the rook immediately seems very tempting. However, if White plays `47. Bxh4`, Black will reply with `47... gxh5`. While White wins the exchange, Black is left with a dangerous passed pawn on the h-file in addition to their two queenside pawns (a6 and b7). White would be down 3 pawns to zero in an opposite-colored bishop endgame, making it a difficult defense. \n \n2. **47. hxg6+!:** Because Black's pawn is now on g6, White's pawn on h5 can capture it. \nLet's see what happens if White chooses this intermediate move:\n- Capturing the pawn comes with a check to Black's king (`47. hxg6+`). \n- Black is forced to address the check (e.g., `47... Kxg6`). \n- Crucially, White's Bishop on f6 has not moved and *still* maintains its attack on the Black rook on h4!\n- After Black's king moves, White simply follows up with `48. Bxh4`. \n\n**Conclusion:**\nBy playing `47. hxg6+`, White not only eliminates Black's g-pawn but also trades off their own h-pawn before capturing the rook. This completely dismantles Black's kingside pawn structure. In the resulting endgame (Bishop + King vs Bishop + King + 2 Queenside pawns), White's drawing chances are significantly better without a passed Black h-pawn on the board. The opposite-colored bishops heavily favor a draw despite the pawn deficit. \n\nTherefore, capturing the pawn with check is the most forceful and favorable continuation.\n\nFinal Answer: hxg6+"
+        },
+        "info": {
+          "actionApplied": 4437,
+          "actionSubmitted": 4437,
+          "actionSubmittedToString": "hxg6+",
+          "agentSelfReportedStatus": "OK",
+          "timeTaken": 66.899
+        },
+        "observation": {
+          "currentPlayer": 0,
+          "isTerminal": false,
+          "observationString": "8/1p5k/p1b2BP1/4K3/7r/8/8/8 b - - 0 47",
+          "playerId": 1,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n1258\n3572\n1841\n1842\n1431\n3132\n3572\n656\n89\n1215\n2425\n3010\n1808\n1768\n749\n30\n1065\n2571\n1942\n3196\n3131\n1384\n4177\n3854\n381\n615\n498\n1869\n2001\n2977\n2975\n4350\n1431\n1770\n2581\n1257\n4673\n4673\n656\n2627\n1895\n2940\n1386\n1358\n3634\n2528\n254\n4496\n3110\n3705\n2948\n2161\n1771\n2833\n2059\n3853\n2002\n3326\n3166\n1358\n1406\n3561\n1694\n3050\n1637\n2497\n1212\n2425\n1882\n3593\n32\n2016\n1770\n3666\n2498\n4178\n2571\n2498\n1986\n2571\n1914\n2686\n1999\n4323\n3548\n3739\n819\n3196\n911\n3812\n3037\n4437\n\n"
+        },
+        "reward": null,
+        "status": "INACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "actionString": "Kxg6",
+          "generate_returns": [
+            "{\n  \"main_response\": \"Final Answer: Kxg6\",\n  \"main_response_and_thoughts\": \"\",\n  \"request_for_logging\": {\n    \"model\": \"openai/gpt-5.5-2026-04-23\",\n    \"messages\": [\n      {\n        \"role\": \"user\",\n        \"content\": [\n          {\n            \"type\": \"text\",\n            \"text\": \"Let's play chess. The current game state in Forsyth-Edwards Notation (FEN) notation is:\\n8/1p5k/p1b2BP1/4K3/7r/8/8/8 b - - 0 47\\nThe moves played so far are:\\n1. e4 c5 2. Nf3 d6 3. d4 cxd4 4. Nxd4 Nf6 5. Nc3 a6 6. Bg5 e6 7. f4 Qb6 8. Qd2 Qxb2 9. Rb1 Qa3 10. e5 dxe5 11. fxe5 Nfd7 12. Ne4 h6 13. Bh4 Qxa2 14. Rd1 Qd5 15. Qe3 Qxe5 16. Be2 Bc5 17. Bg3 Bxd4 18. Rxd4 Qa5+ 19. c3 O-O 20. O-O Nc6 21. Nf6+ Nxf6 22. Rxf6 Nxd4 23. cxd4 gxf6 24. Qxh6 Qg5 25. Qxg5+ fxg5 26. Bd6 Rd8 27. Be7 Rxd4 28. Bxg5 Rd5 29. Bf6 Rf5 30. Bc3 Rc5 31. Bd4 Rc1+ 32. Kf2 Rc2 33. Ke3 Rxe2+ 34. Kxe2 Bd7 35. Ke3 Bc6 36. g3 Rd8 37. Bf6 Rd5 38. g4 e5 39. h4 e4 40. Kxe4 Rd6+ 41. Ke5 Rd5+ 42. Kf4 Rb5 43. h5 Kh7 44. g5 Rb4+ 45. Ke5 Rh4 46. g6+ fxg6 47. hxg6+\\nYou are playing as player Black.\\nIt is now your turn. Play your strongest move. The move MUST be legal. Reason step by step to come up with your move, then output your final answer in the format \\\"Final Answer: X\\\" where X is your chosen move in standard algebraic notation (SAN).\\n\"\n          }\n        ]\n      }\n    ],\n    \"config\": {\n      \"temperature\": \"NOT_GIVEN\",\n      \"top_p\": \"NOT_GIVEN\",\n      \"max_completion_tokens\": \"NOT_GIVEN\",\n      \"reasoning_effort\": \"high\"\n    },\n    \"stream_options\": {\n      \"include_usage\": true\n    }\n  },\n  \"response_for_logging\": {\n    \"response_chunks\": [\n      {\n        \"id\": \"chatcmpl-DcOHKaOrGHpucVLMx5X6pGTEPPb3C\",\n        \"created\": 1778042162,\n        \"model\": \"openai/gpt-5.5-2026-04-23\",\n        \"object\": \"chat.completion.chunk\",\n        \"usage\": {\n          \"completion_tokens\": 10888,\n          \"prompt_tokens\": 514,\n          \"total_tokens\": 11402,\n          \"cost\": {\n            \"input_tokens_cost_nanodollars\": 2570000,\n            \"output_tokens_cost_nanodollars\": 326640000\n          },\n          \"total_backend_latency_ms\": 225458\n        }\n      }\n    ]\n  },\n  \"generation_tokens\": 10888,\n  \"prompt_tokens\": 514,\n  \"reasoning_tokens\": null,\n  \"total_tokens\": 11402,\n  \"duration_success_only_secs\": 225.94919929800017\n}"
+          ],
+          "status": "OK",
+          "submission": 4218,
+          "thoughts": "Final Answer: Kxg6"
+        },
+        "info": {
+          "actionApplied": 4218,
+          "actionSubmitted": 4218,
+          "actionSubmittedToString": "Kxg6",
+          "agentSelfReportedStatus": "OK",
+          "timeTaken": 227.678
+        },
+        "observation": {
+          "currentPlayer": 1,
+          "isTerminal": false,
+          "observationString": "8/1p6/p1b2Bk1/4K3/7r/8/8/8 w - - 0 48",
+          "playerId": 0,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n1258\n3572\n1841\n1842\n1431\n3132\n3572\n656\n89\n1215\n2425\n3010\n1808\n1768\n749\n30\n1065\n2571\n1942\n3196\n3131\n1384\n4177\n3854\n381\n615\n498\n1869\n2001\n2977\n2975\n4350\n1431\n1770\n2581\n1257\n4673\n4673\n656\n2627\n1895\n2940\n1386\n1358\n3634\n2528\n254\n4496\n3110\n3705\n2948\n2161\n1771\n2833\n2059\n3853\n2002\n3326\n3166\n1358\n1406\n3561\n1694\n3050\n1637\n2497\n1212\n2425\n1882\n3593\n32\n2016\n1770\n3666\n2498\n4178\n2571\n2498\n1986\n2571\n1914\n2686\n1999\n4323\n3548\n3739\n819\n3196\n911\n3812\n3037\n4437\n4218\n\n",
+          "step": 95
+        },
+        "reward": null,
+        "status": "INACTIVE"
+      },
+      {
+        "action": {
+          "submission": -1
+        },
+        "info": {},
+        "observation": {
+          "currentPlayer": 1,
+          "isTerminal": false,
+          "observationString": "8/1p6/p1b2Bk1/4K3/7r/8/8/8 w - - 0 48",
+          "playerId": 1,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n1258\n3572\n1841\n1842\n1431\n3132\n3572\n656\n89\n1215\n2425\n3010\n1808\n1768\n749\n30\n1065\n2571\n1942\n3196\n3131\n1384\n4177\n3854\n381\n615\n498\n1869\n2001\n2977\n2975\n4350\n1431\n1770\n2581\n1257\n4673\n4673\n656\n2627\n1895\n2940\n1386\n1358\n3634\n2528\n254\n4496\n3110\n3705\n2948\n2161\n1771\n2833\n2059\n3853\n2002\n3326\n3166\n1358\n1406\n3561\n1694\n3050\n1637\n2497\n1212\n2425\n1882\n3593\n32\n2016\n1770\n3666\n2498\n4178\n2571\n2498\n1986\n2571\n1914\n2686\n1999\n4323\n3548\n3739\n819\n3196\n911\n3812\n3037\n4437\n4218\n\n"
+        },
+        "reward": null,
+        "status": "ACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "submission": -1
+        },
+        "info": {},
+        "observation": {
+          "currentPlayer": 0,
+          "isTerminal": false,
+          "observationString": "8/1p6/p1b3k1/4K3/7B/8/8/8 b - - 0 48",
+          "playerId": 0,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n1258\n3572\n1841\n1842\n1431\n3132\n3572\n656\n89\n1215\n2425\n3010\n1808\n1768\n749\n30\n1065\n2571\n1942\n3196\n3131\n1384\n4177\n3854\n381\n615\n498\n1869\n2001\n2977\n2975\n4350\n1431\n1770\n2581\n1257\n4673\n4673\n656\n2627\n1895\n2940\n1386\n1358\n3634\n2528\n254\n4496\n3110\n3705\n2948\n2161\n1771\n2833\n2059\n3853\n2002\n3326\n3166\n1358\n1406\n3561\n1694\n3050\n1637\n2497\n1212\n2425\n1882\n3593\n32\n2016\n1770\n3666\n2498\n4178\n2571\n2498\n1986\n2571\n1914\n2686\n1999\n4323\n3548\n3739\n819\n3196\n911\n3812\n3037\n4437\n4218\n3344\n\n",
+          "step": 96
+        },
+        "reward": null,
+        "status": "ACTIVE"
+      },
+      {
+        "action": {
+          "actionString": "Bxh4",
+          "generate_returns": [
+            "{\n  \"main_response\": \"To determine the best move, let's analyze the current position and the sequence of moves that just occurred. \\n\\nIn the previous moves, you sacrificed your g- and h-pawns with 46. g6+ fxg6 47. hxg6+ Kxg6 to force the Black King onto g6. By doing this, you've brilliantly opened up the long dark-square diagonal (f6-h4) for your Bishop. \\n\\nCurrently:\\n- Your Bishop on f6 is under attack by the Black King on g6.\\n- However, with the pawns cleared out of the way, your Bishop now has a direct line of sight to Black's hanging Rook on h4. \\n\\nBy capturing the Rook, you simultaneously move your Bishop to safety and eliminate Black's most powerful remaining piece. After this sequence, you will have a King and Bishop against Black's King, Bishop, and two pawns. Since the remaining Bishops are on opposite colors (your Bishop is on dark squares, Black's is on light squares), this endgame holds excellent drawing chances for you despite being down two pawns.\\n\\nFinal Answer: Bxh4\",\n  \"main_response_and_thoughts\": \"\",\n  \"request_for_logging\": {\n    \"model\": \"google/gemini-3.1-pro-preview\",\n    \"messages\": [\n      {\n        \"role\": \"user\",\n        \"content\": [\n          {\n            \"type\": \"text\",\n            \"text\": \"Let's play chess. The current game state in Forsyth-Edwards Notation (FEN) notation is:\\n8/1p6/p1b2Bk1/4K3/7r/8/8/8 w - - 0 48\\nThe moves played so far are:\\n1. e4 c5 2. Nf3 d6 3. d4 cxd4 4. Nxd4 Nf6 5. Nc3 a6 6. Bg5 e6 7. f4 Qb6 8. Qd2 Qxb2 9. Rb1 Qa3 10. e5 dxe5 11. fxe5 Nfd7 12. Ne4 h6 13. Bh4 Qxa2 14. Rd1 Qd5 15. Qe3 Qxe5 16. Be2 Bc5 17. Bg3 Bxd4 18. Rxd4 Qa5+ 19. c3 O-O 20. O-O Nc6 21. Nf6+ Nxf6 22. Rxf6 Nxd4 23. cxd4 gxf6 24. Qxh6 Qg5 25. Qxg5+ fxg5 26. Bd6 Rd8 27. Be7 Rxd4 28. Bxg5 Rd5 29. Bf6 Rf5 30. Bc3 Rc5 31. Bd4 Rc1+ 32. Kf2 Rc2 33. Ke3 Rxe2+ 34. Kxe2 Bd7 35. Ke3 Bc6 36. g3 Rd8 37. Bf6 Rd5 38. g4 e5 39. h4 e4 40. Kxe4 Rd6+ 41. Ke5 Rd5+ 42. Kf4 Rb5 43. h5 Kh7 44. g5 Rb4+ 45. Ke5 Rh4 46. g6+ fxg6 47. hxg6+ Kxg6 48.\\nYou are playing as player White.\\nIt is now your turn. Play your strongest move. The move MUST be legal. Reason step by step to come up with your move, then output your final answer in the format \\\"Final Answer: X\\\" where X is your chosen move in standard algebraic notation (SAN).\\n\"\n          }\n        ]\n      }\n    ],\n    \"config\": {\n      \"temperature\": \"NOT_GIVEN\",\n      \"top_p\": \"NOT_GIVEN\",\n      \"max_completion_tokens\": \"NOT_GIVEN\"\n    },\n    \"stream_options\": {\n      \"include_usage\": true\n    }\n  },\n  \"response_for_logging\": {\n    \"response_chunks\": [\n      {\n        \"id\": \"Fsb6aaftIPiMmecPq_Dk8QQ\",\n        \"choices\": [\n          {\n            \"delta\": {\n              \"content\": \" holds excellent drawing chances for you despite being down two pawns.\\n\\nFinal Answer: Bxh4\",\n              \"role\": \"assistant\"\n            },\n            \"finish_reason\": \"stop\",\n            \"index\": 0\n          }\n        ],\n        \"created\": 1778042390,\n        \"model\": \"google/gemini-3.1-pro-preview\",\n        \"object\": \"chat.completion.chunk\",\n        \"usage\": {\n          \"completion_tokens\": 241,\n          \"prompt_tokens\": 512,\n          \"total_tokens\": 3058,\n          \"cost\": {\n            \"input_tokens_cost_nanodollars\": 1024000,\n            \"output_tokens_cost_nanodollars\": 30552000\n          },\n          \"total_backend_latency_ms\": 19589\n        }\n      }\n    ]\n  },\n  \"generation_tokens\": 241,\n  \"prompt_tokens\": 512,\n  \"reasoning_tokens\": null,\n  \"total_tokens\": 3058,\n  \"duration_success_only_secs\": 20.641052858001785\n}"
+          ],
+          "status": "OK",
+          "submission": 3344,
+          "thoughts": "To determine the best move, let's analyze the current position and the sequence of moves that just occurred. \n\nIn the previous moves, you sacrificed your g- and h-pawns with 46. g6+ fxg6 47. hxg6+ Kxg6 to force the Black King onto g6. By doing this, you've brilliantly opened up the long dark-square diagonal (f6-h4) for your Bishop. \n\nCurrently:\n- Your Bishop on f6 is under attack by the Black King on g6.\n- However, with the pawns cleared out of the way, your Bishop now has a direct line of sight to Black's hanging Rook on h4. \n\nBy capturing the Rook, you simultaneously move your Bishop to safety and eliminate Black's most powerful remaining piece. After this sequence, you will have a King and Bishop against Black's King, Bishop, and two pawns. Since the remaining Bishops are on opposite colors (your Bishop is on dark squares, Black's is on light squares), this endgame holds excellent drawing chances for you despite being down two pawns.\n\nFinal Answer: Bxh4"
+        },
+        "info": {
+          "actionApplied": 3344,
+          "actionSubmitted": 3344,
+          "actionSubmittedToString": "Bxh4",
+          "agentSelfReportedStatus": "OK",
+          "timeTaken": 21.888
+        },
+        "observation": {
+          "currentPlayer": 0,
+          "isTerminal": false,
+          "observationString": "8/1p6/p1b3k1/4K3/7B/8/8/8 b - - 0 48",
+          "playerId": 1,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n1258\n3572\n1841\n1842\n1431\n3132\n3572\n656\n89\n1215\n2425\n3010\n1808\n1768\n749\n30\n1065\n2571\n1942\n3196\n3131\n1384\n4177\n3854\n381\n615\n498\n1869\n2001\n2977\n2975\n4350\n1431\n1770\n2581\n1257\n4673\n4673\n656\n2627\n1895\n2940\n1386\n1358\n3634\n2528\n254\n4496\n3110\n3705\n2948\n2161\n1771\n2833\n2059\n3853\n2002\n3326\n3166\n1358\n1406\n3561\n1694\n3050\n1637\n2497\n1212\n2425\n1882\n3593\n32\n2016\n1770\n3666\n2498\n4178\n2571\n2498\n1986\n2571\n1914\n2686\n1999\n4323\n3548\n3739\n819\n3196\n911\n3812\n3037\n4437\n4218\n3344\n\n"
+        },
+        "reward": null,
+        "status": "INACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "actionString": "Kh5",
+          "generate_returns": [
+            "{\n  \"main_response\": \"The strongest move is to use the black king to attack White\\u2019s bishop immediately, gaining an important tempo.\\n\\nFinal Answer: Kh5\",\n  \"main_response_and_thoughts\": \"\",\n  \"request_for_logging\": {\n    \"model\": \"openai/gpt-5.5-2026-04-23\",\n    \"messages\": [\n      {\n        \"role\": \"user\",\n        \"content\": [\n          {\n            \"type\": \"text\",\n            \"text\": \"Let's play chess. The current game state in Forsyth-Edwards Notation (FEN) notation is:\\n8/1p6/p1b3k1/4K3/7B/8/8/8 b - - 0 48\\nThe moves played so far are:\\n1. e4 c5 2. Nf3 d6 3. d4 cxd4 4. Nxd4 Nf6 5. Nc3 a6 6. Bg5 e6 7. f4 Qb6 8. Qd2 Qxb2 9. Rb1 Qa3 10. e5 dxe5 11. fxe5 Nfd7 12. Ne4 h6 13. Bh4 Qxa2 14. Rd1 Qd5 15. Qe3 Qxe5 16. Be2 Bc5 17. Bg3 Bxd4 18. Rxd4 Qa5+ 19. c3 O-O 20. O-O Nc6 21. Nf6+ Nxf6 22. Rxf6 Nxd4 23. cxd4 gxf6 24. Qxh6 Qg5 25. Qxg5+ fxg5 26. Bd6 Rd8 27. Be7 Rxd4 28. Bxg5 Rd5 29. Bf6 Rf5 30. Bc3 Rc5 31. Bd4 Rc1+ 32. Kf2 Rc2 33. Ke3 Rxe2+ 34. Kxe2 Bd7 35. Ke3 Bc6 36. g3 Rd8 37. Bf6 Rd5 38. g4 e5 39. h4 e4 40. Kxe4 Rd6+ 41. Ke5 Rd5+ 42. Kf4 Rb5 43. h5 Kh7 44. g5 Rb4+ 45. Ke5 Rh4 46. g6+ fxg6 47. hxg6+ Kxg6 48. Bxh4\\nYou are playing as player Black.\\nIt is now your turn. Play your strongest move. The move MUST be legal. Reason step by step to come up with your move, then output your final answer in the format \\\"Final Answer: X\\\" where X is your chosen move in standard algebraic notation (SAN).\\n\"\n          }\n        ]\n      }\n    ],\n    \"config\": {\n      \"temperature\": \"NOT_GIVEN\",\n      \"top_p\": \"NOT_GIVEN\",\n      \"max_completion_tokens\": \"NOT_GIVEN\",\n      \"reasoning_effort\": \"high\"\n    },\n    \"stream_options\": {\n      \"include_usage\": true\n    }\n  },\n  \"response_for_logging\": {\n    \"response_chunks\": [\n      {\n        \"id\": \"chatcmpl-DcOLLWJjl0K5qlOgjEoABfJpfpcc9\",\n        \"created\": 1778042411,\n        \"model\": \"openai/gpt-5.5-2026-04-23\",\n        \"object\": \"chat.completion.chunk\",\n        \"usage\": {\n          \"completion_tokens\": 10389,\n          \"prompt_tokens\": 524,\n          \"total_tokens\": 10913,\n          \"cost\": {\n            \"input_tokens_cost_nanodollars\": 2620000,\n            \"output_tokens_cost_nanodollars\": 311670000\n          },\n          \"total_backend_latency_ms\": 216019\n        }\n      }\n    ]\n  },\n  \"generation_tokens\": 10389,\n  \"prompt_tokens\": 524,\n  \"reasoning_tokens\": null,\n  \"total_tokens\": 10913,\n  \"duration_success_only_secs\": 216.4762924409988\n}"
+          ],
+          "status": "OK",
+          "submission": 3694,
+          "thoughts": "The strongest move is to use the black king to attack White\u2019s bishop immediately, gaining an important tempo.\n\nFinal Answer: Kh5"
+        },
+        "info": {
+          "actionApplied": 3694,
+          "actionSubmitted": 3694,
+          "actionSubmittedToString": "Kh5",
+          "agentSelfReportedStatus": "OK",
+          "timeTaken": 218.16
+        },
+        "observation": {
+          "currentPlayer": 1,
+          "isTerminal": false,
+          "observationString": "8/1p6/p1b5/4K2k/7B/8/8/8 w - - 1 49",
+          "playerId": 0,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n1258\n3572\n1841\n1842\n1431\n3132\n3572\n656\n89\n1215\n2425\n3010\n1808\n1768\n749\n30\n1065\n2571\n1942\n3196\n3131\n1384\n4177\n3854\n381\n615\n498\n1869\n2001\n2977\n2975\n4350\n1431\n1770\n2581\n1257\n4673\n4673\n656\n2627\n1895\n2940\n1386\n1358\n3634\n2528\n254\n4496\n3110\n3705\n2948\n2161\n1771\n2833\n2059\n3853\n2002\n3326\n3166\n1358\n1406\n3561\n1694\n3050\n1637\n2497\n1212\n2425\n1882\n3593\n32\n2016\n1770\n3666\n2498\n4178\n2571\n2498\n1986\n2571\n1914\n2686\n1999\n4323\n3548\n3739\n819\n3196\n911\n3812\n3037\n4437\n4218\n3344\n3694\n\n",
+          "step": 97
+        },
+        "reward": null,
+        "status": "INACTIVE"
+      },
+      {
+        "action": {
+          "submission": -1
+        },
+        "info": {},
+        "observation": {
+          "currentPlayer": 1,
+          "isTerminal": false,
+          "observationString": "8/1p6/p1b5/4K2k/7B/8/8/8 w - - 1 49",
+          "playerId": 1,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n1258\n3572\n1841\n1842\n1431\n3132\n3572\n656\n89\n1215\n2425\n3010\n1808\n1768\n749\n30\n1065\n2571\n1942\n3196\n3131\n1384\n4177\n3854\n381\n615\n498\n1869\n2001\n2977\n2975\n4350\n1431\n1770\n2581\n1257\n4673\n4673\n656\n2627\n1895\n2940\n1386\n1358\n3634\n2528\n254\n4496\n3110\n3705\n2948\n2161\n1771\n2833\n2059\n3853\n2002\n3326\n3166\n1358\n1406\n3561\n1694\n3050\n1637\n2497\n1212\n2425\n1882\n3593\n32\n2016\n1770\n3666\n2498\n4178\n2571\n2498\n1986\n2571\n1914\n2686\n1999\n4323\n3548\n3739\n819\n3196\n911\n3812\n3037\n4437\n4218\n3344\n3694\n\n"
+        },
+        "reward": null,
+        "status": "ACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "submission": -1
+        },
+        "info": {},
+        "observation": {
+          "currentPlayer": 0,
+          "isTerminal": false,
+          "observationString": "3B4/1p6/p1b5/4K2k/8/8/8/8 b - - 2 49",
+          "playerId": 0,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n1258\n3572\n1841\n1842\n1431\n3132\n3572\n656\n89\n1215\n2425\n3010\n1808\n1768\n749\n30\n1065\n2571\n1942\n3196\n3131\n1384\n4177\n3854\n381\n615\n498\n1869\n2001\n2977\n2975\n4350\n1431\n1770\n2581\n1257\n4673\n4673\n656\n2627\n1895\n2940\n1386\n1358\n3634\n2528\n254\n4496\n3110\n3705\n2948\n2161\n1771\n2833\n2059\n3853\n2002\n3326\n3166\n1358\n1406\n3561\n1694\n3050\n1637\n2497\n1212\n2425\n1882\n3593\n32\n2016\n1770\n3666\n2498\n4178\n2571\n2498\n1986\n2571\n1914\n2686\n1999\n4323\n3548\n3739\n819\n3196\n911\n3812\n3037\n4437\n4218\n3344\n3694\n4361\n\n",
+          "step": 98
+        },
+        "reward": null,
+        "status": "ACTIVE"
+      },
+      {
+        "action": {
+          "actionString": "Bd8",
+          "generate_returns": [
+            "{\n  \"main_response\": \"To evaluate the position, we must recognize that White is down two pawns (a6 and b7) in an endgame with opposite-colored bishops. Despite the material deficit, these types of endgames are notorious for their drawing tendencies, provided the defending side can blockade the pawns. Since Black's pawns are on a6 (a dark square) and b7 (a light square), and White possesses a dark-squared Bishop, White has excellent blockading prospects on the dark squares (b6, c7, a5, etc.). \\n\\nSince the Black king on h5 is currently attacking our bishop on h4, the immediate priority is to move the bishop to safety while keeping it on a functional diagonal to aid the king in blockading the queenside pawns.\\n\\n1. **49. Bd8!**\\nThis is the most principled and safest retreat. By moving the bishop to d8, White keeps it on the critical a5-d8 diagonal. From this diagonal, the bishop controls key dark squares like a5, b6, and c7, which are essential for halting the advance of Black's pawns.\\n\\nIf Black tries to bring the king over and push the pawns, White's plan is simple and effective:\\n- White will march the king to the queenside (Kd6-c7-b8 or b6). \\n- If Black's king comes to the center (e.g., ...Kg4, ...Kf5, ...Ke6, ...Kd7), White's Bishop can comfortably reposition (such as to b6 or a5) where it completely paralyzes the a6 and b7 pawns. \\n- If Black hastily pushes ...b5, White's Bishop can immediately swing to a5 (or White's King can capture the c6 bishop and the d8 bishop can drop back to c7 or b6 depending on the exact timing), stopping ...b4 and permanently cementing a blockade on the dark squares, resulting in an unbreakable fortress and a theoretical draw. \\n\\nFinal Answer: Bd8\",\n  \"main_response_and_thoughts\": \"\",\n  \"request_for_logging\": {\n    \"model\": \"google/gemini-3.1-pro-preview\",\n    \"messages\": [\n      {\n        \"role\": \"user\",\n        \"content\": [\n          {\n            \"type\": \"text\",\n            \"text\": \"Let's play chess. The current game state in Forsyth-Edwards Notation (FEN) notation is:\\n8/1p6/p1b5/4K2k/7B/8/8/8 w - - 1 49\\nThe moves played so far are:\\n1. e4 c5 2. Nf3 d6 3. d4 cxd4 4. Nxd4 Nf6 5. Nc3 a6 6. Bg5 e6 7. f4 Qb6 8. Qd2 Qxb2 9. Rb1 Qa3 10. e5 dxe5 11. fxe5 Nfd7 12. Ne4 h6 13. Bh4 Qxa2 14. Rd1 Qd5 15. Qe3 Qxe5 16. Be2 Bc5 17. Bg3 Bxd4 18. Rxd4 Qa5+ 19. c3 O-O 20. O-O Nc6 21. Nf6+ Nxf6 22. Rxf6 Nxd4 23. cxd4 gxf6 24. Qxh6 Qg5 25. Qxg5+ fxg5 26. Bd6 Rd8 27. Be7 Rxd4 28. Bxg5 Rd5 29. Bf6 Rf5 30. Bc3 Rc5 31. Bd4 Rc1+ 32. Kf2 Rc2 33. Ke3 Rxe2+ 34. Kxe2 Bd7 35. Ke3 Bc6 36. g3 Rd8 37. Bf6 Rd5 38. g4 e5 39. h4 e4 40. Kxe4 Rd6+ 41. Ke5 Rd5+ 42. Kf4 Rb5 43. h5 Kh7 44. g5 Rb4+ 45. Ke5 Rh4 46. g6+ fxg6 47. hxg6+ Kxg6 48. Bxh4 Kh5 49.\\nYou are playing as player White.\\nIt is now your turn. Play your strongest move. The move MUST be legal. Reason step by step to come up with your move, then output your final answer in the format \\\"Final Answer: X\\\" where X is your chosen move in standard algebraic notation (SAN).\\n\"\n          }\n        ]\n      }\n    ],\n    \"config\": {\n      \"temperature\": \"NOT_GIVEN\",\n      \"top_p\": \"NOT_GIVEN\",\n      \"max_completion_tokens\": \"NOT_GIVEN\"\n    },\n    \"stream_options\": {\n      \"include_usage\": true\n    }\n  },\n  \"response_for_logging\": {\n    \"response_chunks\": [\n      {\n        \"id\": \"Bcf6aZXQOcudmecPmbT14Qk\",\n        \"choices\": [\n          {\n            \"delta\": {\n              \"content\": \", resulting in an unbreakable fortress and a theoretical draw. \\n\\nFinal Answer: Bd8\",\n              \"role\": \"assistant\"\n            },\n            \"finish_reason\": \"stop\",\n            \"index\": 0\n          }\n        ],\n        \"created\": 1778042629,\n        \"model\": \"google/gemini-3.1-pro-preview\",\n        \"object\": \"chat.completion.chunk\",\n        \"usage\": {\n          \"completion_tokens\": 433,\n          \"prompt_tokens\": 519,\n          \"total_tokens\": 6153,\n          \"cost\": {\n            \"input_tokens_cost_nanodollars\": 1038000,\n            \"output_tokens_cost_nanodollars\": 67608000\n          },\n          \"total_backend_latency_ms\": 51488\n        }\n      }\n    ]\n  },\n  \"generation_tokens\": 433,\n  \"prompt_tokens\": 519,\n  \"reasoning_tokens\": null,\n  \"total_tokens\": 6153,\n  \"duration_success_only_secs\": 51.98342380000031\n}"
+          ],
+          "status": "OK",
+          "submission": 4361,
+          "thoughts": "To evaluate the position, we must recognize that White is down two pawns (a6 and b7) in an endgame with opposite-colored bishops. Despite the material deficit, these types of endgames are notorious for their drawing tendencies, provided the defending side can blockade the pawns. Since Black's pawns are on a6 (a dark square) and b7 (a light square), and White possesses a dark-squared Bishop, White has excellent blockading prospects on the dark squares (b6, c7, a5, etc.). \n\nSince the Black king on h5 is currently attacking our bishop on h4, the immediate priority is to move the bishop to safety while keeping it on a functional diagonal to aid the king in blockading the queenside pawns.\n\n1. **49. Bd8!**\nThis is the most principled and safest retreat. By moving the bishop to d8, White keeps it on the critical a5-d8 diagonal. From this diagonal, the bishop controls key dark squares like a5, b6, and c7, which are essential for halting the advance of Black's pawns.\n\nIf Black tries to bring the king over and push the pawns, White's plan is simple and effective:\n- White will march the king to the queenside (Kd6-c7-b8 or b6). \n- If Black's king comes to the center (e.g., ...Kg4, ...Kf5, ...Ke6, ...Kd7), White's Bishop can comfortably reposition (such as to b6 or a5) where it completely paralyzes the a6 and b7 pawns. \n- If Black hastily pushes ...b5, White's Bishop can immediately swing to a5 (or White's King can capture the c6 bishop and the d8 bishop can drop back to c7 or b6 depending on the exact timing), stopping ...b4 and permanently cementing a blockade on the dark squares, resulting in an unbreakable fortress and a theoretical draw. \n\nFinal Answer: Bd8"
+        },
+        "info": {
+          "actionApplied": 4361,
+          "actionSubmitted": 4361,
+          "actionSubmittedToString": "Bd8",
+          "agentSelfReportedStatus": "OK",
+          "timeTaken": 53.197
+        },
+        "observation": {
+          "currentPlayer": 0,
+          "isTerminal": false,
+          "observationString": "3B4/1p6/p1b5/4K2k/8/8/8/8 b - - 2 49",
+          "playerId": 1,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n1258\n3572\n1841\n1842\n1431\n3132\n3572\n656\n89\n1215\n2425\n3010\n1808\n1768\n749\n30\n1065\n2571\n1942\n3196\n3131\n1384\n4177\n3854\n381\n615\n498\n1869\n2001\n2977\n2975\n4350\n1431\n1770\n2581\n1257\n4673\n4673\n656\n2627\n1895\n2940\n1386\n1358\n3634\n2528\n254\n4496\n3110\n3705\n2948\n2161\n1771\n2833\n2059\n3853\n2002\n3326\n3166\n1358\n1406\n3561\n1694\n3050\n1637\n2497\n1212\n2425\n1882\n3593\n32\n2016\n1770\n3666\n2498\n4178\n2571\n2498\n1986\n2571\n1914\n2686\n1999\n4323\n3548\n3739\n819\n3196\n911\n3812\n3037\n4437\n4218\n3344\n3694\n4361\n\n"
+        },
+        "reward": null,
+        "status": "INACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "actionString": "b5",
+          "generate_returns": [
+            "{\n  \"main_response\": \"Black should activate the queenside majority immediately. The key is to use the two-square advance so the white bishop on d8 cannot simply stop the b-pawn on b6.\\n\\nAfter 49...b5, Black creates a dangerous connected passer structure; if White tries 50.Kd6, Black can move the bishop away (e.g. 50...Bf3) and continue coordinating the king and pawns.\\n\\nFinal Answer: b5\",\n  \"main_response_and_thoughts\": \"\",\n  \"request_for_logging\": {\n    \"model\": \"openai/gpt-5.5-2026-04-23\",\n    \"messages\": [\n      {\n        \"role\": \"user\",\n        \"content\": [\n          {\n            \"type\": \"text\",\n            \"text\": \"Let's play chess. The current game state in Forsyth-Edwards Notation (FEN) notation is:\\n3B4/1p6/p1b5/4K2k/8/8/8/8 b - - 2 49\\nThe moves played so far are:\\n1. e4 c5 2. Nf3 d6 3. d4 cxd4 4. Nxd4 Nf6 5. Nc3 a6 6. Bg5 e6 7. f4 Qb6 8. Qd2 Qxb2 9. Rb1 Qa3 10. e5 dxe5 11. fxe5 Nfd7 12. Ne4 h6 13. Bh4 Qxa2 14. Rd1 Qd5 15. Qe3 Qxe5 16. Be2 Bc5 17. Bg3 Bxd4 18. Rxd4 Qa5+ 19. c3 O-O 20. O-O Nc6 21. Nf6+ Nxf6 22. Rxf6 Nxd4 23. cxd4 gxf6 24. Qxh6 Qg5 25. Qxg5+ fxg5 26. Bd6 Rd8 27. Be7 Rxd4 28. Bxg5 Rd5 29. Bf6 Rf5 30. Bc3 Rc5 31. Bd4 Rc1+ 32. Kf2 Rc2 33. Ke3 Rxe2+ 34. Kxe2 Bd7 35. Ke3 Bc6 36. g3 Rd8 37. Bf6 Rd5 38. g4 e5 39. h4 e4 40. Kxe4 Rd6+ 41. Ke5 Rd5+ 42. Kf4 Rb5 43. h5 Kh7 44. g5 Rb4+ 45. Ke5 Rh4 46. g6+ fxg6 47. hxg6+ Kxg6 48. Bxh4 Kh5 49. Bd8\\nYou are playing as player Black.\\nIt is now your turn. Play your strongest move. The move MUST be legal. Reason step by step to come up with your move, then output your final answer in the format \\\"Final Answer: X\\\" where X is your chosen move in standard algebraic notation (SAN).\\n\"\n          }\n        ]\n      }\n    ],\n    \"config\": {\n      \"temperature\": \"NOT_GIVEN\",\n      \"top_p\": \"NOT_GIVEN\",\n      \"max_completion_tokens\": \"NOT_GIVEN\",\n      \"reasoning_effort\": \"high\"\n    },\n    \"stream_options\": {\n      \"include_usage\": true\n    }\n  },\n  \"response_for_logging\": {\n    \"response_chunks\": [\n      {\n        \"id\": \"chatcmpl-DcOPjWvhSCTi27iQzyzX4Vxgk4cW1\",\n        \"created\": 1778042683,\n        \"model\": \"openai/gpt-5.5-2026-04-23\",\n        \"object\": \"chat.completion.chunk\",\n        \"usage\": {\n          \"completion_tokens\": 32447,\n          \"prompt_tokens\": 531,\n          \"total_tokens\": 32978,\n          \"cost\": {\n            \"input_tokens_cost_nanodollars\": 2655000,\n            \"output_tokens_cost_nanodollars\": 973410000\n          },\n          \"total_backend_latency_ms\": 629034\n        }\n      }\n    ]\n  },\n  \"generation_tokens\": 32447,\n  \"prompt_tokens\": 531,\n  \"reasoning_tokens\": null,\n  \"total_tokens\": 32978,\n  \"duration_success_only_secs\": 629.9597257640016\n}"
+          ],
+          "status": "OK",
+          "submission": 674,
+          "thoughts": "Black should activate the queenside majority immediately. The key is to use the two-square advance so the white bishop on d8 cannot simply stop the b-pawn on b6.\n\nAfter 49...b5, Black creates a dangerous connected passer structure; if White tries 50.Kd6, Black can move the bishop away (e.g. 50...Bf3) and continue coordinating the king and pawns.\n\nFinal Answer: b5"
+        },
+        "info": {
+          "actionApplied": 674,
+          "actionSubmitted": 674,
+          "actionSubmittedToString": "b5",
+          "agentSelfReportedStatus": "OK",
+          "timeTaken": 631.721
+        },
+        "observation": {
+          "currentPlayer": 1,
+          "isTerminal": false,
+          "observationString": "3B4/8/p1b5/1p2K2k/8/8/8/8 w - - 0 50",
+          "playerId": 0,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n1258\n3572\n1841\n1842\n1431\n3132\n3572\n656\n89\n1215\n2425\n3010\n1808\n1768\n749\n30\n1065\n2571\n1942\n3196\n3131\n1384\n4177\n3854\n381\n615\n498\n1869\n2001\n2977\n2975\n4350\n1431\n1770\n2581\n1257\n4673\n4673\n656\n2627\n1895\n2940\n1386\n1358\n3634\n2528\n254\n4496\n3110\n3705\n2948\n2161\n1771\n2833\n2059\n3853\n2002\n3326\n3166\n1358\n1406\n3561\n1694\n3050\n1637\n2497\n1212\n2425\n1882\n3593\n32\n2016\n1770\n3666\n2498\n4178\n2571\n2498\n1986\n2571\n1914\n2686\n1999\n4323\n3548\n3739\n819\n3196\n911\n3812\n3037\n4437\n4218\n3344\n3694\n4361\n674\n\n",
+          "step": 99
+        },
+        "reward": null,
+        "status": "INACTIVE"
+      },
+      {
+        "action": {
+          "submission": -1
+        },
+        "info": {},
+        "observation": {
+          "currentPlayer": 1,
+          "isTerminal": false,
+          "observationString": "3B4/8/p1b5/1p2K2k/8/8/8/8 w - - 0 50",
+          "playerId": 1,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n1258\n3572\n1841\n1842\n1431\n3132\n3572\n656\n89\n1215\n2425\n3010\n1808\n1768\n749\n30\n1065\n2571\n1942\n3196\n3131\n1384\n4177\n3854\n381\n615\n498\n1869\n2001\n2977\n2975\n4350\n1431\n1770\n2581\n1257\n4673\n4673\n656\n2627\n1895\n2940\n1386\n1358\n3634\n2528\n254\n4496\n3110\n3705\n2948\n2161\n1771\n2833\n2059\n3853\n2002\n3326\n3166\n1358\n1406\n3561\n1694\n3050\n1637\n2497\n1212\n2425\n1882\n3593\n32\n2016\n1770\n3666\n2498\n4178\n2571\n2498\n1986\n2571\n1914\n2686\n1999\n4323\n3548\n3739\n819\n3196\n911\n3812\n3037\n4437\n4218\n3344\n3694\n4361\n674\n\n"
+        },
+        "reward": null,
+        "status": "ACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "submission": -1
+        },
+        "info": {},
+        "observation": {
+          "currentPlayer": 0,
+          "isTerminal": false,
+          "observationString": "3B4/8/p1bK4/1p5k/8/8/8/8 b - - 1 50",
+          "playerId": 0,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n1258\n3572\n1841\n1842\n1431\n3132\n3572\n656\n89\n1215\n2425\n3010\n1808\n1768\n749\n30\n1065\n2571\n1942\n3196\n3131\n1384\n4177\n3854\n381\n615\n498\n1869\n2001\n2977\n2975\n4350\n1431\n1770\n2581\n1257\n4673\n4673\n656\n2627\n1895\n2940\n1386\n1358\n3634\n2528\n254\n4496\n3110\n3705\n2948\n2161\n1771\n2833\n2059\n3853\n2002\n3326\n3166\n1358\n1406\n3561\n1694\n3050\n1637\n2497\n1212\n2425\n1882\n3593\n32\n2016\n1770\n3666\n2498\n4178\n2571\n2498\n1986\n2571\n1914\n2686\n1999\n4323\n3548\n3739\n819\n3196\n911\n3812\n3037\n4437\n4218\n3344\n3694\n4361\n674\n2685\n\n",
+          "step": 100
+        },
+        "reward": null,
+        "status": "ACTIVE"
+      },
+      {
+        "action": {
+          "actionString": "Kd6",
+          "generate_returns": [
+            "{\n  \"main_response\": \"To determine the correct move, we must evaluate the endgame. We are down two pawns and defending an opposite-colored bishop endgame. White's goal is to set up an unbreakable blockade to secure a draw. \\n\\nThe pawns on a6 and b5 are both on light squares, and Black's bishop is a light-squared bishop. White has a dark-squared bishop, which means it will be excellent at stopping pawns on dark squares, but cannot attack them on light squares. Our primary drawing mechanism relies on bringing the White King to the queenside to attack the pawn chain and blockade it on the dark squares, rendering Black's light-squared bishop completely useless.\\n\\n**Step-by-step reasoning:**\\n1. **1. Kd6!** is the most forcing and active move. It immediately attacks Black's bishop on c6, forcing it to retreat, and prepares the White King to invade via c5.\\n2. If Black moves the bishop to save it (e.g., `1... Bb7` or `1... Be8`), White follows up with **2. Kc5!** attacking the b5 pawn. The b5 pawn is defended by the a6 pawn, so White plans to maneuver to b6 to attack the base of the pawn chain (the a6 pawn).\\n3. Let's say Black tries to bring their king closer: `2... Kg4 3. Kb6`. Now White's king attacks the a6 pawn. \\n4. If Black tries to hold the pawns together by pushing **3... b4**, the b-pawn steps onto a dark square. White can simply play **4. Kxa6** (since a6 is now undefended by the b-pawn). Black is left with a single b-pawn.\\n5. Black pushes `4... b3`. White retreats the bishop to the long diagonal, for example, **5. Bf6**. Because White's bishop is dark-squared, it perfectly covers the b2 promotion square. White's King will easily step to a5 and blockade. The remaining position (White King on a dark square, Bishop patrolling the diagonal to b2) is an impregnable theoretical fortress because Black's light-squared bishop can never attack the White King on a dark square to force it away, nor block White's bishop on the dark-square diagonal.\\n6. Alternatively, if Black tries a discovered defense to prevent `Kxa6` (for instance, retreating the bishop to e2 earlier so that pushing `...b4` opens the bishop's vision to defend a6), White simply plays **Ka5!** blockading the a6 pawn. The b-pawn is still halted by White's dark-squared bishop controlling b2.\\n7. If Black abandons the bishop altogether with `1... b4`, White accepts the sacrifice with `2. Kxc6 b3 3. Bf6 a5 4. Kb5`. White's king gets inside the pawn structure and catches the a-pawn, while the bishop keeps the b-pawn firmly under control.\\n\\nBy moving the king to d6, you successfully eliminate Black's winning chances.\\n\\nFinal Answer: Kd6\",\n  \"main_response_and_thoughts\": \"\",\n  \"request_for_logging\": {\n    \"model\": \"google/gemini-3.1-pro-preview\",\n    \"messages\": [\n      {\n        \"role\": \"user\",\n        \"content\": [\n          {\n            \"type\": \"text\",\n            \"text\": \"Let's play chess. The current game state in Forsyth-Edwards Notation (FEN) notation is:\\n3B4/8/p1b5/1p2K2k/8/8/8/8 w - - 0 50\\nThe moves played so far are:\\n1. e4 c5 2. Nf3 d6 3. d4 cxd4 4. Nxd4 Nf6 5. Nc3 a6 6. Bg5 e6 7. f4 Qb6 8. Qd2 Qxb2 9. Rb1 Qa3 10. e5 dxe5 11. fxe5 Nfd7 12. Ne4 h6 13. Bh4 Qxa2 14. Rd1 Qd5 15. Qe3 Qxe5 16. Be2 Bc5 17. Bg3 Bxd4 18. Rxd4 Qa5+ 19. c3 O-O 20. O-O Nc6 21. Nf6+ Nxf6 22. Rxf6 Nxd4 23. cxd4 gxf6 24. Qxh6 Qg5 25. Qxg5+ fxg5 26. Bd6 Rd8 27. Be7 Rxd4 28. Bxg5 Rd5 29. Bf6 Rf5 30. Bc3 Rc5 31. Bd4 Rc1+ 32. Kf2 Rc2 33. Ke3 Rxe2+ 34. Kxe2 Bd7 35. Ke3 Bc6 36. g3 Rd8 37. Bf6 Rd5 38. g4 e5 39. h4 e4 40. Kxe4 Rd6+ 41. Ke5 Rd5+ 42. Kf4 Rb5 43. h5 Kh7 44. g5 Rb4+ 45. Ke5 Rh4 46. g6+ fxg6 47. hxg6+ Kxg6 48. Bxh4 Kh5 49. Bd8 b5 50.\\nYou are playing as player White.\\nIt is now your turn. Play your strongest move. The move MUST be legal. Reason step by step to come up with your move, then output your final answer in the format \\\"Final Answer: X\\\" where X is your chosen move in standard algebraic notation (SAN).\\n\"\n          }\n        ]\n      }\n    ],\n    \"config\": {\n      \"temperature\": \"NOT_GIVEN\",\n      \"top_p\": \"NOT_GIVEN\",\n      \"max_completion_tokens\": \"NOT_GIVEN\"\n    },\n    \"stream_options\": {\n      \"include_usage\": true\n    }\n  },\n  \"response_for_logging\": {\n    \"response_chunks\": [\n      {\n        \"id\": \"s8n6acPVGauEm9IP2rm86QE\",\n        \"choices\": [\n          {\n            \"delta\": {\n              \"content\": \" the king to d6, you successfully eliminate Black's winning chances.\\n\\nFinal Answer: Kd6\",\n              \"role\": \"assistant\"\n            },\n            \"finish_reason\": \"stop\",\n            \"index\": 0\n          }\n        ],\n        \"created\": 1778043315,\n        \"model\": \"google/gemini-3.1-pro-preview\",\n        \"object\": \"chat.completion.chunk\",\n        \"usage\": {\n          \"completion_tokens\": 680,\n          \"prompt_tokens\": 528,\n          \"total_tokens\": 21378,\n          \"cost\": {\n            \"input_tokens_cost_nanodollars\": 1056000,\n            \"output_tokens_cost_nanodollars\": 250200000\n          },\n          \"total_backend_latency_ms\": 152831\n        }\n      }\n    ]\n  },\n  \"generation_tokens\": 680,\n  \"prompt_tokens\": 528,\n  \"reasoning_tokens\": null,\n  \"total_tokens\": 21378,\n  \"duration_success_only_secs\": 153.36732814199786\n}"
+          ],
+          "status": "OK",
+          "submission": 2685,
+          "thoughts": "To determine the correct move, we must evaluate the endgame. We are down two pawns and defending an opposite-colored bishop endgame. White's goal is to set up an unbreakable blockade to secure a draw. \n\nThe pawns on a6 and b5 are both on light squares, and Black's bishop is a light-squared bishop. White has a dark-squared bishop, which means it will be excellent at stopping pawns on dark squares, but cannot attack them on light squares. Our primary drawing mechanism relies on bringing the White King to the queenside to attack the pawn chain and blockade it on the dark squares, rendering Black's light-squared bishop completely useless.\n\n**Step-by-step reasoning:**\n1. **1. Kd6!** is the most forcing and active move. It immediately attacks Black's bishop on c6, forcing it to retreat, and prepares the White King to invade via c5.\n2. If Black moves the bishop to save it (e.g., `1... Bb7` or `1... Be8`), White follows up with **2. Kc5!** attacking the b5 pawn. The b5 pawn is defended by the a6 pawn, so White plans to maneuver to b6 to attack the base of the pawn chain (the a6 pawn).\n3. Let's say Black tries to bring their king closer: `2... Kg4 3. Kb6`. Now White's king attacks the a6 pawn. \n4. If Black tries to hold the pawns together by pushing **3... b4**, the b-pawn steps onto a dark square. White can simply play **4. Kxa6** (since a6 is now undefended by the b-pawn). Black is left with a single b-pawn.\n5. Black pushes `4... b3`. White retreats the bishop to the long diagonal, for example, **5. Bf6**. Because White's bishop is dark-squared, it perfectly covers the b2 promotion square. White's King will easily step to a5 and blockade. The remaining position (White King on a dark square, Bishop patrolling the diagonal to b2) is an impregnable theoretical fortress because Black's light-squared bishop can never attack the White King on a dark square to force it away, nor block White's bishop on the dark-square diagonal.\n6. Alternatively, if Black tries a discovered defense to prevent `Kxa6` (for instance, retreating the bishop to e2 earlier so that pushing `...b4` opens the bishop's vision to defend a6), White simply plays **Ka5!** blockading the a6 pawn. The b-pawn is still halted by White's dark-squared bishop controlling b2.\n7. If Black abandons the bishop altogether with `1... b4`, White accepts the sacrifice with `2. Kxc6 b3 3. Bf6 a5 4. Kb5`. White's king gets inside the pawn structure and catches the a-pawn, while the bishop keeps the b-pawn firmly under control.\n\nBy moving the king to d6, you successfully eliminate Black's winning chances.\n\nFinal Answer: Kd6"
+        },
+        "info": {
+          "actionApplied": 2685,
+          "actionSubmitted": 2685,
+          "actionSubmittedToString": "Kd6",
+          "agentSelfReportedStatus": "OK",
+          "timeTaken": 155.127
+        },
+        "observation": {
+          "currentPlayer": 0,
+          "isTerminal": false,
+          "observationString": "3B4/8/p1bK4/1p5k/8/8/8/8 b - - 1 50",
+          "playerId": 1,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n1258\n3572\n1841\n1842\n1431\n3132\n3572\n656\n89\n1215\n2425\n3010\n1808\n1768\n749\n30\n1065\n2571\n1942\n3196\n3131\n1384\n4177\n3854\n381\n615\n498\n1869\n2001\n2977\n2975\n4350\n1431\n1770\n2581\n1257\n4673\n4673\n656\n2627\n1895\n2940\n1386\n1358\n3634\n2528\n254\n4496\n3110\n3705\n2948\n2161\n1771\n2833\n2059\n3853\n2002\n3326\n3166\n1358\n1406\n3561\n1694\n3050\n1637\n2497\n1212\n2425\n1882\n3593\n32\n2016\n1770\n3666\n2498\n4178\n2571\n2498\n1986\n2571\n1914\n2686\n1999\n4323\n3548\n3739\n819\n3196\n911\n3812\n3037\n4437\n4218\n3344\n3694\n4361\n674\n2685\n\n"
+        },
+        "reward": null,
+        "status": "INACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "actionString": "Bb7",
+          "generate_returns": [
+            "{\n  \"main_response\": \"Final Answer: Bb7\",\n  \"main_response_and_thoughts\": \"\",\n  \"request_for_logging\": {\n    \"model\": \"openai/gpt-5.5-2026-04-23\",\n    \"messages\": [\n      {\n        \"role\": \"user\",\n        \"content\": [\n          {\n            \"type\": \"text\",\n            \"text\": \"Let's play chess. The current game state in Forsyth-Edwards Notation (FEN) notation is:\\n3B4/8/p1bK4/1p5k/8/8/8/8 b - - 1 50\\nThe moves played so far are:\\n1. e4 c5 2. Nf3 d6 3. d4 cxd4 4. Nxd4 Nf6 5. Nc3 a6 6. Bg5 e6 7. f4 Qb6 8. Qd2 Qxb2 9. Rb1 Qa3 10. e5 dxe5 11. fxe5 Nfd7 12. Ne4 h6 13. Bh4 Qxa2 14. Rd1 Qd5 15. Qe3 Qxe5 16. Be2 Bc5 17. Bg3 Bxd4 18. Rxd4 Qa5+ 19. c3 O-O 20. O-O Nc6 21. Nf6+ Nxf6 22. Rxf6 Nxd4 23. cxd4 gxf6 24. Qxh6 Qg5 25. Qxg5+ fxg5 26. Bd6 Rd8 27. Be7 Rxd4 28. Bxg5 Rd5 29. Bf6 Rf5 30. Bc3 Rc5 31. Bd4 Rc1+ 32. Kf2 Rc2 33. Ke3 Rxe2+ 34. Kxe2 Bd7 35. Ke3 Bc6 36. g3 Rd8 37. Bf6 Rd5 38. g4 e5 39. h4 e4 40. Kxe4 Rd6+ 41. Ke5 Rd5+ 42. Kf4 Rb5 43. h5 Kh7 44. g5 Rb4+ 45. Ke5 Rh4 46. g6+ fxg6 47. hxg6+ Kxg6 48. Bxh4 Kh5 49. Bd8 b5 50. Kd6\\nYou are playing as player Black.\\nIt is now your turn. Play your strongest move. The move MUST be legal. Reason step by step to come up with your move, then output your final answer in the format \\\"Final Answer: X\\\" where X is your chosen move in standard algebraic notation (SAN).\\n\"\n          }\n        ]\n      }\n    ],\n    \"config\": {\n      \"temperature\": \"NOT_GIVEN\",\n      \"top_p\": \"NOT_GIVEN\",\n      \"max_completion_tokens\": \"NOT_GIVEN\",\n      \"reasoning_effort\": \"high\"\n    },\n    \"stream_options\": {\n      \"include_usage\": true\n    }\n  },\n  \"response_for_logging\": {\n    \"response_chunks\": [\n      {\n        \"id\": \"chatcmpl-DcOcQXGPO1PvZHph6aMOxlVOEZs9E\",\n        \"created\": 1778043470,\n        \"model\": \"openai/gpt-5.5-2026-04-23\",\n        \"object\": \"chat.completion.chunk\",\n        \"usage\": {\n          \"completion_tokens\": 35750,\n          \"prompt_tokens\": 538,\n          \"total_tokens\": 36288,\n          \"cost\": {\n            \"input_tokens_cost_nanodollars\": 2690000,\n            \"output_tokens_cost_nanodollars\": 1072500000\n          },\n          \"total_backend_latency_ms\": 737465\n        }\n      }\n    ]\n  },\n  \"generation_tokens\": 35750,\n  \"prompt_tokens\": 538,\n  \"reasoning_tokens\": null,\n  \"total_tokens\": 36288,\n  \"duration_success_only_secs\": 737.8915959180013\n}"
+          ],
+          "status": "OK",
+          "submission": 1357,
+          "thoughts": "Final Answer: Bb7"
+        },
+        "info": {
+          "actionApplied": 1357,
+          "actionSubmitted": 1357,
+          "actionSubmittedToString": "Bb7",
+          "agentSelfReportedStatus": "OK",
+          "timeTaken": 739.092
+        },
+        "observation": {
+          "currentPlayer": 1,
+          "isTerminal": false,
+          "observationString": "3B4/1b6/p2K4/1p5k/8/8/8/8 w - - 2 51",
+          "playerId": 0,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n1258\n3572\n1841\n1842\n1431\n3132\n3572\n656\n89\n1215\n2425\n3010\n1808\n1768\n749\n30\n1065\n2571\n1942\n3196\n3131\n1384\n4177\n3854\n381\n615\n498\n1869\n2001\n2977\n2975\n4350\n1431\n1770\n2581\n1257\n4673\n4673\n656\n2627\n1895\n2940\n1386\n1358\n3634\n2528\n254\n4496\n3110\n3705\n2948\n2161\n1771\n2833\n2059\n3853\n2002\n3326\n3166\n1358\n1406\n3561\n1694\n3050\n1637\n2497\n1212\n2425\n1882\n3593\n32\n2016\n1770\n3666\n2498\n4178\n2571\n2498\n1986\n2571\n1914\n2686\n1999\n4323\n3548\n3739\n819\n3196\n911\n3812\n3037\n4437\n4218\n3344\n3694\n4361\n674\n2685\n1357\n\n",
+          "step": 101
+        },
+        "reward": null,
+        "status": "INACTIVE"
+      },
+      {
+        "action": {
+          "submission": -1
+        },
+        "info": {},
+        "observation": {
+          "currentPlayer": 1,
+          "isTerminal": false,
+          "observationString": "3B4/1b6/p2K4/1p5k/8/8/8/8 w - - 2 51",
+          "playerId": 1,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n1258\n3572\n1841\n1842\n1431\n3132\n3572\n656\n89\n1215\n2425\n3010\n1808\n1768\n749\n30\n1065\n2571\n1942\n3196\n3131\n1384\n4177\n3854\n381\n615\n498\n1869\n2001\n2977\n2975\n4350\n1431\n1770\n2581\n1257\n4673\n4673\n656\n2627\n1895\n2940\n1386\n1358\n3634\n2528\n254\n4496\n3110\n3705\n2948\n2161\n1771\n2833\n2059\n3853\n2002\n3326\n3166\n1358\n1406\n3561\n1694\n3050\n1637\n2497\n1212\n2425\n1882\n3593\n32\n2016\n1770\n3666\n2498\n4178\n2571\n2498\n1986\n2571\n1914\n2686\n1999\n4323\n3548\n3739\n819\n3196\n911\n3812\n3037\n4437\n4218\n3344\n3694\n4361\n674\n2685\n1357\n\n"
+        },
+        "reward": null,
+        "status": "ACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "submission": -1
+        },
+        "info": {},
+        "observation": {
+          "currentPlayer": 0,
+          "isTerminal": false,
+          "observationString": "3B4/1bK5/p7/1p5k/8/8/8/8 b - - 3 51",
+          "playerId": 0,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n1258\n3572\n1841\n1842\n1431\n3132\n3572\n656\n89\n1215\n2425\n3010\n1808\n1768\n749\n30\n1065\n2571\n1942\n3196\n3131\n1384\n4177\n3854\n381\n615\n498\n1869\n2001\n2977\n2975\n4350\n1431\n1770\n2581\n1257\n4673\n4673\n656\n2627\n1895\n2940\n1386\n1358\n3634\n2528\n254\n4496\n3110\n3705\n2948\n2161\n1771\n2833\n2059\n3853\n2002\n3326\n3166\n1358\n1406\n3561\n1694\n3050\n1637\n2497\n1212\n2425\n1882\n3593\n32\n2016\n1770\n3666\n2498\n4178\n2571\n2498\n1986\n2571\n1914\n2686\n1999\n4323\n3548\n3739\n819\n3196\n911\n3812\n3037\n4437\n4218\n3344\n3694\n4361\n674\n2685\n1357\n2174\n\n",
+          "step": 102
+        },
+        "reward": null,
+        "status": "ACTIVE"
+      },
+      {
+        "action": {
+          "actionString": "Kc7",
+          "generate_returns": [
+            "{\n  \"main_response\": \"To secure the draw in this endgame, your main goal is to eliminate Black's queenside pawns or sacrifice your bishop for them so that Black is left with insufficient material to win. \\n\\nBy bringing your king towards the queenside, you can attack Black's pieces and win the crucial tempos needed to halt the pawns' advancement.\\n\\nStep-by-step reasoning:\\n1. You play **51. Kc7**. This move serves a dual purpose: it directly attacks the undefended Black bishop on b7 and places your king perfectly to infiltrate the queenside pawns.\\n2. Black's bishop must move to avoid being captured.\\n   - If Black plays 51... Ba8, you can respond with 52. Kb8. Black's bishop is trapped. If Black tries to push the pawn with 52... b4, you take the bishop with 53. Kxa8 b3, and simply play 54. Bf6. The pawn is stopped, and the position is a dead draw.\\n   - If Black moves the bishop along the diagonal (e.g., 51... Bf3 or 51... Be4), you follow up with 52. Kb6, directly attacking the pawn on a6. If Black tries to save it with 52... Be2 (defending a6), you can still capture it! After 53. Kxa6 b4+, you simply slide your king over with 54. Ka5 b3 55. Bf6. Your bishop covers the promotion square, ensuring the draw.\\n   - If Black ignores the bishop and pushes a pawn (e.g. 51... a5), you simply take the bishop with 52. Kxb7. After 52... b4, 53. Bxa5 b3 54. Bc3 stops everything.\\n\\nIn every variation, attacking the bishop with your king forces Black's hand, seamlessly stopping the pawns and concluding the game in a theoretical draw.\\n\\nFinal Answer: Kc7\",\n  \"main_response_and_thoughts\": \"\",\n  \"request_for_logging\": {\n    \"model\": \"google/gemini-3.1-pro-preview\",\n    \"messages\": [\n      {\n        \"role\": \"user\",\n        \"content\": [\n          {\n            \"type\": \"text\",\n            \"text\": \"Let's play chess. The current game state in Forsyth-Edwards Notation (FEN) notation is:\\n3B4/1b6/p2K4/1p5k/8/8/8/8 w - - 2 51\\nThe moves played so far are:\\n1. e4 c5 2. Nf3 d6 3. d4 cxd4 4. Nxd4 Nf6 5. Nc3 a6 6. Bg5 e6 7. f4 Qb6 8. Qd2 Qxb2 9. Rb1 Qa3 10. e5 dxe5 11. fxe5 Nfd7 12. Ne4 h6 13. Bh4 Qxa2 14. Rd1 Qd5 15. Qe3 Qxe5 16. Be2 Bc5 17. Bg3 Bxd4 18. Rxd4 Qa5+ 19. c3 O-O 20. O-O Nc6 21. Nf6+ Nxf6 22. Rxf6 Nxd4 23. cxd4 gxf6 24. Qxh6 Qg5 25. Qxg5+ fxg5 26. Bd6 Rd8 27. Be7 Rxd4 28. Bxg5 Rd5 29. Bf6 Rf5 30. Bc3 Rc5 31. Bd4 Rc1+ 32. Kf2 Rc2 33. Ke3 Rxe2+ 34. Kxe2 Bd7 35. Ke3 Bc6 36. g3 Rd8 37. Bf6 Rd5 38. g4 e5 39. h4 e4 40. Kxe4 Rd6+ 41. Ke5 Rd5+ 42. Kf4 Rb5 43. h5 Kh7 44. g5 Rb4+ 45. Ke5 Rh4 46. g6+ fxg6 47. hxg6+ Kxg6 48. Bxh4 Kh5 49. Bd8 b5 50. Kd6 Bb7 51.\\nYou are playing as player White.\\nIt is now your turn. Play your strongest move. The move MUST be legal. Reason step by step to come up with your move, then output your final answer in the format \\\"Final Answer: X\\\" where X is your chosen move in standard algebraic notation (SAN).\\n\"\n          }\n        ]\n      }\n    ],\n    \"config\": {\n      \"temperature\": \"NOT_GIVEN\",\n      \"top_p\": \"NOT_GIVEN\",\n      \"max_completion_tokens\": \"NOT_GIVEN\"\n    },\n    \"stream_options\": {\n      \"include_usage\": true\n    }\n  },\n  \"response_for_logging\": {\n    \"response_chunks\": [\n      {\n        \"id\": \"Mc36abLxCfiMmecPq_Dk8QQ\",\n        \"choices\": [\n          {\n            \"delta\": {\n              \"content\": \" a theoretical draw.\\n\\nFinal Answer: Kc7\",\n              \"role\": \"assistant\"\n            },\n            \"finish_reason\": \"stop\",\n            \"index\": 0\n          }\n        ],\n        \"created\": 1778044209,\n        \"model\": \"google/gemini-3.1-pro-preview\",\n        \"object\": \"chat.completion.chunk\",\n        \"usage\": {\n          \"completion_tokens\": 434,\n          \"prompt_tokens\": 536,\n          \"total_tokens\": 4482,\n          \"cost\": {\n            \"input_tokens_cost_nanodollars\": 1072000,\n            \"output_tokens_cost_nanodollars\": 47352000\n          },\n          \"total_backend_latency_ms\": 33606\n        }\n      }\n    ]\n  },\n  \"generation_tokens\": 434,\n  \"prompt_tokens\": 536,\n  \"reasoning_tokens\": null,\n  \"total_tokens\": 4482,\n  \"duration_success_only_secs\": 34.11050861900003\n}"
+          ],
+          "status": "OK",
+          "submission": 2174,
+          "thoughts": "To secure the draw in this endgame, your main goal is to eliminate Black's queenside pawns or sacrifice your bishop for them so that Black is left with insufficient material to win. \n\nBy bringing your king towards the queenside, you can attack Black's pieces and win the crucial tempos needed to halt the pawns' advancement.\n\nStep-by-step reasoning:\n1. You play **51. Kc7**. This move serves a dual purpose: it directly attacks the undefended Black bishop on b7 and places your king perfectly to infiltrate the queenside pawns.\n2. Black's bishop must move to avoid being captured.\n   - If Black plays 51... Ba8, you can respond with 52. Kb8. Black's bishop is trapped. If Black tries to push the pawn with 52... b4, you take the bishop with 53. Kxa8 b3, and simply play 54. Bf6. The pawn is stopped, and the position is a dead draw.\n   - If Black moves the bishop along the diagonal (e.g., 51... Bf3 or 51... Be4), you follow up with 52. Kb6, directly attacking the pawn on a6. If Black tries to save it with 52... Be2 (defending a6), you can still capture it! After 53. Kxa6 b4+, you simply slide your king over with 54. Ka5 b3 55. Bf6. Your bishop covers the promotion square, ensuring the draw.\n   - If Black ignores the bishop and pushes a pawn (e.g. 51... a5), you simply take the bishop with 52. Kxb7. After 52... b4, 53. Bxa5 b3 54. Bc3 stops everything.\n\nIn every variation, attacking the bishop with your king forces Black's hand, seamlessly stopping the pawns and concluding the game in a theoretical draw.\n\nFinal Answer: Kc7"
+        },
+        "info": {
+          "actionApplied": 2174,
+          "actionSubmitted": 2174,
+          "actionSubmittedToString": "Kc7",
+          "agentSelfReportedStatus": "OK",
+          "timeTaken": 35.352
+        },
+        "observation": {
+          "currentPlayer": 0,
+          "isTerminal": false,
+          "observationString": "3B4/1bK5/p7/1p5k/8/8/8/8 b - - 3 51",
+          "playerId": 1,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n1258\n3572\n1841\n1842\n1431\n3132\n3572\n656\n89\n1215\n2425\n3010\n1808\n1768\n749\n30\n1065\n2571\n1942\n3196\n3131\n1384\n4177\n3854\n381\n615\n498\n1869\n2001\n2977\n2975\n4350\n1431\n1770\n2581\n1257\n4673\n4673\n656\n2627\n1895\n2940\n1386\n1358\n3634\n2528\n254\n4496\n3110\n3705\n2948\n2161\n1771\n2833\n2059\n3853\n2002\n3326\n3166\n1358\n1406\n3561\n1694\n3050\n1637\n2497\n1212\n2425\n1882\n3593\n32\n2016\n1770\n3666\n2498\n4178\n2571\n2498\n1986\n2571\n1914\n2686\n1999\n4323\n3548\n3739\n819\n3196\n911\n3812\n3037\n4437\n4218\n3344\n3694\n4361\n674\n2685\n1357\n2174\n\n"
+        },
+        "reward": null,
+        "status": "INACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "actionString": "Bf3",
+          "generate_returns": [
+            "{\n  \"main_response\": \"The black bishop is attacked on b7, and the strongest way to save it is to put it on f3, keeping key control over the diagonal and preparing to advance the queenside pawns.\\n\\nFinal Answer: Bf3\",\n  \"main_response_and_thoughts\": \"\",\n  \"request_for_logging\": {\n    \"model\": \"openai/gpt-5.5-2026-04-23\",\n    \"messages\": [\n      {\n        \"role\": \"user\",\n        \"content\": [\n          {\n            \"type\": \"text\",\n            \"text\": \"Let's play chess. The current game state in Forsyth-Edwards Notation (FEN) notation is:\\n3B4/1bK5/p7/1p5k/8/8/8/8 b - - 3 51\\nThe moves played so far are:\\n1. e4 c5 2. Nf3 d6 3. d4 cxd4 4. Nxd4 Nf6 5. Nc3 a6 6. Bg5 e6 7. f4 Qb6 8. Qd2 Qxb2 9. Rb1 Qa3 10. e5 dxe5 11. fxe5 Nfd7 12. Ne4 h6 13. Bh4 Qxa2 14. Rd1 Qd5 15. Qe3 Qxe5 16. Be2 Bc5 17. Bg3 Bxd4 18. Rxd4 Qa5+ 19. c3 O-O 20. O-O Nc6 21. Nf6+ Nxf6 22. Rxf6 Nxd4 23. cxd4 gxf6 24. Qxh6 Qg5 25. Qxg5+ fxg5 26. Bd6 Rd8 27. Be7 Rxd4 28. Bxg5 Rd5 29. Bf6 Rf5 30. Bc3 Rc5 31. Bd4 Rc1+ 32. Kf2 Rc2 33. Ke3 Rxe2+ 34. Kxe2 Bd7 35. Ke3 Bc6 36. g3 Rd8 37. Bf6 Rd5 38. g4 e5 39. h4 e4 40. Kxe4 Rd6+ 41. Ke5 Rd5+ 42. Kf4 Rb5 43. h5 Kh7 44. g5 Rb4+ 45. Ke5 Rh4 46. g6+ fxg6 47. hxg6+ Kxg6 48. Bxh4 Kh5 49. Bd8 b5 50. Kd6 Bb7 51. Kc7\\nYou are playing as player Black.\\nIt is now your turn. Play your strongest move. The move MUST be legal. Reason step by step to come up with your move, then output your final answer in the format \\\"Final Answer: X\\\" where X is your chosen move in standard algebraic notation (SAN).\\n\"\n          }\n        ]\n      }\n    ],\n    \"config\": {\n      \"temperature\": \"NOT_GIVEN\",\n      \"top_p\": \"NOT_GIVEN\",\n      \"max_completion_tokens\": \"NOT_GIVEN\",\n      \"reasoning_effort\": \"high\"\n    },\n    \"stream_options\": {\n      \"include_usage\": true\n    }\n  },\n  \"response_for_logging\": {\n    \"response_chunks\": [\n      {\n        \"id\": \"chatcmpl-DcOoukmJ5uWj7S6yU1fQjzQowsXm9\",\n        \"created\": 1778044244,\n        \"model\": \"openai/gpt-5.5-2026-04-23\",\n        \"object\": \"chat.completion.chunk\",\n        \"usage\": {\n          \"completion_tokens\": 35791,\n          \"prompt_tokens\": 546,\n          \"total_tokens\": 36337,\n          \"cost\": {\n            \"input_tokens_cost_nanodollars\": 2730000,\n            \"output_tokens_cost_nanodollars\": 1073730000\n          },\n          \"total_backend_latency_ms\": 724354\n        }\n      }\n    ]\n  },\n  \"generation_tokens\": 35791,\n  \"prompt_tokens\": 546,\n  \"reasoning_tokens\": null,\n  \"total_tokens\": 36337,\n  \"duration_success_only_secs\": 724.8145759319996\n}"
+          ],
+          "status": "OK",
+          "submission": 704,
+          "thoughts": "The black bishop is attacked on b7, and the strongest way to save it is to put it on f3, keeping key control over the diagonal and preparing to advance the queenside pawns.\n\nFinal Answer: Bf3"
+        },
+        "info": {
+          "actionApplied": 704,
+          "actionSubmitted": 704,
+          "actionSubmittedToString": "Bf3",
+          "agentSelfReportedStatus": "OK",
+          "timeTaken": 726.027
+        },
+        "observation": {
+          "currentPlayer": 1,
+          "isTerminal": false,
+          "observationString": "3B4/2K5/p7/1p5k/8/5b2/8/8 w - - 4 52",
+          "playerId": 0,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n1258\n3572\n1841\n1842\n1431\n3132\n3572\n656\n89\n1215\n2425\n3010\n1808\n1768\n749\n30\n1065\n2571\n1942\n3196\n3131\n1384\n4177\n3854\n381\n615\n498\n1869\n2001\n2977\n2975\n4350\n1431\n1770\n2581\n1257\n4673\n4673\n656\n2627\n1895\n2940\n1386\n1358\n3634\n2528\n254\n4496\n3110\n3705\n2948\n2161\n1771\n2833\n2059\n3853\n2002\n3326\n3166\n1358\n1406\n3561\n1694\n3050\n1637\n2497\n1212\n2425\n1882\n3593\n32\n2016\n1770\n3666\n2498\n4178\n2571\n2498\n1986\n2571\n1914\n2686\n1999\n4323\n3548\n3739\n819\n3196\n911\n3812\n3037\n4437\n4218\n3344\n3694\n4361\n674\n2685\n1357\n2174\n704\n\n",
+          "step": 103
+        },
+        "reward": null,
+        "status": "INACTIVE"
+      },
+      {
+        "action": {
+          "submission": -1
+        },
+        "info": {},
+        "observation": {
+          "currentPlayer": 1,
+          "isTerminal": false,
+          "observationString": "3B4/2K5/p7/1p5k/8/5b2/8/8 w - - 4 52",
+          "playerId": 1,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n1258\n3572\n1841\n1842\n1431\n3132\n3572\n656\n89\n1215\n2425\n3010\n1808\n1768\n749\n30\n1065\n2571\n1942\n3196\n3131\n1384\n4177\n3854\n381\n615\n498\n1869\n2001\n2977\n2975\n4350\n1431\n1770\n2581\n1257\n4673\n4673\n656\n2627\n1895\n2940\n1386\n1358\n3634\n2528\n254\n4496\n3110\n3705\n2948\n2161\n1771\n2833\n2059\n3853\n2002\n3326\n3166\n1358\n1406\n3561\n1694\n3050\n1637\n2497\n1212\n2425\n1882\n3593\n32\n2016\n1770\n3666\n2498\n4178\n2571\n2498\n1986\n2571\n1914\n2686\n1999\n4323\n3548\n3739\n819\n3196\n911\n3812\n3037\n4437\n4218\n3344\n3694\n4361\n674\n2685\n1357\n2174\n704\n\n"
+        },
+        "reward": null,
+        "status": "ACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "submission": -1
+        },
+        "info": {},
+        "observation": {
+          "currentPlayer": 0,
+          "isTerminal": false,
+          "observationString": "3B4/8/pK6/1p5k/8/5b2/8/8 b - - 5 52",
+          "playerId": 0,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n1258\n3572\n1841\n1842\n1431\n3132\n3572\n656\n89\n1215\n2425\n3010\n1808\n1768\n749\n30\n1065\n2571\n1942\n3196\n3131\n1384\n4177\n3854\n381\n615\n498\n1869\n2001\n2977\n2975\n4350\n1431\n1770\n2581\n1257\n4673\n4673\n656\n2627\n1895\n2940\n1386\n1358\n3634\n2528\n254\n4496\n3110\n3705\n2948\n2161\n1771\n2833\n2059\n3853\n2002\n3326\n3166\n1358\n1406\n3561\n1694\n3050\n1637\n2497\n1212\n2425\n1882\n3593\n32\n2016\n1770\n3666\n2498\n4178\n2571\n2498\n1986\n2571\n1914\n2686\n1999\n4323\n3548\n3739\n819\n3196\n911\n3812\n3037\n4437\n4218\n3344\n3694\n4361\n674\n2685\n1357\n2174\n704\n1649\n\n",
+          "step": 104
+        },
+        "reward": null,
+        "status": "ACTIVE"
+      },
+      {
+        "action": {
+          "actionString": "Kb6",
+          "generate_returns": [
+            "{\n  \"main_response\": \"To secure the draw, White must eliminate or stop Black's remaining pawns on the queenside. The most active and direct way to achieve this is to immediately attack them with the King. \\n\\nBy playing the King to b6, White forces the issue. Black's pawns are on a6 and b5. Let's look at the responses:\\n- If Black pushes the pawn with 52... b4, White simply captures the a-pawn with 53. Kxa6. Black's b-pawn will then advance to b3, but White's dark-squared bishop will easily slide to f6 (54. Bf6) or another square on the a1-h8 diagonal, controlling the b2 promotion square. After that, the White King can march back (Kb5-b4) and help eliminate the last pawn, ending the game in a dead draw.\\n- If Black tries to defend with a move like 52... Be2, White plays 53. Kxa6. Then if Black reveals a discovered check with 53... b4+, White responds with 54. Ka5 b3 55. Bf6, once again successfully controlling the promotion square and bringing a swift end to Black's hopes of winning. \\n\\nIn every variation, White comfortably liquidates the remaining pawns or sacrifices the bishop for the last pawn to earn a textbook draw.\\n\\nFinal Answer: Kb6\",\n  \"main_response_and_thoughts\": \"\",\n  \"request_for_logging\": {\n    \"model\": \"google/gemini-3.1-pro-preview\",\n    \"messages\": [\n      {\n        \"role\": \"user\",\n        \"content\": [\n          {\n            \"type\": \"text\",\n            \"text\": \"Let's play chess. The current game state in Forsyth-Edwards Notation (FEN) notation is:\\n3B4/2K5/p7/1p5k/8/5b2/8/8 w - - 4 52\\nThe moves played so far are:\\n1. e4 c5 2. Nf3 d6 3. d4 cxd4 4. Nxd4 Nf6 5. Nc3 a6 6. Bg5 e6 7. f4 Qb6 8. Qd2 Qxb2 9. Rb1 Qa3 10. e5 dxe5 11. fxe5 Nfd7 12. Ne4 h6 13. Bh4 Qxa2 14. Rd1 Qd5 15. Qe3 Qxe5 16. Be2 Bc5 17. Bg3 Bxd4 18. Rxd4 Qa5+ 19. c3 O-O 20. O-O Nc6 21. Nf6+ Nxf6 22. Rxf6 Nxd4 23. cxd4 gxf6 24. Qxh6 Qg5 25. Qxg5+ fxg5 26. Bd6 Rd8 27. Be7 Rxd4 28. Bxg5 Rd5 29. Bf6 Rf5 30. Bc3 Rc5 31. Bd4 Rc1+ 32. Kf2 Rc2 33. Ke3 Rxe2+ 34. Kxe2 Bd7 35. Ke3 Bc6 36. g3 Rd8 37. Bf6 Rd5 38. g4 e5 39. h4 e4 40. Kxe4 Rd6+ 41. Ke5 Rd5+ 42. Kf4 Rb5 43. h5 Kh7 44. g5 Rb4+ 45. Ke5 Rh4 46. g6+ fxg6 47. hxg6+ Kxg6 48. Bxh4 Kh5 49. Bd8 b5 50. Kd6 Bb7 51. Kc7 Bf3 52.\\nYou are playing as player White.\\nIt is now your turn. Play your strongest move. The move MUST be legal. Reason step by step to come up with your move, then output your final answer in the format \\\"Final Answer: X\\\" where X is your chosen move in standard algebraic notation (SAN).\\n\"\n          }\n        ]\n      }\n    ],\n    \"config\": {\n      \"temperature\": \"NOT_GIVEN\",\n      \"top_p\": \"NOT_GIVEN\",\n      \"max_completion_tokens\": \"NOT_GIVEN\"\n    },\n    \"stream_options\": {\n      \"include_usage\": true\n    }\n  },\n  \"response_for_logging\": {\n    \"response_chunks\": [\n      {\n        \"id\": \"K9D6aZ3NIMudmecPmbT14Qk\",\n        \"choices\": [\n          {\n            \"delta\": {\n              \"content\": \" sacrifices the bishop for the last pawn to earn a textbook draw.\\n\\nFinal Answer: Kb6\",\n              \"role\": \"assistant\"\n            },\n            \"finish_reason\": \"stop\",\n            \"index\": 0\n          }\n        ],\n        \"created\": 1778044971,\n        \"model\": \"google/gemini-3.1-pro-preview\",\n        \"object\": \"chat.completion.chunk\",\n        \"usage\": {\n          \"completion_tokens\": 305,\n          \"prompt_tokens\": 544,\n          \"total_tokens\": 3468,\n          \"cost\": {\n            \"input_tokens_cost_nanodollars\": 1088000,\n            \"output_tokens_cost_nanodollars\": 35088000\n          },\n          \"total_backend_latency_ms\": 29627\n        }\n      }\n    ]\n  },\n  \"generation_tokens\": 305,\n  \"prompt_tokens\": 544,\n  \"reasoning_tokens\": null,\n  \"total_tokens\": 3468,\n  \"duration_success_only_secs\": 30.637678406001214\n}"
+          ],
+          "status": "OK",
+          "submission": 1649,
+          "thoughts": "To secure the draw, White must eliminate or stop Black's remaining pawns on the queenside. The most active and direct way to achieve this is to immediately attack them with the King. \n\nBy playing the King to b6, White forces the issue. Black's pawns are on a6 and b5. Let's look at the responses:\n- If Black pushes the pawn with 52... b4, White simply captures the a-pawn with 53. Kxa6. Black's b-pawn will then advance to b3, but White's dark-squared bishop will easily slide to f6 (54. Bf6) or another square on the a1-h8 diagonal, controlling the b2 promotion square. After that, the White King can march back (Kb5-b4) and help eliminate the last pawn, ending the game in a dead draw.\n- If Black tries to defend with a move like 52... Be2, White plays 53. Kxa6. Then if Black reveals a discovered check with 53... b4+, White responds with 54. Ka5 b3 55. Bf6, once again successfully controlling the promotion square and bringing a swift end to Black's hopes of winning. \n\nIn every variation, White comfortably liquidates the remaining pawns or sacrifices the bishop for the last pawn to earn a textbook draw.\n\nFinal Answer: Kb6"
+        },
+        "info": {
+          "actionApplied": 1649,
+          "actionSubmitted": 1649,
+          "actionSubmittedToString": "Kb6",
+          "agentSelfReportedStatus": "OK",
+          "timeTaken": 32.4
+        },
+        "observation": {
+          "currentPlayer": 0,
+          "isTerminal": false,
+          "observationString": "3B4/8/pK6/1p5k/8/5b2/8/8 b - - 5 52",
+          "playerId": 1,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n1258\n3572\n1841\n1842\n1431\n3132\n3572\n656\n89\n1215\n2425\n3010\n1808\n1768\n749\n30\n1065\n2571\n1942\n3196\n3131\n1384\n4177\n3854\n381\n615\n498\n1869\n2001\n2977\n2975\n4350\n1431\n1770\n2581\n1257\n4673\n4673\n656\n2627\n1895\n2940\n1386\n1358\n3634\n2528\n254\n4496\n3110\n3705\n2948\n2161\n1771\n2833\n2059\n3853\n2002\n3326\n3166\n1358\n1406\n3561\n1694\n3050\n1637\n2497\n1212\n2425\n1882\n3593\n32\n2016\n1770\n3666\n2498\n4178\n2571\n2498\n1986\n2571\n1914\n2686\n1999\n4323\n3548\n3739\n819\n3196\n911\n3812\n3037\n4437\n4218\n3344\n3694\n4361\n674\n2685\n1357\n2174\n704\n1649\n\n"
+        },
+        "reward": null,
+        "status": "INACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "actionString": "b4",
+          "generate_returns": [
+            "{\n  \"main_response\": \"Final Answer: b4\",\n  \"main_response_and_thoughts\": \"\",\n  \"request_for_logging\": {\n    \"model\": \"openai/gpt-5.5-2026-04-23\",\n    \"messages\": [\n      {\n        \"role\": \"user\",\n        \"content\": [\n          {\n            \"type\": \"text\",\n            \"text\": \"Let's play chess. The current game state in Forsyth-Edwards Notation (FEN) notation is:\\n3B4/8/pK6/1p5k/8/5b2/8/8 b - - 5 52\\nThe moves played so far are:\\n1. e4 c5 2. Nf3 d6 3. d4 cxd4 4. Nxd4 Nf6 5. Nc3 a6 6. Bg5 e6 7. f4 Qb6 8. Qd2 Qxb2 9. Rb1 Qa3 10. e5 dxe5 11. fxe5 Nfd7 12. Ne4 h6 13. Bh4 Qxa2 14. Rd1 Qd5 15. Qe3 Qxe5 16. Be2 Bc5 17. Bg3 Bxd4 18. Rxd4 Qa5+ 19. c3 O-O 20. O-O Nc6 21. Nf6+ Nxf6 22. Rxf6 Nxd4 23. cxd4 gxf6 24. Qxh6 Qg5 25. Qxg5+ fxg5 26. Bd6 Rd8 27. Be7 Rxd4 28. Bxg5 Rd5 29. Bf6 Rf5 30. Bc3 Rc5 31. Bd4 Rc1+ 32. Kf2 Rc2 33. Ke3 Rxe2+ 34. Kxe2 Bd7 35. Ke3 Bc6 36. g3 Rd8 37. Bf6 Rd5 38. g4 e5 39. h4 e4 40. Kxe4 Rd6+ 41. Ke5 Rd5+ 42. Kf4 Rb5 43. h5 Kh7 44. g5 Rb4+ 45. Ke5 Rh4 46. g6+ fxg6 47. hxg6+ Kxg6 48. Bxh4 Kh5 49. Bd8 b5 50. Kd6 Bb7 51. Kc7 Bf3 52. Kb6\\nYou are playing as player Black.\\nIt is now your turn. Play your strongest move. The move MUST be legal. Reason step by step to come up with your move, then output your final answer in the format \\\"Final Answer: X\\\" where X is your chosen move in standard algebraic notation (SAN).\\n\"\n          }\n        ]\n      }\n    ],\n    \"config\": {\n      \"temperature\": \"NOT_GIVEN\",\n      \"top_p\": \"NOT_GIVEN\",\n      \"max_completion_tokens\": \"NOT_GIVEN\",\n      \"reasoning_effort\": \"high\"\n    },\n    \"stream_options\": {\n      \"include_usage\": true\n    }\n  },\n  \"response_for_logging\": {\n    \"response_chunks\": [\n      {\n        \"id\": \"chatcmpl-DcP19rSRvzZWPgTpkKxucZtqIp7xI\",\n        \"created\": 1778045003,\n        \"model\": \"openai/gpt-5.5-2026-04-23\",\n        \"object\": \"chat.completion.chunk\",\n        \"usage\": {\n          \"completion_tokens\": 20728,\n          \"prompt_tokens\": 555,\n          \"total_tokens\": 21283,\n          \"cost\": {\n            \"input_tokens_cost_nanodollars\": 2775000,\n            \"output_tokens_cost_nanodollars\": 621840000\n          },\n          \"total_backend_latency_ms\": 440058\n        }\n      }\n    ]\n  },\n  \"generation_tokens\": 20728,\n  \"prompt_tokens\": 555,\n  \"reasoning_tokens\": null,\n  \"total_tokens\": 21283,\n  \"duration_success_only_secs\": 440.5132355679998\n}"
+          ],
+          "status": "OK",
+          "submission": 819,
+          "thoughts": "Final Answer: b4"
+        },
+        "info": {
+          "actionApplied": 819,
+          "actionSubmitted": 819,
+          "actionSubmittedToString": "b4",
+          "agentSelfReportedStatus": "OK",
+          "timeTaken": 441.775
+        },
+        "observation": {
+          "currentPlayer": 1,
+          "isTerminal": false,
+          "observationString": "3B4/8/pK6/7k/1p6/5b2/8/8 w - - 0 53",
+          "playerId": 0,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n1258\n3572\n1841\n1842\n1431\n3132\n3572\n656\n89\n1215\n2425\n3010\n1808\n1768\n749\n30\n1065\n2571\n1942\n3196\n3131\n1384\n4177\n3854\n381\n615\n498\n1869\n2001\n2977\n2975\n4350\n1431\n1770\n2581\n1257\n4673\n4673\n656\n2627\n1895\n2940\n1386\n1358\n3634\n2528\n254\n4496\n3110\n3705\n2948\n2161\n1771\n2833\n2059\n3853\n2002\n3326\n3166\n1358\n1406\n3561\n1694\n3050\n1637\n2497\n1212\n2425\n1882\n3593\n32\n2016\n1770\n3666\n2498\n4178\n2571\n2498\n1986\n2571\n1914\n2686\n1999\n4323\n3548\n3739\n819\n3196\n911\n3812\n3037\n4437\n4218\n3344\n3694\n4361\n674\n2685\n1357\n2174\n704\n1649\n819\n\n",
+          "step": 105
+        },
+        "reward": null,
+        "status": "INACTIVE"
+      },
+      {
+        "action": {
+          "submission": -1
+        },
+        "info": {},
+        "observation": {
+          "currentPlayer": 1,
+          "isTerminal": false,
+          "observationString": "3B4/8/pK6/7k/1p6/5b2/8/8 w - - 0 53",
+          "playerId": 1,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n1258\n3572\n1841\n1842\n1431\n3132\n3572\n656\n89\n1215\n2425\n3010\n1808\n1768\n749\n30\n1065\n2571\n1942\n3196\n3131\n1384\n4177\n3854\n381\n615\n498\n1869\n2001\n2977\n2975\n4350\n1431\n1770\n2581\n1257\n4673\n4673\n656\n2627\n1895\n2940\n1386\n1358\n3634\n2528\n254\n4496\n3110\n3705\n2948\n2161\n1771\n2833\n2059\n3853\n2002\n3326\n3166\n1358\n1406\n3561\n1694\n3050\n1637\n2497\n1212\n2425\n1882\n3593\n32\n2016\n1770\n3666\n2498\n4178\n2571\n2498\n1986\n2571\n1914\n2686\n1999\n4323\n3548\n3739\n819\n3196\n911\n3812\n3037\n4437\n4218\n3344\n3694\n4361\n674\n2685\n1357\n2174\n704\n1649\n819\n\n"
+        },
+        "reward": null,
+        "status": "ACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "submission": -1
+        },
+        "info": {},
+        "observation": {
+          "currentPlayer": 0,
+          "isTerminal": false,
+          "observationString": "3B4/8/K7/7k/1p6/5b2/8/8 b - - 0 53",
+          "playerId": 0,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n1258\n3572\n1841\n1842\n1431\n3132\n3572\n656\n89\n1215\n2425\n3010\n1808\n1768\n749\n30\n1065\n2571\n1942\n3196\n3131\n1384\n4177\n3854\n381\n615\n498\n1869\n2001\n2977\n2975\n4350\n1431\n1770\n2581\n1257\n4673\n4673\n656\n2627\n1895\n2940\n1386\n1358\n3634\n2528\n254\n4496\n3110\n3705\n2948\n2161\n1771\n2833\n2059\n3853\n2002\n3326\n3166\n1358\n1406\n3561\n1694\n3050\n1637\n2497\n1212\n2425\n1882\n3593\n32\n2016\n1770\n3666\n2498\n4178\n2571\n2498\n1986\n2571\n1914\n2686\n1999\n4323\n3548\n3739\n819\n3196\n911\n3812\n3037\n4437\n4218\n3344\n3694\n4361\n674\n2685\n1357\n2174\n704\n1649\n819\n978\n\n",
+          "step": 106
+        },
+        "reward": null,
+        "status": "ACTIVE"
+      },
+      {
+        "action": {
+          "actionString": "Kxa6",
+          "generate_returns": [
+            "{\n  \"main_response\": \"To secure the draw, White must eliminate Black's remaining pawns. By taking the pawn on a6, White simplifies the position and ensures that Black's last remaining pawn (on b4) can be easily stopped. \\n\\nHere is the step-by-step reasoning:\\n1. White's King is ideally placed on b6 to capture the a6 pawn: 53. Kxa6.\\n2. After 53. Kxa6, Black's most dangerous attempt is to push the b-pawn with 53... b3. \\n3. White then has the simple and fully effective reply 54. Bf6, using the Bishop to control the b2 promotion square.\\n4. From there, White's King is perfectly in time to march over (Kb5-c4) to blockade and win the b3 pawn, completely neutralizing any threat of promotion. Since White is prepared to sacrifice the Bishop for the final pawn if necessary, a theoretical draw is trivially achieved. \\n\\nFinal Answer: Kxa6\",\n  \"main_response_and_thoughts\": \"\",\n  \"request_for_logging\": {\n    \"model\": \"google/gemini-3.1-pro-preview\",\n    \"messages\": [\n      {\n        \"role\": \"user\",\n        \"content\": [\n          {\n            \"type\": \"text\",\n            \"text\": \"Let's play chess. The current game state in Forsyth-Edwards Notation (FEN) notation is:\\n3B4/8/pK6/7k/1p6/5b2/8/8 w - - 0 53\\nThe moves played so far are:\\n1. e4 c5 2. Nf3 d6 3. d4 cxd4 4. Nxd4 Nf6 5. Nc3 a6 6. Bg5 e6 7. f4 Qb6 8. Qd2 Qxb2 9. Rb1 Qa3 10. e5 dxe5 11. fxe5 Nfd7 12. Ne4 h6 13. Bh4 Qxa2 14. Rd1 Qd5 15. Qe3 Qxe5 16. Be2 Bc5 17. Bg3 Bxd4 18. Rxd4 Qa5+ 19. c3 O-O 20. O-O Nc6 21. Nf6+ Nxf6 22. Rxf6 Nxd4 23. cxd4 gxf6 24. Qxh6 Qg5 25. Qxg5+ fxg5 26. Bd6 Rd8 27. Be7 Rxd4 28. Bxg5 Rd5 29. Bf6 Rf5 30. Bc3 Rc5 31. Bd4 Rc1+ 32. Kf2 Rc2 33. Ke3 Rxe2+ 34. Kxe2 Bd7 35. Ke3 Bc6 36. g3 Rd8 37. Bf6 Rd5 38. g4 e5 39. h4 e4 40. Kxe4 Rd6+ 41. Ke5 Rd5+ 42. Kf4 Rb5 43. h5 Kh7 44. g5 Rb4+ 45. Ke5 Rh4 46. g6+ fxg6 47. hxg6+ Kxg6 48. Bxh4 Kh5 49. Bd8 b5 50. Kd6 Bb7 51. Kc7 Bf3 52. Kb6 b4 53.\\nYou are playing as player White.\\nIt is now your turn. Play your strongest move. The move MUST be legal. Reason step by step to come up with your move, then output your final answer in the format \\\"Final Answer: X\\\" where X is your chosen move in standard algebraic notation (SAN).\\n\"\n          }\n        ]\n      }\n    ],\n    \"config\": {\n      \"temperature\": \"NOT_GIVEN\",\n      \"top_p\": \"NOT_GIVEN\",\n      \"max_completion_tokens\": \"NOT_GIVEN\"\n    },\n    \"stream_options\": {\n      \"include_usage\": true\n    }\n  },\n  \"response_for_logging\": {\n    \"response_chunks\": [\n      {\n        \"id\": \"BNL6aZSbKPiMmecPq_Dk8QQ\",\n        \"choices\": [\n          {\n            \"delta\": {\n              \"content\": \" a theoretical draw is trivially achieved. \\n\\nFinal Answer: Kxa6\",\n              \"role\": \"assistant\"\n            },\n            \"finish_reason\": \"stop\",\n            \"index\": 0\n          }\n        ],\n        \"created\": 1778045444,\n        \"model\": \"google/gemini-3.1-pro-preview\",\n        \"object\": \"chat.completion.chunk\",\n        \"usage\": {\n          \"completion_tokens\": 218,\n          \"prompt_tokens\": 550,\n          \"total_tokens\": 3454,\n          \"cost\": {\n            \"input_tokens_cost_nanodollars\": 1100000,\n            \"output_tokens_cost_nanodollars\": 34848000\n          },\n          \"total_backend_latency_ms\": 28480\n        }\n      }\n    ]\n  },\n  \"generation_tokens\": 218,\n  \"prompt_tokens\": 550,\n  \"reasoning_tokens\": null,\n  \"total_tokens\": 3454,\n  \"duration_success_only_secs\": 28.96201397099867\n}"
+          ],
+          "status": "OK",
+          "submission": 978,
+          "thoughts": "To secure the draw, White must eliminate Black's remaining pawns. By taking the pawn on a6, White simplifies the position and ensures that Black's last remaining pawn (on b4) can be easily stopped. \n\nHere is the step-by-step reasoning:\n1. White's King is ideally placed on b6 to capture the a6 pawn: 53. Kxa6.\n2. After 53. Kxa6, Black's most dangerous attempt is to push the b-pawn with 53... b3. \n3. White then has the simple and fully effective reply 54. Bf6, using the Bishop to control the b2 promotion square.\n4. From there, White's King is perfectly in time to march over (Kb5-c4) to blockade and win the b3 pawn, completely neutralizing any threat of promotion. Since White is prepared to sacrifice the Bishop for the final pawn if necessary, a theoretical draw is trivially achieved. \n\nFinal Answer: Kxa6"
+        },
+        "info": {
+          "actionApplied": 978,
+          "actionSubmitted": 978,
+          "actionSubmittedToString": "Kxa6",
+          "agentSelfReportedStatus": "OK",
+          "timeTaken": 30.175
+        },
+        "observation": {
+          "currentPlayer": 0,
+          "isTerminal": false,
+          "observationString": "3B4/8/K7/7k/1p6/5b2/8/8 b - - 0 53",
+          "playerId": 1,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n1258\n3572\n1841\n1842\n1431\n3132\n3572\n656\n89\n1215\n2425\n3010\n1808\n1768\n749\n30\n1065\n2571\n1942\n3196\n3131\n1384\n4177\n3854\n381\n615\n498\n1869\n2001\n2977\n2975\n4350\n1431\n1770\n2581\n1257\n4673\n4673\n656\n2627\n1895\n2940\n1386\n1358\n3634\n2528\n254\n4496\n3110\n3705\n2948\n2161\n1771\n2833\n2059\n3853\n2002\n3326\n3166\n1358\n1406\n3561\n1694\n3050\n1637\n2497\n1212\n2425\n1882\n3593\n32\n2016\n1770\n3666\n2498\n4178\n2571\n2498\n1986\n2571\n1914\n2686\n1999\n4323\n3548\n3739\n819\n3196\n911\n3812\n3037\n4437\n4218\n3344\n3694\n4361\n674\n2685\n1357\n2174\n704\n1649\n819\n978\n\n"
+        },
+        "reward": null,
+        "status": "INACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "actionString": "b3",
+          "generate_returns": [
+            "{\n  \"main_response\": \"Black\\u2019s strongest move is to advance the passed pawn immediately.\\n\\n- The pawn move is legal: Black pawn on b4 can move to b3.\\n- It creates a decisive threat: ...b2 followed by ...b1=Q.\\n- White\\u2019s bishop is on dark squares and cannot control the promotion square b1.\\n- White is forced to try 54. Bf6 to control b2, after which Black can continue coordinating king and bishop to win.\\n\\nFinal Answer: b3\",\n  \"main_response_and_thoughts\": \"\",\n  \"request_for_logging\": {\n    \"model\": \"openai/gpt-5.5-2026-04-23\",\n    \"messages\": [\n      {\n        \"role\": \"user\",\n        \"content\": [\n          {\n            \"type\": \"text\",\n            \"text\": \"Let's play chess. The current game state in Forsyth-Edwards Notation (FEN) notation is:\\n3B4/8/K7/7k/1p6/5b2/8/8 b - - 0 53\\nThe moves played so far are:\\n1. e4 c5 2. Nf3 d6 3. d4 cxd4 4. Nxd4 Nf6 5. Nc3 a6 6. Bg5 e6 7. f4 Qb6 8. Qd2 Qxb2 9. Rb1 Qa3 10. e5 dxe5 11. fxe5 Nfd7 12. Ne4 h6 13. Bh4 Qxa2 14. Rd1 Qd5 15. Qe3 Qxe5 16. Be2 Bc5 17. Bg3 Bxd4 18. Rxd4 Qa5+ 19. c3 O-O 20. O-O Nc6 21. Nf6+ Nxf6 22. Rxf6 Nxd4 23. cxd4 gxf6 24. Qxh6 Qg5 25. Qxg5+ fxg5 26. Bd6 Rd8 27. Be7 Rxd4 28. Bxg5 Rd5 29. Bf6 Rf5 30. Bc3 Rc5 31. Bd4 Rc1+ 32. Kf2 Rc2 33. Ke3 Rxe2+ 34. Kxe2 Bd7 35. Ke3 Bc6 36. g3 Rd8 37. Bf6 Rd5 38. g4 e5 39. h4 e4 40. Kxe4 Rd6+ 41. Ke5 Rd5+ 42. Kf4 Rb5 43. h5 Kh7 44. g5 Rb4+ 45. Ke5 Rh4 46. g6+ fxg6 47. hxg6+ Kxg6 48. Bxh4 Kh5 49. Bd8 b5 50. Kd6 Bb7 51. Kc7 Bf3 52. Kb6 b4 53. Kxa6\\nYou are playing as player Black.\\nIt is now your turn. Play your strongest move. The move MUST be legal. Reason step by step to come up with your move, then output your final answer in the format \\\"Final Answer: X\\\" where X is your chosen move in standard algebraic notation (SAN).\\n\"\n          }\n        ]\n      }\n    ],\n    \"config\": {\n      \"temperature\": \"NOT_GIVEN\",\n      \"top_p\": \"NOT_GIVEN\",\n      \"max_completion_tokens\": \"NOT_GIVEN\",\n      \"reasoning_effort\": \"high\"\n    },\n    \"stream_options\": {\n      \"include_usage\": true\n    }\n  },\n  \"response_for_logging\": {\n    \"response_chunks\": [\n      {\n        \"id\": \"chatcmpl-DcP8kMRLaNPicMeT6q1oMxz8tJA50\",\n        \"created\": 1778045474,\n        \"model\": \"openai/gpt-5.5-2026-04-23\",\n        \"object\": \"chat.completion.chunk\",\n        \"usage\": {\n          \"completion_tokens\": 18750,\n          \"prompt_tokens\": 562,\n          \"total_tokens\": 19312,\n          \"cost\": {\n            \"input_tokens_cost_nanodollars\": 2810000,\n            \"output_tokens_cost_nanodollars\": 562500000\n          },\n          \"total_backend_latency_ms\": 394815\n        }\n      }\n    ]\n  },\n  \"generation_tokens\": 18750,\n  \"prompt_tokens\": 562,\n  \"reasoning_tokens\": null,\n  \"total_tokens\": 19312,\n  \"duration_success_only_secs\": 395.2795689300001\n}"
+          ],
+          "status": "OK",
+          "submission": 892,
+          "thoughts": "Black\u2019s strongest move is to advance the passed pawn immediately.\n\n- The pawn move is legal: Black pawn on b4 can move to b3.\n- It creates a decisive threat: ...b2 followed by ...b1=Q.\n- White\u2019s bishop is on dark squares and cannot control the promotion square b1.\n- White is forced to try 54. Bf6 to control b2, after which Black can continue coordinating king and bishop to win.\n\nFinal Answer: b3"
+        },
+        "info": {
+          "actionApplied": 892,
+          "actionSubmitted": 892,
+          "actionSubmittedToString": "b3",
+          "agentSelfReportedStatus": "OK",
+          "timeTaken": 396.986
+        },
+        "observation": {
+          "currentPlayer": 1,
+          "isTerminal": false,
+          "observationString": "3B4/8/K7/7k/8/1p3b2/8/8 w - - 0 54",
+          "playerId": 0,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n1258\n3572\n1841\n1842\n1431\n3132\n3572\n656\n89\n1215\n2425\n3010\n1808\n1768\n749\n30\n1065\n2571\n1942\n3196\n3131\n1384\n4177\n3854\n381\n615\n498\n1869\n2001\n2977\n2975\n4350\n1431\n1770\n2581\n1257\n4673\n4673\n656\n2627\n1895\n2940\n1386\n1358\n3634\n2528\n254\n4496\n3110\n3705\n2948\n2161\n1771\n2833\n2059\n3853\n2002\n3326\n3166\n1358\n1406\n3561\n1694\n3050\n1637\n2497\n1212\n2425\n1882\n3593\n32\n2016\n1770\n3666\n2498\n4178\n2571\n2498\n1986\n2571\n1914\n2686\n1999\n4323\n3548\n3739\n819\n3196\n911\n3812\n3037\n4437\n4218\n3344\n3694\n4361\n674\n2685\n1357\n2174\n704\n1649\n819\n978\n892\n\n",
+          "step": 107
+        },
+        "reward": null,
+        "status": "INACTIVE"
+      },
+      {
+        "action": {
+          "submission": -1
+        },
+        "info": {},
+        "observation": {
+          "currentPlayer": 1,
+          "isTerminal": false,
+          "observationString": "3B4/8/K7/7k/8/1p3b2/8/8 w - - 0 54",
+          "playerId": 1,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n1258\n3572\n1841\n1842\n1431\n3132\n3572\n656\n89\n1215\n2425\n3010\n1808\n1768\n749\n30\n1065\n2571\n1942\n3196\n3131\n1384\n4177\n3854\n381\n615\n498\n1869\n2001\n2977\n2975\n4350\n1431\n1770\n2581\n1257\n4673\n4673\n656\n2627\n1895\n2940\n1386\n1358\n3634\n2528\n254\n4496\n3110\n3705\n2948\n2161\n1771\n2833\n2059\n3853\n2002\n3326\n3166\n1358\n1406\n3561\n1694\n3050\n1637\n2497\n1212\n2425\n1882\n3593\n32\n2016\n1770\n3666\n2498\n4178\n2571\n2498\n1986\n2571\n1914\n2686\n1999\n4323\n3548\n3739\n819\n3196\n911\n3812\n3037\n4437\n4218\n3344\n3694\n4361\n674\n2685\n1357\n2174\n704\n1649\n819\n978\n892\n\n"
+        },
+        "reward": null,
+        "status": "ACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "submission": -1
+        },
+        "info": {},
+        "observation": {
+          "currentPlayer": 0,
+          "isTerminal": false,
+          "observationString": "8/8/K4B2/7k/8/1p3b2/8/8 b - - 1 54",
+          "playerId": 0,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n1258\n3572\n1841\n1842\n1431\n3132\n3572\n656\n89\n1215\n2425\n3010\n1808\n1768\n749\n30\n1065\n2571\n1942\n3196\n3131\n1384\n4177\n3854\n381\n615\n498\n1869\n2001\n2977\n2975\n4350\n1431\n1770\n2581\n1257\n4673\n4673\n656\n2627\n1895\n2940\n1386\n1358\n3634\n2528\n254\n4496\n3110\n3705\n2948\n2161\n1771\n2833\n2059\n3853\n2002\n3326\n3166\n1358\n1406\n3561\n1694\n3050\n1637\n2497\n1212\n2425\n1882\n3593\n32\n2016\n1770\n3666\n2498\n4178\n2571\n2498\n1986\n2571\n1914\n2686\n1999\n4323\n3548\n3739\n819\n3196\n911\n3812\n3037\n4437\n4218\n3344\n3694\n4361\n674\n2685\n1357\n2174\n704\n1649\n819\n978\n892\n2322\n\n",
+          "step": 108
+        },
+        "reward": null,
+        "status": "ACTIVE"
+      },
+      {
+        "action": {
+          "actionString": "Bf6",
+          "generate_returns": [
+            "{\n  \"main_response\": \"To prevent the black pawn on b3 from promoting, White must immediately find a way to control the b2 square. Black's pawn is only two steps away from becoming a Queen, and White's king is currently too far away to stop it on its own. \\n\\nFortunately, White's bishop on d8 is on a dark square and can easily reposition itself to the long dark-square diagonal.\\n\\nBy playing 54. Bf6, White's bishop eyes the b2 square directly. \\n- If Black pushes the pawn anyway (54... b2), White will simply capture it (55. Bxb2) securing a completely drawn endgame (King vs King + Bishop). \\n- If Black tries to attack the bishop with the King (e.g., 54... Kg6), White can just slide the bishop down the diagonal to firmly block the pawn (55. Bb2), safely buying enough time for the White King to walk over and permanently neutralize any remaining threats. Black's light-squared bishop on f3 is completely powerless to break a blockade on the dark squares.\\n\\nFinal Answer: Bf6\",\n  \"main_response_and_thoughts\": \"\",\n  \"request_for_logging\": {\n    \"model\": \"google/gemini-3.1-pro-preview\",\n    \"messages\": [\n      {\n        \"role\": \"user\",\n        \"content\": [\n          {\n            \"type\": \"text\",\n            \"text\": \"Let's play chess. The current game state in Forsyth-Edwards Notation (FEN) notation is:\\n3B4/8/K7/7k/8/1p3b2/8/8 w - - 0 54\\nThe moves played so far are:\\n1. e4 c5 2. Nf3 d6 3. d4 cxd4 4. Nxd4 Nf6 5. Nc3 a6 6. Bg5 e6 7. f4 Qb6 8. Qd2 Qxb2 9. Rb1 Qa3 10. e5 dxe5 11. fxe5 Nfd7 12. Ne4 h6 13. Bh4 Qxa2 14. Rd1 Qd5 15. Qe3 Qxe5 16. Be2 Bc5 17. Bg3 Bxd4 18. Rxd4 Qa5+ 19. c3 O-O 20. O-O Nc6 21. Nf6+ Nxf6 22. Rxf6 Nxd4 23. cxd4 gxf6 24. Qxh6 Qg5 25. Qxg5+ fxg5 26. Bd6 Rd8 27. Be7 Rxd4 28. Bxg5 Rd5 29. Bf6 Rf5 30. Bc3 Rc5 31. Bd4 Rc1+ 32. Kf2 Rc2 33. Ke3 Rxe2+ 34. Kxe2 Bd7 35. Ke3 Bc6 36. g3 Rd8 37. Bf6 Rd5 38. g4 e5 39. h4 e4 40. Kxe4 Rd6+ 41. Ke5 Rd5+ 42. Kf4 Rb5 43. h5 Kh7 44. g5 Rb4+ 45. Ke5 Rh4 46. g6+ fxg6 47. hxg6+ Kxg6 48. Bxh4 Kh5 49. Bd8 b5 50. Kd6 Bb7 51. Kc7 Bf3 52. Kb6 b4 53. Kxa6 b3 54.\\nYou are playing as player White.\\nIt is now your turn. Play your strongest move. The move MUST be legal. Reason step by step to come up with your move, then output your final answer in the format \\\"Final Answer: X\\\" where X is your chosen move in standard algebraic notation (SAN).\\n\"\n          }\n        ]\n      }\n    ],\n    \"config\": {\n      \"temperature\": \"NOT_GIVEN\",\n      \"top_p\": \"NOT_GIVEN\",\n      \"max_completion_tokens\": \"NOT_GIVEN\"\n    },\n    \"stream_options\": {\n      \"include_usage\": true\n    }\n  },\n  \"response_for_logging\": {\n    \"response_chunks\": [\n      {\n        \"id\": \"r9P6abGpM_iMmecPq_Dk8QQ\",\n        \"choices\": [\n          {\n            \"delta\": {\n              \"content\": \" f3 is completely powerless to break a blockade on the dark squares.\\n\\nFinal Answer: Bf6\",\n              \"role\": \"assistant\"\n            },\n            \"finish_reason\": \"stop\",\n            \"index\": 0\n          }\n        ],\n        \"created\": 1778045871,\n        \"model\": \"google/gemini-3.1-pro-preview\",\n        \"object\": \"chat.completion.chunk\",\n        \"usage\": {\n          \"completion_tokens\": 237,\n          \"prompt_tokens\": 558,\n          \"total_tokens\": 3236,\n          \"cost\": {\n            \"input_tokens_cost_nanodollars\": 1116000,\n            \"output_tokens_cost_nanodollars\": 32136000\n          },\n          \"total_backend_latency_ms\": 26259\n        }\n      }\n    ]\n  },\n  \"generation_tokens\": 237,\n  \"prompt_tokens\": 558,\n  \"reasoning_tokens\": null,\n  \"total_tokens\": 3236,\n  \"duration_success_only_secs\": 26.78735842899914\n}"
+          ],
+          "status": "OK",
+          "submission": 2322,
+          "thoughts": "To prevent the black pawn on b3 from promoting, White must immediately find a way to control the b2 square. Black's pawn is only two steps away from becoming a Queen, and White's king is currently too far away to stop it on its own. \n\nFortunately, White's bishop on d8 is on a dark square and can easily reposition itself to the long dark-square diagonal.\n\nBy playing 54. Bf6, White's bishop eyes the b2 square directly. \n- If Black pushes the pawn anyway (54... b2), White will simply capture it (55. Bxb2) securing a completely drawn endgame (King vs King + Bishop). \n- If Black tries to attack the bishop with the King (e.g., 54... Kg6), White can just slide the bishop down the diagonal to firmly block the pawn (55. Bb2), safely buying enough time for the White King to walk over and permanently neutralize any remaining threats. Black's light-squared bishop on f3 is completely powerless to break a blockade on the dark squares.\n\nFinal Answer: Bf6"
+        },
+        "info": {
+          "actionApplied": 2322,
+          "actionSubmitted": 2322,
+          "actionSubmittedToString": "Bf6",
+          "agentSelfReportedStatus": "OK",
+          "timeTaken": 27.992
+        },
+        "observation": {
+          "currentPlayer": 0,
+          "isTerminal": false,
+          "observationString": "8/8/K4B2/7k/8/1p3b2/8/8 b - - 1 54",
+          "playerId": 1,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n1258\n3572\n1841\n1842\n1431\n3132\n3572\n656\n89\n1215\n2425\n3010\n1808\n1768\n749\n30\n1065\n2571\n1942\n3196\n3131\n1384\n4177\n3854\n381\n615\n498\n1869\n2001\n2977\n2975\n4350\n1431\n1770\n2581\n1257\n4673\n4673\n656\n2627\n1895\n2940\n1386\n1358\n3634\n2528\n254\n4496\n3110\n3705\n2948\n2161\n1771\n2833\n2059\n3853\n2002\n3326\n3166\n1358\n1406\n3561\n1694\n3050\n1637\n2497\n1212\n2425\n1882\n3593\n32\n2016\n1770\n3666\n2498\n4178\n2571\n2498\n1986\n2571\n1914\n2686\n1999\n4323\n3548\n3739\n819\n3196\n911\n3812\n3037\n4437\n4218\n3344\n3694\n4361\n674\n2685\n1357\n2174\n704\n1649\n819\n978\n892\n2322\n\n"
+        },
+        "reward": null,
+        "status": "INACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "actionString": "Kg6",
+          "generate_returns": [
+            "{\n  \"main_response\": \"I\\u2019ll activate the king and attack White\\u2019s bishop, which is the key defender controlling b2.\\n\\nFinal Answer: Kg6\",\n  \"main_response_and_thoughts\": \"\",\n  \"request_for_logging\": {\n    \"model\": \"openai/gpt-5.5-2026-04-23\",\n    \"messages\": [\n      {\n        \"role\": \"user\",\n        \"content\": [\n          {\n            \"type\": \"text\",\n            \"text\": \"Let's play chess. The current game state in Forsyth-Edwards Notation (FEN) notation is:\\n8/8/K4B2/7k/8/1p3b2/8/8 b - - 1 54\\nThe moves played so far are:\\n1. e4 c5 2. Nf3 d6 3. d4 cxd4 4. Nxd4 Nf6 5. Nc3 a6 6. Bg5 e6 7. f4 Qb6 8. Qd2 Qxb2 9. Rb1 Qa3 10. e5 dxe5 11. fxe5 Nfd7 12. Ne4 h6 13. Bh4 Qxa2 14. Rd1 Qd5 15. Qe3 Qxe5 16. Be2 Bc5 17. Bg3 Bxd4 18. Rxd4 Qa5+ 19. c3 O-O 20. O-O Nc6 21. Nf6+ Nxf6 22. Rxf6 Nxd4 23. cxd4 gxf6 24. Qxh6 Qg5 25. Qxg5+ fxg5 26. Bd6 Rd8 27. Be7 Rxd4 28. Bxg5 Rd5 29. Bf6 Rf5 30. Bc3 Rc5 31. Bd4 Rc1+ 32. Kf2 Rc2 33. Ke3 Rxe2+ 34. Kxe2 Bd7 35. Ke3 Bc6 36. g3 Rd8 37. Bf6 Rd5 38. g4 e5 39. h4 e4 40. Kxe4 Rd6+ 41. Ke5 Rd5+ 42. Kf4 Rb5 43. h5 Kh7 44. g5 Rb4+ 45. Ke5 Rh4 46. g6+ fxg6 47. hxg6+ Kxg6 48. Bxh4 Kh5 49. Bd8 b5 50. Kd6 Bb7 51. Kc7 Bf3 52. Kb6 b4 53. Kxa6 b3 54. Bf6\\nYou are playing as player Black.\\nIt is now your turn. Play your strongest move. The move MUST be legal. Reason step by step to come up with your move, then output your final answer in the format \\\"Final Answer: X\\\" where X is your chosen move in standard algebraic notation (SAN).\\n\"\n          }\n        ]\n      }\n    ],\n    \"config\": {\n      \"temperature\": \"NOT_GIVEN\",\n      \"top_p\": \"NOT_GIVEN\",\n      \"max_completion_tokens\": \"NOT_GIVEN\",\n      \"reasoning_effort\": \"high\"\n    },\n    \"stream_options\": {\n      \"include_usage\": true\n    }\n  },\n  \"response_for_logging\": {\n    \"response_chunks\": [\n      {\n        \"id\": \"chatcmpl-DcPFcw3NXFRGHEMafKX6XPKmtMlkx\",\n        \"created\": 1778045900,\n        \"model\": \"openai/gpt-5.5-2026-04-23\",\n        \"object\": \"chat.completion.chunk\",\n        \"usage\": {\n          \"completion_tokens\": 17122,\n          \"prompt_tokens\": 570,\n          \"total_tokens\": 17692,\n          \"cost\": {\n            \"input_tokens_cost_nanodollars\": 2850000,\n            \"output_tokens_cost_nanodollars\": 513660000\n          },\n          \"total_backend_latency_ms\": 364933\n        }\n      }\n    ]\n  },\n  \"generation_tokens\": 17122,\n  \"prompt_tokens\": 570,\n  \"reasoning_tokens\": null,\n  \"total_tokens\": 17692,\n  \"duration_success_only_secs\": 365.37553573900004\n}"
+          ],
+          "status": "OK",
+          "submission": 4350,
+          "thoughts": "I\u2019ll activate the king and attack White\u2019s bishop, which is the key defender controlling b2.\n\nFinal Answer: Kg6"
+        },
+        "info": {
+          "actionApplied": 4350,
+          "actionSubmitted": 4350,
+          "actionSubmittedToString": "Kg6",
+          "agentSelfReportedStatus": "OK",
+          "timeTaken": 367.015
+        },
+        "observation": {
+          "currentPlayer": 1,
+          "isTerminal": false,
+          "observationString": "8/8/K4Bk1/8/8/1p3b2/8/8 w - - 2 55",
+          "playerId": 0,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n1258\n3572\n1841\n1842\n1431\n3132\n3572\n656\n89\n1215\n2425\n3010\n1808\n1768\n749\n30\n1065\n2571\n1942\n3196\n3131\n1384\n4177\n3854\n381\n615\n498\n1869\n2001\n2977\n2975\n4350\n1431\n1770\n2581\n1257\n4673\n4673\n656\n2627\n1895\n2940\n1386\n1358\n3634\n2528\n254\n4496\n3110\n3705\n2948\n2161\n1771\n2833\n2059\n3853\n2002\n3326\n3166\n1358\n1406\n3561\n1694\n3050\n1637\n2497\n1212\n2425\n1882\n3593\n32\n2016\n1770\n3666\n2498\n4178\n2571\n2498\n1986\n2571\n1914\n2686\n1999\n4323\n3548\n3739\n819\n3196\n911\n3812\n3037\n4437\n4218\n3344\n3694\n4361\n674\n2685\n1357\n2174\n704\n1649\n819\n978\n892\n2322\n4350\n\n",
+          "step": 109
+        },
+        "reward": null,
+        "status": "INACTIVE"
+      },
+      {
+        "action": {
+          "submission": -1
+        },
+        "info": {},
+        "observation": {
+          "currentPlayer": 1,
+          "isTerminal": false,
+          "observationString": "8/8/K4Bk1/8/8/1p3b2/8/8 w - - 2 55",
+          "playerId": 1,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n1258\n3572\n1841\n1842\n1431\n3132\n3572\n656\n89\n1215\n2425\n3010\n1808\n1768\n749\n30\n1065\n2571\n1942\n3196\n3131\n1384\n4177\n3854\n381\n615\n498\n1869\n2001\n2977\n2975\n4350\n1431\n1770\n2581\n1257\n4673\n4673\n656\n2627\n1895\n2940\n1386\n1358\n3634\n2528\n254\n4496\n3110\n3705\n2948\n2161\n1771\n2833\n2059\n3853\n2002\n3326\n3166\n1358\n1406\n3561\n1694\n3050\n1637\n2497\n1212\n2425\n1882\n3593\n32\n2016\n1770\n3666\n2498\n4178\n2571\n2498\n1986\n2571\n1914\n2686\n1999\n4323\n3548\n3739\n819\n3196\n911\n3812\n3037\n4437\n4218\n3344\n3694\n4361\n674\n2685\n1357\n2174\n704\n1649\n819\n978\n892\n2322\n4350\n\n"
+        },
+        "reward": null,
+        "status": "ACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "submission": -1
+        },
+        "info": {},
+        "observation": {
+          "currentPlayer": 0,
+          "isTerminal": false,
+          "observationString": "8/8/K5k1/8/8/1p3b2/1B6/8 b - - 3 55",
+          "playerId": 0,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n1258\n3572\n1841\n1842\n1431\n3132\n3572\n656\n89\n1215\n2425\n3010\n1808\n1768\n749\n30\n1065\n2571\n1942\n3196\n3131\n1384\n4177\n3854\n381\n615\n498\n1869\n2001\n2977\n2975\n4350\n1431\n1770\n2581\n1257\n4673\n4673\n656\n2627\n1895\n2940\n1386\n1358\n3634\n2528\n254\n4496\n3110\n3705\n2948\n2161\n1771\n2833\n2059\n3853\n2002\n3326\n3166\n1358\n1406\n3561\n1694\n3050\n1637\n2497\n1212\n2425\n1882\n3593\n32\n2016\n1770\n3666\n2498\n4178\n2571\n2498\n1986\n2571\n1914\n2686\n1999\n4323\n3548\n3739\n819\n3196\n911\n3812\n3037\n4437\n4218\n3344\n3694\n4361\n674\n2685\n1357\n2174\n704\n1649\n819\n978\n892\n2322\n4350\n3325\n\n",
+          "step": 110
+        },
+        "reward": null,
+        "status": "ACTIVE"
+      },
+      {
+        "action": {
+          "actionString": "Bb2",
+          "generate_returns": [
+            "{\n  \"main_response\": \"The current position is an endgame where you have a King and a Bishop against Black's King, Bishop, and a dangerous passed pawn on b3. Black's King on g6 is currently attacking your Bishop on f6. You must move your Bishop to safety while ensuring that Black's b3 pawn cannot promote.\\n\\nFortunately, your dark-squared Bishop controls the critical long diagonal (a1-h8) and can successfully halt the pawn. By placing your Bishop in front of the pawn or along the diagonal, you secure a draw since Black's light-squared Bishop can never interact with the dark squares.\\n\\nThe simplest and most robust approach is to safely move your Bishop away from the attacking King and physically blockade the pawn's advance. \\n\\nStep-by-step reasoning:\\n1. The Bishop on f6 is under attack by the Black King on g6. If you do not move the Bishop or defend it, you will lose it and subsequently the game after Black promotes the b-pawn.\\n2. Defending the Bishop with your King is impossible as your King is too far away on a6.\\n3. Therefore, you must slide the Bishop away to safety along the a1-h8 diagonal, which guarantees you keep an eye on the crucial b2 square (the promotion path of the b3 pawn). \\n4. Moving the Bishop to b2 is the most principled choice. It directly blockades the b3 pawn, making it physically impossible for the pawn to ever advance to b2. Since Black has a light-squared Bishop, it can never attack your dark-squared Bishop on b2, and your King on a6 is perfectly positioned to come over to the c-file and assist in preventing the Black King from ever dislodging it.\\n\\nThis completely shuts down Black's only winning idea and easily secures the draw.\\n\\nFinal Answer: Bb2\",\n  \"main_response_and_thoughts\": \"\",\n  \"request_for_logging\": {\n    \"model\": \"google/gemini-3.1-pro-preview\",\n    \"messages\": [\n      {\n        \"role\": \"user\",\n        \"content\": [\n          {\n            \"type\": \"text\",\n            \"text\": \"Let's play chess. The current game state in Forsyth-Edwards Notation (FEN) notation is:\\n8/8/K4Bk1/8/8/1p3b2/8/8 w - - 2 55\\nThe moves played so far are:\\n1. e4 c5 2. Nf3 d6 3. d4 cxd4 4. Nxd4 Nf6 5. Nc3 a6 6. Bg5 e6 7. f4 Qb6 8. Qd2 Qxb2 9. Rb1 Qa3 10. e5 dxe5 11. fxe5 Nfd7 12. Ne4 h6 13. Bh4 Qxa2 14. Rd1 Qd5 15. Qe3 Qxe5 16. Be2 Bc5 17. Bg3 Bxd4 18. Rxd4 Qa5+ 19. c3 O-O 20. O-O Nc6 21. Nf6+ Nxf6 22. Rxf6 Nxd4 23. cxd4 gxf6 24. Qxh6 Qg5 25. Qxg5+ fxg5 26. Bd6 Rd8 27. Be7 Rxd4 28. Bxg5 Rd5 29. Bf6 Rf5 30. Bc3 Rc5 31. Bd4 Rc1+ 32. Kf2 Rc2 33. Ke3 Rxe2+ 34. Kxe2 Bd7 35. Ke3 Bc6 36. g3 Rd8 37. Bf6 Rd5 38. g4 e5 39. h4 e4 40. Kxe4 Rd6+ 41. Ke5 Rd5+ 42. Kf4 Rb5 43. h5 Kh7 44. g5 Rb4+ 45. Ke5 Rh4 46. g6+ fxg6 47. hxg6+ Kxg6 48. Bxh4 Kh5 49. Bd8 b5 50. Kd6 Bb7 51. Kc7 Bf3 52. Kb6 b4 53. Kxa6 b3 54. Bf6 Kg6 55.\\nYou are playing as player White.\\nIt is now your turn. Play your strongest move. The move MUST be legal. Reason step by step to come up with your move, then output your final answer in the format \\\"Final Answer: X\\\" where X is your chosen move in standard algebraic notation (SAN).\\n\"\n          }\n        ]\n      }\n    ],\n    \"config\": {\n      \"temperature\": \"NOT_GIVEN\",\n      \"top_p\": \"NOT_GIVEN\",\n      \"max_completion_tokens\": \"NOT_GIVEN\"\n    },\n    \"stream_options\": {\n      \"include_usage\": true\n    }\n  },\n  \"response_for_logging\": {\n    \"response_chunks\": [\n      {\n        \"id\": \"OtX6aei4NMudmecPmbT14Qk\",\n        \"choices\": [\n          {\n            \"delta\": {\n              \"content\": \" Bb2\",\n              \"role\": \"assistant\"\n            },\n            \"finish_reason\": \"stop\",\n            \"index\": 0\n          }\n        ],\n        \"created\": 1778046266,\n        \"model\": \"google/gemini-3.1-pro-preview\",\n        \"object\": \"chat.completion.chunk\",\n        \"usage\": {\n          \"completion_tokens\": 392,\n          \"prompt_tokens\": 565,\n          \"total_tokens\": 7136,\n          \"cost\": {\n            \"input_tokens_cost_nanodollars\": 1130000,\n            \"output_tokens_cost_nanodollars\": 78852000\n          },\n          \"total_backend_latency_ms\": 47940\n        }\n      }\n    ]\n  },\n  \"generation_tokens\": 392,\n  \"prompt_tokens\": 565,\n  \"reasoning_tokens\": null,\n  \"total_tokens\": 7136,\n  \"duration_success_only_secs\": 48.43560148300094\n}"
+          ],
+          "status": "OK",
+          "submission": 3325,
+          "thoughts": "The current position is an endgame where you have a King and a Bishop against Black's King, Bishop, and a dangerous passed pawn on b3. Black's King on g6 is currently attacking your Bishop on f6. You must move your Bishop to safety while ensuring that Black's b3 pawn cannot promote.\n\nFortunately, your dark-squared Bishop controls the critical long diagonal (a1-h8) and can successfully halt the pawn. By placing your Bishop in front of the pawn or along the diagonal, you secure a draw since Black's light-squared Bishop can never interact with the dark squares.\n\nThe simplest and most robust approach is to safely move your Bishop away from the attacking King and physically blockade the pawn's advance. \n\nStep-by-step reasoning:\n1. The Bishop on f6 is under attack by the Black King on g6. If you do not move the Bishop or defend it, you will lose it and subsequently the game after Black promotes the b-pawn.\n2. Defending the Bishop with your King is impossible as your King is too far away on a6.\n3. Therefore, you must slide the Bishop away to safety along the a1-h8 diagonal, which guarantees you keep an eye on the crucial b2 square (the promotion path of the b3 pawn). \n4. Moving the Bishop to b2 is the most principled choice. It directly blockades the b3 pawn, making it physically impossible for the pawn to ever advance to b2. Since Black has a light-squared Bishop, it can never attack your dark-squared Bishop on b2, and your King on a6 is perfectly positioned to come over to the c-file and assist in preventing the Black King from ever dislodging it.\n\nThis completely shuts down Black's only winning idea and easily secures the draw.\n\nFinal Answer: Bb2"
+        },
+        "info": {
+          "actionApplied": 3325,
+          "actionSubmitted": 3325,
+          "actionSubmittedToString": "Bb2",
+          "agentSelfReportedStatus": "OK",
+          "timeTaken": 49.653
+        },
+        "observation": {
+          "currentPlayer": 0,
+          "isTerminal": false,
+          "observationString": "8/8/K5k1/8/8/1p3b2/1B6/8 b - - 3 55",
+          "playerId": 1,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n1258\n3572\n1841\n1842\n1431\n3132\n3572\n656\n89\n1215\n2425\n3010\n1808\n1768\n749\n30\n1065\n2571\n1942\n3196\n3131\n1384\n4177\n3854\n381\n615\n498\n1869\n2001\n2977\n2975\n4350\n1431\n1770\n2581\n1257\n4673\n4673\n656\n2627\n1895\n2940\n1386\n1358\n3634\n2528\n254\n4496\n3110\n3705\n2948\n2161\n1771\n2833\n2059\n3853\n2002\n3326\n3166\n1358\n1406\n3561\n1694\n3050\n1637\n2497\n1212\n2425\n1882\n3593\n32\n2016\n1770\n3666\n2498\n4178\n2571\n2498\n1986\n2571\n1914\n2686\n1999\n4323\n3548\n3739\n819\n3196\n911\n3812\n3037\n4437\n4218\n3344\n3694\n4361\n674\n2685\n1357\n2174\n704\n1649\n819\n978\n892\n2322\n4350\n3325\n\n"
+        },
+        "reward": null,
+        "status": "INACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "actionString": "Bd5",
+          "generate_returns": [
+            "{\n  \"main_response\": \"The b-pawn is blockaded, so Black should keep it protected while restricting the white king\\u2019s approach. Moving the bishop to d5 guards b3 and controls the key c4 square.\\n\\nFinal Answer: Bd5\",\n  \"main_response_and_thoughts\": \"\",\n  \"request_for_logging\": {\n    \"model\": \"openai/gpt-5.5-2026-04-23\",\n    \"messages\": [\n      {\n        \"role\": \"user\",\n        \"content\": [\n          {\n            \"type\": \"text\",\n            \"text\": \"Let's play chess. The current game state in Forsyth-Edwards Notation (FEN) notation is:\\n8/8/K5k1/8/8/1p3b2/1B6/8 b - - 3 55\\nThe moves played so far are:\\n1. e4 c5 2. Nf3 d6 3. d4 cxd4 4. Nxd4 Nf6 5. Nc3 a6 6. Bg5 e6 7. f4 Qb6 8. Qd2 Qxb2 9. Rb1 Qa3 10. e5 dxe5 11. fxe5 Nfd7 12. Ne4 h6 13. Bh4 Qxa2 14. Rd1 Qd5 15. Qe3 Qxe5 16. Be2 Bc5 17. Bg3 Bxd4 18. Rxd4 Qa5+ 19. c3 O-O 20. O-O Nc6 21. Nf6+ Nxf6 22. Rxf6 Nxd4 23. cxd4 gxf6 24. Qxh6 Qg5 25. Qxg5+ fxg5 26. Bd6 Rd8 27. Be7 Rxd4 28. Bxg5 Rd5 29. Bf6 Rf5 30. Bc3 Rc5 31. Bd4 Rc1+ 32. Kf2 Rc2 33. Ke3 Rxe2+ 34. Kxe2 Bd7 35. Ke3 Bc6 36. g3 Rd8 37. Bf6 Rd5 38. g4 e5 39. h4 e4 40. Kxe4 Rd6+ 41. Ke5 Rd5+ 42. Kf4 Rb5 43. h5 Kh7 44. g5 Rb4+ 45. Ke5 Rh4 46. g6+ fxg6 47. hxg6+ Kxg6 48. Bxh4 Kh5 49. Bd8 b5 50. Kd6 Bb7 51. Kc7 Bf3 52. Kb6 b4 53. Kxa6 b3 54. Bf6 Kg6 55. Bb2\\nYou are playing as player Black.\\nIt is now your turn. Play your strongest move. The move MUST be legal. Reason step by step to come up with your move, then output your final answer in the format \\\"Final Answer: X\\\" where X is your chosen move in standard algebraic notation (SAN).\\n\"\n          }\n        ]\n      }\n    ],\n    \"config\": {\n      \"temperature\": \"NOT_GIVEN\",\n      \"top_p\": \"NOT_GIVEN\",\n      \"max_completion_tokens\": \"NOT_GIVEN\",\n      \"reasoning_effort\": \"high\"\n    },\n    \"stream_options\": {\n      \"include_usage\": true\n    }\n  },\n  \"response_for_logging\": {\n    \"response_chunks\": [\n      {\n        \"id\": \"chatcmpl-DcPg6u4mA2BJMUGIamhct9V8Ii7yl\",\n        \"created\": 1778047542,\n        \"model\": \"openai/gpt-5.5-2026-04-23\",\n        \"object\": \"chat.completion.chunk\",\n        \"usage\": {\n          \"completion_tokens\": 27323,\n          \"prompt_tokens\": 578,\n          \"total_tokens\": 27901,\n          \"cost\": {\n            \"input_tokens_cost_nanodollars\": 2890000,\n            \"output_tokens_cost_nanodollars\": 819690000\n          },\n          \"total_backend_latency_ms\": 558300\n        }\n      }\n    ]\n  },\n  \"generation_tokens\": 27323,\n  \"prompt_tokens\": 578,\n  \"reasoning_tokens\": null,\n  \"total_tokens\": 27901,\n  \"duration_success_only_secs\": 558.7395602450015\n}"
+          ],
+          "status": "OK",
+          "submission": 3327,
+          "thoughts": "The b-pawn is blockaded, so Black should keep it protected while restricting the white king\u2019s approach. Moving the bishop to d5 guards b3 and controls the key c4 square.\n\nFinal Answer: Bd5"
+        },
+        "info": {
+          "actionApplied": 3327,
+          "actionSubmitted": 3327,
+          "actionSubmittedToString": "Bd5",
+          "agentSelfReportedStatus": "OK",
+          "timeTaken": 1786.216
+        },
+        "observation": {
+          "currentPlayer": 1,
+          "isTerminal": false,
+          "observationString": "8/8/K5k1/3b4/8/1p6/1B6/8 w - - 4 56",
+          "playerId": 0,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n1258\n3572\n1841\n1842\n1431\n3132\n3572\n656\n89\n1215\n2425\n3010\n1808\n1768\n749\n30\n1065\n2571\n1942\n3196\n3131\n1384\n4177\n3854\n381\n615\n498\n1869\n2001\n2977\n2975\n4350\n1431\n1770\n2581\n1257\n4673\n4673\n656\n2627\n1895\n2940\n1386\n1358\n3634\n2528\n254\n4496\n3110\n3705\n2948\n2161\n1771\n2833\n2059\n3853\n2002\n3326\n3166\n1358\n1406\n3561\n1694\n3050\n1637\n2497\n1212\n2425\n1882\n3593\n32\n2016\n1770\n3666\n2498\n4178\n2571\n2498\n1986\n2571\n1914\n2686\n1999\n4323\n3548\n3739\n819\n3196\n911\n3812\n3037\n4437\n4218\n3344\n3694\n4361\n674\n2685\n1357\n2174\n704\n1649\n819\n978\n892\n2322\n4350\n3325\n3327\n\n",
+          "step": 111
+        },
+        "reward": null,
+        "status": "INACTIVE"
+      },
+      {
+        "action": {
+          "submission": -1
+        },
+        "info": {},
+        "observation": {
+          "currentPlayer": 1,
+          "isTerminal": false,
+          "observationString": "8/8/K5k1/3b4/8/1p6/1B6/8 w - - 4 56",
+          "playerId": 1,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n1258\n3572\n1841\n1842\n1431\n3132\n3572\n656\n89\n1215\n2425\n3010\n1808\n1768\n749\n30\n1065\n2571\n1942\n3196\n3131\n1384\n4177\n3854\n381\n615\n498\n1869\n2001\n2977\n2975\n4350\n1431\n1770\n2581\n1257\n4673\n4673\n656\n2627\n1895\n2940\n1386\n1358\n3634\n2528\n254\n4496\n3110\n3705\n2948\n2161\n1771\n2833\n2059\n3853\n2002\n3326\n3166\n1358\n1406\n3561\n1694\n3050\n1637\n2497\n1212\n2425\n1882\n3593\n32\n2016\n1770\n3666\n2498\n4178\n2571\n2498\n1986\n2571\n1914\n2686\n1999\n4323\n3548\n3739\n819\n3196\n911\n3812\n3037\n4437\n4218\n3344\n3694\n4361\n674\n2685\n1357\n2174\n704\n1649\n819\n978\n892\n2322\n4350\n3325\n3327\n\n"
+        },
+        "reward": null,
+        "status": "ACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "submission": -1
+        },
+        "info": {},
+        "observation": {
+          "currentPlayer": 0,
+          "isTerminal": false,
+          "observationString": "8/8/6k1/1K1b4/8/1p6/1B6/8 b - - 5 56",
+          "playerId": 0,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n1258\n3572\n1841\n1842\n1431\n3132\n3572\n656\n89\n1215\n2425\n3010\n1808\n1768\n749\n30\n1065\n2571\n1942\n3196\n3131\n1384\n4177\n3854\n381\n615\n498\n1869\n2001\n2977\n2975\n4350\n1431\n1770\n2581\n1257\n4673\n4673\n656\n2627\n1895\n2940\n1386\n1358\n3634\n2528\n254\n4496\n3110\n3705\n2948\n2161\n1771\n2833\n2059\n3853\n2002\n3326\n3166\n1358\n1406\n3561\n1694\n3050\n1637\n2497\n1212\n2425\n1882\n3593\n32\n2016\n1770\n3666\n2498\n4178\n2571\n2498\n1986\n2571\n1914\n2686\n1999\n4323\n3548\n3739\n819\n3196\n911\n3812\n3037\n4437\n4218\n3344\n3694\n4361\n674\n2685\n1357\n2174\n704\n1649\n819\n978\n892\n2322\n4350\n3325\n3327\n423\n\n",
+          "step": 112
+        },
+        "reward": null,
+        "status": "ACTIVE"
+      },
+      {
+        "action": {
+          "actionString": "Kb5",
+          "generate_returns": [
+            "{\n  \"main_response\": \"To determine the best move, let's analyze the endgame position:\\n\\n**1. Material and Position Analysis**\\n* White has a King on a6 and a Bishop on b2 (a dark square).\\n* Black has a King on g6, a Bishop on d5 (a light square), and a pawn on b3. \\n* Notice that the Bishops are of opposite colors. Black's pawn on b3 wants to advance to b2 to promote, but White's dark-squared Bishop is physically occupying the b2 square, acting as an absolute blockade.\\n* Because b2 is a dark square and Black's Bishop is light-squared (restricted to the light squares), Black's Bishop can never attack the blockading White Bishop, nor can it defend the b2 square if the pawn were to somehow advance. \\n\\n**2. Formulating a Plan**\\nThis is a dead-drawn position. Black has absolutely no way to force the pawn through or chase your Bishop away from its perfect blockading square. White simply needs to pass the turn by shuffling the King. While virtually any King move secures the draw, bringing the King slightly closer to the center is the most principled choice. It actively prevents the Black King from walking over and attempting to create any annoying (albeit harmless) penetration on the queenside.\\n\\n**3. Checking Candidate Moves**\\n* `Kb5`, `Kb6`, `Ka5`, and `Ka7` are all completely safe King moves that maintain the ironclad blockade. \\n* Moving the King to b5 centralized it slightly and prepares to meet the Black King (e.g., if Black plays ...Kf5, White can respond with Kc5 or Kc4 to hold the line).\\n* The b5 square is not attacked by Black's Bishop on d5 or the pawn on b3. No checks or tactics exist. \\n\\nWhite comfortably holds the draw by shuffling.\\n\\nFinal Answer: Kb5\",\n  \"main_response_and_thoughts\": \"\",\n  \"request_for_logging\": {\n    \"model\": \"google/gemini-3.1-pro-preview\",\n    \"messages\": [\n      {\n        \"role\": \"user\",\n        \"content\": [\n          {\n            \"type\": \"text\",\n            \"text\": \"Let's play chess. The current game state in Forsyth-Edwards Notation (FEN) notation is:\\n8/8/K5k1/3b4/8/1p6/1B6/8 w - - 4 56\\nThe moves played so far are:\\n1. e4 c5 2. Nf3 d6 3. d4 cxd4 4. Nxd4 Nf6 5. Nc3 a6 6. Bg5 e6 7. f4 Qb6 8. Qd2 Qxb2 9. Rb1 Qa3 10. e5 dxe5 11. fxe5 Nfd7 12. Ne4 h6 13. Bh4 Qxa2 14. Rd1 Qd5 15. Qe3 Qxe5 16. Be2 Bc5 17. Bg3 Bxd4 18. Rxd4 Qa5+ 19. c3 O-O 20. O-O Nc6 21. Nf6+ Nxf6 22. Rxf6 Nxd4 23. cxd4 gxf6 24. Qxh6 Qg5 25. Qxg5+ fxg5 26. Bd6 Rd8 27. Be7 Rxd4 28. Bxg5 Rd5 29. Bf6 Rf5 30. Bc3 Rc5 31. Bd4 Rc1+ 32. Kf2 Rc2 33. Ke3 Rxe2+ 34. Kxe2 Bd7 35. Ke3 Bc6 36. g3 Rd8 37. Bf6 Rd5 38. g4 e5 39. h4 e4 40. Kxe4 Rd6+ 41. Ke5 Rd5+ 42. Kf4 Rb5 43. h5 Kh7 44. g5 Rb4+ 45. Ke5 Rh4 46. g6+ fxg6 47. hxg6+ Kxg6 48. Bxh4 Kh5 49. Bd8 b5 50. Kd6 Bb7 51. Kc7 Bf3 52. Kb6 b4 53. Kxa6 b3 54. Bf6 Kg6 55. Bb2 Bd5 56.\\nYou are playing as player White.\\nIt is now your turn. Play your strongest move. The move MUST be legal. Reason step by step to come up with your move, then output your final answer in the format \\\"Final Answer: X\\\" where X is your chosen move in standard algebraic notation (SAN).\\n\"\n          }\n        ]\n      }\n    ],\n    \"config\": {\n      \"temperature\": \"NOT_GIVEN\",\n      \"top_p\": \"NOT_GIVEN\",\n      \"max_completion_tokens\": \"NOT_GIVEN\"\n    },\n    \"stream_options\": {\n      \"include_usage\": true\n    }\n  },\n  \"response_for_logging\": {\n    \"response_chunks\": [\n      {\n        \"id\": \"Ztz6aaHjLLWKmecPxOar6Aw\",\n        \"choices\": [\n          {\n            \"delta\": {\n              \"content\": \" tactics exist. \\n\\nWhite comfortably holds the draw by shuffling.\\n\\nFinal Answer: Kb5\",\n              \"role\": \"assistant\"\n            },\n            \"finish_reason\": \"stop\",\n            \"index\": 0\n          }\n        ],\n        \"created\": 1778048102,\n        \"model\": \"google/gemini-3.1-pro-preview\",\n        \"object\": \"chat.completion.chunk\",\n        \"usage\": {\n          \"completion_tokens\": 406,\n          \"prompt_tokens\": 575,\n          \"total_tokens\": 9890,\n          \"cost\": {\n            \"input_tokens_cost_nanodollars\": 1150000,\n            \"output_tokens_cost_nanodollars\": 111780000\n          },\n          \"total_backend_latency_ms\": 97712\n        }\n      }\n    ]\n  },\n  \"generation_tokens\": 406,\n  \"prompt_tokens\": 575,\n  \"reasoning_tokens\": null,\n  \"total_tokens\": 9890,\n  \"duration_success_only_secs\": 98.2781237220006\n}"
+          ],
+          "status": "OK",
+          "submission": 423,
+          "thoughts": "To determine the best move, let's analyze the endgame position:\n\n**1. Material and Position Analysis**\n* White has a King on a6 and a Bishop on b2 (a dark square).\n* Black has a King on g6, a Bishop on d5 (a light square), and a pawn on b3. \n* Notice that the Bishops are of opposite colors. Black's pawn on b3 wants to advance to b2 to promote, but White's dark-squared Bishop is physically occupying the b2 square, acting as an absolute blockade.\n* Because b2 is a dark square and Black's Bishop is light-squared (restricted to the light squares), Black's Bishop can never attack the blockading White Bishop, nor can it defend the b2 square if the pawn were to somehow advance. \n\n**2. Formulating a Plan**\nThis is a dead-drawn position. Black has absolutely no way to force the pawn through or chase your Bishop away from its perfect blockading square. White simply needs to pass the turn by shuffling the King. While virtually any King move secures the draw, bringing the King slightly closer to the center is the most principled choice. It actively prevents the Black King from walking over and attempting to create any annoying (albeit harmless) penetration on the queenside.\n\n**3. Checking Candidate Moves**\n* `Kb5`, `Kb6`, `Ka5`, and `Ka7` are all completely safe King moves that maintain the ironclad blockade. \n* Moving the King to b5 centralized it slightly and prepares to meet the Black King (e.g., if Black plays ...Kf5, White can respond with Kc5 or Kc4 to hold the line).\n* The b5 square is not attacked by Black's Bishop on d5 or the pawn on b3. No checks or tactics exist. \n\nWhite comfortably holds the draw by shuffling.\n\nFinal Answer: Kb5"
+        },
+        "info": {
+          "actionApplied": 423,
+          "actionSubmitted": 423,
+          "actionSubmittedToString": "Kb5",
+          "agentSelfReportedStatus": "OK",
+          "timeTaken": 99.532
+        },
+        "observation": {
+          "currentPlayer": 0,
+          "isTerminal": false,
+          "observationString": "8/8/6k1/1K1b4/8/1p6/1B6/8 b - - 5 56",
+          "playerId": 1,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n1258\n3572\n1841\n1842\n1431\n3132\n3572\n656\n89\n1215\n2425\n3010\n1808\n1768\n749\n30\n1065\n2571\n1942\n3196\n3131\n1384\n4177\n3854\n381\n615\n498\n1869\n2001\n2977\n2975\n4350\n1431\n1770\n2581\n1257\n4673\n4673\n656\n2627\n1895\n2940\n1386\n1358\n3634\n2528\n254\n4496\n3110\n3705\n2948\n2161\n1771\n2833\n2059\n3853\n2002\n3326\n3166\n1358\n1406\n3561\n1694\n3050\n1637\n2497\n1212\n2425\n1882\n3593\n32\n2016\n1770\n3666\n2498\n4178\n2571\n2498\n1986\n2571\n1914\n2686\n1999\n4323\n3548\n3739\n819\n3196\n911\n3812\n3037\n4437\n4218\n3344\n3694\n4361\n674\n2685\n1357\n2174\n704\n1649\n819\n978\n892\n2322\n4350\n3325\n3327\n423\n\n"
+        },
+        "reward": null,
+        "status": "INACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "actionString": "Kf5",
+          "generate_returns": [
+            "{\n  \"main_response\": \"Final Answer: Kf5\",\n  \"main_response_and_thoughts\": \"\",\n  \"request_for_logging\": {\n    \"model\": \"openai/gpt-5.5-2026-04-23\",\n    \"messages\": [\n      {\n        \"role\": \"user\",\n        \"content\": [\n          {\n            \"type\": \"text\",\n            \"text\": \"Let's play chess. The current game state in Forsyth-Edwards Notation (FEN) notation is:\\n8/8/6k1/1K1b4/8/1p6/1B6/8 b - - 5 56\\nThe moves played so far are:\\n1. e4 c5 2. Nf3 d6 3. d4 cxd4 4. Nxd4 Nf6 5. Nc3 a6 6. Bg5 e6 7. f4 Qb6 8. Qd2 Qxb2 9. Rb1 Qa3 10. e5 dxe5 11. fxe5 Nfd7 12. Ne4 h6 13. Bh4 Qxa2 14. Rd1 Qd5 15. Qe3 Qxe5 16. Be2 Bc5 17. Bg3 Bxd4 18. Rxd4 Qa5+ 19. c3 O-O 20. O-O Nc6 21. Nf6+ Nxf6 22. Rxf6 Nxd4 23. cxd4 gxf6 24. Qxh6 Qg5 25. Qxg5+ fxg5 26. Bd6 Rd8 27. Be7 Rxd4 28. Bxg5 Rd5 29. Bf6 Rf5 30. Bc3 Rc5 31. Bd4 Rc1+ 32. Kf2 Rc2 33. Ke3 Rxe2+ 34. Kxe2 Bd7 35. Ke3 Bc6 36. g3 Rd8 37. Bf6 Rd5 38. g4 e5 39. h4 e4 40. Kxe4 Rd6+ 41. Ke5 Rd5+ 42. Kf4 Rb5 43. h5 Kh7 44. g5 Rb4+ 45. Ke5 Rh4 46. g6+ fxg6 47. hxg6+ Kxg6 48. Bxh4 Kh5 49. Bd8 b5 50. Kd6 Bb7 51. Kc7 Bf3 52. Kb6 b4 53. Kxa6 b3 54. Bf6 Kg6 55. Bb2 Bd5 56. Kb5\\nYou are playing as player Black.\\nIt is now your turn. Play your strongest move. The move MUST be legal. Reason step by step to come up with your move, then output your final answer in the format \\\"Final Answer: X\\\" where X is your chosen move in standard algebraic notation (SAN).\\n\"\n          }\n        ]\n      }\n    ],\n    \"config\": {\n      \"temperature\": \"NOT_GIVEN\",\n      \"top_p\": \"NOT_GIVEN\",\n      \"max_completion_tokens\": \"NOT_GIVEN\",\n      \"reasoning_effort\": \"high\"\n    },\n    \"stream_options\": {\n      \"include_usage\": true\n    }\n  },\n  \"response_for_logging\": {\n    \"response_chunks\": [\n      {\n        \"id\": \"chatcmpl-DcPqk5NZOcokx5GfzElZQJvuHwhS8\",\n        \"created\": 1778048202,\n        \"model\": \"openai/gpt-5.5-2026-04-23\",\n        \"object\": \"chat.completion.chunk\",\n        \"usage\": {\n          \"completion_tokens\": 23319,\n          \"prompt_tokens\": 588,\n          \"total_tokens\": 23907,\n          \"cost\": {\n            \"input_tokens_cost_nanodollars\": 2940000,\n            \"output_tokens_cost_nanodollars\": 699570000\n          },\n          \"total_backend_latency_ms\": 484414\n        }\n      }\n    ]\n  },\n  \"generation_tokens\": 23319,\n  \"prompt_tokens\": 588,\n  \"reasoning_tokens\": null,\n  \"total_tokens\": 23907,\n  \"duration_success_only_secs\": 484.9876805620006\n}"
+          ],
+          "status": "OK",
+          "submission": 3707,
+          "thoughts": "Final Answer: Kf5"
+        },
+        "info": {
+          "actionApplied": 3707,
+          "actionSubmitted": 3707,
+          "actionSubmittedToString": "Kf5",
+          "agentSelfReportedStatus": "OK",
+          "timeTaken": 486.259
+        },
+        "observation": {
+          "currentPlayer": 1,
+          "isTerminal": false,
+          "observationString": "8/8/8/1K1b1k2/8/1p6/1B6/8 w - - 6 57",
+          "playerId": 0,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n1258\n3572\n1841\n1842\n1431\n3132\n3572\n656\n89\n1215\n2425\n3010\n1808\n1768\n749\n30\n1065\n2571\n1942\n3196\n3131\n1384\n4177\n3854\n381\n615\n498\n1869\n2001\n2977\n2975\n4350\n1431\n1770\n2581\n1257\n4673\n4673\n656\n2627\n1895\n2940\n1386\n1358\n3634\n2528\n254\n4496\n3110\n3705\n2948\n2161\n1771\n2833\n2059\n3853\n2002\n3326\n3166\n1358\n1406\n3561\n1694\n3050\n1637\n2497\n1212\n2425\n1882\n3593\n32\n2016\n1770\n3666\n2498\n4178\n2571\n2498\n1986\n2571\n1914\n2686\n1999\n4323\n3548\n3739\n819\n3196\n911\n3812\n3037\n4437\n4218\n3344\n3694\n4361\n674\n2685\n1357\n2174\n704\n1649\n819\n978\n892\n2322\n4350\n3325\n3327\n423\n3707\n\n",
+          "step": 113
+        },
+        "reward": null,
+        "status": "INACTIVE"
+      },
+      {
+        "action": {
+          "submission": -1
+        },
+        "info": {},
+        "observation": {
+          "currentPlayer": 1,
+          "isTerminal": false,
+          "observationString": "8/8/8/1K1b1k2/8/1p6/1B6/8 w - - 6 57",
+          "playerId": 1,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n1258\n3572\n1841\n1842\n1431\n3132\n3572\n656\n89\n1215\n2425\n3010\n1808\n1768\n749\n30\n1065\n2571\n1942\n3196\n3131\n1384\n4177\n3854\n381\n615\n498\n1869\n2001\n2977\n2975\n4350\n1431\n1770\n2581\n1257\n4673\n4673\n656\n2627\n1895\n2940\n1386\n1358\n3634\n2528\n254\n4496\n3110\n3705\n2948\n2161\n1771\n2833\n2059\n3853\n2002\n3326\n3166\n1358\n1406\n3561\n1694\n3050\n1637\n2497\n1212\n2425\n1882\n3593\n32\n2016\n1770\n3666\n2498\n4178\n2571\n2498\n1986\n2571\n1914\n2686\n1999\n4323\n3548\n3739\n819\n3196\n911\n3812\n3037\n4437\n4218\n3344\n3694\n4361\n674\n2685\n1357\n2174\n704\n1649\n819\n978\n892\n2322\n4350\n3325\n3327\n423\n3707\n\n"
+        },
+        "reward": null,
+        "status": "ACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "submission": -1
+        },
+        "info": {},
+        "observation": {
+          "currentPlayer": 0,
+          "isTerminal": false,
+          "observationString": "8/8/8/3b1k2/1K6/1p6/1B6/8 b - - 7 57",
+          "playerId": 0,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n1258\n3572\n1841\n1842\n1431\n3132\n3572\n656\n89\n1215\n2425\n3010\n1808\n1768\n749\n30\n1065\n2571\n1942\n3196\n3131\n1384\n4177\n3854\n381\n615\n498\n1869\n2001\n2977\n2975\n4350\n1431\n1770\n2581\n1257\n4673\n4673\n656\n2627\n1895\n2940\n1386\n1358\n3634\n2528\n254\n4496\n3110\n3705\n2948\n2161\n1771\n2833\n2059\n3853\n2002\n3326\n3166\n1358\n1406\n3561\n1694\n3050\n1637\n2497\n1212\n2425\n1882\n3593\n32\n2016\n1770\n3666\n2498\n4178\n2571\n2498\n1986\n2571\n1914\n2686\n1999\n4323\n3548\n3739\n819\n3196\n911\n3812\n3037\n4437\n4218\n3344\n3694\n4361\n674\n2685\n1357\n2174\n704\n1649\n819\n978\n892\n2322\n4350\n3325\n3327\n423\n3707\n891\n\n",
+          "step": 114
+        },
+        "reward": null,
+        "status": "ACTIVE"
+      },
+      {
+        "action": {
+          "actionString": "Kb4",
+          "generate_returns": [
+            "{\n  \"main_response\": \"To determine the best move, let's evaluate the endgame position. White currently has a King and a Bishop against Black's King, Bishop, and a pawn. Black's dangerous passed pawn has advanced to b3, but White has achieved a theoretical draw because the White Bishop is perfectly placed on b2, physically blockading the pawn from advancing any further. \\n\\nBecause the pawn on b3 is safely neutralized by our Bishop on b2, White simply needs to maintain this blockade and avoid losing the Bishop. White's King should remain active and close to the pawn to support the Bishop and prevent the Black King from easily infiltrating to squares like c2 or a2.\\n\\nLet's look at White's legal King moves from b5:\\n- **Kc4** and **Kc6** are illegal because they are covered by Black's light-squared Bishop on d5. \\n- **Ka4**, **Ka5**, **Ka6**, **Kb6**, **Kc5**, and **Kb4** are all perfectly safe and legal squares for the King.\\n\\nAmong these, moving the King to **b4** is the most forcing and active choice. \\n\\nBy playing **Kb4**, White directly attacks the b3 pawn. Although the pawn is currently protected by Black's Bishop on d5, this move applies pressure and strictly ties down Black's Bishop to the a2-g8 diagonal. If Black's Bishop ever leaves that diagonal, White will simply play Kxb3, completely eliminating Black's only winning chance and resulting in a completely drawn position of King + Bishop vs. King + Bishop.\\n\\nWith the King on b4, White creates an impregnable fortress. We can simply shuffle the King safely around b4, a4, and c3 as needed while the Bishop holds the line forever. \\n\\nFinal Answer: Kb4\",\n  \"main_response_and_thoughts\": \"\",\n  \"request_for_logging\": {\n    \"model\": \"google/gemini-3.1-pro-preview\",\n    \"messages\": [\n      {\n        \"role\": \"user\",\n        \"content\": [\n          {\n            \"type\": \"text\",\n            \"text\": \"Let's play chess. The current game state in Forsyth-Edwards Notation (FEN) notation is:\\n8/8/8/1K1b1k2/8/1p6/1B6/8 w - - 6 57\\nThe moves played so far are:\\n1. e4 c5 2. Nf3 d6 3. d4 cxd4 4. Nxd4 Nf6 5. Nc3 a6 6. Bg5 e6 7. f4 Qb6 8. Qd2 Qxb2 9. Rb1 Qa3 10. e5 dxe5 11. fxe5 Nfd7 12. Ne4 h6 13. Bh4 Qxa2 14. Rd1 Qd5 15. Qe3 Qxe5 16. Be2 Bc5 17. Bg3 Bxd4 18. Rxd4 Qa5+ 19. c3 O-O 20. O-O Nc6 21. Nf6+ Nxf6 22. Rxf6 Nxd4 23. cxd4 gxf6 24. Qxh6 Qg5 25. Qxg5+ fxg5 26. Bd6 Rd8 27. Be7 Rxd4 28. Bxg5 Rd5 29. Bf6 Rf5 30. Bc3 Rc5 31. Bd4 Rc1+ 32. Kf2 Rc2 33. Ke3 Rxe2+ 34. Kxe2 Bd7 35. Ke3 Bc6 36. g3 Rd8 37. Bf6 Rd5 38. g4 e5 39. h4 e4 40. Kxe4 Rd6+ 41. Ke5 Rd5+ 42. Kf4 Rb5 43. h5 Kh7 44. g5 Rb4+ 45. Ke5 Rh4 46. g6+ fxg6 47. hxg6+ Kxg6 48. Bxh4 Kh5 49. Bd8 b5 50. Kd6 Bb7 51. Kc7 Bf3 52. Kb6 b4 53. Kxa6 b3 54. Bf6 Kg6 55. Bb2 Bd5 56. Kb5 Kf5 57.\\nYou are playing as player White.\\nIt is now your turn. Play your strongest move. The move MUST be legal. Reason step by step to come up with your move, then output your final answer in the format \\\"Final Answer: X\\\" where X is your chosen move in standard algebraic notation (SAN).\\n\"\n          }\n        ]\n      }\n    ],\n    \"config\": {\n      \"temperature\": \"NOT_GIVEN\",\n      \"top_p\": \"NOT_GIVEN\",\n      \"max_completion_tokens\": \"NOT_GIVEN\"\n    },\n    \"stream_options\": {\n      \"include_usage\": true\n    }\n  },\n  \"response_for_logging\": {\n    \"response_chunks\": [\n      {\n        \"id\": \"sN76aavAPI-SmecPifn04Ak\",\n        \"choices\": [\n          {\n            \"delta\": {\n              \"content\": \" Kb4\",\n              \"role\": \"assistant\"\n            },\n            \"finish_reason\": \"stop\",\n            \"index\": 0\n          }\n        ],\n        \"created\": 1778048688,\n        \"model\": \"google/gemini-3.1-pro-preview\",\n        \"object\": \"chat.completion.chunk\",\n        \"usage\": {\n          \"completion_tokens\": 385,\n          \"prompt_tokens\": 584,\n          \"total_tokens\": 10616,\n          \"cost\": {\n            \"input_tokens_cost_nanodollars\": 1168000,\n            \"output_tokens_cost_nanodollars\": 120384000\n          },\n          \"total_backend_latency_ms\": 105307\n        }\n      }\n    ]\n  },\n  \"generation_tokens\": 385,\n  \"prompt_tokens\": 584,\n  \"reasoning_tokens\": null,\n  \"total_tokens\": 10616,\n  \"duration_success_only_secs\": 105.81283095199979\n}"
+          ],
+          "status": "OK",
+          "submission": 891,
+          "thoughts": "To determine the best move, let's evaluate the endgame position. White currently has a King and a Bishop against Black's King, Bishop, and a pawn. Black's dangerous passed pawn has advanced to b3, but White has achieved a theoretical draw because the White Bishop is perfectly placed on b2, physically blockading the pawn from advancing any further. \n\nBecause the pawn on b3 is safely neutralized by our Bishop on b2, White simply needs to maintain this blockade and avoid losing the Bishop. White's King should remain active and close to the pawn to support the Bishop and prevent the Black King from easily infiltrating to squares like c2 or a2.\n\nLet's look at White's legal King moves from b5:\n- **Kc4** and **Kc6** are illegal because they are covered by Black's light-squared Bishop on d5. \n- **Ka4**, **Ka5**, **Ka6**, **Kb6**, **Kc5**, and **Kb4** are all perfectly safe and legal squares for the King.\n\nAmong these, moving the King to **b4** is the most forcing and active choice. \n\nBy playing **Kb4**, White directly attacks the b3 pawn. Although the pawn is currently protected by Black's Bishop on d5, this move applies pressure and strictly ties down Black's Bishop to the a2-g8 diagonal. If Black's Bishop ever leaves that diagonal, White will simply play Kxb3, completely eliminating Black's only winning chance and resulting in a completely drawn position of King + Bishop vs. King + Bishop.\n\nWith the King on b4, White creates an impregnable fortress. We can simply shuffle the King safely around b4, a4, and c3 as needed while the Bishop holds the line forever. \n\nFinal Answer: Kb4"
+        },
+        "info": {
+          "actionApplied": 891,
+          "actionSubmitted": 891,
+          "actionSubmittedToString": "Kb4",
+          "agentSelfReportedStatus": "OK",
+          "timeTaken": 107.461
+        },
+        "observation": {
+          "currentPlayer": 0,
+          "isTerminal": false,
+          "observationString": "8/8/8/3b1k2/1K6/1p6/1B6/8 b - - 7 57",
+          "playerId": 1,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n1258\n3572\n1841\n1842\n1431\n3132\n3572\n656\n89\n1215\n2425\n3010\n1808\n1768\n749\n30\n1065\n2571\n1942\n3196\n3131\n1384\n4177\n3854\n381\n615\n498\n1869\n2001\n2977\n2975\n4350\n1431\n1770\n2581\n1257\n4673\n4673\n656\n2627\n1895\n2940\n1386\n1358\n3634\n2528\n254\n4496\n3110\n3705\n2948\n2161\n1771\n2833\n2059\n3853\n2002\n3326\n3166\n1358\n1406\n3561\n1694\n3050\n1637\n2497\n1212\n2425\n1882\n3593\n32\n2016\n1770\n3666\n2498\n4178\n2571\n2498\n1986\n2571\n1914\n2686\n1999\n4323\n3548\n3739\n819\n3196\n911\n3812\n3037\n4437\n4218\n3344\n3694\n4361\n674\n2685\n1357\n2174\n704\n1649\n819\n978\n892\n2322\n4350\n3325\n3327\n423\n3707\n891\n\n"
+        },
+        "reward": null,
+        "status": "INACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "actionString": "Ke4",
+          "generate_returns": [
+            "{\n  \"main_response\": \"Final Answer: Ke4\",\n  \"main_response_and_thoughts\": \"\",\n  \"request_for_logging\": {\n    \"model\": \"openai/gpt-5.5-2026-04-23\",\n    \"messages\": [\n      {\n        \"role\": \"user\",\n        \"content\": [\n          {\n            \"type\": \"text\",\n            \"text\": \"Let's play chess. The current game state in Forsyth-Edwards Notation (FEN) notation is:\\n8/8/8/3b1k2/1K6/1p6/1B6/8 b - - 7 57\\nThe moves played so far are:\\n1. e4 c5 2. Nf3 d6 3. d4 cxd4 4. Nxd4 Nf6 5. Nc3 a6 6. Bg5 e6 7. f4 Qb6 8. Qd2 Qxb2 9. Rb1 Qa3 10. e5 dxe5 11. fxe5 Nfd7 12. Ne4 h6 13. Bh4 Qxa2 14. Rd1 Qd5 15. Qe3 Qxe5 16. Be2 Bc5 17. Bg3 Bxd4 18. Rxd4 Qa5+ 19. c3 O-O 20. O-O Nc6 21. Nf6+ Nxf6 22. Rxf6 Nxd4 23. cxd4 gxf6 24. Qxh6 Qg5 25. Qxg5+ fxg5 26. Bd6 Rd8 27. Be7 Rxd4 28. Bxg5 Rd5 29. Bf6 Rf5 30. Bc3 Rc5 31. Bd4 Rc1+ 32. Kf2 Rc2 33. Ke3 Rxe2+ 34. Kxe2 Bd7 35. Ke3 Bc6 36. g3 Rd8 37. Bf6 Rd5 38. g4 e5 39. h4 e4 40. Kxe4 Rd6+ 41. Ke5 Rd5+ 42. Kf4 Rb5 43. h5 Kh7 44. g5 Rb4+ 45. Ke5 Rh4 46. g6+ fxg6 47. hxg6+ Kxg6 48. Bxh4 Kh5 49. Bd8 b5 50. Kd6 Bb7 51. Kc7 Bf3 52. Kb6 b4 53. Kxa6 b3 54. Bf6 Kg6 55. Bb2 Bd5 56. Kb5 Kf5 57. Kb4\\nYou are playing as player Black.\\nIt is now your turn. Play your strongest move. The move MUST be legal. Reason step by step to come up with your move, then output your final answer in the format \\\"Final Answer: X\\\" where X is your chosen move in standard algebraic notation (SAN).\\n\"\n          }\n        ]\n      }\n    ],\n    \"config\": {\n      \"temperature\": \"NOT_GIVEN\",\n      \"top_p\": \"NOT_GIVEN\",\n      \"max_completion_tokens\": \"NOT_GIVEN\",\n      \"reasoning_effort\": \"high\"\n    },\n    \"stream_options\": {\n      \"include_usage\": true\n    }\n  },\n  \"response_for_logging\": {\n    \"response_chunks\": [\n      {\n        \"id\": \"chatcmpl-DcQ0Nbl1syh2Dxca65fvraBjaMx3c\",\n        \"created\": 1778048799,\n        \"model\": \"openai/gpt-5.5-2026-04-23\",\n        \"object\": \"chat.completion.chunk\",\n        \"usage\": {\n          \"completion_tokens\": 19174,\n          \"prompt_tokens\": 597,\n          \"total_tokens\": 19771,\n          \"cost\": {\n            \"input_tokens_cost_nanodollars\": 2985000,\n            \"output_tokens_cost_nanodollars\": 575220000\n          },\n          \"total_backend_latency_ms\": 385219\n        }\n      }\n    ]\n  },\n  \"generation_tokens\": 19174,\n  \"prompt_tokens\": 597,\n  \"reasoning_tokens\": null,\n  \"total_tokens\": 19771,\n  \"duration_success_only_secs\": 385.6692975170008\n}"
+          ],
+          "status": "OK",
+          "submission": 3196,
+          "thoughts": "Final Answer: Ke4"
+        },
+        "info": {
+          "actionApplied": 3196,
+          "actionSubmitted": 3196,
+          "actionSubmittedToString": "Ke4",
+          "agentSelfReportedStatus": "OK",
+          "timeTaken": 387.494
+        },
+        "observation": {
+          "currentPlayer": 1,
+          "isTerminal": false,
+          "observationString": "8/8/8/3b4/1K2k3/1p6/1B6/8 w - - 8 58",
+          "playerId": 0,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n1258\n3572\n1841\n1842\n1431\n3132\n3572\n656\n89\n1215\n2425\n3010\n1808\n1768\n749\n30\n1065\n2571\n1942\n3196\n3131\n1384\n4177\n3854\n381\n615\n498\n1869\n2001\n2977\n2975\n4350\n1431\n1770\n2581\n1257\n4673\n4673\n656\n2627\n1895\n2940\n1386\n1358\n3634\n2528\n254\n4496\n3110\n3705\n2948\n2161\n1771\n2833\n2059\n3853\n2002\n3326\n3166\n1358\n1406\n3561\n1694\n3050\n1637\n2497\n1212\n2425\n1882\n3593\n32\n2016\n1770\n3666\n2498\n4178\n2571\n2498\n1986\n2571\n1914\n2686\n1999\n4323\n3548\n3739\n819\n3196\n911\n3812\n3037\n4437\n4218\n3344\n3694\n4361\n674\n2685\n1357\n2174\n704\n1649\n819\n978\n892\n2322\n4350\n3325\n3327\n423\n3707\n891\n3196\n\n",
+          "step": 115
+        },
+        "reward": null,
+        "status": "INACTIVE"
+      },
+      {
+        "action": {
+          "submission": -1
+        },
+        "info": {},
+        "observation": {
+          "currentPlayer": 1,
+          "isTerminal": false,
+          "observationString": "8/8/8/3b4/1K2k3/1p6/1B6/8 w - - 8 58",
+          "playerId": 1,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n1258\n3572\n1841\n1842\n1431\n3132\n3572\n656\n89\n1215\n2425\n3010\n1808\n1768\n749\n30\n1065\n2571\n1942\n3196\n3131\n1384\n4177\n3854\n381\n615\n498\n1869\n2001\n2977\n2975\n4350\n1431\n1770\n2581\n1257\n4673\n4673\n656\n2627\n1895\n2940\n1386\n1358\n3634\n2528\n254\n4496\n3110\n3705\n2948\n2161\n1771\n2833\n2059\n3853\n2002\n3326\n3166\n1358\n1406\n3561\n1694\n3050\n1637\n2497\n1212\n2425\n1882\n3593\n32\n2016\n1770\n3666\n2498\n4178\n2571\n2498\n1986\n2571\n1914\n2686\n1999\n4323\n3548\n3739\n819\n3196\n911\n3812\n3037\n4437\n4218\n3344\n3694\n4361\n674\n2685\n1357\n2174\n704\n1649\n819\n978\n892\n2322\n4350\n3325\n3327\n423\n3707\n891\n3196\n\n"
+        },
+        "reward": null,
+        "status": "ACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "submission": -1
+        },
+        "info": {},
+        "observation": {
+          "currentPlayer": 0,
+          "isTerminal": false,
+          "observationString": "8/8/8/3b4/4k3/1pK5/1B6/8 b - - 9 58",
+          "playerId": 0,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n1258\n3572\n1841\n1842\n1431\n3132\n3572\n656\n89\n1215\n2425\n3010\n1808\n1768\n749\n30\n1065\n2571\n1942\n3196\n3131\n1384\n4177\n3854\n381\n615\n498\n1869\n2001\n2977\n2975\n4350\n1431\n1770\n2581\n1257\n4673\n4673\n656\n2627\n1895\n2940\n1386\n1358\n3634\n2528\n254\n4496\n3110\n3705\n2948\n2161\n1771\n2833\n2059\n3853\n2002\n3326\n3166\n1358\n1406\n3561\n1694\n3050\n1637\n2497\n1212\n2425\n1882\n3593\n32\n2016\n1770\n3666\n2498\n4178\n2571\n2498\n1986\n2571\n1914\n2686\n1999\n4323\n3548\n3739\n819\n3196\n911\n3812\n3037\n4437\n4218\n3344\n3694\n4361\n674\n2685\n1357\n2174\n704\n1649\n819\n978\n892\n2322\n4350\n3325\n3327\n423\n3707\n891\n3196\n861\n\n",
+          "step": 116
+        },
+        "reward": null,
+        "status": "ACTIVE"
+      },
+      {
+        "action": {
+          "actionString": "Kc3",
+          "generate_returns": [
+            "{\n  \"main_response\": \"To determine the best move, let's evaluate the position. White has a King and a Bishop, while Black has a King, a Bishop, and a pawn. \\n\\nBlack's only winning chance would be to promote their remaining pawn on b3. However, White has successfully established an ironclad blockade. The White Bishop on b2 is perfectly placed on the square directly in front of the pawn, blocking its path to promotion. Because the remaining bishops are of opposite colors (White's is on a dark square, Black's is on a light square), Black's light-squared Bishop on d5 can never attack the White Bishop on b2 to force it away. \\n\\nSince the White Bishop can happily sacrifice itself for the pawn if it ever advances (leaving Black with just a King and a Bishop, which is insufficient material to deliver checkmate), White simply needs to wait and shuffle their King to secure the draw. \\n\\nThe most solid and active choice here is to move the White King to c3. \\nBy playing **Kc3**, White creates an impenetrable wall. The White King controls the crucial d2, d3, d4, c2, and c4 squares, essentially creating a fortress that cuts off the Black King from ever reaching the queenside to try and support the pawn. \\n\\nFinal Answer: Kc3\",\n  \"main_response_and_thoughts\": \"\",\n  \"request_for_logging\": {\n    \"model\": \"google/gemini-3.1-pro-preview\",\n    \"messages\": [\n      {\n        \"role\": \"user\",\n        \"content\": [\n          {\n            \"type\": \"text\",\n            \"text\": \"Let's play chess. The current game state in Forsyth-Edwards Notation (FEN) notation is:\\n8/8/8/3b4/1K2k3/1p6/1B6/8 w - - 8 58\\nThe moves played so far are:\\n1. e4 c5 2. Nf3 d6 3. d4 cxd4 4. Nxd4 Nf6 5. Nc3 a6 6. Bg5 e6 7. f4 Qb6 8. Qd2 Qxb2 9. Rb1 Qa3 10. e5 dxe5 11. fxe5 Nfd7 12. Ne4 h6 13. Bh4 Qxa2 14. Rd1 Qd5 15. Qe3 Qxe5 16. Be2 Bc5 17. Bg3 Bxd4 18. Rxd4 Qa5+ 19. c3 O-O 20. O-O Nc6 21. Nf6+ Nxf6 22. Rxf6 Nxd4 23. cxd4 gxf6 24. Qxh6 Qg5 25. Qxg5+ fxg5 26. Bd6 Rd8 27. Be7 Rxd4 28. Bxg5 Rd5 29. Bf6 Rf5 30. Bc3 Rc5 31. Bd4 Rc1+ 32. Kf2 Rc2 33. Ke3 Rxe2+ 34. Kxe2 Bd7 35. Ke3 Bc6 36. g3 Rd8 37. Bf6 Rd5 38. g4 e5 39. h4 e4 40. Kxe4 Rd6+ 41. Ke5 Rd5+ 42. Kf4 Rb5 43. h5 Kh7 44. g5 Rb4+ 45. Ke5 Rh4 46. g6+ fxg6 47. hxg6+ Kxg6 48. Bxh4 Kh5 49. Bd8 b5 50. Kd6 Bb7 51. Kc7 Bf3 52. Kb6 b4 53. Kxa6 b3 54. Bf6 Kg6 55. Bb2 Bd5 56. Kb5 Kf5 57. Kb4 Ke4 58.\\nYou are playing as player White.\\nIt is now your turn. Play your strongest move. The move MUST be legal. Reason step by step to come up with your move, then output your final answer in the format \\\"Final Answer: X\\\" where X is your chosen move in standard algebraic notation (SAN).\\n\"\n          }\n        ]\n      }\n    ],\n    \"config\": {\n      \"temperature\": \"NOT_GIVEN\",\n      \"top_p\": \"NOT_GIVEN\",\n      \"max_completion_tokens\": \"NOT_GIVEN\"\n    },\n    \"stream_options\": {\n      \"include_usage\": true\n    }\n  },\n  \"response_for_logging\": {\n    \"response_chunks\": [\n      {\n        \"id\": \"oOD6adwaj5KZ5w-J-fTgCQ\",\n        \"choices\": [\n          {\n            \"delta\": {\n              \"role\": \"assistant\"\n            },\n            \"finish_reason\": \"stop\",\n            \"index\": 0\n          }\n        ],\n        \"created\": 1778049184,\n        \"model\": \"google/gemini-3.1-pro-preview\",\n        \"object\": \"chat.completion.chunk\",\n        \"usage\": {\n          \"completion_tokens\": 277,\n          \"prompt_tokens\": 592,\n          \"total_tokens\": 6325,\n          \"cost\": {\n            \"input_tokens_cost_nanodollars\": 1184000,\n            \"output_tokens_cost_nanodollars\": 68796000\n          },\n          \"total_backend_latency_ms\": 55029\n        }\n      }\n    ]\n  },\n  \"generation_tokens\": 277,\n  \"prompt_tokens\": 592,\n  \"reasoning_tokens\": null,\n  \"total_tokens\": 6325,\n  \"duration_success_only_secs\": 55.54068489600104\n}"
+          ],
+          "status": "OK",
+          "submission": 861,
+          "thoughts": "To determine the best move, let's evaluate the position. White has a King and a Bishop, while Black has a King, a Bishop, and a pawn. \n\nBlack's only winning chance would be to promote their remaining pawn on b3. However, White has successfully established an ironclad blockade. The White Bishop on b2 is perfectly placed on the square directly in front of the pawn, blocking its path to promotion. Because the remaining bishops are of opposite colors (White's is on a dark square, Black's is on a light square), Black's light-squared Bishop on d5 can never attack the White Bishop on b2 to force it away. \n\nSince the White Bishop can happily sacrifice itself for the pawn if it ever advances (leaving Black with just a King and a Bishop, which is insufficient material to deliver checkmate), White simply needs to wait and shuffle their King to secure the draw. \n\nThe most solid and active choice here is to move the White King to c3. \nBy playing **Kc3**, White creates an impenetrable wall. The White King controls the crucial d2, d3, d4, c2, and c4 squares, essentially creating a fortress that cuts off the Black King from ever reaching the queenside to try and support the pawn. \n\nFinal Answer: Kc3"
+        },
+        "info": {
+          "actionApplied": 861,
+          "actionSubmitted": 861,
+          "actionSubmittedToString": "Kc3",
+          "agentSelfReportedStatus": "OK",
+          "timeTaken": 57.287
+        },
+        "observation": {
+          "currentPlayer": 0,
+          "isTerminal": false,
+          "observationString": "8/8/8/3b4/4k3/1pK5/1B6/8 b - - 9 58",
+          "playerId": 1,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n1258\n3572\n1841\n1842\n1431\n3132\n3572\n656\n89\n1215\n2425\n3010\n1808\n1768\n749\n30\n1065\n2571\n1942\n3196\n3131\n1384\n4177\n3854\n381\n615\n498\n1869\n2001\n2977\n2975\n4350\n1431\n1770\n2581\n1257\n4673\n4673\n656\n2627\n1895\n2940\n1386\n1358\n3634\n2528\n254\n4496\n3110\n3705\n2948\n2161\n1771\n2833\n2059\n3853\n2002\n3326\n3166\n1358\n1406\n3561\n1694\n3050\n1637\n2497\n1212\n2425\n1882\n3593\n32\n2016\n1770\n3666\n2498\n4178\n2571\n2498\n1986\n2571\n1914\n2686\n1999\n4323\n3548\n3739\n819\n3196\n911\n3812\n3037\n4437\n4218\n3344\n3694\n4361\n674\n2685\n1357\n2174\n704\n1649\n819\n978\n892\n2322\n4350\n3325\n3327\n423\n3707\n891\n3196\n861\n\n"
+        },
+        "reward": null,
+        "status": "INACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "actionString": "Ke3",
+          "generate_returns": [
+            "{\n  \"main_response\": \"Final Answer: Ke3\",\n  \"main_response_and_thoughts\": \"\",\n  \"request_for_logging\": {\n    \"model\": \"openai/gpt-5.5-2026-04-23\",\n    \"messages\": [\n      {\n        \"role\": \"user\",\n        \"content\": [\n          {\n            \"type\": \"text\",\n            \"text\": \"Let's play chess. The current game state in Forsyth-Edwards Notation (FEN) notation is:\\n8/8/8/3b4/4k3/1pK5/1B6/8 b - - 9 58\\nThe moves played so far are:\\n1. e4 c5 2. Nf3 d6 3. d4 cxd4 4. Nxd4 Nf6 5. Nc3 a6 6. Bg5 e6 7. f4 Qb6 8. Qd2 Qxb2 9. Rb1 Qa3 10. e5 dxe5 11. fxe5 Nfd7 12. Ne4 h6 13. Bh4 Qxa2 14. Rd1 Qd5 15. Qe3 Qxe5 16. Be2 Bc5 17. Bg3 Bxd4 18. Rxd4 Qa5+ 19. c3 O-O 20. O-O Nc6 21. Nf6+ Nxf6 22. Rxf6 Nxd4 23. cxd4 gxf6 24. Qxh6 Qg5 25. Qxg5+ fxg5 26. Bd6 Rd8 27. Be7 Rxd4 28. Bxg5 Rd5 29. Bf6 Rf5 30. Bc3 Rc5 31. Bd4 Rc1+ 32. Kf2 Rc2 33. Ke3 Rxe2+ 34. Kxe2 Bd7 35. Ke3 Bc6 36. g3 Rd8 37. Bf6 Rd5 38. g4 e5 39. h4 e4 40. Kxe4 Rd6+ 41. Ke5 Rd5+ 42. Kf4 Rb5 43. h5 Kh7 44. g5 Rb4+ 45. Ke5 Rh4 46. g6+ fxg6 47. hxg6+ Kxg6 48. Bxh4 Kh5 49. Bd8 b5 50. Kd6 Bb7 51. Kc7 Bf3 52. Kb6 b4 53. Kxa6 b3 54. Bf6 Kg6 55. Bb2 Bd5 56. Kb5 Kf5 57. Kb4 Ke4 58. Kc3\\nYou are playing as player Black.\\nIt is now your turn. Play your strongest move. The move MUST be legal. Reason step by step to come up with your move, then output your final answer in the format \\\"Final Answer: X\\\" where X is your chosen move in standard algebraic notation (SAN).\\n\"\n          }\n        ]\n      }\n    ],\n    \"config\": {\n      \"temperature\": \"NOT_GIVEN\",\n      \"top_p\": \"NOT_GIVEN\",\n      \"max_completion_tokens\": \"NOT_GIVEN\",\n      \"reasoning_effort\": \"high\"\n    },\n    \"stream_options\": {\n      \"include_usage\": true\n    }\n  },\n  \"response_for_logging\": {\n    \"response_chunks\": [\n      {\n        \"id\": \"chatcmpl-DcQ7V95tfu7lJqpKM9tUDdL6qHGlK\",\n        \"created\": 1778049241,\n        \"model\": \"openai/gpt-5.5-2026-04-23\",\n        \"object\": \"chat.completion.chunk\",\n        \"usage\": {\n          \"completion_tokens\": 14512,\n          \"prompt_tokens\": 604,\n          \"total_tokens\": 15116,\n          \"cost\": {\n            \"input_tokens_cost_nanodollars\": 3020000,\n            \"output_tokens_cost_nanodollars\": 435360000\n          },\n          \"total_backend_latency_ms\": 296831\n        }\n      }\n    ]\n  },\n  \"generation_tokens\": 14512,\n  \"prompt_tokens\": 604,\n  \"reasoning_tokens\": null,\n  \"total_tokens\": 15116,\n  \"duration_success_only_secs\": 297.78018930799954\n}"
+          ],
+          "status": "OK",
+          "submission": 2644,
+          "thoughts": "Final Answer: Ke3"
+        },
+        "info": {
+          "actionApplied": 2644,
+          "actionSubmitted": 2644,
+          "actionSubmittedToString": "Ke3",
+          "agentSelfReportedStatus": "OK",
+          "timeTaken": 299.069
+        },
+        "observation": {
+          "currentPlayer": 1,
+          "isTerminal": false,
+          "observationString": "8/8/8/3b4/8/1pK1k3/1B6/8 w - - 10 59",
+          "playerId": 0,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n1258\n3572\n1841\n1842\n1431\n3132\n3572\n656\n89\n1215\n2425\n3010\n1808\n1768\n749\n30\n1065\n2571\n1942\n3196\n3131\n1384\n4177\n3854\n381\n615\n498\n1869\n2001\n2977\n2975\n4350\n1431\n1770\n2581\n1257\n4673\n4673\n656\n2627\n1895\n2940\n1386\n1358\n3634\n2528\n254\n4496\n3110\n3705\n2948\n2161\n1771\n2833\n2059\n3853\n2002\n3326\n3166\n1358\n1406\n3561\n1694\n3050\n1637\n2497\n1212\n2425\n1882\n3593\n32\n2016\n1770\n3666\n2498\n4178\n2571\n2498\n1986\n2571\n1914\n2686\n1999\n4323\n3548\n3739\n819\n3196\n911\n3812\n3037\n4437\n4218\n3344\n3694\n4361\n674\n2685\n1357\n2174\n704\n1649\n819\n978\n892\n2322\n4350\n3325\n3327\n423\n3707\n891\n3196\n861\n2644\n\n",
+          "step": 117
+        },
+        "reward": null,
+        "status": "INACTIVE"
+      },
+      {
+        "action": {
+          "submission": -1
+        },
+        "info": {},
+        "observation": {
+          "currentPlayer": 1,
+          "isTerminal": false,
+          "observationString": "8/8/8/3b4/8/1pK1k3/1B6/8 w - - 10 59",
+          "playerId": 1,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n1258\n3572\n1841\n1842\n1431\n3132\n3572\n656\n89\n1215\n2425\n3010\n1808\n1768\n749\n30\n1065\n2571\n1942\n3196\n3131\n1384\n4177\n3854\n381\n615\n498\n1869\n2001\n2977\n2975\n4350\n1431\n1770\n2581\n1257\n4673\n4673\n656\n2627\n1895\n2940\n1386\n1358\n3634\n2528\n254\n4496\n3110\n3705\n2948\n2161\n1771\n2833\n2059\n3853\n2002\n3326\n3166\n1358\n1406\n3561\n1694\n3050\n1637\n2497\n1212\n2425\n1882\n3593\n32\n2016\n1770\n3666\n2498\n4178\n2571\n2498\n1986\n2571\n1914\n2686\n1999\n4323\n3548\n3739\n819\n3196\n911\n3812\n3037\n4437\n4218\n3344\n3694\n4361\n674\n2685\n1357\n2174\n704\n1649\n819\n978\n892\n2322\n4350\n3325\n3327\n423\n3707\n891\n3196\n861\n2644\n\n"
+        },
+        "reward": null,
+        "status": "ACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "submission": -1
+        },
+        "info": {},
+        "observation": {
+          "currentPlayer": 0,
+          "isTerminal": false,
+          "observationString": "8/8/8/3b4/8/1pK1k3/8/2B5 b - - 11 59",
+          "playerId": 0,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n1258\n3572\n1841\n1842\n1431\n3132\n3572\n656\n89\n1215\n2425\n3010\n1808\n1768\n749\n30\n1065\n2571\n1942\n3196\n3131\n1384\n4177\n3854\n381\n615\n498\n1869\n2001\n2977\n2975\n4350\n1431\n1770\n2581\n1257\n4673\n4673\n656\n2627\n1895\n2940\n1386\n1358\n3634\n2528\n254\n4496\n3110\n3705\n2948\n2161\n1771\n2833\n2059\n3853\n2002\n3326\n3166\n1358\n1406\n3561\n1694\n3050\n1637\n2497\n1212\n2425\n1882\n3593\n32\n2016\n1770\n3666\n2498\n4178\n2571\n2498\n1986\n2571\n1914\n2686\n1999\n4323\n3548\n3739\n819\n3196\n911\n3812\n3037\n4437\n4218\n3344\n3694\n4361\n674\n2685\n1357\n2174\n704\n1649\n819\n978\n892\n2322\n4350\n3325\n3327\n423\n3707\n891\n3196\n861\n2644\n715\n\n",
+          "step": 118
+        },
+        "reward": null,
+        "status": "ACTIVE"
+      },
+      {
+        "action": {
+          "actionString": "Bc1+",
+          "generate_returns": [
+            "{\n  \"main_response\": \"To determine the best move, we must evaluate the endgame position. We have a King and a Bishop against a King, a Bishop, and a pawn. The bishops are of opposite colors (White's Bishop is on the dark squares, Black's Bishop is on the light squares). \\n\\nWhite's primary goal is to easily secure the draw by preventing Black's b3 pawn from ever promoting. \\nCurrently, White's King is perfectly placed on c3. From c3, the White King solidly blockades the b3 pawn and completely controls the critical squares around it (b2, b4, c2, c4, d2, d3, d4). Because of this central King placement, the Black King is physically walled off from penetrating into White's position or supporting the pawn. \\n\\nIf White were to move the King away (e.g., Kb4), it would unnecessarily let the Black King advance towards the queenside (e.g., ...Kd3 and ...Kc2). Therefore, keeping the King planted on c3 is strategically optimal.\\n\\nThis leaves us with a Bishop move. By moving the Bishop along its dark-square diagonal, we keep an eye on the b2 promotion square. Any advance of the pawn (...b2) would simply be met by Bxb2, leading to an immediate dead draw (King vs. King and Bishop). \\n\\nThe most active and forcing move in this position is to slide the Bishop to c1, delivering a check to the Black King.\\n\\n1. Bc1+ \\n\\nThis forces the Black King to retreat or move sideways (for example, to e2 or e4), making absolutely zero progress. White will just shuffle the Bishop between c1, b2, or a1 on subsequent turns while leaving the King safely anchored on c3. The fortress is completely impenetrable. \\n\\nFinal Answer: Bc1+\",\n  \"main_response_and_thoughts\": \"\",\n  \"request_for_logging\": {\n    \"model\": \"google/gemini-3.1-pro-preview\",\n    \"messages\": [\n      {\n        \"role\": \"user\",\n        \"content\": [\n          {\n            \"type\": \"text\",\n            \"text\": \"Let's play chess. The current game state in Forsyth-Edwards Notation (FEN) notation is:\\n8/8/8/3b4/8/1pK1k3/1B6/8 w - - 10 59\\nThe moves played so far are:\\n1. e4 c5 2. Nf3 d6 3. d4 cxd4 4. Nxd4 Nf6 5. Nc3 a6 6. Bg5 e6 7. f4 Qb6 8. Qd2 Qxb2 9. Rb1 Qa3 10. e5 dxe5 11. fxe5 Nfd7 12. Ne4 h6 13. Bh4 Qxa2 14. Rd1 Qd5 15. Qe3 Qxe5 16. Be2 Bc5 17. Bg3 Bxd4 18. Rxd4 Qa5+ 19. c3 O-O 20. O-O Nc6 21. Nf6+ Nxf6 22. Rxf6 Nxd4 23. cxd4 gxf6 24. Qxh6 Qg5 25. Qxg5+ fxg5 26. Bd6 Rd8 27. Be7 Rxd4 28. Bxg5 Rd5 29. Bf6 Rf5 30. Bc3 Rc5 31. Bd4 Rc1+ 32. Kf2 Rc2 33. Ke3 Rxe2+ 34. Kxe2 Bd7 35. Ke3 Bc6 36. g3 Rd8 37. Bf6 Rd5 38. g4 e5 39. h4 e4 40. Kxe4 Rd6+ 41. Ke5 Rd5+ 42. Kf4 Rb5 43. h5 Kh7 44. g5 Rb4+ 45. Ke5 Rh4 46. g6+ fxg6 47. hxg6+ Kxg6 48. Bxh4 Kh5 49. Bd8 b5 50. Kd6 Bb7 51. Kc7 Bf3 52. Kb6 b4 53. Kxa6 b3 54. Bf6 Kg6 55. Bb2 Bd5 56. Kb5 Kf5 57. Kb4 Ke4 58. Kc3 Ke3 59.\\nYou are playing as player White.\\nIt is now your turn. Play your strongest move. The move MUST be legal. Reason step by step to come up with your move, then output your final answer in the format \\\"Final Answer: X\\\" where X is your chosen move in standard algebraic notation (SAN).\\n\"\n          }\n        ]\n      }\n    ],\n    \"config\": {\n      \"temperature\": \"NOT_GIVEN\",\n      \"top_p\": \"NOT_GIVEN\",\n      \"max_completion_tokens\": \"NOT_GIVEN\"\n    },\n    \"stream_options\": {\n      \"include_usage\": true\n    }\n  },\n  \"response_for_logging\": {\n    \"response_chunks\": [\n      {\n        \"id\": \"BOL6af2xI8udmecPmbT14Qk\",\n        \"choices\": [\n          {\n            \"delta\": {\n              \"content\": \" is completely impenetrable. \\n\\nFinal Answer: Bc1+\",\n              \"role\": \"assistant\"\n            },\n            \"finish_reason\": \"stop\",\n            \"index\": 0\n          }\n        ],\n        \"created\": 1778049540,\n        \"model\": \"google/gemini-3.1-pro-preview\",\n        \"object\": \"chat.completion.chunk\",\n        \"usage\": {\n          \"completion_tokens\": 391,\n          \"prompt_tokens\": 599,\n          \"total_tokens\": 11101,\n          \"cost\": {\n            \"input_tokens_cost_nanodollars\": 1198000,\n            \"output_tokens_cost_nanodollars\": 126024000\n          },\n          \"total_backend_latency_ms\": 100873\n        }\n      }\n    ]\n  },\n  \"generation_tokens\": 391,\n  \"prompt_tokens\": 599,\n  \"reasoning_tokens\": null,\n  \"total_tokens\": 11101,\n  \"duration_success_only_secs\": 101.9179677209977\n}"
+          ],
+          "status": "OK",
+          "submission": 715,
+          "thoughts": "To determine the best move, we must evaluate the endgame position. We have a King and a Bishop against a King, a Bishop, and a pawn. The bishops are of opposite colors (White's Bishop is on the dark squares, Black's Bishop is on the light squares). \n\nWhite's primary goal is to easily secure the draw by preventing Black's b3 pawn from ever promoting. \nCurrently, White's King is perfectly placed on c3. From c3, the White King solidly blockades the b3 pawn and completely controls the critical squares around it (b2, b4, c2, c4, d2, d3, d4). Because of this central King placement, the Black King is physically walled off from penetrating into White's position or supporting the pawn. \n\nIf White were to move the King away (e.g., Kb4), it would unnecessarily let the Black King advance towards the queenside (e.g., ...Kd3 and ...Kc2). Therefore, keeping the King planted on c3 is strategically optimal.\n\nThis leaves us with a Bishop move. By moving the Bishop along its dark-square diagonal, we keep an eye on the b2 promotion square. Any advance of the pawn (...b2) would simply be met by Bxb2, leading to an immediate dead draw (King vs. King and Bishop). \n\nThe most active and forcing move in this position is to slide the Bishop to c1, delivering a check to the Black King.\n\n1. Bc1+ \n\nThis forces the Black King to retreat or move sideways (for example, to e2 or e4), making absolutely zero progress. White will just shuffle the Bishop between c1, b2, or a1 on subsequent turns while leaving the King safely anchored on c3. The fortress is completely impenetrable. \n\nFinal Answer: Bc1+"
+        },
+        "info": {
+          "actionApplied": 715,
+          "actionSubmitted": 715,
+          "actionSubmittedToString": "Bc1+",
+          "agentSelfReportedStatus": "OK",
+          "timeTaken": 103.883
+        },
+        "observation": {
+          "currentPlayer": 0,
+          "isTerminal": false,
+          "observationString": "8/8/8/3b4/8/1pK1k3/8/2B5 b - - 11 59",
+          "playerId": 1,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n1258\n3572\n1841\n1842\n1431\n3132\n3572\n656\n89\n1215\n2425\n3010\n1808\n1768\n749\n30\n1065\n2571\n1942\n3196\n3131\n1384\n4177\n3854\n381\n615\n498\n1869\n2001\n2977\n2975\n4350\n1431\n1770\n2581\n1257\n4673\n4673\n656\n2627\n1895\n2940\n1386\n1358\n3634\n2528\n254\n4496\n3110\n3705\n2948\n2161\n1771\n2833\n2059\n3853\n2002\n3326\n3166\n1358\n1406\n3561\n1694\n3050\n1637\n2497\n1212\n2425\n1882\n3593\n32\n2016\n1770\n3666\n2498\n4178\n2571\n2498\n1986\n2571\n1914\n2686\n1999\n4323\n3548\n3739\n819\n3196\n911\n3812\n3037\n4437\n4218\n3344\n3694\n4361\n674\n2685\n1357\n2174\n704\n1649\n819\n978\n892\n2322\n4350\n3325\n3327\n423\n3707\n891\n3196\n861\n2644\n715\n\n"
+        },
+        "reward": null,
+        "status": "INACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "actionString": "Ke4",
+          "generate_returns": [
+            "{\n  \"main_response\": \"The strongest legal move is to step out of check while keeping the black king active and controlling key squares near the pawn blockade.\\n\\nFinal Answer: Ke4\",\n  \"main_response_and_thoughts\": \"\",\n  \"request_for_logging\": {\n    \"model\": \"openai/gpt-5.5-2026-04-23\",\n    \"messages\": [\n      {\n        \"role\": \"user\",\n        \"content\": [\n          {\n            \"type\": \"text\",\n            \"text\": \"Let's play chess. The current game state in Forsyth-Edwards Notation (FEN) notation is:\\n8/8/8/3b4/8/1pK1k3/8/2B5 b - - 11 59\\nThe moves played so far are:\\n1. e4 c5 2. Nf3 d6 3. d4 cxd4 4. Nxd4 Nf6 5. Nc3 a6 6. Bg5 e6 7. f4 Qb6 8. Qd2 Qxb2 9. Rb1 Qa3 10. e5 dxe5 11. fxe5 Nfd7 12. Ne4 h6 13. Bh4 Qxa2 14. Rd1 Qd5 15. Qe3 Qxe5 16. Be2 Bc5 17. Bg3 Bxd4 18. Rxd4 Qa5+ 19. c3 O-O 20. O-O Nc6 21. Nf6+ Nxf6 22. Rxf6 Nxd4 23. cxd4 gxf6 24. Qxh6 Qg5 25. Qxg5+ fxg5 26. Bd6 Rd8 27. Be7 Rxd4 28. Bxg5 Rd5 29. Bf6 Rf5 30. Bc3 Rc5 31. Bd4 Rc1+ 32. Kf2 Rc2 33. Ke3 Rxe2+ 34. Kxe2 Bd7 35. Ke3 Bc6 36. g3 Rd8 37. Bf6 Rd5 38. g4 e5 39. h4 e4 40. Kxe4 Rd6+ 41. Ke5 Rd5+ 42. Kf4 Rb5 43. h5 Kh7 44. g5 Rb4+ 45. Ke5 Rh4 46. g6+ fxg6 47. hxg6+ Kxg6 48. Bxh4 Kh5 49. Bd8 b5 50. Kd6 Bb7 51. Kc7 Bf3 52. Kb6 b4 53. Kxa6 b3 54. Bf6 Kg6 55. Bb2 Bd5 56. Kb5 Kf5 57. Kb4 Ke4 58. Kc3 Ke3 59. Bc1+\\nYou are playing as player Black.\\nIt is now your turn. Play your strongest move. The move MUST be legal. Reason step by step to come up with your move, then output your final answer in the format \\\"Final Answer: X\\\" where X is your chosen move in standard algebraic notation (SAN).\\n\"\n          }\n        ]\n      }\n    ],\n    \"config\": {\n      \"temperature\": \"NOT_GIVEN\",\n      \"top_p\": \"NOT_GIVEN\",\n      \"max_completion_tokens\": \"NOT_GIVEN\",\n      \"reasoning_effort\": \"high\"\n    },\n    \"stream_options\": {\n      \"include_usage\": true\n    }\n  },\n  \"response_for_logging\": {\n    \"response_chunks\": [\n      {\n        \"id\": \"chatcmpl-DcQOIaTZhtbCYVi4PYATNi1CvJRwH\",\n        \"created\": 1778050282,\n        \"model\": \"openai/gpt-5.5-2026-04-23\",\n        \"object\": \"chat.completion.chunk\",\n        \"usage\": {\n          \"completion_tokens\": 21271,\n          \"prompt_tokens\": 612,\n          \"total_tokens\": 21883,\n          \"cost\": {\n            \"input_tokens_cost_nanodollars\": 3060000,\n            \"output_tokens_cost_nanodollars\": 638130000\n          },\n          \"total_backend_latency_ms\": 484422\n        }\n      }\n    ]\n  },\n  \"generation_tokens\": 21271,\n  \"prompt_tokens\": 612,\n  \"reasoning_tokens\": null,\n  \"total_tokens\": 21883,\n  \"duration_success_only_secs\": 484.87614945199675\n}"
+          ],
+          "status": "OK",
+          "submission": 2716,
+          "thoughts": "The strongest legal move is to step out of check while keeping the black king active and controlling key squares near the pawn blockade.\n\nFinal Answer: Ke4"
+        },
+        "info": {
+          "actionApplied": 2716,
+          "actionSubmitted": 2716,
+          "actionSubmittedToString": "Ke4",
+          "agentSelfReportedStatus": "OK",
+          "timeTaken": 1124.499
+        },
+        "observation": {
+          "currentPlayer": 1,
+          "isTerminal": false,
+          "observationString": "8/8/8/3b4/4k3/1pK5/8/2B5 w - - 12 60",
+          "playerId": 0,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n1258\n3572\n1841\n1842\n1431\n3132\n3572\n656\n89\n1215\n2425\n3010\n1808\n1768\n749\n30\n1065\n2571\n1942\n3196\n3131\n1384\n4177\n3854\n381\n615\n498\n1869\n2001\n2977\n2975\n4350\n1431\n1770\n2581\n1257\n4673\n4673\n656\n2627\n1895\n2940\n1386\n1358\n3634\n2528\n254\n4496\n3110\n3705\n2948\n2161\n1771\n2833\n2059\n3853\n2002\n3326\n3166\n1358\n1406\n3561\n1694\n3050\n1637\n2497\n1212\n2425\n1882\n3593\n32\n2016\n1770\n3666\n2498\n4178\n2571\n2498\n1986\n2571\n1914\n2686\n1999\n4323\n3548\n3739\n819\n3196\n911\n3812\n3037\n4437\n4218\n3344\n3694\n4361\n674\n2685\n1357\n2174\n704\n1649\n819\n978\n892\n2322\n4350\n3325\n3327\n423\n3707\n891\n3196\n861\n2644\n715\n2716\n\n",
+          "step": 119
+        },
+        "reward": null,
+        "status": "INACTIVE"
+      },
+      {
+        "action": {
+          "submission": -1
+        },
+        "info": {},
+        "observation": {
+          "currentPlayer": 1,
+          "isTerminal": false,
+          "observationString": "8/8/8/3b4/4k3/1pK5/8/2B5 w - - 12 60",
+          "playerId": 1,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n1258\n3572\n1841\n1842\n1431\n3132\n3572\n656\n89\n1215\n2425\n3010\n1808\n1768\n749\n30\n1065\n2571\n1942\n3196\n3131\n1384\n4177\n3854\n381\n615\n498\n1869\n2001\n2977\n2975\n4350\n1431\n1770\n2581\n1257\n4673\n4673\n656\n2627\n1895\n2940\n1386\n1358\n3634\n2528\n254\n4496\n3110\n3705\n2948\n2161\n1771\n2833\n2059\n3853\n2002\n3326\n3166\n1358\n1406\n3561\n1694\n3050\n1637\n2497\n1212\n2425\n1882\n3593\n32\n2016\n1770\n3666\n2498\n4178\n2571\n2498\n1986\n2571\n1914\n2686\n1999\n4323\n3548\n3739\n819\n3196\n911\n3812\n3037\n4437\n4218\n3344\n3694\n4361\n674\n2685\n1357\n2174\n704\n1649\n819\n978\n892\n2322\n4350\n3325\n3327\n423\n3707\n891\n3196\n861\n2644\n715\n2716\n\n"
+        },
+        "reward": null,
+        "status": "ACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "submission": -1
+        },
+        "info": {},
+        "observation": {
+          "currentPlayer": 0,
+          "isTerminal": false,
+          "observationString": "8/8/8/3b4/4k3/1pK5/1B6/8 b - - 13 60",
+          "playerId": 0,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n1258\n3572\n1841\n1842\n1431\n3132\n3572\n656\n89\n1215\n2425\n3010\n1808\n1768\n749\n30\n1065\n2571\n1942\n3196\n3131\n1384\n4177\n3854\n381\n615\n498\n1869\n2001\n2977\n2975\n4350\n1431\n1770\n2581\n1257\n4673\n4673\n656\n2627\n1895\n2940\n1386\n1358\n3634\n2528\n254\n4496\n3110\n3705\n2948\n2161\n1771\n2833\n2059\n3853\n2002\n3326\n3166\n1358\n1406\n3561\n1694\n3050\n1637\n2497\n1212\n2425\n1882\n3593\n32\n2016\n1770\n3666\n2498\n4178\n2571\n2498\n1986\n2571\n1914\n2686\n1999\n4323\n3548\n3739\n819\n3196\n911\n3812\n3037\n4437\n4218\n3344\n3694\n4361\n674\n2685\n1357\n2174\n704\n1649\n819\n978\n892\n2322\n4350\n3325\n3327\n423\n3707\n891\n3196\n861\n2644\n715\n2716\n1225\n\n",
+          "step": 120
+        },
+        "reward": null,
+        "status": "ACTIVE"
+      },
+      {
+        "action": {
+          "actionString": "Bb2",
+          "generate_returns": [
+            "{\n  \"main_response\": \"To maintain the blockade and easily secure the draw, White's best strategy is to keep the Black king at bay and firmly block the b3 pawn. \\n\\nThe pawn on b3 is a light-square pawn, heading for b2. By moving your dark-squared bishop to b2, you physically block the pawn's path. Furthermore, the bishop is completely untouchable on b2:\\n1. Black's pawn moves straight but captures diagonally, meaning it cannot capture a piece directly in front of it on b2.\\n2. Black's bishop is stuck on the light squares (d5) and will never be able to attack the dark b2 square.\\n3. Your own king on c3 covers the key entry squares (d2, d3, d4) which permanently boxes out the Black king from ever getting close enough to threaten your bishop or support the pawn. \\n\\nThis sets up an impenetrable fortress, a very standard drawing technique in this endgame.\\n\\nFinal Answer: Bb2\",\n  \"main_response_and_thoughts\": \"\",\n  \"request_for_logging\": {\n    \"model\": \"google/gemini-3.1-pro-preview\",\n    \"messages\": [\n      {\n        \"role\": \"user\",\n        \"content\": [\n          {\n            \"type\": \"text\",\n            \"text\": \"Let's play chess. The current game state in Forsyth-Edwards Notation (FEN) notation is:\\n8/8/8/3b4/4k3/1pK5/8/2B5 w - - 12 60\\nThe moves played so far are:\\n1. e4 c5 2. Nf3 d6 3. d4 cxd4 4. Nxd4 Nf6 5. Nc3 a6 6. Bg5 e6 7. f4 Qb6 8. Qd2 Qxb2 9. Rb1 Qa3 10. e5 dxe5 11. fxe5 Nfd7 12. Ne4 h6 13. Bh4 Qxa2 14. Rd1 Qd5 15. Qe3 Qxe5 16. Be2 Bc5 17. Bg3 Bxd4 18. Rxd4 Qa5+ 19. c3 O-O 20. O-O Nc6 21. Nf6+ Nxf6 22. Rxf6 Nxd4 23. cxd4 gxf6 24. Qxh6 Qg5 25. Qxg5+ fxg5 26. Bd6 Rd8 27. Be7 Rxd4 28. Bxg5 Rd5 29. Bf6 Rf5 30. Bc3 Rc5 31. Bd4 Rc1+ 32. Kf2 Rc2 33. Ke3 Rxe2+ 34. Kxe2 Bd7 35. Ke3 Bc6 36. g3 Rd8 37. Bf6 Rd5 38. g4 e5 39. h4 e4 40. Kxe4 Rd6+ 41. Ke5 Rd5+ 42. Kf4 Rb5 43. h5 Kh7 44. g5 Rb4+ 45. Ke5 Rh4 46. g6+ fxg6 47. hxg6+ Kxg6 48. Bxh4 Kh5 49. Bd8 b5 50. Kd6 Bb7 51. Kc7 Bf3 52. Kb6 b4 53. Kxa6 b3 54. Bf6 Kg6 55. Bb2 Bd5 56. Kb5 Kf5 57. Kb4 Ke4 58. Kc3 Ke3 59. Bc1+ Ke4 60.\\nYou are playing as player White.\\nIt is now your turn. Play your strongest move. The move MUST be legal. Reason step by step to come up with your move, then output your final answer in the format \\\"Final Answer: X\\\" where X is your chosen move in standard algebraic notation (SAN).\\n\"\n          }\n        ]\n      }\n    ],\n    \"config\": {\n      \"temperature\": \"NOT_GIVEN\",\n      \"top_p\": \"NOT_GIVEN\",\n      \"max_completion_tokens\": \"NOT_GIVEN\"\n    },\n    \"stream_options\": {\n      \"include_usage\": true\n    }\n  },\n  \"response_for_logging\": {\n    \"response_chunks\": [\n      {\n        \"id\": \"0Ob6aezbEPiMmecPq_Dk8QQ\",\n        \"choices\": [\n          {\n            \"delta\": {\n              \"content\": \" very standard drawing technique in this endgame.\\n\\nFinal Answer: Bb2\",\n              \"role\": \"assistant\"\n            },\n            \"finish_reason\": \"stop\",\n            \"index\": 0\n          }\n        ],\n        \"created\": 1778050768,\n        \"model\": \"google/gemini-3.1-pro-preview\",\n        \"object\": \"chat.completion.chunk\",\n        \"usage\": {\n          \"completion_tokens\": 209,\n          \"prompt_tokens\": 608,\n          \"total_tokens\": 6922,\n          \"cost\": {\n            \"input_tokens_cost_nanodollars\": 1216000,\n            \"output_tokens_cost_nanodollars\": 75768000\n          },\n          \"total_backend_latency_ms\": 59539\n        }\n      }\n    ]\n  },\n  \"generation_tokens\": 209,\n  \"prompt_tokens\": 608,\n  \"reasoning_tokens\": null,\n  \"total_tokens\": 6922,\n  \"duration_success_only_secs\": 60.049748784003896\n}"
+          ],
+          "status": "OK",
+          "submission": 1225,
+          "thoughts": "To maintain the blockade and easily secure the draw, White's best strategy is to keep the Black king at bay and firmly block the b3 pawn. \n\nThe pawn on b3 is a light-square pawn, heading for b2. By moving your dark-squared bishop to b2, you physically block the pawn's path. Furthermore, the bishop is completely untouchable on b2:\n1. Black's pawn moves straight but captures diagonally, meaning it cannot capture a piece directly in front of it on b2.\n2. Black's bishop is stuck on the light squares (d5) and will never be able to attack the dark b2 square.\n3. Your own king on c3 covers the key entry squares (d2, d3, d4) which permanently boxes out the Black king from ever getting close enough to threaten your bishop or support the pawn. \n\nThis sets up an impenetrable fortress, a very standard drawing technique in this endgame.\n\nFinal Answer: Bb2"
+        },
+        "info": {
+          "actionApplied": 1225,
+          "actionSubmitted": 1225,
+          "actionSubmittedToString": "Bb2",
+          "agentSelfReportedStatus": "OK",
+          "timeTaken": 61.761
+        },
+        "observation": {
+          "currentPlayer": 0,
+          "isTerminal": false,
+          "observationString": "8/8/8/3b4/4k3/1pK5/1B6/8 b - - 13 60",
+          "playerId": 1,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n1258\n3572\n1841\n1842\n1431\n3132\n3572\n656\n89\n1215\n2425\n3010\n1808\n1768\n749\n30\n1065\n2571\n1942\n3196\n3131\n1384\n4177\n3854\n381\n615\n498\n1869\n2001\n2977\n2975\n4350\n1431\n1770\n2581\n1257\n4673\n4673\n656\n2627\n1895\n2940\n1386\n1358\n3634\n2528\n254\n4496\n3110\n3705\n2948\n2161\n1771\n2833\n2059\n3853\n2002\n3326\n3166\n1358\n1406\n3561\n1694\n3050\n1637\n2497\n1212\n2425\n1882\n3593\n32\n2016\n1770\n3666\n2498\n4178\n2571\n2498\n1986\n2571\n1914\n2686\n1999\n4323\n3548\n3739\n819\n3196\n911\n3812\n3037\n4437\n4218\n3344\n3694\n4361\n674\n2685\n1357\n2174\n704\n1649\n819\n978\n892\n2322\n4350\n3325\n3327\n423\n3707\n891\n3196\n861\n2644\n715\n2716\n1225\n\n"
+        },
+        "reward": null,
+        "status": "INACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "actionString": "Ke3",
+          "generate_returns": [
+            "{\n  \"main_response\": \"Final Answer: Ke3\",\n  \"main_response_and_thoughts\": \"\",\n  \"request_for_logging\": {\n    \"model\": \"openai/gpt-5.5-2026-04-23\",\n    \"messages\": [\n      {\n        \"role\": \"user\",\n        \"content\": [\n          {\n            \"type\": \"text\",\n            \"text\": \"Let's play chess. The current game state in Forsyth-Edwards Notation (FEN) notation is:\\n8/8/8/3b4/4k3/1pK5/1B6/8 b - - 13 60\\nThe moves played so far are:\\n1. e4 c5 2. Nf3 d6 3. d4 cxd4 4. Nxd4 Nf6 5. Nc3 a6 6. Bg5 e6 7. f4 Qb6 8. Qd2 Qxb2 9. Rb1 Qa3 10. e5 dxe5 11. fxe5 Nfd7 12. Ne4 h6 13. Bh4 Qxa2 14. Rd1 Qd5 15. Qe3 Qxe5 16. Be2 Bc5 17. Bg3 Bxd4 18. Rxd4 Qa5+ 19. c3 O-O 20. O-O Nc6 21. Nf6+ Nxf6 22. Rxf6 Nxd4 23. cxd4 gxf6 24. Qxh6 Qg5 25. Qxg5+ fxg5 26. Bd6 Rd8 27. Be7 Rxd4 28. Bxg5 Rd5 29. Bf6 Rf5 30. Bc3 Rc5 31. Bd4 Rc1+ 32. Kf2 Rc2 33. Ke3 Rxe2+ 34. Kxe2 Bd7 35. Ke3 Bc6 36. g3 Rd8 37. Bf6 Rd5 38. g4 e5 39. h4 e4 40. Kxe4 Rd6+ 41. Ke5 Rd5+ 42. Kf4 Rb5 43. h5 Kh7 44. g5 Rb4+ 45. Ke5 Rh4 46. g6+ fxg6 47. hxg6+ Kxg6 48. Bxh4 Kh5 49. Bd8 b5 50. Kd6 Bb7 51. Kc7 Bf3 52. Kb6 b4 53. Kxa6 b3 54. Bf6 Kg6 55. Bb2 Bd5 56. Kb5 Kf5 57. Kb4 Ke4 58. Kc3 Ke3 59. Bc1+ Ke4 60. Bb2\\nYou are playing as player Black.\\nIt is now your turn. Play your strongest move. The move MUST be legal. Reason step by step to come up with your move, then output your final answer in the format \\\"Final Answer: X\\\" where X is your chosen move in standard algebraic notation (SAN).\\n\"\n          }\n        ]\n      }\n    ],\n    \"config\": {\n      \"temperature\": \"NOT_GIVEN\",\n      \"top_p\": \"NOT_GIVEN\",\n      \"max_completion_tokens\": \"NOT_GIVEN\",\n      \"reasoning_effort\": \"high\"\n    },\n    \"stream_options\": {\n      \"include_usage\": true\n    }\n  },\n  \"response_for_logging\": {\n    \"response_chunks\": [\n      {\n        \"id\": \"chatcmpl-DcQX8RhtHfxzAThKTsuJtnM3ohrAN\",\n        \"created\": 1778050830,\n        \"model\": \"openai/gpt-5.5-2026-04-23\",\n        \"object\": \"chat.completion.chunk\",\n        \"usage\": {\n          \"completion_tokens\": 13476,\n          \"prompt_tokens\": 620,\n          \"total_tokens\": 14096,\n          \"cost\": {\n            \"input_tokens_cost_nanodollars\": 3100000,\n            \"output_tokens_cost_nanodollars\": 404280000\n          },\n          \"total_backend_latency_ms\": 291445\n        }\n      }\n    ]\n  },\n  \"generation_tokens\": 13476,\n  \"prompt_tokens\": 620,\n  \"reasoning_tokens\": null,\n  \"total_tokens\": 14096,\n  \"duration_success_only_secs\": 291.9233391529997\n}"
+          ],
+          "status": "OK",
+          "submission": 2644,
+          "thoughts": "Final Answer: Ke3"
+        },
+        "info": {
+          "actionApplied": 2644,
+          "actionSubmitted": 2644,
+          "actionSubmittedToString": "Ke3",
+          "agentSelfReportedStatus": "OK",
+          "timeTaken": 293.176
+        },
+        "observation": {
+          "currentPlayer": 1,
+          "isTerminal": false,
+          "observationString": "8/8/8/3b4/8/1pK1k3/1B6/8 w - - 14 61",
+          "playerId": 0,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n1258\n3572\n1841\n1842\n1431\n3132\n3572\n656\n89\n1215\n2425\n3010\n1808\n1768\n749\n30\n1065\n2571\n1942\n3196\n3131\n1384\n4177\n3854\n381\n615\n498\n1869\n2001\n2977\n2975\n4350\n1431\n1770\n2581\n1257\n4673\n4673\n656\n2627\n1895\n2940\n1386\n1358\n3634\n2528\n254\n4496\n3110\n3705\n2948\n2161\n1771\n2833\n2059\n3853\n2002\n3326\n3166\n1358\n1406\n3561\n1694\n3050\n1637\n2497\n1212\n2425\n1882\n3593\n32\n2016\n1770\n3666\n2498\n4178\n2571\n2498\n1986\n2571\n1914\n2686\n1999\n4323\n3548\n3739\n819\n3196\n911\n3812\n3037\n4437\n4218\n3344\n3694\n4361\n674\n2685\n1357\n2174\n704\n1649\n819\n978\n892\n2322\n4350\n3325\n3327\n423\n3707\n891\n3196\n861\n2644\n715\n2716\n1225\n2644\n\n",
+          "step": 121
+        },
+        "reward": null,
+        "status": "INACTIVE"
+      },
+      {
+        "action": {
+          "submission": -1
+        },
+        "info": {},
+        "observation": {
+          "currentPlayer": 1,
+          "isTerminal": false,
+          "observationString": "8/8/8/3b4/8/1pK1k3/1B6/8 w - - 14 61",
+          "playerId": 1,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n1258\n3572\n1841\n1842\n1431\n3132\n3572\n656\n89\n1215\n2425\n3010\n1808\n1768\n749\n30\n1065\n2571\n1942\n3196\n3131\n1384\n4177\n3854\n381\n615\n498\n1869\n2001\n2977\n2975\n4350\n1431\n1770\n2581\n1257\n4673\n4673\n656\n2627\n1895\n2940\n1386\n1358\n3634\n2528\n254\n4496\n3110\n3705\n2948\n2161\n1771\n2833\n2059\n3853\n2002\n3326\n3166\n1358\n1406\n3561\n1694\n3050\n1637\n2497\n1212\n2425\n1882\n3593\n32\n2016\n1770\n3666\n2498\n4178\n2571\n2498\n1986\n2571\n1914\n2686\n1999\n4323\n3548\n3739\n819\n3196\n911\n3812\n3037\n4437\n4218\n3344\n3694\n4361\n674\n2685\n1357\n2174\n704\n1649\n819\n978\n892\n2322\n4350\n3325\n3327\n423\n3707\n891\n3196\n861\n2644\n715\n2716\n1225\n2644\n\n"
+        },
+        "reward": null,
+        "status": "ACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "submission": -1
+        },
+        "info": {},
+        "observation": {
+          "currentPlayer": 0,
+          "isTerminal": false,
+          "observationString": "8/8/8/3b4/8/1pK1k3/8/2B5 b - - 15 61",
+          "playerId": 0,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n1258\n3572\n1841\n1842\n1431\n3132\n3572\n656\n89\n1215\n2425\n3010\n1808\n1768\n749\n30\n1065\n2571\n1942\n3196\n3131\n1384\n4177\n3854\n381\n615\n498\n1869\n2001\n2977\n2975\n4350\n1431\n1770\n2581\n1257\n4673\n4673\n656\n2627\n1895\n2940\n1386\n1358\n3634\n2528\n254\n4496\n3110\n3705\n2948\n2161\n1771\n2833\n2059\n3853\n2002\n3326\n3166\n1358\n1406\n3561\n1694\n3050\n1637\n2497\n1212\n2425\n1882\n3593\n32\n2016\n1770\n3666\n2498\n4178\n2571\n2498\n1986\n2571\n1914\n2686\n1999\n4323\n3548\n3739\n819\n3196\n911\n3812\n3037\n4437\n4218\n3344\n3694\n4361\n674\n2685\n1357\n2174\n704\n1649\n819\n978\n892\n2322\n4350\n3325\n3327\n423\n3707\n891\n3196\n861\n2644\n715\n2716\n1225\n2644\n715\n\n",
+          "step": 122
+        },
+        "reward": null,
+        "status": "ACTIVE"
+      },
+      {
+        "action": {
+          "actionString": "Bc1+",
+          "generate_returns": [
+            "{\n  \"main_response\": \"To determine the best move, let's analyze the current position and the game's situation. \\n\\n**Evaluation:**\\nYou are in an endgame holding a draw against Black's King, Bishop, and Pawn. Black's only remaining pawn is on b3, hoping to promote on b1. However, the promotion square (b1) is a light square, and Black's bishop on d5 is also a light-squared bishop. Your White Bishop on b2 (a dark square) is currently blockading the pawn and your King on c3 is ideally placed to prevent the Black King from infiltrating to support it. Since Black has only one pawn and it is firmly blockaded on a dark square, this position is a dead draw as long as you maintain the blockade.\\n\\n**Finding the move:**\\nBlack just played 60... Ke3, attempting to bring their King closer to aid the pawn. \\nBy playing **61. Bc1+**, you force the Black King away:\\n- The bishop moves safely to c1, directly along the c1-h6 diagonal. \\n- It checks the Black King on e3.\\n- The White King perfectly guards the d-file (d2, d3, and d4), which means the Black King cannot step forward or maintain its active position and is forced to retreat backwards (e.g., ...Ke4).\\n\\nThis move is incredibly safe, maintains the absolute blockade, stops Black's King from making any forward progress, and also effectively repeats the position that occurred just two moves prior (after 59. Bc1+), ensuring the drawn outcome. \\n\\nFinal Answer: Bc1+\",\n  \"main_response_and_thoughts\": \"\",\n  \"request_for_logging\": {\n    \"model\": \"google/gemini-3.1-pro-preview\",\n    \"messages\": [\n      {\n        \"role\": \"user\",\n        \"content\": [\n          {\n            \"type\": \"text\",\n            \"text\": \"Let's play chess. The current game state in Forsyth-Edwards Notation (FEN) notation is:\\n8/8/8/3b4/8/1pK1k3/1B6/8 w - - 14 61\\nThe moves played so far are:\\n1. e4 c5 2. Nf3 d6 3. d4 cxd4 4. Nxd4 Nf6 5. Nc3 a6 6. Bg5 e6 7. f4 Qb6 8. Qd2 Qxb2 9. Rb1 Qa3 10. e5 dxe5 11. fxe5 Nfd7 12. Ne4 h6 13. Bh4 Qxa2 14. Rd1 Qd5 15. Qe3 Qxe5 16. Be2 Bc5 17. Bg3 Bxd4 18. Rxd4 Qa5+ 19. c3 O-O 20. O-O Nc6 21. Nf6+ Nxf6 22. Rxf6 Nxd4 23. cxd4 gxf6 24. Qxh6 Qg5 25. Qxg5+ fxg5 26. Bd6 Rd8 27. Be7 Rxd4 28. Bxg5 Rd5 29. Bf6 Rf5 30. Bc3 Rc5 31. Bd4 Rc1+ 32. Kf2 Rc2 33. Ke3 Rxe2+ 34. Kxe2 Bd7 35. Ke3 Bc6 36. g3 Rd8 37. Bf6 Rd5 38. g4 e5 39. h4 e4 40. Kxe4 Rd6+ 41. Ke5 Rd5+ 42. Kf4 Rb5 43. h5 Kh7 44. g5 Rb4+ 45. Ke5 Rh4 46. g6+ fxg6 47. hxg6+ Kxg6 48. Bxh4 Kh5 49. Bd8 b5 50. Kd6 Bb7 51. Kc7 Bf3 52. Kb6 b4 53. Kxa6 b3 54. Bf6 Kg6 55. Bb2 Bd5 56. Kb5 Kf5 57. Kb4 Ke4 58. Kc3 Ke3 59. Bc1+ Ke4 60. Bb2 Ke3 61.\\nYou are playing as player White.\\nIt is now your turn. Play your strongest move. The move MUST be legal. Reason step by step to come up with your move, then output your final answer in the format \\\"Final Answer: X\\\" where X is your chosen move in standard algebraic notation (SAN).\\n\"\n          }\n        ]\n      }\n    ],\n    \"config\": {\n      \"temperature\": \"NOT_GIVEN\",\n      \"top_p\": \"NOT_GIVEN\",\n      \"max_completion_tokens\": \"NOT_GIVEN\"\n    },\n    \"stream_options\": {\n      \"include_usage\": true\n    }\n  },\n  \"response_for_logging\": {\n    \"response_chunks\": [\n      {\n        \"id\": \"M-j6abD_MauEm9IP2rm86QE\",\n        \"choices\": [\n          {\n            \"delta\": {\n              \"content\": \"+\",\n              \"role\": \"assistant\"\n            },\n            \"finish_reason\": \"stop\",\n            \"index\": 0\n          }\n        ],\n        \"created\": 1778051123,\n        \"model\": \"google/gemini-3.1-pro-preview\",\n        \"object\": \"chat.completion.chunk\",\n        \"usage\": {\n          \"completion_tokens\": 348,\n          \"prompt_tokens\": 616,\n          \"total_tokens\": 7747,\n          \"cost\": {\n            \"input_tokens_cost_nanodollars\": 1232000,\n            \"output_tokens_cost_nanodollars\": 85572000\n          },\n          \"total_backend_latency_ms\": 63491\n        }\n      }\n    ]\n  },\n  \"generation_tokens\": 348,\n  \"prompt_tokens\": 616,\n  \"reasoning_tokens\": null,\n  \"total_tokens\": 7747,\n  \"duration_success_only_secs\": 64.55710127599741\n}"
+          ],
+          "status": "OK",
+          "submission": 715,
+          "thoughts": "To determine the best move, let's analyze the current position and the game's situation. \n\n**Evaluation:**\nYou are in an endgame holding a draw against Black's King, Bishop, and Pawn. Black's only remaining pawn is on b3, hoping to promote on b1. However, the promotion square (b1) is a light square, and Black's bishop on d5 is also a light-squared bishop. Your White Bishop on b2 (a dark square) is currently blockading the pawn and your King on c3 is ideally placed to prevent the Black King from infiltrating to support it. Since Black has only one pawn and it is firmly blockaded on a dark square, this position is a dead draw as long as you maintain the blockade.\n\n**Finding the move:**\nBlack just played 60... Ke3, attempting to bring their King closer to aid the pawn. \nBy playing **61. Bc1+**, you force the Black King away:\n- The bishop moves safely to c1, directly along the c1-h6 diagonal. \n- It checks the Black King on e3.\n- The White King perfectly guards the d-file (d2, d3, and d4), which means the Black King cannot step forward or maintain its active position and is forced to retreat backwards (e.g., ...Ke4).\n\nThis move is incredibly safe, maintains the absolute blockade, stops Black's King from making any forward progress, and also effectively repeats the position that occurred just two moves prior (after 59. Bc1+), ensuring the drawn outcome. \n\nFinal Answer: Bc1+"
+        },
+        "info": {
+          "actionApplied": 715,
+          "actionSubmitted": 715,
+          "actionSubmittedToString": "Bc1+",
+          "agentSelfReportedStatus": "OK",
+          "timeTaken": 65.796
+        },
+        "observation": {
+          "currentPlayer": 0,
+          "isTerminal": false,
+          "observationString": "8/8/8/3b4/8/1pK1k3/8/2B5 b - - 15 61",
+          "playerId": 1,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n1258\n3572\n1841\n1842\n1431\n3132\n3572\n656\n89\n1215\n2425\n3010\n1808\n1768\n749\n30\n1065\n2571\n1942\n3196\n3131\n1384\n4177\n3854\n381\n615\n498\n1869\n2001\n2977\n2975\n4350\n1431\n1770\n2581\n1257\n4673\n4673\n656\n2627\n1895\n2940\n1386\n1358\n3634\n2528\n254\n4496\n3110\n3705\n2948\n2161\n1771\n2833\n2059\n3853\n2002\n3326\n3166\n1358\n1406\n3561\n1694\n3050\n1637\n2497\n1212\n2425\n1882\n3593\n32\n2016\n1770\n3666\n2498\n4178\n2571\n2498\n1986\n2571\n1914\n2686\n1999\n4323\n3548\n3739\n819\n3196\n911\n3812\n3037\n4437\n4218\n3344\n3694\n4361\n674\n2685\n1357\n2174\n704\n1649\n819\n978\n892\n2322\n4350\n3325\n3327\n423\n3707\n891\n3196\n861\n2644\n715\n2716\n1225\n2644\n715\n\n"
+        },
+        "reward": null,
+        "status": "INACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "actionString": "Ke4",
+          "generate_returns": [
+            "{\n  \"main_response\": \"The check is along the c1\\u2013d2\\u2013e3 diagonal, so Black must move the king. The most active escape is to centralize and keep control of key squares.\\n\\nFinal Answer: Ke4\",\n  \"main_response_and_thoughts\": \"\",\n  \"request_for_logging\": {\n    \"model\": \"openai/gpt-5.5-2026-04-23\",\n    \"messages\": [\n      {\n        \"role\": \"user\",\n        \"content\": [\n          {\n            \"type\": \"text\",\n            \"text\": \"Let's play chess. The current game state in Forsyth-Edwards Notation (FEN) notation is:\\n8/8/8/3b4/8/1pK1k3/8/2B5 b - - 15 61\\nThe moves played so far are:\\n1. e4 c5 2. Nf3 d6 3. d4 cxd4 4. Nxd4 Nf6 5. Nc3 a6 6. Bg5 e6 7. f4 Qb6 8. Qd2 Qxb2 9. Rb1 Qa3 10. e5 dxe5 11. fxe5 Nfd7 12. Ne4 h6 13. Bh4 Qxa2 14. Rd1 Qd5 15. Qe3 Qxe5 16. Be2 Bc5 17. Bg3 Bxd4 18. Rxd4 Qa5+ 19. c3 O-O 20. O-O Nc6 21. Nf6+ Nxf6 22. Rxf6 Nxd4 23. cxd4 gxf6 24. Qxh6 Qg5 25. Qxg5+ fxg5 26. Bd6 Rd8 27. Be7 Rxd4 28. Bxg5 Rd5 29. Bf6 Rf5 30. Bc3 Rc5 31. Bd4 Rc1+ 32. Kf2 Rc2 33. Ke3 Rxe2+ 34. Kxe2 Bd7 35. Ke3 Bc6 36. g3 Rd8 37. Bf6 Rd5 38. g4 e5 39. h4 e4 40. Kxe4 Rd6+ 41. Ke5 Rd5+ 42. Kf4 Rb5 43. h5 Kh7 44. g5 Rb4+ 45. Ke5 Rh4 46. g6+ fxg6 47. hxg6+ Kxg6 48. Bxh4 Kh5 49. Bd8 b5 50. Kd6 Bb7 51. Kc7 Bf3 52. Kb6 b4 53. Kxa6 b3 54. Bf6 Kg6 55. Bb2 Bd5 56. Kb5 Kf5 57. Kb4 Ke4 58. Kc3 Ke3 59. Bc1+ Ke4 60. Bb2 Ke3 61. Bc1+\\nYou are playing as player Black.\\nIt is now your turn. Play your strongest move. The move MUST be legal. Reason step by step to come up with your move, then output your final answer in the format \\\"Final Answer: X\\\" where X is your chosen move in standard algebraic notation (SAN).\\n\"\n          }\n        ]\n      }\n    ],\n    \"config\": {\n      \"temperature\": \"NOT_GIVEN\",\n      \"top_p\": \"NOT_GIVEN\",\n      \"max_completion_tokens\": \"NOT_GIVEN\",\n      \"reasoning_effort\": \"high\"\n    },\n    \"stream_options\": {\n      \"include_usage\": true\n    }\n  },\n  \"response_for_logging\": {\n    \"response_chunks\": [\n      {\n        \"id\": \"chatcmpl-DcQcveLQcpQiMM6RqLZW9DseMgRYh\",\n        \"created\": 1778051189,\n        \"model\": \"openai/gpt-5.5-2026-04-23\",\n        \"object\": \"chat.completion.chunk\",\n        \"usage\": {\n          \"completion_tokens\": 20247,\n          \"prompt_tokens\": 628,\n          \"total_tokens\": 20875,\n          \"cost\": {\n            \"input_tokens_cost_nanodollars\": 3140000,\n            \"output_tokens_cost_nanodollars\": 607410000\n          },\n          \"total_backend_latency_ms\": 423220\n        }\n      }\n    ]\n  },\n  \"generation_tokens\": 20247,\n  \"prompt_tokens\": 628,\n  \"reasoning_tokens\": null,\n  \"total_tokens\": 20875,\n  \"duration_success_only_secs\": 424.25919100899773\n}"
+          ],
+          "status": "OK",
+          "submission": 2716,
+          "thoughts": "The check is along the c1\u2013d2\u2013e3 diagonal, so Black must move the king. The most active escape is to centralize and keep control of key squares.\n\nFinal Answer: Ke4"
+        },
+        "info": {
+          "actionApplied": 2716,
+          "actionSubmitted": 2716,
+          "actionSubmittedToString": "Ke4",
+          "agentSelfReportedStatus": "OK",
+          "timeTaken": 425.995
+        },
+        "observation": {
+          "currentPlayer": 1,
+          "isTerminal": false,
+          "observationString": "8/8/8/3b4/4k3/1pK5/8/2B5 w - - 16 62",
+          "playerId": 0,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n1258\n3572\n1841\n1842\n1431\n3132\n3572\n656\n89\n1215\n2425\n3010\n1808\n1768\n749\n30\n1065\n2571\n1942\n3196\n3131\n1384\n4177\n3854\n381\n615\n498\n1869\n2001\n2977\n2975\n4350\n1431\n1770\n2581\n1257\n4673\n4673\n656\n2627\n1895\n2940\n1386\n1358\n3634\n2528\n254\n4496\n3110\n3705\n2948\n2161\n1771\n2833\n2059\n3853\n2002\n3326\n3166\n1358\n1406\n3561\n1694\n3050\n1637\n2497\n1212\n2425\n1882\n3593\n32\n2016\n1770\n3666\n2498\n4178\n2571\n2498\n1986\n2571\n1914\n2686\n1999\n4323\n3548\n3739\n819\n3196\n911\n3812\n3037\n4437\n4218\n3344\n3694\n4361\n674\n2685\n1357\n2174\n704\n1649\n819\n978\n892\n2322\n4350\n3325\n3327\n423\n3707\n891\n3196\n861\n2644\n715\n2716\n1225\n2644\n715\n2716\n\n",
+          "step": 123
+        },
+        "reward": null,
+        "status": "INACTIVE"
+      },
+      {
+        "action": {
+          "submission": -1
+        },
+        "info": {},
+        "observation": {
+          "currentPlayer": 1,
+          "isTerminal": false,
+          "observationString": "8/8/8/3b4/4k3/1pK5/8/2B5 w - - 16 62",
+          "playerId": 1,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n1258\n3572\n1841\n1842\n1431\n3132\n3572\n656\n89\n1215\n2425\n3010\n1808\n1768\n749\n30\n1065\n2571\n1942\n3196\n3131\n1384\n4177\n3854\n381\n615\n498\n1869\n2001\n2977\n2975\n4350\n1431\n1770\n2581\n1257\n4673\n4673\n656\n2627\n1895\n2940\n1386\n1358\n3634\n2528\n254\n4496\n3110\n3705\n2948\n2161\n1771\n2833\n2059\n3853\n2002\n3326\n3166\n1358\n1406\n3561\n1694\n3050\n1637\n2497\n1212\n2425\n1882\n3593\n32\n2016\n1770\n3666\n2498\n4178\n2571\n2498\n1986\n2571\n1914\n2686\n1999\n4323\n3548\n3739\n819\n3196\n911\n3812\n3037\n4437\n4218\n3344\n3694\n4361\n674\n2685\n1357\n2174\n704\n1649\n819\n978\n892\n2322\n4350\n3325\n3327\n423\n3707\n891\n3196\n861\n2644\n715\n2716\n1225\n2644\n715\n2716\n\n"
+        },
+        "reward": null,
+        "status": "ACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "submission": -1
+        },
+        "info": {},
+        "observation": {
+          "currentPlayer": -4,
+          "isTerminal": true,
+          "observationString": "8/8/8/3b4/4k3/1pK5/1B6/8 b - - 17 62",
+          "playerId": 0,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n1258\n3572\n1841\n1842\n1431\n3132\n3572\n656\n89\n1215\n2425\n3010\n1808\n1768\n749\n30\n1065\n2571\n1942\n3196\n3131\n1384\n4177\n3854\n381\n615\n498\n1869\n2001\n2977\n2975\n4350\n1431\n1770\n2581\n1257\n4673\n4673\n656\n2627\n1895\n2940\n1386\n1358\n3634\n2528\n254\n4496\n3110\n3705\n2948\n2161\n1771\n2833\n2059\n3853\n2002\n3326\n3166\n1358\n1406\n3561\n1694\n3050\n1637\n2497\n1212\n2425\n1882\n3593\n32\n2016\n1770\n3666\n2498\n4178\n2571\n2498\n1986\n2571\n1914\n2686\n1999\n4323\n3548\n3739\n819\n3196\n911\n3812\n3037\n4437\n4218\n3344\n3694\n4361\n674\n2685\n1357\n2174\n704\n1649\n819\n978\n892\n2322\n4350\n3325\n3327\n423\n3707\n891\n3196\n861\n2644\n715\n2716\n1225\n2644\n715\n2716\n1225\n\n",
+          "step": 124
+        },
+        "reward": 0.0,
+        "status": "DONE"
+      },
+      {
+        "action": {
+          "actionString": "Bb2",
+          "generate_returns": [
+            "{\n  \"main_response\": \"The position is a completely drawn opposite-colored bishops endgame where Black is up a single pawn. White has constructed an unbreakable blockade by placing the King on c3 and the Bishop on b2, or simply shuffling the Bishop to check the Black King and keep it at bay. \\n\\nThe pawn on b3 is on a light square and is securely blocked by the b2 square (a dark square), which is perfectly safe from Black's light-squared bishop. By playing Bb2, White places the Bishop right in front of the passed b-pawn and solidly guards it with the King on c3. The game will inevitably end in a draw as Black can make no progress.\\n\\nFinal Answer: Bb2\",\n  \"main_response_and_thoughts\": \"\",\n  \"request_for_logging\": {\n    \"model\": \"google/gemini-3.1-pro-preview\",\n    \"messages\": [\n      {\n        \"role\": \"user\",\n        \"content\": [\n          {\n            \"type\": \"text\",\n            \"text\": \"Let's play chess. The current game state in Forsyth-Edwards Notation (FEN) notation is:\\n8/8/8/3b4/4k3/1pK5/8/2B5 w - - 16 62\\nThe moves played so far are:\\n1. e4 c5 2. Nf3 d6 3. d4 cxd4 4. Nxd4 Nf6 5. Nc3 a6 6. Bg5 e6 7. f4 Qb6 8. Qd2 Qxb2 9. Rb1 Qa3 10. e5 dxe5 11. fxe5 Nfd7 12. Ne4 h6 13. Bh4 Qxa2 14. Rd1 Qd5 15. Qe3 Qxe5 16. Be2 Bc5 17. Bg3 Bxd4 18. Rxd4 Qa5+ 19. c3 O-O 20. O-O Nc6 21. Nf6+ Nxf6 22. Rxf6 Nxd4 23. cxd4 gxf6 24. Qxh6 Qg5 25. Qxg5+ fxg5 26. Bd6 Rd8 27. Be7 Rxd4 28. Bxg5 Rd5 29. Bf6 Rf5 30. Bc3 Rc5 31. Bd4 Rc1+ 32. Kf2 Rc2 33. Ke3 Rxe2+ 34. Kxe2 Bd7 35. Ke3 Bc6 36. g3 Rd8 37. Bf6 Rd5 38. g4 e5 39. h4 e4 40. Kxe4 Rd6+ 41. Ke5 Rd5+ 42. Kf4 Rb5 43. h5 Kh7 44. g5 Rb4+ 45. Ke5 Rh4 46. g6+ fxg6 47. hxg6+ Kxg6 48. Bxh4 Kh5 49. Bd8 b5 50. Kd6 Bb7 51. Kc7 Bf3 52. Kb6 b4 53. Kxa6 b3 54. Bf6 Kg6 55. Bb2 Bd5 56. Kb5 Kf5 57. Kb4 Ke4 58. Kc3 Ke3 59. Bc1+ Ke4 60. Bb2 Ke3 61. Bc1+ Ke4 62.\\nYou are playing as player White.\\nIt is now your turn. Play your strongest move. The move MUST be legal. Reason step by step to come up with your move, then output your final answer in the format \\\"Final Answer: X\\\" where X is your chosen move in standard algebraic notation (SAN).\\n\"\n          }\n        ]\n      }\n    ],\n    \"config\": {\n      \"temperature\": \"NOT_GIVEN\",\n      \"top_p\": \"NOT_GIVEN\",\n      \"max_completion_tokens\": \"NOT_GIVEN\"\n    },\n    \"stream_options\": {\n      \"include_usage\": true\n    }\n  },\n  \"response_for_logging\": {\n    \"response_chunks\": [\n      {\n        \"id\": \"H-r6abWOAtCfmecP0erHwQ0\",\n        \"choices\": [\n          {\n            \"delta\": {\n              \"content\": \" Bb2\",\n              \"role\": \"assistant\"\n            },\n            \"finish_reason\": \"stop\",\n            \"index\": 0\n          }\n        ],\n        \"created\": 1778051615,\n        \"model\": \"google/gemini-3.1-pro-preview\",\n        \"object\": \"chat.completion.chunk\",\n        \"usage\": {\n          \"completion_tokens\": 145,\n          \"prompt_tokens\": 625,\n          \"total_tokens\": 2552,\n          \"cost\": {\n            \"input_tokens_cost_nanodollars\": 1250000,\n            \"output_tokens_cost_nanodollars\": 23124000\n          },\n          \"total_backend_latency_ms\": 21031\n        }\n      }\n    ]\n  },\n  \"generation_tokens\": 145,\n  \"prompt_tokens\": 625,\n  \"reasoning_tokens\": null,\n  \"total_tokens\": 2552,\n  \"duration_success_only_secs\": 21.516227973996138\n}"
+          ],
+          "status": "OK",
+          "submission": 1225,
+          "thoughts": "The position is a completely drawn opposite-colored bishops endgame where Black is up a single pawn. White has constructed an unbreakable blockade by placing the King on c3 and the Bishop on b2, or simply shuffling the Bishop to check the Black King and keep it at bay. \n\nThe pawn on b3 is on a light square and is securely blocked by the b2 square (a dark square), which is perfectly safe from Black's light-squared bishop. By playing Bb2, White places the Bishop right in front of the passed b-pawn and solidly guards it with the King on c3. The game will inevitably end in a draw as Black can make no progress.\n\nFinal Answer: Bb2"
+        },
+        "info": {
+          "actionApplied": 1225,
+          "actionSubmitted": 1225,
+          "actionSubmittedToString": "Bb2",
+          "agentSelfReportedStatus": "OK",
+          "timeTaken": 22.796
+        },
+        "observation": {
+          "currentPlayer": -4,
+          "isTerminal": true,
+          "observationString": "8/8/8/3b4/4k3/1pK5/1B6/8 b - - 17 62",
+          "playerId": 1,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n1258\n3572\n1841\n1842\n1431\n3132\n3572\n656\n89\n1215\n2425\n3010\n1808\n1768\n749\n30\n1065\n2571\n1942\n3196\n3131\n1384\n4177\n3854\n381\n615\n498\n1869\n2001\n2977\n2975\n4350\n1431\n1770\n2581\n1257\n4673\n4673\n656\n2627\n1895\n2940\n1386\n1358\n3634\n2528\n254\n4496\n3110\n3705\n2948\n2161\n1771\n2833\n2059\n3853\n2002\n3326\n3166\n1358\n1406\n3561\n1694\n3050\n1637\n2497\n1212\n2425\n1882\n3593\n32\n2016\n1770\n3666\n2498\n4178\n2571\n2498\n1986\n2571\n1914\n2686\n1999\n4323\n3548\n3739\n819\n3196\n911\n3812\n3037\n4437\n4218\n3344\n3694\n4361\n674\n2685\n1357\n2174\n704\n1649\n819\n978\n892\n2322\n4350\n3325\n3327\n423\n3707\n891\n3196\n861\n2644\n715\n2716\n1225\n2644\n715\n2716\n1225\n\n"
+        },
+        "reward": 0.0,
+        "status": "DONE"
+      }
+    ]
+  ],
+  "title": "Open Spiel: chess",
+  "version": "0.1.0"
+}

--- a/kaggle_environments/envs/open_spiel_env/games/chess/visualizer/v2/src/components/GameOver.tsx
+++ b/kaggle_environments/envs/open_spiel_env/games/chess/visualizer/v2/src/components/GameOver.tsx
@@ -38,12 +38,13 @@ export default function GameOver() {
   const step = options.replay.steps.at(options.step);
   // TODO(pim-at-stink): https://github.com/Stinkstudios/kaggle-ai-visualiser/issues/15
   if (!step) return null;
-  if (!step.winner) return null;
+  if (!step.isTerminal) return null;
 
   const winnerColor = step.winner;
   const blackName = game.getHeaders()['b'] ?? 'Black';
   const whiteName = game.getHeaders()['w'] ?? 'White';
   const winnerName = winnerColor === 'black' ? blackName : whiteName;
+  const loserName = winnerColor === 'black' ? whiteName : blackName;
 
   const board = game.board().flat();
   const captures = {
@@ -83,6 +84,15 @@ export default function GameOver() {
   const allDurations = [...durations.black, ...durations.white];
   const gameDuration = allDurations.reduce((a, b) => a + b, 0);
 
+  const winnerText = step.winner ? `Winner is ${winnerName}!` : `It's a draw!`;
+
+  const forfeits = new Map<string, string>([
+    ['TIMEOUT', `${loserName} ran out of time.`],
+    ['ERROR', `${loserName} submitted an illegal move.`],
+    ['INVALID', `${loserName} failed to produce valid input.`],
+  ]);
+  const forfeitText = forfeits.get(step.status || '') || null;
+
   const rows: StatRow[] = [
     {
       label: 'Pieces Captured',
@@ -101,39 +111,67 @@ export default function GameOver() {
     },
   ];
 
-  trackEvent('game-over');
+  switch (step.status) {
+    case 'TIMEOUT':
+      trackEvent('game-over-timeout');
+      break;
+    case 'ERROR':
+      trackEvent('game-over-error');
+      break;
+    case 'INVALID':
+      trackEvent('game-over-invalid');
+      break;
+    default:
+      if (!step.winner) {
+        trackEvent('game-over-draw');
+      } else {
+        trackEvent('game-over');
+      }
+  }
 
   return (
     <dialog ref={dialogRef} className={styles.modal} aria-label="Game over" tabIndex={-1}>
       <div className="ribbon">
         <Ribbon>
-          <h2 className={styles.heading}>Winner is {winnerName}!</h2>
+          <h2 className={styles.heading}>{winnerText}</h2>
         </Ribbon>
       </div>
-      {step.forfeitReason && <p className={styles.forfeit}>{step.forfeitReason}</p>}
-      <div className={styles.meta}>
-        Game Duration: {formatDuration(gameDuration)}
-        <br />
-        Total Moves: {totalMoves}
-      </div>
-      <table className={styles.table}>
-        <thead>
-          <tr>
-            <th />
-            <th>{blackName}</th>
-            <th>{whiteName}</th>
-          </tr>
-        </thead>
-        <tbody>
-          {rows.map((row) => (
-            <tr key={row.label}>
-              <td>{row.label}</td>
-              <td>{row.black}</td>
-              <td>{row.white}</td>
-            </tr>
-          ))}
-        </tbody>
-      </table>
+
+      {forfeitText && (
+        <p className={styles.forfeit}>
+          {forfeitText}
+          <br />
+          <b>Game Over.</b>
+        </p>
+      )}
+
+      {!forfeitText && (
+        <>
+          <div className={styles.meta}>
+            Game Duration: {formatDuration(gameDuration)}
+            <br />
+            Total Moves: {totalMoves}
+          </div>
+          <table className={styles.table}>
+            <thead>
+              <tr>
+                <th />
+                <th>{blackName}</th>
+                <th>{whiteName}</th>
+              </tr>
+            </thead>
+            <tbody>
+              {rows.map((row) => (
+                <tr key={row.label}>
+                  <td>{row.label}</td>
+                  <td>{row.black}</td>
+                  <td>{row.white}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </>
+      )}
     </dialog>
   );
 }

--- a/kaggle_environments/envs/open_spiel_env/games/chess/visualizer/v2/src/transformers/chessReplayTypes.ts
+++ b/kaggle_environments/envs/open_spiel_env/games/chess/visualizer/v2/src/transformers/chessReplayTypes.ts
@@ -26,8 +26,7 @@ export interface ChessStep extends Omit<BaseGameStep, 'players'> {
   fenState: FenState;
   isTerminal: boolean;
   winner: string | null;
-  /** Set when the loser failed to produce a valid action (e.g. ran out of overage time, errored, or submitted an illegal move). */
-  forfeitReason?: string | null;
+  status: string | null;
 }
 
 /**

--- a/kaggle_environments/envs/open_spiel_env/games/chess/visualizer/v2/src/transformers/chessTransformer.ts
+++ b/kaggle_environments/envs/open_spiel_env/games/chess/visualizer/v2/src/transformers/chessTransformer.ts
@@ -47,58 +47,15 @@ function parseFen(fen?: string): FenState {
   };
 }
 
-export function getChessStepLabel(step: ChessStep) {
-  if (step.isTerminal) {
-    return '';
-  }
-
-  return step.players.find((player) => player.isTurn)?.actionDisplayText ?? '';
-}
-
-export function getChessStepDescription(step: ChessStep) {
-  if (step.isTerminal) {
-    return step.winner ?? '';
-  }
-
-  return step.players.find((player) => player.isTurn)?.thoughts ?? '';
-}
-
 function deriveWinner(step: ChessReplayStep[]): string | null {
-  const isForfeit = step.some((p) => FORFEIT_STATUSES.has(p.status));
-  if (!isForfeit && step[0].observation.isTerminal === false) return null;
-  if (step[0].reward === step[1].reward) return null;
-  // Player 0 = Black, player 1 = White (matches GameRenderer.setHeader convention).
-  return step[0].reward === 1 ? 'black' : 'white';
+  if (step[0].reward === 1) return 'black';
+  if (step[1].reward === 1) return 'white';
+  return null;
 }
 
-/**
- * Statuses set by open_spiel_env when an agent fails to produce a valid action:
- *   TIMEOUT — exceeded the per-move / overage time budget
- *   ERROR   — agent crashed or response was unparsable / cut off
- *   INVALID — submitted an illegal move
- * In all three cases the opponent wins by default.
- */
-const FORFEIT_STATUSES = new Set(['TIMEOUT', 'ERROR', 'INVALID']);
-
-function describeForfeit(status: string): string {
-  switch (status) {
-    case 'TIMEOUT':
-      return 'ran out of time';
-    case 'INVALID':
-      return 'submitted an illegal move';
-    case 'ERROR':
-    default:
-      return 'failed to produce valid input';
-  }
-}
-
-function deriveForfeitReason(step: ChessReplayStep[], agents: string[]): string | null {
-  const loserIndex = step.findIndex((p) => FORFEIT_STATUSES.has(p.status));
-  if (loserIndex === -1 || step.length < 2) return null;
-  const winnerIndex = 1 - loserIndex;
-  const loserName = agents[loserIndex] || `Player ${loserIndex + 1}`;
-  const winnerName = agents[winnerIndex] || `Player ${winnerIndex + 1}`;
-  return `${loserName} ${describeForfeit(step[loserIndex].status)}. ${winnerName} wins by default.`;
+function deriveStatus(step: ChessReplayStep[]): string | null {
+  const forfeit = step.find((p) => ['TIMEOUT', 'ERROR', 'INVALID'].includes(p.status));
+  return forfeit?.status || null;
 }
 
 export const chessTransformer = (environment: any): ChessStep[] => {
@@ -124,6 +81,7 @@ export const chessTransformer = (environment: any): ChessStep[] => {
     fenState: parseFen(''),
     isTerminal: false,
     winner: null,
+    status: null,
   });
 
   for (const step of chessReplay.steps) {
@@ -150,6 +108,7 @@ export const chessTransformer = (environment: any): ChessStep[] => {
         fenState: parseFen(step[0].observation.observationString),
         isTerminal: false,
         winner: '',
+        status: null,
       });
     }
   }
@@ -162,7 +121,7 @@ export const chessTransformer = (environment: any): ChessStep[] => {
     fenState: chessSteps[chessSteps.length - 1].fenState,
     step: chessSteps.length,
     winner: deriveWinner(lastReplayStep),
-    forfeitReason: deriveForfeitReason(lastReplayStep, environment.info.TeamNames),
+    status: deriveStatus(lastReplayStep),
   });
 
   return chessSteps;

--- a/kaggle_environments/envs/open_spiel_env/games/chess/visualizer/v2/src/utils/getStepLabel.ts
+++ b/kaggle_environments/envs/open_spiel_env/games/chess/visualizer/v2/src/utils/getStepLabel.ts
@@ -23,5 +23,9 @@ export function getStepLabel(step: BaseGameStep) {
     return `${winner === 'black' ? blackName : whiteName} wins`;
   }
 
+  if ((step as ChessStep).isTerminal) {
+    return 'Draw';
+  }
+
   return '';
 }


### PR DESCRIPTION
The change updates how the game over state displays the game statistics, adding a separate layout for games that were forfeit due to an agent `ERROR`, `TIMEOUT` or `INVALID` move.

Moves message copy from `chessTransformer` into the `GameOver` component.

<img width="1309" height="936" alt="Screenshot 2026-05-13 at 12 12 36" src="https://github.com/user-attachments/assets/4cc4589a-78c2-4056-aa56-7a848cd7c793" />

<img width="1309" height="936" alt="Screenshot 2026-05-13 at 12 12 19" src="https://github.com/user-attachments/assets/14df8b7f-b1e2-444a-9a87-b12fb387baf5" />

<img width="1309" height="936" alt="Screenshot 2026-05-13 at 12 11 55" src="https://github.com/user-attachments/assets/de7d36af-1b05-494b-ae20-1032ac54eaa7" />

Also updates the tracking event for `GameOver` to include reference to these new states (`game-over`, `game-over-draw`, `game-over-timeout`, `game-over-error`, `game-over-invalid`).