### PR TITLE
Rewrite kaggriculture market price curves with per-resource shape functions

### DIFF
--- a/kaggle_environments/envs/kaggriculture/README.md
+++ b/kaggle_environments/envs/kaggriculture/README.md
@@ -169,50 +169,49 @@ In addition, the town center consumes one of every product (excluding fertilizer
 
 ## Market Mechanics
 
-The market has an unlimited number of each type of seeds and animals to purchase, and the costs for those products is fixed. However, the price to sell each item varies dynamically and persists across days.
+The market has an unlimited supply of seeds and animals at fixed prices. Sell prices, however, move dynamically per resource and persist across days.
 
-To start with, we start with an initial inventory of each product (including fertilizer) in the market. The price adjusts with the total amount of inventory in the market. As more products are added to the market (as players sell) the total inventory increases, driving down the price. As product is removed (by the town center / buildings / players buying) the price will increase.
+Every product (and fertilizer) starts the game with a market inventory of `I0 = 10,000` units, far above any single game's realistic production volume so that inventory is essentially guaranteed to stay positive. The sell price for a product is `base` at `I0`, rises as inventory falls (players buying or town consumption draining supply), and falls as inventory grows (players selling).
 
 ### Selling inventory to the market
 
-The price function should be log decreasing once we have more inventory than the starting amount, so that inventory prices decrease slowly. Once the price reaches $1 we do not allow any more product to be added to the market (anything sold at $1 will not be added to the total supply) which ensures that the price will remain sensitive to changes.
+Players can queue any number of sell or buy orders (for any quantity) in the market action list. Orders are processed concurrently across players, one unit at a time. For example, when both players issue `SELL CARROT 10` first, we take the current carrot price, give both players that price for their first carrot, then add 2 carrots to the market (1 from each player) — which may shift the price — and repeat until both orders complete.
 
-Players can queue up any number of orders (both sell and buy) (for any amount) to sell products in their storage shed. These orders are processed concurrently in order. For example when both players send the SELL\_PRODUCT CARROT 10 command first, we process both sell orders at the same time.
-
-To process orders concurrently, we take the current carrot price, give both players that price for the first carrot, then update the market supply with 2 carrots (1 from each player) (which may or may not change the price) and repeat the process until both orders are complete.
-
-Then we repeat the process until all orders are completed.
+If the sell price has been driven down to `$1` (the price floor), the unit is still purchased but is *not* added to market inventory, so the floor remains responsive to subsequent buys.
 
 ### Buying inventory from the market
 
-The price function should instead be linearly increasing when we have less inventory than the starting amount. The market “inventory” can go negative and price will continue to increase linearly forever.
-
-There are two types of “buying” inventory. In one, the town buildings (town center and shops) buy from the market (which doesn’t cost any $, but just depletes the items from the inventory, potentially increasing price). The other is a BUY\_PRODUCT order in the market queue sent by the player. It uses the exact reverse of the procedure explained above. For each order, process the buy one item at a time, update the inventory and change the price. If a player at any point does not have enough to buy the next item, stop the buy order.
+Two things drain market inventory: town buildings (town center and shops, which consume products for free) and player `BUY_PRODUCT` orders. Buy orders follow the same one-unit-at-a-time concurrent procedure as sell orders. If a player runs out of money mid-order, the order is stopped.
 
 ### The Price Function
 
-The price function is of the form
+For each resource the curve is defined by a base price, an anchor throughput `T`, and an independent **shape function** + **target move** for each side of the equilibrium:
 
-* `price = -a_ln * inventory + b_ln`  
-  *  for inventory \< original inventory   
-  * Where `a_ln` and `b_ln` are configurable constants (per item)  
-* `price = a_lg * log ( inventory) + b_lg`  
-  * For inventory \> original inventory  
-  * Where `a_lb` and `b_lb` are configurable constants (per item)  
-* Thus both sides of the function need to meet at the original inventory/price level.   
-* Prices are always rounded to the nearest $
+```
+price(inv) = base + sign · amp · f(|inv − I0|)
+  sign = +1  if inv < I0   (scarcity → price up)
+  sign = −1  if inv > I0   (glut    → price down)
+  amp  = target · base / f(T)        (derived; not stored)
+  f    ∈ { linear, sq, sqrt, log, log10 }   (log uses ln(1+x), so f(0)=0)
+```
 
-| Product | BasePrice | I0 | a\_ln | b\_ln | a\_lg | b\_lg | P(inv=0) | P(join lin) | P(join log) | P(KI0) |
+Floored at `$1` and rounded to the nearest dollar.
+
+`T` is the production capacity of a single 5×5 field over a 24-day game at optimal watering with no fertilizer (animal totals are pre-discounted by 30% to account for wheat-feed overhead). `target` says "moving `T` units past `I0` shifts the price by `target × base`." Picking different `f` and `target` on each side lets resources with similar production profiles play very differently strategically — wheat panics on scarcity but absorbs gluts, carrot is the opposite; melon barely reacts to scarcity but crashes hard on overproduction; wool mirrors melon at a smaller scale.
+
+| Resource | Base | I0 | T | Below func | Below target | Above func | Above target | P(I0−T) | P(I0+T) | P(I0+2T) |
 | ----- | ----- | ----- | ----- | ----- | ----- | ----- | ----- | ----- | ----- | ----- |
-| **Wheat** | 25 | 200 | 0.2500 | 75.0000 | \-10.4231 | 80.2247 | 75.0000 | 25.0000 | 25.0000 | 1.0000 |
-| **Carrot** | 35 | 150 | 0.4667 | 105.0000 | \-14.7660 | 108.9871 | 105.0000 | 35.0000 | 35.0000 | 1.0000 |
-| **Tomato** | 60 | 120 | 1.0000 | 180.0000 | \-25.6234 | 182.6717 | 180.0000 | 60.0000 | 60.0000 | 1.0000 |
-| **Strawberry** | 120 | 100 | 2.4000 | 360.0000 | \-51.6810 | 358.0000 | 360.0000 | 120.0000 | 120.0000 | 1.0000 |
-| **Melon** | 250 | 60 | 8.3333 | 750.0000 | \-108.1393 | 692.7597 | 750.0000 | 250.0000 | 250.0000 | 1.0000 |
-| **Egg** | 50 | 120 | 0.8333 | 150.0000 | \-21.2804 | 151.8799 | 150.0000 | 50.0000 | 50.0000 | 1.0000 |
-| **Milk** | 160 | 80 | 4.0000 | 480.0000 | \-69.0528 | 462.5913 | 480.0000 | 160.0000 | 160.0000 | 1.0000 |
-| **Wool** | 200 | 60 | 6.6667 | 600.0000 | \-86.4246 | 553.8521 | 600.0000 | 200.0000 | 200.0000 | 1.0000 |
-| **Fertilizer** | 100 | 80 | 2.5000 | 300.0000 | \-42.9952 | 288.4059 | 300.0000 | 100.0000 | 100.0000 | 1.0000 |
+| **Wheat** | 25 | 10,000 | 400 | sqrt | 0.80 | log | 0.20 | $45 | $20 | $19 |
+| **Carrot** | 35 | 10,000 | 450 | log | 0.20 | sqrt | 0.70 | $42 | $10 | $1 |
+| **Tomato** | 60 | 10,000 | 200 | linear | 0.40 | sqrt | 0.60 | $84 | $24 | $9 |
+| **Strawberry** | 120 | 10,000 | 100 | sqrt | 0.70 | linear | 0.40 | $204 | $72 | $24 |
+| **Melon** | 250 | 10,000 | 300 | log | 0.20 | sq | 0.90 | $300 | $25 | $1 |
+| **Egg** | 50 | 10,000 | 332 | linear | 0.40 | log | 0.20 | $70 | $40 | $39 |
+| **Milk** | 160 | 10,000 | 122 | sqrt | 0.60 | linear | 0.40 | $256 | $96 | $32 |
+| **Wool** | 200 | 10,000 | 105 | log | 0.20 | sq | 0.80 | $240 | $40 | $1 |
+| **Fertilizer** | 100 | 10,000 | 200 | linear | 0.40 | linear | 0.40 | $140 | $60 | $20 |
+
+The defaults live in `MARKET_PARAMS` in `kaggriculture.py`. Per-resource overrides (sparse: any subset of `base`, `I0`, `T`, `below_func`, `below_target`, `above_func`, `above_target`) can be supplied at episode creation via `env.configuration["marketParams"]` without touching code, e.g. `{"WOOL": {"above_target": 0.95}}`.
 
 ## Turn Processing Order
 

--- a/kaggle_environments/envs/kaggriculture/kaggriculture.json
+++ b/kaggle_environments/envs/kaggriculture/kaggriculture.json
@@ -65,6 +65,11 @@
       "description": "Optional input seed for deterministic episode generation. The interpreter clears this from configuration after reading and stores the resolved seed on env.info['seed'] so it stays out of agent observations but is still recorded in the replay.",
       "type": ["integer", "null"],
       "default": null
+    },
+    "marketParams": {
+      "description": "Per-resource market price-curve overrides. Sparse: keyed by product name; each entry may set any subset of {base, I0, T, below_func, below_target, above_func, above_target}. Missing keys (and missing products) inherit from MARKET_PARAMS defaults in kaggriculture.py. Functions: linear, sq, sqrt, log, log10. amp is derived as target * base / f(T).",
+      "type": "object",
+      "default": {}
     }
   },
   "reward": {

--- a/kaggle_environments/envs/kaggriculture/kaggriculture.py
+++ b/kaggle_environments/envs/kaggriculture/kaggriculture.py
@@ -22,20 +22,51 @@ ANIMALS = {
 
 PRODUCTS = ["WHEAT", "CARROT", "TOMATO", "STRAWBERRY", "MELON", "EGG", "MILK", "WOOL", "FERTILIZER"]
 
-# Linear branch applies for inventory < I0 (price = -a_ln*inv + b_ln);
-# log branch applies for inventory >= I0 (price = a_lg * ln(inv) + b_lg).
-# Both branches meet at (I0, base).
+# Pricing model:
+#     price(inv) = base + sign * amp * f(|inv - I0|)
+#     sign = +1 below I0 (scarcity), -1 above I0 (glut)
+#     amp  = target * base / f(T)            (derived; selling T units moves
+#                                             price by `target` * base)
+#     T    = production capacity of one 5x5 field over a 24-day game at
+#            optimal watering, no fertilizer (animal T pre-discounted 30% for
+#            wheat-feed overhead)
+#     f    in {linear, sq, sqrt, log, log10}; log uses ln(1+x) so f(0)=0
+# Floored at PRICE_FLOOR.
+MARKET_I0 = 10000
+PRICE_FLOOR = 1
+
 MARKET_PARAMS = {
-    "WHEAT":      {"base": 25,  "I0": 200, "a_ln": 0.25,    "b_ln": 75.0,  "a_lg": -10.4231,  "b_lg": 80.2247},
-    "CARROT":     {"base": 35,  "I0": 150, "a_ln": 0.4667,  "b_ln": 105.0, "a_lg": -14.7660,  "b_lg": 108.9871},
-    "TOMATO":     {"base": 60,  "I0": 120, "a_ln": 1.0,     "b_ln": 180.0, "a_lg": -25.6234,  "b_lg": 182.6717},
-    "STRAWBERRY": {"base": 120, "I0": 100, "a_ln": 2.4,     "b_ln": 360.0, "a_lg": -51.6810,  "b_lg": 358.0},
-    "MELON":      {"base": 250, "I0": 60,  "a_ln": 8.3333,  "b_ln": 750.0, "a_lg": -108.1393, "b_lg": 692.7597},
-    "EGG":        {"base": 50,  "I0": 120, "a_ln": 0.8333,  "b_ln": 150.0, "a_lg": -21.2804,  "b_lg": 151.8799},
-    "MILK":       {"base": 160, "I0": 80,  "a_ln": 4.0,     "b_ln": 480.0, "a_lg": -69.0528,  "b_lg": 462.5913},
-    "WOOL":       {"base": 200, "I0": 60,  "a_ln": 6.6667,  "b_ln": 600.0, "a_lg": -86.4246,  "b_lg": 553.8521},
-    "FERTILIZER": {"base": 100, "I0": 80,  "a_ln": 2.5,     "b_ln": 300.0, "a_lg": -42.9952,  "b_lg": 288.4059},
+    "WHEAT":      {"base":  25, "I0": MARKET_I0, "T": 400, "below_func": "sqrt",   "below_target": 0.80, "above_func": "log",    "above_target": 0.20},
+    "CARROT":     {"base":  35, "I0": MARKET_I0, "T": 450, "below_func": "log",    "below_target": 0.20, "above_func": "sqrt",   "above_target": 0.70},
+    "TOMATO":     {"base":  60, "I0": MARKET_I0, "T": 200, "below_func": "linear", "below_target": 0.40, "above_func": "sqrt",   "above_target": 0.60},
+    "STRAWBERRY": {"base": 120, "I0": MARKET_I0, "T": 100, "below_func": "sqrt",   "below_target": 0.70, "above_func": "linear", "above_target": 0.40},
+    "MELON":      {"base": 250, "I0": MARKET_I0, "T": 300, "below_func": "log",    "below_target": 0.20, "above_func": "sq",     "above_target": 0.90},
+    "EGG":        {"base":  50, "I0": MARKET_I0, "T": 332, "below_func": "linear", "below_target": 0.40, "above_func": "log",    "above_target": 0.20},
+    "MILK":       {"base": 160, "I0": MARKET_I0, "T": 122, "below_func": "sqrt",   "below_target": 0.60, "above_func": "linear", "above_target": 0.40},
+    "WOOL":       {"base": 200, "I0": MARKET_I0, "T": 105, "below_func": "log",    "below_target": 0.20, "above_func": "sq",     "above_target": 0.80},
+    "FERTILIZER": {"base": 100, "I0": MARKET_I0, "T": 200, "below_func": "linear", "below_target": 0.40, "above_func": "linear", "above_target": 0.40},
 }
+
+
+def _shape(func, x):
+    x = max(0.0, x)
+    if func == "linear": return x
+    if func == "sq":     return x * x
+    if func == "sqrt":   return math.sqrt(x)
+    if func == "log":    return math.log(1.0 + x)
+    if func == "log10":  return math.log10(1.0 + x)
+    return x
+
+
+def _resolve_market_params(overrides):
+    """Merge per-resource overrides onto MARKET_PARAMS defaults (sparse)."""
+    resolved = {item: dict(p) for item, p in MARKET_PARAMS.items()}
+    if not overrides:
+        return resolved
+    for item, patch in overrides.items():
+        if item in resolved and isinstance(patch, dict):
+            resolved[item].update(patch)
+    return resolved
 
 # (dx, dy); y grows downward.
 FARMER_MOVES = {
@@ -126,30 +157,41 @@ def _new_private():
     }
 
 
-def _new_market():
-    inv = {item: MARKET_PARAMS[item]["I0"] for item in PRODUCTS}
-    prices = {item: MARKET_PARAMS[item]["base"] for item in PRODUCTS}
-    return {"inventory": inv, "prices": prices}
+def _new_market(params=None):
+    params = params or MARKET_PARAMS
+    inv = {item: params[item]["I0"] for item in PRODUCTS}
+    prices = {item: params[item]["base"] for item in PRODUCTS}
+    market = {"inventory": inv, "prices": prices}
+    if params is not MARKET_PARAMS:
+        market["params"] = params
+    return market
 
 
 def _new_town():
     return {"unlocked_shops": []}
 
 
-def market_price(item, inventory):
-    """Floor at 1."""
-    p = MARKET_PARAMS[item]
-    if inventory < p["I0"]:
-        price = -p["a_ln"] * inventory + p["b_ln"]
+def market_price(item, inventory, params=None):
+    """Floor at PRICE_FLOOR."""
+    p = (params or MARKET_PARAMS)[item]
+    base = p["base"]
+    I0 = p["I0"]
+    T = p["T"]
+    if inventory < I0:
+        f = p["below_func"]
+        amp = p["below_target"] * base / _shape(f, T)
+        price = base + amp * _shape(f, I0 - inventory)
     else:
-        price = p["a_lg"] * math.log(max(inventory, 1)) + p["b_lg"]
-    price = round(price)
-    return max(1, int(price))
+        f = p["above_func"]
+        amp = p["above_target"] * base / _shape(f, T)
+        price = base - amp * _shape(f, inventory - I0)
+    return max(PRICE_FLOOR, int(round(price)))
 
 
 def _refresh_prices(market):
+    params = market.get("params")
     for item in PRODUCTS:
-        market["prices"][item] = market_price(item, market["inventory"][item])
+        market["prices"][item] = market_price(item, market["inventory"][item], params)
 
 
 def _new_plant(crop, day, turns_per_day):
@@ -205,7 +247,9 @@ def _initialize(state, env):
 
     farms = [_new_farm(board_size, starting_money) for _ in range(num_agents)]
     privates = [_new_private() for _ in range(num_agents)]
-    market = _new_market()
+    market_overrides = get(configuration, "marketParams", None)
+    resolved_params = _resolve_market_params(market_overrides) if market_overrides else None
+    market = _new_market(resolved_params)
     town = _new_town()
 
     obs0.farms = farms
@@ -517,9 +561,9 @@ def _process_market(state, env):
                 op = ostate["type"]
                 item = ostate["item"]
                 if op == "SELL" and item in PRODUCTS and item != "FERTILIZER":
-                    quoted[player_id] = ("SELL", item, market_price(item, market["inventory"][item]), ostate)
+                    quoted[player_id] = ("SELL", item, market_price(item, market["inventory"][item], market.get("params")), ostate)
                 elif op == "BUY_PRODUCT" and item in PRODUCTS:
-                    quoted[player_id] = ("BUY_PRODUCT", item, market_price(item, market["inventory"][item]), ostate)
+                    quoted[player_id] = ("BUY_PRODUCT", item, market_price(item, market["inventory"][item], market.get("params")), ostate)
                 elif op == "BUY_SEED" and item in CROPS:
                     quoted[player_id] = ("BUY_SEED", item, CROPS[item]["seed"], ostate)
                 elif op == "BUY_ANIMAL" and item in ANIMALS:

--- a/tests/envs/kaggriculture/test_kaggriculture.py
+++ b/tests/envs/kaggriculture/test_kaggriculture.py
@@ -465,8 +465,10 @@ def test_market_price_rises_with_low_inventory():
 
 def test_market_price_floored_at_one_dollar():
     # At sufficiently high inventory, price floors at 1.
-    very_high = MARKET_PARAMS["WHEAT"]["I0"] * 1000
-    assert market_price("WHEAT", very_high) == 1
+    # Use CARROT: above-side is sqrt (steep glut), so it actually hits the
+    # floor at a reasonable inventory.
+    very_high = MARKET_PARAMS["CARROT"]["I0"] * 1000
+    assert market_price("CARROT", very_high) == 1
 
 
 def test_sell_credits_at_current_price_and_grows_inventory():
@@ -484,16 +486,18 @@ def test_sell_credits_at_current_price_and_grows_inventory():
 
 
 def test_sell_at_one_dollar_does_not_grow_inventory():
+    # CARROT's above-side is sqrt (steep glut), so a massive inventory floors
+    # the price at $1 quickly. WHEAT uses log above and never floors here.
     farm = _new_farm(10, 0)
     private = _new_private()
-    private["shed"]["WHEAT"] = 1
+    private["shed"]["CARROT"] = 1
     market = _new_market()
-    market["inventory"]["WHEAT"] = MARKET_PARAMS["WHEAT"]["I0"] * 1000
-    price = market_price("WHEAT", market["inventory"]["WHEAT"])
+    market["inventory"]["CARROT"] = MARKET_PARAMS["CARROT"]["I0"] * 1000
+    price = market_price("CARROT", market["inventory"]["CARROT"])
     assert price == 1
-    inv_before = market["inventory"]["WHEAT"]
-    _commit_unit("SELL", "WHEAT", price, farm, private, market)
-    assert market["inventory"]["WHEAT"] == inv_before  # unchanged
+    inv_before = market["inventory"]["CARROT"]
+    _commit_unit("SELL", "CARROT", price, farm, private, market)
+    assert market["inventory"]["CARROT"] == inv_before  # unchanged
 
 
 def test_buy_product_charges_and_depletes_market():


### PR DESCRIPTION
Replace the universal "linear-below / log-above, slope proportional to base price" curve with a per-resource piecewise model whose shape and sensitivity are tuned independently per side.

  price(inv) = base + sign * amp * f(|inv - I0|)
  amp        = target * base / f(T)   (derived, not stored)
  f in {linear, sq, sqrt, log, log10}; log uses ln(1+x) so f(0)=0

T is the per-game throughput of a single 5x5 field (24-day game, optimal watering, no fertilizer; animal T pre-discounted 30% for wheat-feed overhead). Picking different (func, target) on each side lets resources with similar production profiles (wheat vs carrot; wool vs melon) feel different: e.g. carrot's price barely rises on scarcity (log) but crashes hard on glut (sqrt), while wheat is the opposite (sqrt below, log above). Melon's above-side uses sq with target 0.9 so a single tile's worth of overproduction drops the price ~90%, matching the "timing crop" design intent.

Starting market inventory is now 10000 for every product (was 60-200), so inventory can no longer go negative under any realistic play.

Per-resource overrides can be supplied via env.configuration.marketParams (sparse merge over the defaults) without touching code.