### PR TITLE
Fix negative market inventory in Kaggriculture price overflow

### DIFF
--- a/kaggle_environments/envs/kaggriculture/kaggriculture.py
+++ b/kaggle_environments/envs/kaggriculture/kaggriculture.py
@@ -140,7 +140,7 @@ def market_price(item, inventory):
     """Floor at 1."""
     p = MARKET_PARAMS[item]
     if inventory < p["I0"]:
-        price = -p["a_ln"] * inventory + p["b_ln"]
+        price = -p["a_ln"] * max(0, inventory) + p["b_ln"]
     else:
         price = p["a_lg"] * math.log(max(inventory, 1)) + p["b_lg"]
     price = round(price)
@@ -519,7 +519,10 @@ def _process_market(state, env):
                 if op == "SELL" and item in PRODUCTS and item != "FERTILIZER":
                     quoted[player_id] = ("SELL", item, market_price(item, market["inventory"][item]), ostate)
                 elif op == "BUY_PRODUCT" and item in PRODUCTS:
-                    quoted[player_id] = ("BUY_PRODUCT", item, market_price(item, market["inventory"][item]), ostate)
+                    if market["inventory"][item] <= 0:
+                        order_states[player_id] = None  # nothing left to buy
+                    else:
+                        quoted[player_id] = ("BUY_PRODUCT", item, market_price(item, market["inventory"][item]), ostate)
                 elif op == "BUY_SEED" and item in CROPS:
                     quoted[player_id] = ("BUY_SEED", item, CROPS[item]["seed"], ostate)
                 elif op == "BUY_ANIMAL" and item in ANIMALS:
@@ -582,6 +585,8 @@ def _commit_unit(op, item, price, farm, private, market):
         return True
     if op == "BUY_PRODUCT":
         if farm["money"] < price:
+            return False
+        if market["inventory"][item] <= 0:
             return False
         farm["money"] -= price
         private["shed"][item] = private["shed"].get(item, 0) + 1
@@ -650,12 +655,12 @@ def _town_consume(env, state, step):
             products = SHOPS[shop_name]
             multiplier = 2 if len(products) == 1 else 1
             for item in products:
-                market["inventory"][item] -= multiplier
+                market["inventory"][item] = max(0, market["inventory"][item] - multiplier)
 
     if step % center_interval == 0:
         center_mult = next(m for threshold, m in TOWN_CENTER_DEMAND_SCHEDULE if day >= threshold)
         for item in TOWN_CENTER_PRODUCTS:
-            market["inventory"][item] -= center_mult
+            market["inventory"][item] = max(0, market["inventory"][item] - center_mult)
 
     _refresh_prices(market)
 

--- a/tests/envs/kaggriculture/test_kaggriculture.py
+++ b/tests/envs/kaggriculture/test_kaggriculture.py
@@ -751,3 +751,75 @@ def test_default_starting_money_is_2000():
     env.run(["pass", "pass"])
     j = env.toJSON()
     assert j["rewards"] == [2000.0, 2000.0]
+
+
+# --- Market inventory floor & price cap ------------------------------------
+
+def test_market_inventory_never_negative_under_heavy_town_demand():
+    """Run an episode with aggressive town consumption (every turn, every
+    interval) and confirm market inventory never dips below zero and prices
+    never exceed each item's b_ln cap."""
+    env = make(
+        "kaggriculture",
+        configuration={
+            "episodeSteps": 200,
+            "seed": 13,
+            "townShopSellInterval": 1,
+            "townCenterSellInterval": 1,
+        },
+    )
+    env.run(["pass", "pass"])
+    j = env.toJSON()
+    for step in j["steps"]:
+        market = step[0]["observation"]["market"]
+        assert min(market["inventory"].values()) >= 0, market["inventory"]
+        for item, price in market["prices"].items():
+            assert price <= MARKET_PARAMS[item]["b_ln"], (item, price)
+
+
+def test_buy_product_refused_when_market_empty():
+    farm = _new_farm(10, 1000)
+    private = _new_private()
+    market = _new_market()
+    market["inventory"]["WHEAT"] = 0
+    price = market_price("WHEAT", 0)
+    ok = _commit_unit("BUY_PRODUCT", "WHEAT", price, farm, private, market)
+    assert ok is False
+    assert farm["money"] == 1000
+    assert market["inventory"]["WHEAT"] == 0
+    assert private["shed"].get("WHEAT", 0) == 0
+
+
+def test_town_consumption_clamps_inventory_at_zero():
+    """If shop demand exceeds inventory in a single tick, inventory floors at
+    zero rather than going negative."""
+    env = make(
+        "kaggriculture",
+        configuration={
+            "episodeSteps": 2,
+            "seed": 1,
+            "townShopSellInterval": 1,
+        },
+    )
+    env.reset(num_agents=2)
+    market = env.state[0].observation.market
+    town = env.state[0].observation.town
+    # Force a shop unlock and zero out a product it consumes.
+    target_shop = next(iter(SHOPS))
+    town["unlocked_shops"] = [target_shop]
+    target_item = SHOPS[target_shop][0]
+    market["inventory"][target_item] = 1
+    env.step([
+        {"farmer": ["PASS"], "hands": [], "market": []},
+        {"farmer": ["PASS"], "hands": [], "market": []},
+    ])
+    assert env.state[0].observation.market["inventory"][target_item] >= 0
+
+
+def test_market_price_at_negative_inventory_does_not_exceed_cap():
+    """Defense in depth: even if inventory is somehow negative, price should
+    still floor at b_ln (the cap at inventory=0)."""
+    for item, p in MARKET_PARAMS.items():
+        cap = market_price(item, 0)
+        assert market_price(item, -10) == cap, item
+        assert cap <= p["b_ln"], item


### PR DESCRIPTION
Town shop/center demand and player BUY_PRODUCT could drive market
inventory negative, which dropped market_price into the linear branch
where prices climbed past the intended b_ln cap (most visible on
STRAWBERRY and MELON). Floor inventory at zero in all three deduction
sites, refuse BUY_PRODUCT when stock is empty (and don't quote a price
for it), and add a defensive clamp inside market_price.

Note: @bovard mentioned negative inventory is currently a designed
feature and is being reworked. Holding for guidance on whether to land
this as a short-term cap or defer to the larger rework.

cc @domino @bovard

---

Task: [mooneyp-20260515201333-0cd3f89a](https://agents.dev.kaggle.net/tasks/mooneyp-20260515201333-0cd3f89a)
Context: https://chat.kaggle.net/kaggle/pl/3pm5dsowgbr6i8tazc7n3t1j5a

