### PR TITLE
Crawl: add directional factory spawn actions

### DIFF
--- a/kaggle_environments/envs/crawl/README.md
+++ b/kaggle_environments/envs/crawl/README.md
@@ -27,7 +27,7 @@ Each turn, you return a dictionary mapping robot UIDs to action strings.
 - `NORTH`, `SOUTH`, `EAST`, `WEST` — Move one cell in that direction (blocked by walls). **A unit that successfully moves off the north or south edge of the board (no wall blocking) is destroyed.** East/west are always blocked by perimeter walls.
 
 ### Factory Actions
-- `BUILD_SCOUT`, `BUILD_WORKER`, `BUILD_MINER` — Spawn a new robot in the cell **north** of the factory. Requires no wall between factory and spawn cell. 10-turn cooldown between builds. The new robot is placed *before* the movement phase, so it counts as a stationary occupant during combat — if an enemy on that cell moves away the same turn, the new robot lands safely; otherwise crush combat resolves on the spawn cell.
+- `BUILD_SCOUT`, `BUILD_WORKER`, `BUILD_MINER` — Spawn a new robot in an adjacent cell. **Defaults to spawning north** when no direction is given (legacy form). To choose a direction explicitly, append a suffix: `BUILD_SCOUT_NORTH`, `BUILD_SCOUT_SOUTH`, `BUILD_SCOUT_EAST`, `BUILD_SCOUT_WEST` (same for `WORKER` and `MINER`). Requires no wall between factory and spawn cell, and the spawn cell must be in-bounds. 10-turn cooldown between builds. The new robot is placed *before* the movement phase, so it counts as a stationary occupant during combat — if an enemy on that cell moves away the same turn, the new robot lands safely; otherwise crush combat resolves on the spawn cell.
 - `JUMP_NORTH`, `JUMP_SOUTH`, `JUMP_EAST`, `JUMP_WEST` — Leap 2 cells in a direction, ignoring all walls. The jump always happens and the cooldown is consumed. **If the landing cell is off the board, the factory is destroyed.** 20-turn cooldown.
 
 ### Worker Actions

--- a/kaggle_environments/envs/crawl/crawl.py
+++ b/kaggle_environments/envs/crawl/crawl.py
@@ -29,7 +29,12 @@ TRANSFER_ACTIONS = {
     "TRANSFER_EAST",
     "TRANSFER_WEST",
 }
-FACTORY_BUILD_ACTIONS = {"BUILD_SCOUT", "BUILD_WORKER", "BUILD_MINER"}
+FACTORY_BUILD_UNITS = {"SCOUT": SCOUT, "WORKER": WORKER, "MINER": MINER}
+# Each unit can be built with no suffix (defaults to NORTH for backward
+# compatibility) or with an explicit direction suffix.
+FACTORY_BUILD_ACTIONS = {f"BUILD_{u}" for u in FACTORY_BUILD_UNITS} | {
+    f"BUILD_{u}_{d}" for u in FACTORY_BUILD_UNITS for d in DIR_OFFSETS
+}
 
 
 def is_fixed_wall(col, direction, width):
@@ -681,7 +686,9 @@ def interpreter(state, env):
             if neighbor_in_map:
                 walls[nr_key][nc] &= ~opp_bit
 
-    # 3d: BUILD (Factory spawns robot to the north, combat resolves in Phase 4)
+    # 3d: BUILD (Factory spawns robot in the chosen direction; combat resolves
+    # in Phase 4). `BUILD_<UNIT>` (no suffix) defaults to NORTH for backward
+    # compatibility; `BUILD_<UNIT>_<DIR>` spawns in that direction.
     for uid in list(robots.keys()):
         if uid in destroyed:
             continue
@@ -690,20 +697,18 @@ def interpreter(state, env):
             continue
         r = robots[uid]
 
-        if action == "BUILD_SCOUT":
+        parts = action.split("_")
+        unit_key = parts[1]
+        direction = parts[2] if len(parts) > 2 else "NORTH"
+
+        new_type = FACTORY_BUILD_UNITS[unit_key]
+        if new_type == SCOUT:
             cost = config.scoutCost
-            new_type = SCOUT
-            new_energy = config.scoutCost
-        elif action == "BUILD_WORKER":
+        elif new_type == WORKER:
             cost = config.workerCost
-            new_type = WORKER
-            new_energy = config.workerCost
-        elif action == "BUILD_MINER":
+        else:  # MINER
             cost = config.minerCost
-            new_type = MINER
-            new_energy = config.minerCost
-        else:
-            continue
+        new_energy = cost
 
         if r["energy"] < cost:
             validated_actions[uid] = "IDLE"
@@ -712,14 +717,15 @@ def interpreter(state, env):
             validated_actions[uid] = "IDLE"
             continue
 
-        # Spawn cell is always north of factory
-        sc, sr = r["col"], r["row"] + 1
+        dc, dr = DIR_OFFSETS[direction]
+        sc, sr = r["col"] + dc, r["row"] + dr
 
         # Check wall between factory and spawn cell
-        if not can_move_through(walls, width, r["col"], r["row"], "NORTH"):
+        if not can_move_through(walls, width, r["col"], r["row"], direction):
             validated_actions[uid] = "IDLE"
             continue
-        if sr > north:
+        # Spawn cell must be within the active window and the map width.
+        if sr > north or sr < south or sc < 0 or sc >= width:
             validated_actions[uid] = "IDLE"
             continue
 

--- a/tests/envs/crawl/test_crawl.py
+++ b/tests/envs/crawl/test_crawl.py
@@ -204,6 +204,50 @@ def test_build_miner():
     assert len(miners) >= 1, "Should have built at least one miner"
 
 
+def test_build_directional_spawn():
+    """`BUILD_<UNIT>_<DIR>` spawns the new robot in that direction."""
+    for direction, (dc, dr) in [
+        ("NORTH", (0, 1)),
+        ("SOUTH", (0, -1)),
+        ("EAST", (1, 0)),
+        ("WEST", (-1, 0)),
+    ]:
+        env = make("crawl", configuration={"randomSeed": 42, "episodeSteps": 10}, debug=True)
+        env.reset(2)
+        obs = env.state[0].observation
+        f0 = next(uid for uid, d in obs.globalRobots.items() if d[0] == 0 and d[4] == 0)
+        fc, fr = obs.globalRobots[f0][1], obs.globalRobots[f0][2]
+        # Clear the wall between factory and the target spawn cell (both sides).
+        bits = {"NORTH": (1, 4), "SOUTH": (4, 1), "EAST": (2, 8), "WEST": (8, 2)}
+        my_bit, opp_bit = bits[direction]
+        sc, sr = fc + dc, fr + dr
+        obs.globalWalls[str(fr)][fc] &= ~my_bit
+        if str(sr) in obs.globalWalls and 0 <= sc < env.configuration.width:
+            obs.globalWalls[str(sr)][sc] &= ~opp_bit
+
+        env.step([{f0: f"BUILD_SCOUT_{direction}"}, {}])
+        obs = env.state[0].observation
+        spawned = [uid for uid, d in obs.globalRobots.items()
+                   if d[0] == 1 and d[4] == 0 and d[1] == sc and d[2] == sr]
+        assert len(spawned) == 1, f"BUILD_SCOUT_{direction} should spawn at ({sc},{sr})"
+
+
+def test_build_default_spawns_north():
+    """Legacy `BUILD_<UNIT>` (no direction) still defaults to NORTH."""
+    env = make("crawl", configuration={"randomSeed": 42, "episodeSteps": 10}, debug=True)
+    env.reset(2)
+    obs = env.state[0].observation
+    f0 = next(uid for uid, d in obs.globalRobots.items() if d[0] == 0 and d[4] == 0)
+    fc, fr = obs.globalRobots[f0][1], obs.globalRobots[f0][2]
+    obs.globalWalls[str(fr)][fc] &= ~1
+    obs.globalWalls[str(fr + 1)][fc] &= ~4
+    env.step([{f0: "BUILD_SCOUT"}, {}])
+    obs = env.state[0].observation
+    scouts = [uid for uid, d in obs.globalRobots.items()
+              if d[0] == 1 and d[4] == 0 and d[1] == fc and d[2] == fr + 1]
+    assert len(scouts) == 1, "Legacy BUILD_SCOUT should spawn one cell north of factory"
+
+
 def test_miner_transforms_into_mine():
     """A miner on a mining node TRANSFORMs into a mine; node is consumed, miner is destroyed."""
     env = make("crawl", configuration={"randomSeed": 42, "episodeSteps": 10}, debug=True)


### PR DESCRIPTION
Adds BUILD_<UNIT>_<DIR> variants for SCOUT/WORKER/MINER so factories can spawn into any adjacent cell. Legacy BUILD_<UNIT> remains and defaults to NORTH.