### PR TITLE
Retry on LLM call/parse exception

### DIFF
--- a/kaggle_environments/core_harness.py
+++ b/kaggle_environments/core_harness.py
@@ -502,6 +502,7 @@ def create_agent_fn(
         last_content = ""
         all_responses: list[str] = []
         call_records: list[dict[str, Any]] = []
+        last_exception: Exception | None = None
 
         for attempt in range(max_retries):
             if attempt == 0:
@@ -530,13 +531,14 @@ def create_agent_fn(
                     "model": model_name,
                     **call_details,
                 })
+                result = game_harness.parse_response(content, legal_action_strings)
+                last_exception = None
             except Exception as exc:
-                _log.error(
-                    "LLM call failed on attempt %d: %s", attempt + 1, exc,
+                last_exception = exc
+                _log.warning(
+                    "Attempt %d failed with exception: %s", attempt + 1, exc,
                 )
-                raise
-
-            result = game_harness.parse_response(content, legal_action_strings)
+                continue
 
             # -- check for a valid action --
             matched_submission: Any = None
@@ -596,6 +598,8 @@ def create_agent_fn(
             all_attempts_failed=True,
             total_attempts=max_retries,
         )
+        if last_exception is not None:
+            raise last_exception
         raise ValueError(
             f"Failed to parse a legal move after {max_retries} attempts. "
             f"Last response: {last_content[:200]}"

--- a/tests/core_harness_test.py
+++ b/tests/core_harness_test.py
@@ -402,6 +402,80 @@ class CoreHarnessTest(absltest.TestCase):
         kinds = {k for e in self.events for k in e if k != "module"}
         self.assertIn("llm_call_exception", kinds)
 
+    def test_retry_on_llm_exception_then_succeeds(self):
+        """A raised exception during _call_llm should consume a retry, not abort."""
+        harness = _SimpleHarness()
+        agent = create_agent_fn(harness, max_retries=3)
+        side_effects = [
+            RuntimeError("transient network error"),
+            _fake_completion("move_1"),
+        ]
+        with patch.dict("os.environ", _ENV, clear=False), patch.object(
+            core_harness.litellm, "completion", side_effect=side_effects,
+        ) as mock_call:
+            result = agent({}, {})
+
+        self.assertEqual(result["submission"], 1)
+        self.assertEqual(mock_call.call_count, 2)
+        # Only the successful call should appear in call_details.
+        self.assertLen(result["call_details"], 1)
+        self.assertEqual(result["call_details"][0]["response"], "move_1")
+
+    def test_retry_on_parse_exception_then_succeeds(self):
+        """An exception raised inside parse_response should consume a retry."""
+
+        class _FlakyParseHarness(_SimpleHarness):
+            def __init__(self):
+                super().__init__()
+                self.parse_calls = 0
+
+            def parse_response(self, response, legal_action_strings):
+                self.parse_calls += 1
+                if self.parse_calls == 1:
+                    raise RuntimeError("parser blew up")
+                return super().parse_response(response, legal_action_strings)
+
+        harness = _FlakyParseHarness()
+        agent = create_agent_fn(harness, max_retries=3)
+        responses = [_fake_completion("move_0"), _fake_completion("move_2")]
+        with patch.dict("os.environ", _ENV, clear=False), patch.object(
+            core_harness.litellm, "completion", side_effect=responses,
+        ) as mock_call:
+            result = agent({}, {})
+
+        self.assertEqual(result["submission"], 2)
+        self.assertEqual(mock_call.call_count, 2)
+        self.assertEqual(harness.parse_calls, 2)
+
+    def test_all_attempts_exception_reraises_last(self):
+        """When every attempt raises, the final exception should be re-raised verbatim."""
+        harness = _SimpleHarness()
+        agent = create_agent_fn(harness, max_retries=2)
+        side_effects = [
+            RuntimeError("first failure"),
+            RuntimeError("second failure"),
+        ]
+        with patch.dict("os.environ", _ENV, clear=False), patch.object(
+            core_harness.litellm, "completion", side_effect=side_effects,
+        ):
+            with self.assertRaisesRegex(RuntimeError, "second failure"):
+                agent({}, {})
+
+    def test_exception_then_parse_failure_raises_value_error(self):
+        """If the last attempt was a parse failure (not an exception), raise the
+        usual 'Failed to parse' ValueError — last_exception should not leak through."""
+        harness = _SimpleHarness()
+        agent = create_agent_fn(harness, max_retries=2)
+        side_effects = [
+            RuntimeError("first attempt blew up"),
+            _fake_completion("garbage"),  # parses to None → parse failure
+        ]
+        with patch.dict("os.environ", _ENV, clear=False), patch.object(
+            core_harness.litellm, "completion", side_effect=side_effects,
+        ):
+            with self.assertRaisesRegex(ValueError, "Failed to parse"):
+                agent({}, {})
+
     def test_move_history_accumulates_across_calls(self):
         harness = _SimpleHarness()
         agent = create_agent_fn(harness)


### PR DESCRIPTION
Currently we retry when a legal move cannot be parsed from the response, but we do not retry on exceptions. Exceptions are sometimes transient, so we should retry.