### PR TITLE
Kaggriculture: draw 24-hour price sparkline on each market coin

### DIFF
--- a/kaggle_environments/envs/kaggriculture/visualizer/default/src/renderFarm.ts
+++ b/kaggle_environments/envs/kaggriculture/visualizer/default/src/renderFarm.ts
@@ -33,7 +33,12 @@ function marketList(): string {
     <div class="market-item" data-item="${key}">
       <img class="market-item-icon" src="${spriteSrc(sprite)}" alt="${sprite}" />
       <div class="market-price-row">
-        <img class="market-coin" src="${spriteSrc('coin')}" alt="coins" />
+        <span class="market-coin-stack">
+          <img class="market-coin" src="${spriteSrc('coin')}" alt="coins" />
+          <svg class="market-sparkline" viewBox="0 0 100 20" preserveAspectRatio="none" aria-hidden="true">
+            <path class="market-sparkline-path" d="" fill="none" />
+          </svg>
+        </span>
         <span class="market-price">--</span>
       </div>
     </div>
@@ -206,12 +211,13 @@ function collectPlayerRefs(panel: HTMLElement, board: BoardSize): PlayerRefs {
 }
 
 export function collectRefs(root: HTMLElement, board: BoardSize): LayoutRefs {
-  const marketItems: Record<string, { item: HTMLElement; price: HTMLElement }> = {};
+  const marketItems: LayoutRefs['marketItems'] = {};
   for (const { key } of MARKET_ITEMS) {
     const item = root.querySelector<HTMLElement>(`.market-item[data-item="${key}"]`)!;
     marketItems[key] = {
       item,
       price: item.querySelector<HTMLElement>('.market-price')!,
+      sparkPath: item.querySelector<SVGPathElement>('.market-sparkline-path')!,
     };
   }
   const overlay = root.querySelector<HTMLElement>('.simple-dialog')!;
@@ -479,13 +485,49 @@ function renderPlayer(
   renderShed(refs, priv);
 }
 
-function renderMarket(refs: LayoutRefs, market: MarketPublic): void {
+// SVG viewBox; CSS scales the element to its rendered size while preserving
+// none aspect ratio, so we draw in these abstract units.
+const SPARK_W = 100;
+const SPARK_H = 20;
+const SPARK_PAD = 2;
+
+function sparklinePath(series: number[]): string {
+  if (series.length === 0) return '';
+  let min = series[0];
+  let max = series[0];
+  for (const v of series) {
+    if (v < min) min = v;
+    if (v > max) max = v;
+  }
+  const range = max - min;
+  const yMid = SPARK_H / 2;
+  const yTop = SPARK_PAD;
+  const yBot = SPARK_H - SPARK_PAD;
+  const step = series.length > 1 ? SPARK_W / (series.length - 1) : 0;
+  let d = '';
+  for (let i = 0; i < series.length; i++) {
+    const x = i * step;
+    const y = range === 0 ? yMid : yBot - ((series[i] - min) / range) * (yBot - yTop);
+    d += (i === 0 ? 'M' : 'L') + x.toFixed(2) + ' ' + y.toFixed(2);
+  }
+  return d;
+}
+
+function renderMarket(refs: LayoutRefs, market: MarketPublic, priceHistory: Record<string, number[]>): void {
   const prices = market?.prices ?? {};
   for (const { key } of MARKET_ITEMS) {
     const slot = refs.marketItems[key];
     if (!slot) continue;
     const price = prices[key];
     slot.price.textContent = price == null ? '--' : String(Math.round(price));
+    const series = priceHistory[key] ?? [];
+    // Key off length + each value rounded to 2 decimals so we skip the SVG
+    // write when the visible curve hasn't changed.
+    const sparkKey = series.length + ':' + series.map((v) => v.toFixed(2)).join(',');
+    if (slot.lastSparkKey !== sparkKey) {
+      slot.lastSparkKey = sparkKey;
+      slot.sparkPath.setAttribute('d', sparklinePath(series));
+    }
   }
 }
 
@@ -522,7 +564,7 @@ function renderHeader(refs: LayoutRefs, view: ViewModel, cfg: any): void {
 
 export function renderObservation(refs: LayoutRefs, view: ViewModel, cfg: any): void {
   renderHeader(refs, view, cfg);
-  renderMarket(refs, view.market);
+  renderMarket(refs, view.market, view.priceHistory);
   renderTown(refs, view.town);
   const farms = view.farms ?? [];
   farms.forEach((farm, i) => {

--- a/kaggle_environments/envs/kaggriculture/visualizer/default/src/renderer.ts
+++ b/kaggle_environments/envs/kaggriculture/visualizer/default/src/renderer.ts
@@ -1,7 +1,7 @@
 import type { RendererOptions } from '@kaggle-environments/core';
 import { getStepData } from '@kaggle-environments/core';
 import { buildShell, collectRefs, renderObservation, type BoardSize, type LayoutRefs } from './renderFarm';
-import type { ViewModel, PrivateState } from './types';
+import { MARKET_ITEMS, type ViewModel, type PrivateState } from './types';
 
 const DEFAULT_BOARD: BoardSize = { rows: 10, cols: 10 };
 
@@ -21,7 +21,33 @@ function inferBoardSize(replay: any): BoardSize {
   return DEFAULT_BOARD;
 }
 
-function buildView(replay: any, step: number): ViewModel | null {
+function pricesAt(replay: any, step: number): Record<string, number> {
+  const data = getStepData(replay, step) as any;
+  if (!data) return {};
+  const entry = Array.isArray(data) ? data[0] : data;
+  return entry?.observation?.market?.prices ?? {};
+}
+
+function buildPriceHistory(replay: any, step: number, windowSize: number): Record<string, number[]> {
+  const startPrices = pricesAt(replay, 0);
+  const firstStep = Math.max(0, step - windowSize + 1);
+  const windowPrices: Record<string, number>[] = [];
+  for (let s = firstStep; s <= step; s++) windowPrices.push(pricesAt(replay, s));
+  const padCount = windowSize - windowPrices.length;
+  const history: Record<string, number[]> = {};
+  for (const { key } of MARKET_ITEMS) {
+    const start = Number(startPrices[key] ?? 0);
+    const series: number[] = new Array(padCount).fill(start);
+    for (const p of windowPrices) {
+      const v = p[key];
+      series.push(Number(v == null ? start : v));
+    }
+    history[key] = series;
+  }
+  return history;
+}
+
+function buildView(replay: any, step: number, turnsPerDay: number): ViewModel | null {
   const stepData = getStepData(replay, step) as any;
   if (!stepData) return null;
   const entries = Array.isArray(stepData) ? stepData : [stepData];
@@ -42,6 +68,7 @@ function buildView(replay: any, step: number): ViewModel | null {
     market: obs0.market ?? { prices: {}, inventory: {} },
     town: obs0.town ?? { unlocked_shops: [] },
     privates,
+    priceHistory: buildPriceHistory(replay, step, turnsPerDay),
   };
 }
 
@@ -59,7 +86,9 @@ export function renderer(options: RendererOptions): void {
     shellCache.set(parent, cached);
   }
 
-  const view = buildView(replay, step);
+  const cfg = replay?.configuration ?? {};
+  const turnsPerDay = Math.max(1, Number(cfg.turnsPerDay) || 24);
+  const view = buildView(replay, step, turnsPerDay);
   if (!view) return;
-  renderObservation(cached.refs, view, replay?.configuration ?? {});
+  renderObservation(cached.refs, view, cfg);
 }

--- a/kaggle_environments/envs/kaggriculture/visualizer/default/src/renderer.ts
+++ b/kaggle_environments/envs/kaggriculture/visualizer/default/src/renderer.ts
@@ -1,7 +1,6 @@
 import type { RendererOptions } from '@kaggle-environments/core';
-import { getStepData } from '@kaggle-environments/core';
 import { buildShell, collectRefs, renderObservation, type BoardSize, type LayoutRefs } from './renderFarm';
-import { MARKET_ITEMS, type ViewModel, type PrivateState } from './types';
+import { buildView } from './utils';
 
 const DEFAULT_BOARD: BoardSize = { rows: 10, cols: 10 };
 
@@ -19,57 +18,6 @@ function inferBoardSize(replay: any): BoardSize {
     return { rows: size, cols: size };
   }
   return DEFAULT_BOARD;
-}
-
-function pricesAt(replay: any, step: number): Record<string, number> {
-  const data = getStepData(replay, step) as any;
-  if (!data) return {};
-  const entry = Array.isArray(data) ? data[0] : data;
-  return entry?.observation?.market?.prices ?? {};
-}
-
-function buildPriceHistory(replay: any, step: number, windowSize: number): Record<string, number[]> {
-  const startPrices = pricesAt(replay, 0);
-  const firstStep = Math.max(0, step - windowSize + 1);
-  const windowPrices: Record<string, number>[] = [];
-  for (let s = firstStep; s <= step; s++) windowPrices.push(pricesAt(replay, s));
-  const padCount = windowSize - windowPrices.length;
-  const history: Record<string, number[]> = {};
-  for (const { key } of MARKET_ITEMS) {
-    const start = Number(startPrices[key] ?? 0);
-    const series: number[] = new Array(padCount).fill(start);
-    for (const p of windowPrices) {
-      const v = p[key];
-      series.push(Number(v == null ? start : v));
-    }
-    history[key] = series;
-  }
-  return history;
-}
-
-function buildView(replay: any, step: number, turnsPerDay: number): ViewModel | null {
-  const stepData = getStepData(replay, step) as any;
-  if (!stepData) return null;
-  const entries = Array.isArray(stepData) ? stepData : [stepData];
-  const obs0 = entries[0]?.observation;
-  if (!obs0) return null;
-
-  const privates: (PrivateState | undefined)[] = [];
-  for (const entry of entries) {
-    const obs = entry?.observation;
-    const idx = typeof obs?.player === 'number' ? obs.player : privates.length;
-    privates[idx] = obs?.private;
-  }
-
-  return {
-    day: Number(obs0.day ?? 0),
-    hour: Number(obs0.hour ?? 0),
-    farms: obs0.farms ?? [],
-    market: obs0.market ?? { prices: {}, inventory: {} },
-    town: obs0.town ?? { unlocked_shops: [] },
-    privates,
-    priceHistory: buildPriceHistory(replay, step, turnsPerDay),
-  };
 }
 
 export function renderer(options: RendererOptions): void {

--- a/kaggle_environments/envs/kaggriculture/visualizer/default/src/style.css
+++ b/kaggle_environments/envs/kaggriculture/visualizer/default/src/style.css
@@ -359,9 +359,9 @@ body {
 
 .market-price-row {
   display: inline-flex;
-  flex-direction: column;
+  flex-direction: row;
   align-items: center;
-  gap: 2px;
+  gap: 4px;
 }
 
 .market-price {
@@ -369,10 +369,39 @@ body {
   font-variant-numeric: tabular-nums;
 }
 
+.market-coin-stack {
+  position: relative;
+  display: inline-block;
+  width: 32px;
+  height: 32px;
+}
+
 .market-coin {
-  width: 20px;
-  height: 20px;
+  width: 32px;
+  height: 32px;
   object-fit: contain;
+  display: block;
+}
+
+.market-sparkline {
+  position: absolute;
+  /* Coin is 32x32; inset to sit on the face, clear of the rim. Explicit
+     width/height are required: with only `left/right/top/bottom`, the SVG's
+     intrinsic viewBox aspect ratio collapses its height. */
+  left: 5px;
+  top: 11px;
+  width: 22px;
+  height: 10px;
+  overflow: visible;
+  pointer-events: none;
+}
+
+.market-sparkline-path {
+  stroke: #3a2412;
+  stroke-width: 1.25;
+  stroke-linejoin: round;
+  stroke-linecap: round;
+  vector-effect: non-scaling-stroke;
 }
 
 /* Breakpoints mirror MUI theme aliases in web/core/src/theme.ts:

--- a/kaggle_environments/envs/kaggriculture/visualizer/default/src/types.ts
+++ b/kaggle_environments/envs/kaggriculture/visualizer/default/src/types.ts
@@ -107,6 +107,9 @@ export interface ViewModel {
   market: MarketPublic;
   town: TownPublic;
   privates: (PrivateState | undefined)[];
+  // Per-item price series for the most recent `turnsPerDay` steps; padded on
+  // the left with the starting price when the game is younger than one day.
+  priceHistory: Record<string, number[]>;
 }
 
 export interface CellRefs {
@@ -147,7 +150,10 @@ export interface DialogRefs {
 export interface LayoutRefs {
   dayValue: HTMLElement;
   turnValue: HTMLElement;
-  marketItems: Record<string, { item: HTMLElement; price: HTMLElement }>;
+  marketItems: Record<
+    string,
+    { item: HTMLElement; price: HTMLElement; sparkPath: SVGPathElement; lastSparkKey?: string }
+  >;
   shopSlots: HTMLElement[];
   players: PlayerRefs[];
   dialog: DialogRefs;

--- a/kaggle_environments/envs/kaggriculture/visualizer/default/src/utils.ts
+++ b/kaggle_environments/envs/kaggriculture/visualizer/default/src/utils.ts
@@ -1,4 +1,5 @@
-import { READY_SPRITE_TYPES } from './types';
+import { getStepData } from '@kaggle-environments/core';
+import { MARKET_ITEMS, READY_SPRITE_TYPES, type PrivateState, type ViewModel } from './types';
 
 import bakery from './assets/sprites/bakery.png';
 import brunch_spot from './assets/sprites/brunch_spot.png';
@@ -141,4 +142,55 @@ export function titleCase(s: string): string {
     .filter(Boolean)
     .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
     .join(' ');
+}
+
+export function pricesAt(replay: any, step: number): Record<string, number> {
+  const data = getStepData(replay, step) as any;
+  if (!data) return {};
+  const entry = Array.isArray(data) ? data[0] : data;
+  return entry?.observation?.market?.prices ?? {};
+}
+
+export function buildPriceHistory(replay: any, step: number, windowSize: number): Record<string, number[]> {
+  const startPrices = pricesAt(replay, 0);
+  const firstStep = Math.max(0, step - windowSize + 1);
+  const windowPrices: Record<string, number>[] = [];
+  for (let s = firstStep; s <= step; s++) windowPrices.push(pricesAt(replay, s));
+  const padCount = windowSize - windowPrices.length;
+  const history: Record<string, number[]> = {};
+  for (const { key } of MARKET_ITEMS) {
+    const start = Number(startPrices[key] ?? 0);
+    const series: number[] = new Array(padCount).fill(start);
+    for (const p of windowPrices) {
+      const v = p[key];
+      series.push(Number(v == null ? start : v));
+    }
+    history[key] = series;
+  }
+  return history;
+}
+
+export function buildView(replay: any, step: number, turnsPerDay: number): ViewModel | null {
+  const stepData = getStepData(replay, step) as any;
+  if (!stepData) return null;
+  const entries = Array.isArray(stepData) ? stepData : [stepData];
+  const obs0 = entries[0]?.observation;
+  if (!obs0) return null;
+
+  const privates: (PrivateState | undefined)[] = [];
+  for (const entry of entries) {
+    const obs = entry?.observation;
+    const idx = typeof obs?.player === 'number' ? obs.player : privates.length;
+    privates[idx] = obs?.private;
+  }
+
+  return {
+    day: Number(obs0.day ?? 0),
+    hour: Number(obs0.hour ?? 0),
+    farms: obs0.farms ?? [],
+    market: obs0.market ?? { prices: {}, inventory: {} },
+    town: obs0.town ?? { unlocked_shops: [] },
+    privates,
+    priceHistory: buildPriceHistory(replay, step, turnsPerDay),
+  };
 }


### PR DESCRIPTION
Walks back up to `turnsPerDay` prior replay steps to assemble a per-item price series, left-padded with the starting price for the first day, and overlays a normalized polyline on the coin face.