### PR TITLE
Kaggriculture: fib-based hire cost with configurable multiplier

### DIFF
--- a/kaggle_environments/envs/kaggriculture/README.md
+++ b/kaggle_environments/envs/kaggriculture/README.md
@@ -137,9 +137,9 @@ Each player has their own farm with a set number of squares. Players are unable 
 
 #### Hiring
 
-- Hiring is an action only available to the farmer. It costs more every time you want to hire an additional hand each day. At the end of the day all, hands drop inventory at the farm and disappear (need to be re-hired each day)  
-- Cost  
-  - 100, 100, 200, 300, 500, 800, 1300, etc… (resets to 100 at the start of each day)  
+- Hiring is a market order (`HIRE`). It costs more every time you want to hire an additional hand each day. At the end of the day all, hands drop inventory at the farm and disappear (need to be re-hired each day)  
+- Cost is `farmHandCostMult * fib(n)` where `n` is the number of hires already made today (fib starts 1, 1, 2, 3, 5, 8, 13, ...).  
+  - With the default `farmHandCostMult = 10`: 10, 10, 20, 30, 50, 80, 130, 210, etc… (resets at the start of each day)  
 - A hired hand appears orthogonally adjacent to the shed in a free space following NWSE. If there are not open spaces, it looks for the one with the least occupants, breaking ties by NWSE preference
 
 #### Inventory

--- a/kaggle_environments/envs/kaggriculture/kaggriculture.json
+++ b/kaggle_environments/envs/kaggriculture/kaggriculture.json
@@ -66,6 +66,12 @@
       "type": ["integer", "null"],
       "default": null
     },
+    "farmHandCostMult": {
+      "description": "Multiplier applied to the Fibonacci hire-cost sequence (1, 1, 2, 3, 5, 8, 13, ...). The n-th hire of the day costs this value times fib(n).",
+      "type": "integer",
+      "default": 10,
+      "minimum": 0
+    },
     "marketParams": {
       "description": "Per-resource market price-curve overrides. Sparse: keyed by product name; each entry may set any subset of {base, I0, T, below_func, below_target, above_func, above_target}. Missing keys (and missing products) inherit from MARKET_PARAMS defaults in kaggriculture.py. Functions: linear, sq, sqrt, log, log10. amp is derived as target * base / f(T).",
       "type": "object",

--- a/kaggle_environments/envs/kaggriculture/kaggriculture.py
+++ b/kaggle_environments/envs/kaggriculture/kaggriculture.py
@@ -80,8 +80,9 @@ FARMER_MOVES = {
 LAND_ORDER = ["NE", "SW", "SE"]
 LAND_PRICES = [1000, 2000, 4000]
 
-# n-th hire of the day -> cost.
-HIRE_COSTS = [100, 100, 200, 300, 500, 800, 1300, 2100, 3400, 5500]
+# n-th hire of the day -> cost = FARM_HAND_COST_MULT * fib(n), where
+# fib starts 1, 1, 2, 3, 5, 8, 13, ... Configurable via `farmHandCostMult`.
+FARM_HAND_COST_MULT = 10
 
 SHOPS = {
     "BAKERY":         ["EGG", "WHEAT"],
@@ -518,6 +519,7 @@ def _process_market(state, env):
     privates = [s.observation.private for s in state]
     board_size = int(get(env.configuration, "boardSize", 10))
     max_orders = max(1, int(get(env.configuration, "maxMarketOrdersPerTurn", 10)))
+    hire_mult = int(get(env.configuration, "farmHandCostMult", FARM_HAND_COST_MULT))
 
     queues = []
     for s in state:
@@ -541,7 +543,7 @@ def _process_market(state, env):
                 continue
             op = ostate["type"]
             if op == "HIRE":
-                _do_hire(farms[player_id], privates[player_id], board_size)
+                _do_hire(farms[player_id], privates[player_id], board_size, hire_mult)
                 order_states[player_id] = None
             elif op == "BUY_LAND":
                 _do_buy_land(farms[player_id], board_size)
@@ -646,15 +648,20 @@ def _commit_unit(op, item, price, farm, private, market):
     return False
 
 
-def _hire_cost(n_already_today):
-    if n_already_today < len(HIRE_COSTS):
-        return HIRE_COSTS[n_already_today]
-    # Roughly doubling beyond the table.
-    return HIRE_COSTS[-1] * 2 ** (n_already_today - len(HIRE_COSTS) + 1)
+def _fib(n):
+    """Indexed so _fib(0)=1, _fib(1)=1, _fib(2)=2, _fib(3)=3, _fib(4)=5..."""
+    a, b = 1, 1
+    for _ in range(n):
+        a, b = b, a + b
+    return a
 
 
-def _do_hire(farm, private, board_size):
-    cost = _hire_cost(farm["hires_today"])
+def _hire_cost(n_already_today, mult=FARM_HAND_COST_MULT):
+    return mult * _fib(n_already_today)
+
+
+def _do_hire(farm, private, board_size, mult=FARM_HAND_COST_MULT):
+    cost = _hire_cost(farm["hires_today"], mult)
     if farm["money"] < cost:
         return
     farm["money"] -= cost

--- a/tests/envs/kaggriculture/test_kaggriculture.py
+++ b/tests/envs/kaggriculture/test_kaggriculture.py
@@ -2,7 +2,7 @@ from kaggle_environments import make
 from kaggle_environments.envs.kaggriculture.kaggriculture import (
     ANIMALS,
     CROPS,
-    HIRE_COSTS,
+    FARM_HAND_COST_MULT,
     LAND_ORDER,
     LAND_PRICES,
     MARKET_PARAMS,
@@ -576,18 +576,19 @@ def test_hire_cost_increases_with_each_hire_today():
     initial = farm["money"]
     for i in range(5):
         _do_hire(farm, private, 10)
-    spent = sum(HIRE_COSTS[:5])
+    # Fib: 1, 1, 2, 3, 5 → 12 units × default mult 10 = 120.
+    spent = FARM_HAND_COST_MULT * (1 + 1 + 2 + 3 + 5)
     assert farm["money"] == initial - spent
     assert farm["hires_today"] == 5
     assert len(farm["hands"]) == 5
 
 
 def test_hire_rejected_when_too_expensive():
-    farm = _new_farm(10, 50)
+    farm = _new_farm(10, FARM_HAND_COST_MULT - 1)
     private = _new_private()
     _do_hire(farm, private, 10)
     assert farm["hands"] == []
-    assert farm["money"] == 50
+    assert farm["money"] == FARM_HAND_COST_MULT - 1
 
 
 def test_hand_actions_dispatched_via_hands_field():


### PR DESCRIPTION
Replace the hardcoded HIRE_COSTS table with FARM_HAND_COST_MULT * fib(n), exposed via the new `farmHandCostMult` configuration (default 10). Default per-day costs are now 10, 10, 20, 30, 50, 80, 130, ... Also refresh the README to note HIRE is a market order, not a farmer op.