### PR TITLE
Iterate on Checkers prompt

### DIFF
--- a/kaggle_environments/envs/open_spiel_env/games/checkers/harness.py
+++ b/kaggle_environments/envs/open_spiel_env/games/checkers/harness.py
@@ -67,13 +67,20 @@ Piece counts: Player 0 men={p0_men}, kings={p0_kings}; Player 1 men={p1_men},
 kings={p1_kings}.
 
 You are Player {player_label} ('{my_piece}').
+Your men ('{my_piece}') are at: {my_men_squares}
+Your kings ('{my_king}') are at: {my_king_squares}
+Captures available this turn: {captures_flag}{capture_reminder}
+
 Move number: {move_number}
 Last move played: {last_move}
 Moves you have played so far: {move_history}
 
-Action notation: ``<from><to>`` -- four lowercase characters, e.g.
-``a3b4`` (slide a3 to b4) or ``d6b4`` (capture jump from d6 to b4 over
-the opponent piece on c5).
+Action notation: ``<from><to>`` -- four lowercase characters. As Player
+{player_label}, "forward" for your men means toward rank {forward_rank}.
+Examples: ``{slide_example}`` slides one of your men {slide_explanation};
+``{capture_example}`` is a capture jump that lands two squares diagonally
+away {capture_explanation}. Kings may move and capture in any diagonal
+direction.
 
 It is your turn. Choose a legal move for one of your pieces, remembering
 that if any capture is available you MUST take a capture.
@@ -140,6 +147,34 @@ def _format_board_ascii(board: Sequence[Sequence[str]]) -> str:
     return "\n".join(lines)
 
 
+def _list_own_pieces(
+    board: Sequence[Sequence[str]], player_id: int
+) -> tuple[list[str], list[str]]:
+    """Return (men_squares, king_squares) in algebraic notation for player."""
+    man_char = "o" if player_id == 0 else "+"
+    king_char = "O" if player_id == 0 else "*"
+    men: list[str] = []
+    kings: list[str] = []
+    for r, row in enumerate(board):
+        for c, cell in enumerate(row):
+            square = f"{chr(ord('a') + c)}{r + 1}"
+            if cell == man_char:
+                men.append(square)
+            elif cell == king_char:
+                kings.append(square)
+    return men, kings
+
+
+def _is_capture(action_string: str) -> bool:
+    """A checkers capture jumps two ranks (e.g. d6b4); a slide moves one."""
+    if len(action_string) != 4:
+        return False
+    try:
+        return abs(int(action_string[1]) - int(action_string[3])) == 2
+    except ValueError:
+        return False
+
+
 def _extract_move_from_json(response: str) -> str | None:
     """Pull the move from a ```json``` block or a bare ``{"move": "..."}``."""
     match = _JSON_BLOCK_RE.search(response)
@@ -192,6 +227,35 @@ def generate_prompt(
     last_move = state.get("last_move") or "(none yet)"
     piece_counts = state.get("piece_counts") or {}
     my_piece = "o" if player_id == 0 else "+"
+    my_king = "O" if player_id == 0 else "*"
+
+    men, kings = _list_own_pieces(board, player_id)
+    my_men_squares = ", ".join(men) if men else "(none)"
+    my_king_squares = ", ".join(kings) if kings else "(none)"
+
+    legal_moves = get_legal_moves(observation)
+    captures_available = any(_is_capture(s) for s in legal_moves.values())
+    captures_flag = "yes" if captures_available else "no"
+    capture_reminder = (
+        " (you MUST take a capture this turn)" if captures_available else ""
+    )
+
+    if player_id == 0:
+        forward_rank = 8
+        slide_example = "a3b4"
+        slide_explanation = "forward-right from a3 to the empty square b4"
+        capture_example = "c3e5"
+        capture_explanation = (
+            "from c3 over an opponent on d4 onto the empty square e5"
+        )
+    else:
+        forward_rank = 1
+        slide_example = "f6e5"
+        slide_explanation = "forward-left from f6 to the empty square e5"
+        capture_example = "f6d4"
+        capture_explanation = (
+            "from f6 over an opponent on e5 onto the empty square d4"
+        )
 
     move_history_str = ", ".join(move_history) if move_history else "None"
 
@@ -203,6 +267,16 @@ def generate_prompt(
         p1_kings=piece_counts.get("*", 0),
         player_label=player_id,
         my_piece=my_piece,
+        my_king=my_king,
+        my_men_squares=my_men_squares,
+        my_king_squares=my_king_squares,
+        captures_flag=captures_flag,
+        capture_reminder=capture_reminder,
+        forward_rank=forward_rank,
+        slide_example=slide_example,
+        slide_explanation=slide_explanation,
+        capture_example=capture_example,
+        capture_explanation=capture_explanation,
         move_number=move_number,
         last_move=last_move,
         move_history=move_history_str,

--- a/tests/envs/open_spiel_env/games/checkers/harness_test.py
+++ b/tests/envs/open_spiel_env/games/checkers/harness_test.py
@@ -150,6 +150,49 @@ class GeneratePromptTest(absltest.TestCase):
         self.assertIn("Player 0 men=12", prompt)
         self.assertIn("Player 1 men=12", prompt)
 
+    def test_own_pieces_listed_for_player_0(self):
+        obs = _make_observation(self.state, self.game, player_id=0)
+        prompt = generate_prompt(obs, [])
+        # Initial position: player 0 men on ranks 1-3 dark squares.
+        for sq in ("a1", "c1", "e1", "g1", "b2", "d2", "f2", "h2",
+                   "a3", "c3", "e3", "g3"):
+            self.assertIn(sq, prompt)
+        self.assertIn("Your kings ('O') are at: (none)", prompt)
+
+    def test_own_pieces_listed_for_player_1(self):
+        first = self.state.legal_actions()[0]
+        self.state.apply_action(first)
+        obs = _make_observation(self.state, self.game, player_id=1)
+        prompt = generate_prompt(obs, [])
+        for sq in ("b6", "d6", "f6", "h6", "a7", "c7", "e7", "g7",
+                   "b8", "d8", "f8", "h8"):
+            self.assertIn(sq, prompt)
+        self.assertIn("Your kings ('*') are at: (none)", prompt)
+
+    def test_captures_flag_no_at_start(self):
+        obs = _make_observation(self.state, self.game, player_id=0)
+        prompt = generate_prompt(obs, [])
+        self.assertIn("Captures available this turn: no", prompt)
+        self.assertNotIn("MUST take a capture this turn", prompt)
+
+    def test_captures_flag_yes_when_capture_available(self):
+        obs = _make_observation(self.state, self.game, player_id=0)
+        # Synthesize a capture by overriding legal moves with a 2-rank jump.
+        obs["legalActions"] = [0]
+        obs["legalActionStrings"] = ["c3e5"]
+        prompt = generate_prompt(obs, [])
+        self.assertIn("Captures available this turn: yes", prompt)
+        self.assertIn("MUST take a capture this turn", prompt)
+
+    def test_forward_direction_explained_per_player(self):
+        obs0 = _make_observation(self.state, self.game, player_id=0)
+        self.assertIn("toward rank 8", generate_prompt(obs0, []))
+
+        first = self.state.legal_actions()[0]
+        self.state.apply_action(first)
+        obs1 = _make_observation(self.state, self.game, player_id=1)
+        self.assertIn("toward rank 1", generate_prompt(obs1, []))
+
     def test_rethink_suffix(self):
         obs = _make_observation(self.state, self.game, player_id=0)
         prompt = generate_prompt(obs, [], previous_response="I'll play z9z9", previous_action="z9z9")


### PR DESCRIPTION
After removing the explicitly enumerated legal moves, some weaker LLMs are struggling to make legal moves.

Give some additional information to interpret the board and determine an action, without explicitly giving any legal actions.