### PR TITLE
Default to forfeiting on illegal move exhaustion for OpenSpiel

### DIFF
--- a/kaggle_environments/core_harness.py
+++ b/kaggle_environments/core_harness.py
@@ -601,8 +601,13 @@ def create_agent_fn(
         if last_exception is not None:
             raise last_exception
 
+        # Fallback is False: -1 as a forfeit signal is an OpenSpiel
+        # convention (pyspiel.INVALID_ACTION), and the open_spiel_env spec
+        # opts in by declaring `illegalMoveForfeit` with default True. Any
+        # other environment can support the parameter by adding it to its
+        # own spec and treating submission=-1 as an invalid action.
         illegal_move_forfeit = (
-            bool(config.get("illegalMoveForfeit", True)) if config else True
+            bool(config.get("illegalMoveForfeit", False)) if config else False
         )
         if illegal_move_forfeit:
             # Mimic game_arena: submit pyspiel.INVALID_ACTION (-1) so the env

--- a/kaggle_environments/core_harness.py
+++ b/kaggle_environments/core_harness.py
@@ -600,6 +600,33 @@ def create_agent_fn(
         )
         if last_exception is not None:
             raise last_exception
+
+        illegal_move_forfeit = (
+            bool(config.get("illegalMoveForfeit", True)) if config else True
+        )
+        if illegal_move_forfeit:
+            # Mimic game_arena: submit pyspiel.INVALID_ACTION (-1) so the env
+            # marks this player INVALID and forfeits them, rather than
+            # raising and voiding the whole episode.
+            _TELEMETRY(illegal_move_forfeit=True)
+            action = {
+                "submission": -1,
+                "actionString": previous_action,
+                "thoughts": last_content,
+                "status": (
+                    f"Failed to parse a legal move after {max_retries}"
+                    " attempts; forfeiting."
+                ),
+                "call_details": [
+                    _build_call_detail(r, save_prompt) for r in call_records
+                ],
+            }
+            if include_generate_returns:
+                action["generate_returns"] = [
+                    json.dumps(_build_generate_return(r)) for r in call_records
+                ]
+            return action
+
         raise ValueError(
             f"Failed to parse a legal move after {max_retries} attempts. "
             f"Last response: {last_content[:200]}"

--- a/kaggle_environments/envs/open_spiel_env/open_spiel_env.py
+++ b/kaggle_environments/envs/open_spiel_env/open_spiel_env.py
@@ -190,6 +190,19 @@ CONFIGURATION_SPEC_TEMPLATE = {
         "type": "boolean",
         "default": False,
     },
+    "illegalMoveForfeit": {
+        "description": (
+            "If true (default), when an LLM harness exhausts its retries"
+            " without producing a legal move, it submits an invalid action"
+            " so this player forfeits via the env's INVALID path (matching"
+            " the game_arena convention). If false, the harness re-raises"
+            " the parse failure, which voids the whole episode. Only affects"
+            " exhaustion from illegal/unparsable moves; uncaught exceptions"
+            " still propagate either way."
+        ),
+        "type": "boolean",
+        "default": True,
+    },
 }
 
 OBSERVATION_SPEC_TEMPLATE = {

--- a/tests/core_harness_test.py
+++ b/tests/core_harness_test.py
@@ -151,7 +151,26 @@ class CoreHarnessTest(absltest.TestCase):
         # Second prompt should reflect rethink context.
         self.assertIn("prev=garbage", harness.prompts[1])
 
-    def test_all_attempts_fail_raises(self):
+    def test_all_attempts_fail_forfeits_by_default(self):
+        harness = _SimpleHarness()
+        agent = create_agent_fn(harness, max_retries=2)
+        with patch.dict("os.environ", _ENV, clear=False), patch.object(
+            core_harness.litellm,
+            "completion",
+            side_effect=lambda *a, **kw: _fake_completion("nope"),
+        ):
+            result = agent({}, {})
+
+        self.assertEqual(result["submission"], -1)
+        self.assertEqual(result["actionString"], "nope")
+        self.assertIn("forfeiting", result["status"])
+        kinds = [e.get("module") for e in self.events]
+        self.assertTrue(
+            any("illegal_move_forfeit" in e for e in self.events),
+            f"expected illegal_move_forfeit telemetry, got {kinds}",
+        )
+
+    def test_all_attempts_fail_raises_when_forfeit_disabled(self):
         harness = _SimpleHarness()
         agent = create_agent_fn(harness, max_retries=2)
         with patch.dict("os.environ", _ENV, clear=False), patch.object(
@@ -160,7 +179,7 @@ class CoreHarnessTest(absltest.TestCase):
             side_effect=lambda *a, **kw: _fake_completion("nope"),
         ):
             with self.assertRaisesRegex(ValueError, "Failed to parse"):
-                agent({}, {})
+                agent({}, {"illegalMoveForfeit": False})
 
     def test_no_legal_moves_raises(self):
         harness = _SimpleHarness(num_actions=0)
@@ -461,9 +480,9 @@ class CoreHarnessTest(absltest.TestCase):
             with self.assertRaisesRegex(RuntimeError, "second failure"):
                 agent({}, {})
 
-    def test_exception_then_parse_failure_raises_value_error(self):
-        """If the last attempt was a parse failure (not an exception), raise the
-        usual 'Failed to parse' ValueError — last_exception should not leak through."""
+    def test_exception_then_parse_failure_forfeits_by_default(self):
+        """If the last attempt was a parse failure (not an exception), the
+        forfeit path applies — last_exception should not leak through."""
         harness = _SimpleHarness()
         agent = create_agent_fn(harness, max_retries=2)
         side_effects = [
@@ -473,8 +492,24 @@ class CoreHarnessTest(absltest.TestCase):
         with patch.dict("os.environ", _ENV, clear=False), patch.object(
             core_harness.litellm, "completion", side_effect=side_effects,
         ):
+            result = agent({}, {})
+
+        self.assertEqual(result["submission"], -1)
+        self.assertEqual(result["actionString"], "garbage")
+        self.assertIn("forfeiting", result["status"])
+
+    def test_exception_then_parse_failure_raises_when_forfeit_disabled(self):
+        harness = _SimpleHarness()
+        agent = create_agent_fn(harness, max_retries=2)
+        side_effects = [
+            RuntimeError("first attempt blew up"),
+            _fake_completion("garbage"),
+        ]
+        with patch.dict("os.environ", _ENV, clear=False), patch.object(
+            core_harness.litellm, "completion", side_effect=side_effects,
+        ):
             with self.assertRaisesRegex(ValueError, "Failed to parse"):
-                agent({}, {})
+                agent({}, {"illegalMoveForfeit": False})
 
     def test_move_history_accumulates_across_calls(self):
         harness = _SimpleHarness()
@@ -594,7 +629,20 @@ class FreeFormHarnessTest(absltest.TestCase):
         self.assertEqual(mock_call.call_count, 2)
         self.assertIn("prev=not json", harness.prompts[1])
 
-    def test_free_form_all_attempts_fail_raises(self):
+    def test_free_form_all_attempts_fail_forfeits_by_default(self):
+        harness = _FreeFormHarness()
+        agent = create_agent_fn(harness, max_retries=2)
+        with patch.dict("os.environ", _ENV, clear=False), patch.object(
+            core_harness.litellm,
+            "completion",
+            side_effect=lambda *a, **kw: _fake_completion("garbage"),
+        ):
+            result = agent({}, {"freeForm": True})
+
+        self.assertEqual(result["submission"], -1)
+        self.assertIn("forfeiting", result["status"])
+
+    def test_free_form_all_attempts_fail_raises_when_forfeit_disabled(self):
         harness = _FreeFormHarness()
         agent = create_agent_fn(harness, max_retries=2)
         with patch.dict("os.environ", _ENV, clear=False), patch.object(
@@ -603,7 +651,7 @@ class FreeFormHarnessTest(absltest.TestCase):
             side_effect=lambda *a, **kw: _fake_completion("garbage"),
         ):
             with self.assertRaisesRegex(ValueError, "Failed to parse"):
-                agent({}, {"freeForm": True})
+                agent({}, {"freeForm": True, "illegalMoveForfeit": False})
 
     def test_free_form_move_history_accumulates(self):
         harness = _FreeFormHarness()

--- a/tests/core_harness_test.py
+++ b/tests/core_harness_test.py
@@ -151,7 +151,7 @@ class CoreHarnessTest(absltest.TestCase):
         # Second prompt should reflect rethink context.
         self.assertIn("prev=garbage", harness.prompts[1])
 
-    def test_all_attempts_fail_forfeits_by_default(self):
+    def test_all_attempts_fail_forfeits_when_opted_in(self):
         harness = _SimpleHarness()
         agent = create_agent_fn(harness, max_retries=2)
         with patch.dict("os.environ", _ENV, clear=False), patch.object(
@@ -159,18 +159,28 @@ class CoreHarnessTest(absltest.TestCase):
             "completion",
             side_effect=lambda *a, **kw: _fake_completion("nope"),
         ):
-            result = agent({}, {})
+            result = agent({}, {"illegalMoveForfeit": True})
 
         self.assertEqual(result["submission"], -1)
         self.assertEqual(result["actionString"], "nope")
         self.assertIn("forfeiting", result["status"])
-        kinds = [e.get("module") for e in self.events]
         self.assertTrue(
             any("illegal_move_forfeit" in e for e in self.events),
-            f"expected illegal_move_forfeit telemetry, got {kinds}",
+            "expected illegal_move_forfeit telemetry event",
         )
 
-    def test_all_attempts_fail_raises_when_forfeit_disabled(self):
+    def test_all_attempts_fail_raises_by_default(self):
+        harness = _SimpleHarness()
+        agent = create_agent_fn(harness, max_retries=2)
+        with patch.dict("os.environ", _ENV, clear=False), patch.object(
+            core_harness.litellm,
+            "completion",
+            side_effect=lambda *a, **kw: _fake_completion("nope"),
+        ):
+            with self.assertRaisesRegex(ValueError, "Failed to parse"):
+                agent({}, {})
+
+    def test_all_attempts_fail_raises_when_forfeit_explicitly_disabled(self):
         harness = _SimpleHarness()
         agent = create_agent_fn(harness, max_retries=2)
         with patch.dict("os.environ", _ENV, clear=False), patch.object(
@@ -480,7 +490,7 @@ class CoreHarnessTest(absltest.TestCase):
             with self.assertRaisesRegex(RuntimeError, "second failure"):
                 agent({}, {})
 
-    def test_exception_then_parse_failure_forfeits_by_default(self):
+    def test_exception_then_parse_failure_forfeits_when_opted_in(self):
         """If the last attempt was a parse failure (not an exception), the
         forfeit path applies — last_exception should not leak through."""
         harness = _SimpleHarness()
@@ -492,13 +502,13 @@ class CoreHarnessTest(absltest.TestCase):
         with patch.dict("os.environ", _ENV, clear=False), patch.object(
             core_harness.litellm, "completion", side_effect=side_effects,
         ):
-            result = agent({}, {})
+            result = agent({}, {"illegalMoveForfeit": True})
 
         self.assertEqual(result["submission"], -1)
         self.assertEqual(result["actionString"], "garbage")
         self.assertIn("forfeiting", result["status"])
 
-    def test_exception_then_parse_failure_raises_when_forfeit_disabled(self):
+    def test_exception_then_parse_failure_raises_by_default(self):
         harness = _SimpleHarness()
         agent = create_agent_fn(harness, max_retries=2)
         side_effects = [
@@ -509,7 +519,7 @@ class CoreHarnessTest(absltest.TestCase):
             core_harness.litellm, "completion", side_effect=side_effects,
         ):
             with self.assertRaisesRegex(ValueError, "Failed to parse"):
-                agent({}, {"illegalMoveForfeit": False})
+                agent({}, {})
 
     def test_move_history_accumulates_across_calls(self):
         harness = _SimpleHarness()
@@ -629,7 +639,7 @@ class FreeFormHarnessTest(absltest.TestCase):
         self.assertEqual(mock_call.call_count, 2)
         self.assertIn("prev=not json", harness.prompts[1])
 
-    def test_free_form_all_attempts_fail_forfeits_by_default(self):
+    def test_free_form_all_attempts_fail_forfeits_when_opted_in(self):
         harness = _FreeFormHarness()
         agent = create_agent_fn(harness, max_retries=2)
         with patch.dict("os.environ", _ENV, clear=False), patch.object(
@@ -637,12 +647,12 @@ class FreeFormHarnessTest(absltest.TestCase):
             "completion",
             side_effect=lambda *a, **kw: _fake_completion("garbage"),
         ):
-            result = agent({}, {"freeForm": True})
+            result = agent({}, {"freeForm": True, "illegalMoveForfeit": True})
 
         self.assertEqual(result["submission"], -1)
         self.assertIn("forfeiting", result["status"])
 
-    def test_free_form_all_attempts_fail_raises_when_forfeit_disabled(self):
+    def test_free_form_all_attempts_fail_raises_by_default(self):
         harness = _FreeFormHarness()
         agent = create_agent_fn(harness, max_retries=2)
         with patch.dict("os.environ", _ENV, clear=False), patch.object(
@@ -651,7 +661,7 @@ class FreeFormHarnessTest(absltest.TestCase):
             side_effect=lambda *a, **kw: _fake_completion("garbage"),
         ):
             with self.assertRaisesRegex(ValueError, "Failed to parse"):
-                agent({}, {"freeForm": True, "illegalMoveForfeit": False})
+                agent({}, {"freeForm": True})
 
     def test_free_form_move_history_accumulates(self):
         harness = _FreeFormHarness()


### PR DESCRIPTION
The existing behavior in the legacy harness (used for all existing Chess, Poker, and Four/Five-in-a-Row runs) is to forfeit an agent if it's unable to make a legal move after all retries. Currently, `core_harness` will throw an exception and fail the whole episode.

Add `illegalMoveForfeit` flag, defaulted to `True` for OpenSpiel, to control this behavior. Behavior unchanged for other envs.