### PR TITLE
Rebalance kaggriculture to be more fair to animals

### DIFF
--- a/kaggle_environments/envs/kaggriculture/README.md
+++ b/kaggle_environments/envs/kaggriculture/README.md
@@ -15,9 +15,9 @@ Each player starts with an empty farm and a small amount of income (seed money, 
 | **Tomato** | Ongoing | 50 | 60 | 8 days | NA | every day | 4 | 1 | 4 |
 | **Strawberry** | Ongoing | 100 | 120 | 10 days | NA | every other day | 4 | 1 | 2 |
 | **Melon** | One-time | 80 | 250 | 10 days | 12 days | none | 6 | 1 | .5 |
-| **Goose/Egg** | Ongoing | 400 | 50 | 5 days | NA | every day | 2 | 1 \+ 1 (build coop) | 2 |
-| **Cow/Milk** | Ongoing | 800 | 160 | 10 days | NA | every two days | 4 | 1 \+ 1 (build pasture) | 1 |
-| **Sheep/Wool** | Ongoing | 700 | 200 | 8 days | NA | every three days | 4 | 1 \+ 1 (build pasture) | .67 |
+| **Goose/Egg** | Ongoing | 200 | 80 | 3 days | NA | every day | 4 | 1 \+ 1 (build coop) | 2 |
+| **Cow/Milk** | Ongoing | 500 | 240 | 6 days | NA | every two days | 6 | 1 \+ 1 (build pasture) | 1 |
+| **Sheep/Wool** | Ongoing | 400 | 300 | 5 days | NA | every three days | 6 | 1 \+ 1 (build pasture) | .67 |
 | **Fertilizer** | NA | 100 | X |  | X | X |  | 1 |  |
 
 All plants must be watered every day. They will turn into weeds if they are not watered for two successive days. All animals must be fed every day using wheat. They will escape and be unrecoverable if they are not fed for two successive days. Wheat is also available to buy at the market and can be purchased at the current market price.
@@ -65,7 +65,7 @@ Picks up an item from the shed (must be orthogonally adjacent) into the inventor
 
 CARE banks a yield bonus that is paid out on the animal's next scheduled production:
 
-* At end of day, if the animal was both fed AND cared for that day, `pending_care_bonus` increments by 1. Days where the animal was unfed do not bank a bonus (basic needs first).
+* At end of day, if the animal was both fed AND cared for that day, `pending_care_bonus` increments by 2. Days where the animal was unfed do not bank a bonus (basic needs first).
 * On a scheduled production day, if the animal is fed, the entire banked bonus is added to that production's yield (in addition to the base 1) and the bank resets to 0.
 * If the animal is unfed on the production day, no yield is produced that day and the bank is also reset.
 * `pending_care_bonus` is capped indirectly by the per-animal `max_held` cap on `yield_units`.
@@ -209,9 +209,9 @@ The price function is of the form
 | **Tomato** | 60 | 120 | 1.0000 | 180.0000 | \-25.6234 | 182.6717 | 180.0000 | 60.0000 | 60.0000 | 1.0000 |
 | **Strawberry** | 120 | 100 | 2.4000 | 360.0000 | \-51.6810 | 358.0000 | 360.0000 | 120.0000 | 120.0000 | 1.0000 |
 | **Melon** | 250 | 60 | 8.3333 | 750.0000 | \-108.1393 | 692.7597 | 750.0000 | 250.0000 | 250.0000 | 1.0000 |
-| **Egg** | 50 | 120 | 0.8333 | 150.0000 | \-21.2804 | 151.8799 | 150.0000 | 50.0000 | 50.0000 | 1.0000 |
-| **Milk** | 160 | 80 | 4.0000 | 480.0000 | \-69.0528 | 462.5913 | 480.0000 | 160.0000 | 160.0000 | 1.0000 |
-| **Wool** | 200 | 60 | 6.6667 | 600.0000 | \-86.4246 | 553.8521 | 600.0000 | 200.0000 | 200.0000 | 1.0000 |
+| **Egg** | 80 | 120 | 1.3333 | 240.0000 | \-34.0486 | 243.0078 | 240.0000 | 80.0000 | 80.0000 | 1.0000 |
+| **Milk** | 240 | 80 | 6.0000 | 720.0000 | \-103.5792 | 693.8870 | 720.0000 | 240.0000 | 240.0000 | 1.0000 |
+| **Wool** | 300 | 60 | 10.0000 | 900.0000 | \-129.6369 | 830.7782 | 900.0000 | 300.0000 | 300.0000 | 1.0000 |
 | **Fertilizer** | 100 | 80 | 2.5000 | 300.0000 | \-42.9952 | 288.4059 | 300.0000 | 100.0000 | 100.0000 | 1.0000 |
 
 ## Turn Processing Order

--- a/kaggle_environments/envs/kaggriculture/kaggriculture.py
+++ b/kaggle_environments/envs/kaggriculture/kaggriculture.py
@@ -15,9 +15,9 @@ CROPS = {
 }
 
 ANIMALS = {
-    "GOOSE": {"cost": 400, "structure": "COOP",    "first_yield_day": 5,  "interval": 1, "max_held": 2, "product": "EGG"},
-    "COW":   {"cost": 800, "structure": "PASTURE", "first_yield_day": 10, "interval": 2, "max_held": 4, "product": "MILK"},
-    "SHEEP": {"cost": 700, "structure": "PASTURE", "first_yield_day": 8,  "interval": 3, "max_held": 4, "product": "WOOL"},
+    "GOOSE": {"cost": 200, "structure": "COOP",    "first_yield_day": 3, "interval": 1, "max_held": 4, "product": "EGG"},
+    "COW":   {"cost": 500, "structure": "PASTURE", "first_yield_day": 6, "interval": 2, "max_held": 6, "product": "MILK"},
+    "SHEEP": {"cost": 400, "structure": "PASTURE", "first_yield_day": 5, "interval": 3, "max_held": 6, "product": "WOOL"},
 }
 
 PRODUCTS = ["WHEAT", "CARROT", "TOMATO", "STRAWBERRY", "MELON", "EGG", "MILK", "WOOL", "FERTILIZER"]
@@ -31,9 +31,9 @@ MARKET_PARAMS = {
     "TOMATO":     {"base": 60,  "I0": 120, "a_ln": 1.0,     "b_ln": 180.0, "a_lg": -25.6234,  "b_lg": 182.6717},
     "STRAWBERRY": {"base": 120, "I0": 100, "a_ln": 2.4,     "b_ln": 360.0, "a_lg": -51.6810,  "b_lg": 358.0},
     "MELON":      {"base": 250, "I0": 60,  "a_ln": 8.3333,  "b_ln": 750.0, "a_lg": -108.1393, "b_lg": 692.7597},
-    "EGG":        {"base": 50,  "I0": 120, "a_ln": 0.8333,  "b_ln": 150.0, "a_lg": -21.2804,  "b_lg": 151.8799},
-    "MILK":       {"base": 160, "I0": 80,  "a_ln": 4.0,     "b_ln": 480.0, "a_lg": -69.0528,  "b_lg": 462.5913},
-    "WOOL":       {"base": 200, "I0": 60,  "a_ln": 6.6667,  "b_ln": 600.0, "a_lg": -86.4246,  "b_lg": 553.8521},
+    "EGG":        {"base": 80,  "I0": 120, "a_ln": 1.3333,  "b_ln": 240.0, "a_lg": -34.0486,  "b_lg": 243.0078},
+    "MILK":       {"base": 240, "I0": 80,  "a_ln": 6.0,     "b_ln": 720.0, "a_lg": -103.5792, "b_lg": 693.8870},
+    "WOOL":       {"base": 300, "I0": 60,  "a_ln": 10.0,    "b_ln": 900.0, "a_lg": -129.6369, "b_lg": 830.7782},
     "FERTILIZER": {"base": 100, "I0": 80,  "a_ln": 2.5,     "b_ln": 300.0, "a_lg": -42.9952,  "b_lg": 288.4059},
 }
 
@@ -738,7 +738,7 @@ def _daily_refresh_animals(farm, day):
                 tile["yield_units"] = min(a["max_held"], tile["yield_units"] + base + bonus)
                 tile["pending_care_bonus"] = 0
             if tile["cared_today"] and tile["fed_today"]:
-                tile["pending_care_bonus"] = tile.get("pending_care_bonus", 0) + 1
+                tile["pending_care_bonus"] = tile.get("pending_care_bonus", 0) + 2
             tile["fertilizer_available"] = True
             tile["fed_today"] = False
             tile["cared_today"] = False

--- a/kaggle_environments/envs/kaggriculture/kaggriculture.py
+++ b/kaggle_environments/envs/kaggriculture/kaggriculture.py
@@ -15,9 +15,9 @@ CROPS = {
 }
 
 ANIMALS = {
-    "GOOSE": {"cost": 200, "structure": "COOP",    "first_yield_day": 3, "interval": 1, "max_held": 4, "product": "EGG"},
-    "COW":   {"cost": 500, "structure": "PASTURE", "first_yield_day": 6, "interval": 2, "max_held": 6, "product": "MILK"},
-    "SHEEP": {"cost": 400, "structure": "PASTURE", "first_yield_day": 5, "interval": 3, "max_held": 6, "product": "WOOL"},
+    "GOOSE": {"cost": 300, "structure": "COOP",    "first_yield_day": 4, "interval": 1, "max_held": 4, "product": "EGG"},
+    "COW":   {"cost": 600, "structure": "PASTURE", "first_yield_day": 8, "interval": 2, "max_held": 6, "product": "MILK"},
+    "SHEEP": {"cost": 500, "structure": "PASTURE", "first_yield_day": 6, "interval": 3, "max_held": 6, "product": "WOOL"},
 }
 
 PRODUCTS = ["WHEAT", "CARROT", "TOMATO", "STRAWBERRY", "MELON", "EGG", "MILK", "WOOL", "FERTILIZER"]
@@ -782,7 +782,7 @@ def _daily_refresh_animals(farm, day):
                 tile["yield_units"] = min(a["max_held"], tile["yield_units"] + base + bonus)
                 tile["pending_care_bonus"] = 0
             if tile["cared_today"] and tile["fed_today"]:
-                tile["pending_care_bonus"] = tile.get("pending_care_bonus", 0) + 2
+                tile["pending_care_bonus"] = tile.get("pending_care_bonus", 0) + 1
             tile["fertilizer_available"] = True
             tile["fed_today"] = False
             tile["cared_today"] = False

--- a/tests/envs/kaggriculture/test_kaggriculture.py
+++ b/tests/envs/kaggriculture/test_kaggriculture.py
@@ -377,17 +377,17 @@ def test_animal_produces_on_schedule_and_partial_harvest_works():
     private = _new_private()
     fx, fy = farm["farmer"]
     farm["tiles"][fy][fx] = _new_animal("GOOSE", 0)
-    # Goose: first_yield_day=3, interval=1, max_held=4.
+    # Goose: first_yield_day=4, interval=1, max_held=4.
     # Feed every day, then refresh end-of-day.
     for d in range(0, 6):
         farm["tiles"][fy][fx]["fed_today"] = True
         _daily_refresh_animals(farm, d)
     tile = farm["tiles"][fy][fx]
-    # First production at end of day 2 (next_day=3), then capped at max_held=4.
-    assert tile["yield_units"] == 4
+    # First production at end of day 3 (next_day=4); produces on days 3,4,5 → 3 units.
+    assert tile["yield_units"] == 3
     # Partial harvest before cap is fine — harvest now empties to 0.
     _apply_unit_action(farm, private, 0, ["HARVEST"], 10, 6, 24)
-    assert private["inventories"][0]["EGG"] == 4
+    assert private["inventories"][0]["EGG"] == 3
     assert farm["tiles"][fy][fx]["yield_units"] == 0
 
 

--- a/tests/envs/kaggriculture/test_kaggriculture.py
+++ b/tests/envs/kaggriculture/test_kaggriculture.py
@@ -377,17 +377,17 @@ def test_animal_produces_on_schedule_and_partial_harvest_works():
     private = _new_private()
     fx, fy = farm["farmer"]
     farm["tiles"][fy][fx] = _new_animal("GOOSE", 0)
-    # Goose: first_yield_day=5, interval=1, max_held=2.
+    # Goose: first_yield_day=3, interval=1, max_held=4.
     # Feed every day, then refresh end-of-day.
     for d in range(0, 6):
         farm["tiles"][fy][fx]["fed_today"] = True
         _daily_refresh_animals(farm, d)
     tile = farm["tiles"][fy][fx]
-    # First production at end of day 4 (next_day=5), then capped at 2 by day 5.
-    assert tile["yield_units"] == 2
+    # First production at end of day 2 (next_day=3), then capped at max_held=4.
+    assert tile["yield_units"] == 4
     # Partial harvest before cap is fine — harvest now empties to 0.
     _apply_unit_action(farm, private, 0, ["HARVEST"], 10, 6, 24)
-    assert private["inventories"][0]["EGG"] == 2
+    assert private["inventories"][0]["EGG"] == 4
     assert farm["tiles"][fy][fx]["yield_units"] == 0
 
 
@@ -431,8 +431,8 @@ def test_care_bonus_adds_to_next_production():
     farm["tiles"][fy][fx]["fed_today"] = True
     farm["tiles"][fy][fx]["cared_today"] = True
     _daily_refresh_animals(farm, 4)
-    # Care bonus capped at max_held = 2.
-    assert farm["tiles"][fy][fx]["yield_units"] == 2
+    # Care bonus capped at max_held = 4.
+    assert farm["tiles"][fy][fx]["yield_units"] == 4
 
 
 def test_dig_does_not_remove_placed_animal():


### PR DESCRIPTION
Currently, animals are really underpowered. Initial set of changes to make animals a more appealing strategy:
- animal purchase costs reduced (~40-50%)  
- first-yield duration shortened                                                        
- animal-product market base prices raised                                                                                                                  
- max_held raised                                                                                                                                
- pending_care_bonus now gives +2 per fed-and-cared day instead of +1

There's a lot of other little tweaks we could make but I didn't want to go overboard. I know you were also looking at adjusting the supply/demand curves- while this set of changes is directionally right, I think that would have a big impact here as well so we can keep iterating on it!