### PR TITLE
feat: playwright tests

### DIFF
--- a/kaggle_environments/envs/open_spiel_env/games/go/visualizer/default/e2e/go.test.ts
+++ b/kaggle_environments/envs/open_spiel_env/games/go/visualizer/default/e2e/go.test.ts
@@ -1,0 +1,42 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Go Visualizer', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+  });
+
+  test('Load game', async ({ page }) => {
+    await page.getByLabel('Pause').click();
+
+    const slider = page.locator('input[type="range"]');
+    const maxValue = await slider.getAttribute('max');
+    expect(Number(maxValue)).toBeGreaterThan(5);
+
+    const versusBanner = page.getByTestId('ribbon');
+    await versusBanner.waitFor({ state: 'attached' });
+    await expect(versusBanner).toContainText(' vs. ');
+  });
+
+  test('Mid game', async ({ page }) => {
+    const slider = page.locator('input[type="range"]');
+    const maxValue = await slider.getAttribute('max');
+    const midStep = Math.round(Number(maxValue) / 4) * 2; // always white
+    await slider.fill(String(midStep));
+    await page.waitForTimeout(300);
+
+    const currentPlayer = page.locator('[class*="_active_"]');
+    const currentIcon = currentPlayer.getByAltText('White');
+    await expect(currentIcon).toBeVisible();
+  });
+
+  test('Game over', async ({ page }) => {
+    const slider = page.locator('input[type="range"]');
+    const maxValue = await slider.getAttribute('max');
+    const maxStep = Number(maxValue);
+    await slider.fill(String(maxStep));
+
+    const gameOver = page.getByLabel('Game Over');
+    await gameOver.waitFor({ state: 'attached' });
+    await expect(gameOver).toContainText(/Winner is|It's a draw/);
+  });
+});

--- a/kaggle_environments/envs/open_spiel_env/games/go/visualizer/default/package.json
+++ b/kaggle_environments/envs/open_spiel_env/games/go/visualizer/default/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
+    "dev-with-replay": "cross-env VITE_REPLAY_FILE=./replays/test-replay.json vite",
     "build": "tsc -b && vite build && node ./scripts/build.js",
     "preview": "vite preview",
     "tsc": "tsc -b",
@@ -12,6 +13,8 @@
     "lint:fix": "eslint --fix .",
     "format": "prettier --check .",
     "format:fix": "prettier --write .",
+    "test": "npx playwright test",
+    "test:ui": "npx playwright test --ui",
     "download-replays": "node ./scripts/download.js",
     "ladder": "node ./scripts/ladder.js",
     "monkey": "node ./scripts/monkey.js"
@@ -24,7 +27,8 @@
     "eslint-plugin-react-refresh": "^0.5.0",
     "globals": "^17.3.0",
     "typescript": "^5.0.0",
-    "vite": "^5.0.0"
+    "vite": "^5.0.0",
+    "cross-env": "^10.1.0"
   },
   "dependencies": {
     "@kaggle-environments/core": "workspace:*",

--- a/kaggle_environments/envs/open_spiel_env/games/go/visualizer/default/playwright.config.ts
+++ b/kaggle_environments/envs/open_spiel_env/games/go/visualizer/default/playwright.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+  reporter: 'list',
+  outputDir: '/tmp/test-results',
+  use: {
+    baseURL: 'http://localhost:5173',
+    ...devices['Desktop Chrome'],
+  },
+  webServer: {
+    command: 'pnpm dev',
+    url: 'http://localhost:5173',
+  },
+});

--- a/kaggle_environments/envs/open_spiel_env/games/go/visualizer/default/src/components/Ribbon.tsx
+++ b/kaggle_environments/envs/open_spiel_env/games/go/visualizer/default/src/components/Ribbon.tsx
@@ -21,7 +21,7 @@ export function FlagEnd() {
 
 export function Ribbon({ children }: Props) {
   return (
-    <div className={`grid-pile ${styles.ribbon}`}>
+    <div className={`grid-pile ${styles.ribbon}`} data-testid="ribbon">
       <FlagEnd />
       <FlagEnd />
       <div className={styles.text}>{children}</div>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -522,6 +522,9 @@ importers:
       '@vitejs/plugin-react':
         specifier: ^5.1.2
         version: 5.2.0(vite@5.4.21(@types/node@25.2.1))
+      cross-env:
+        specifier: ^10.1.0
+        version: 10.1.0
       eslint-plugin-react-refresh:
         specifier: ^0.5.0
         version: 0.5.2(eslint@9.39.2)


### PR DESCRIPTION
Adds `playwright.config.ts` set up to run tests with `pnpm test` and `pnpm test:ui`.

Tests in `go.test.ts` validate page elements on load, mid game and game over.

<img width="1392" height="912" alt="Screenshot 2026-05-15 at 14 17 40" src="https://github.com/user-attachments/assets/ecc647ec-df25-4034-824e-5b4a7a26f130" />

<img width="682" height="530" alt="Screenshot 2026-05-15 at 14 16 08" src="https://github.com/user-attachments/assets/1b9321cd-a677-4ec6-912f-770187e975cb" />

Also adds `pnpm dev-with-replay` back again, as it's used by the `playwright.config.ts` to run all tests across the monorepo for CI.
