### PR TITLE
fix: playwright e2e test server

### DIFF
--- a/kaggle_environments/envs/open_spiel_env/games/chess/visualizer/v2/e2e/chess.test.ts
+++ b/kaggle_environments/envs/open_spiel_env/games/chess/visualizer/v2/e2e/chess.test.ts
@@ -1,6 +1,6 @@
 import { test, expect } from '@playwright/test';
 
-test.describe('Chess Visualizer (v2)', () => {
+test.describe('Chess Visualizer', () => {
   test.beforeEach(async ({ page }) => {
     await page.goto('/');
   });

--- a/kaggle_environments/envs/open_spiel_env/games/chess/visualizer/v2/package.json
+++ b/kaggle_environments/envs/open_spiel_env/games/chess/visualizer/v2/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
+    "dev-with-replay": "cross-env VITE_REPLAY_FILE=./replays/test-replay.json vite",
     "build": "tsc -b && vite build && node ./scripts/build.js",
     "preview": "vite preview",
     "tsc": "tsc -b",
@@ -25,7 +26,8 @@
     "eslint-plugin-react-refresh": "^0.5.0",
     "globals": "^17.3.0",
     "typescript": "^5.0.0",
-    "vite": "^5.0.0"
+    "vite": "^5.0.0",
+    "cross-env": "^10.1.0"
   },
   "dependencies": {
     "@kaggle-environments/core": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -375,6 +375,9 @@ importers:
       '@vitejs/plugin-react':
         specifier: ^5.1.2
         version: 5.2.0(vite@5.4.21(@types/node@25.2.1))
+      cross-env:
+        specifier: ^10.1.0
+        version: 10.1.0
       eslint-plugin-react-refresh:
         specifier: ^0.5.0
         version: 0.5.2(eslint@9.39.2)


### PR DESCRIPTION
Aligns the Playwright e2e tests for Chess with latest changes in the Go.

Specifically, this one adds `pnpm test-with-replay` back in, as the root `playwright.config.ts` that is used for CI starts test servers for all the visualizers like ours with that command.