### PR TITLE
Coin Game Arena: convert to sequential dynamics

### DIFF
--- a/kaggle_environments/envs/open_spiel_env/games/coin_game_arena/coin_game_arena_game.py
+++ b/kaggle_environments/envs/open_spiel_env/games/coin_game_arena/coin_game_arena_game.py
@@ -1,9 +1,10 @@
 """Coin Game Arena: 2v2 team variant of OpenSpiel's Coin Game.
 
 Two teams of two LLMs each play their own private coin_game board in
-parallel. Team A is players 0,1; team B is players 2,3. Each step, one
-seat from each team plays simultaneously (turn 0: players 0+2, turn 1:
-players 1+3, repeating). Players only ever see their own team's board.
+parallel. Team A is players 0,1; team B is players 2,3. Players take
+turns one-at-a-time in the order [0, 2, 1, 3] repeating, so the two
+teams interleave while each team's seats alternate. Players only ever
+see their own team's board.
 
 Scoring follows the standard Coin Game rule per player:
 
@@ -15,10 +16,13 @@ unowned colours collected by anyone on that board). The team total is
 the sum of its two players' rewards. Higher team total wins; equal
 totals = draw.
 
-Dynamics are SIMULTANEOUS so the kaggle harness can request both teams'
-moves in parallel each step. Setup (preferences, player and coin
-placement) is baked deterministically into the initial state via the
-``seed`` parameter so paired AA-vs-BB matches can use identical boards.
+Dynamics are SEQUENTIAL — exactly one player is active per step.
+``episode_length`` is the number of moves PER BOARD; the episode runs
+for ``2 * episode_length`` total steps so each board gets the same
+number of moves as it would have under the prior simultaneous design.
+Setup (preferences, player and coin placement) is baked deterministically
+into the initial state via the ``seed`` parameter so paired AA-vs-BB
+matches can use identical boards.
 """
 
 from __future__ import annotations
@@ -69,7 +73,7 @@ _ACTION_DELTAS = {
 _GAME_TYPE = pyspiel.GameType(
     short_name="coin_game_arena",
     long_name="Coin Game Arena (2v2)",
-    dynamics=pyspiel.GameType.Dynamics.SIMULTANEOUS,
+    dynamics=pyspiel.GameType.Dynamics.SEQUENTIAL,
     chance_mode=pyspiel.GameType.ChanceMode.DETERMINISTIC,
     information=pyspiel.GameType.Information.IMPERFECT_INFORMATION,
     utility=pyspiel.GameType.Utility.GENERAL_SUM,
@@ -131,6 +135,10 @@ class CoinGameArenaGame(pyspiel.Game):
         max_utility = float(max_coins * max_coins)
         min_utility = float(-(max_coins * max_coins))
 
+        # Sequential play: 2 moves per "tick" (one per board), so the
+        # total number of game steps is 2 * episode_length.
+        self.total_moves = self.episode_length * _NUM_TEAMS
+
         game_info = pyspiel.GameInfo(
             num_distinct_actions=len(Action),
             max_chance_outcomes=0,
@@ -138,7 +146,7 @@ class CoinGameArenaGame(pyspiel.Game):
             min_utility=min_utility,
             max_utility=max_utility,
             utility_sum=0.0,
-            max_game_length=self.episode_length,
+            max_game_length=self.total_moves,
         )
         super().__init__(_GAME_TYPE, game_info, params)
 
@@ -153,9 +161,10 @@ class CoinGameArenaState(pyspiel.State):
     """State for Coin Game Arena.
 
     Internally holds two ``Board`` dicts (one per team) plus a shared
-    move counter. ``current_player()`` always returns SIMULTANEOUS; the
-    framework reads per-player ``legal_actions(pid)`` and only the seat
-    whose turn it is on each board returns a non-empty list.
+    move counter. Sequential play: players act in the order
+    [0, 2, 1, 3] repeating, so the two teams interleave while each
+    team's seats alternate. ``current_player()`` returns the active
+    player id (or TERMINAL).
     """
 
     def __init__(self, game: CoinGameArenaGame):
@@ -216,43 +225,36 @@ class CoinGameArenaState(pyspiel.State):
 
     # --- OpenSpiel core ----------------------------------------------------
 
+    def _current_player_id(self) -> int:
+        """Player id whose turn it is. Interleaves teams: [0, 2, 1, 3]."""
+        team = self._move_number % _NUM_TEAMS
+        seat = (self._move_number // _NUM_TEAMS) % _PLAYERS_PER_TEAM
+        return team * _PLAYERS_PER_TEAM + seat
+
     def current_player(self):
         if self._is_terminal:
             return pyspiel.PlayerId.TERMINAL
-        return pyspiel.PlayerId.SIMULTANEOUS
-
-    def _active_seat(self) -> int:
-        """Which seat (0 or 1) plays on each board this step."""
-        return self._move_number % _PLAYERS_PER_TEAM
+        return self._current_player_id()
 
     def _legal_actions(self, player: int):
         if self._is_terminal:
             return []
-        if _seat_of(player) != self._active_seat():
+        if player != self._current_player_id():
             return []
         return [a.value for a in Action]
 
-    def _apply_actions(self, actions):
-        """Apply one move per board (the active seat's action).
-
-        ``actions`` is a 4-list. Inactive seats supplied INVALID_ACTION
-        (they have empty legal_actions); we ignore them.
-        """
+    def _apply_action(self, action_value):
         if self._is_terminal:
             return
-        active_seat = self._active_seat()
-        for team in range(_NUM_TEAMS):
-            pid = _team_player_ids(team)[active_seat]
-            action_value = actions[pid]
-            if action_value == pyspiel.INVALID_ACTION:
-                # Should not happen when this seat is active, but guard.
-                continue
-            action = Action(action_value)
-            self._step_player(team, active_seat, action)
-            self._move_history[team].append((active_seat, _ACTION_NAMES[action]))
+        pid = self._current_player_id()
+        team = _team_of(pid)
+        seat = _seat_of(pid)
+        action = Action(action_value)
+        self._step_player(team, seat, action)
+        self._move_history[team].append((seat, _ACTION_NAMES[action]))
 
         self._move_number += 1
-        if self._move_number >= self._game.episode_length:
+        if self._move_number >= self._game.total_moves:
             self._is_terminal = True
 
     def _step_player(self, team: int, seat: int, action: Action) -> None:
@@ -362,14 +364,22 @@ class CoinGameArenaState(pyspiel.State):
 
     def observation_dict(self, player: int | None = None) -> dict[str, Any]:
         episode_length = self._game.episode_length
-        active_seat = (
-            self._active_seat() if not self._is_terminal else None
-        )
+        total_moves = self._game.total_moves
+        if self._is_terminal:
+            active_player_id = None
+            active_team_id = None
+            active_seat = None
+        else:
+            active_player_id = self._current_player_id()
+            active_team_id = _team_of(active_player_id)
+            active_seat = _seat_of(active_player_id)
         result: dict[str, Any] = {
             "phase": "terminal" if self._is_terminal else "play",
             "move_number": self._move_number,
-            "moves_remaining": max(0, episode_length - self._move_number),
+            "moves_remaining": max(0, total_moves - self._move_number),
             "episode_length": episode_length,
+            "active_player_id": active_player_id,
+            "active_team_id": active_team_id,
             "active_seat": active_seat,
             "num_teams": _NUM_TEAMS,
             "players_per_team": _PLAYERS_PER_TEAM,
@@ -392,7 +402,7 @@ class CoinGameArenaState(pyspiel.State):
             result["board"] = self._board_view(team, player)
             # Convenience flag for the harness.
             result["your_turn"] = (
-                not self._is_terminal and _seat_of(player) == active_seat
+                not self._is_terminal and player == active_player_id
             )
         if self._is_terminal:
             result["returns"] = self.returns()

--- a/kaggle_environments/envs/open_spiel_env/open_spiel_env.py
+++ b/kaggle_environments/envs/open_spiel_env/open_spiel_env.py
@@ -801,13 +801,15 @@ def random_agent(
     configuration: dict[str, Any],
 ) -> int:
     """A built-in random agent specifically for OpenSpiel environments."""
-    del configuration
     legal_actions = observation.get("legalActions")
     if not legal_actions:
         return None
-    action = random.choice(legal_actions)
+    action = int(random.choice(legal_actions))
+    # strictMode requires the action dict to contain ONLY 'submission'.
+    if configuration.get("strictMode", False):
+        return {"submission": action}
     thoughts = " ".join(random.choices(_RANDOM_THOUGHT_WORDS, k=8))
-    return {"submission": int(action), "thoughts": thoughts}
+    return {"submission": action, "thoughts": thoughts}
 
 
 AGENT_REGISTRY = {

--- a/tests/envs/open_spiel_env/games/coin_game_arena/env_test.py
+++ b/tests/envs/open_spiel_env/games/coin_game_arena/env_test.py
@@ -18,42 +18,42 @@ def _new_state(seed=0, episode_length=20, **params):
 
 
 def _step_random(state, rng):
-    actions = []
-    for pid in range(4):
-        legal = state.legal_actions(pid)
-        actions.append(rng.choice(legal) if legal else pyspiel.INVALID_ACTION)
-    state.apply_actions(actions)
+    legal = state.legal_actions()
+    state.apply_action(rng.choice(legal))
+
+
+# Sequential player order: teams interleave, seats alternate per team.
+_PLAYER_ORDER = [0, 2, 1, 3]
 
 
 class StructureTest(absltest.TestCase):
-    """Tests for basic game shape: 4 players, 2 teams, simultaneous turns."""
+    """Tests for basic game shape: 4 players, 2 teams, sequential turns."""
 
     def test_four_players(self):
         g = pyspiel.load_game("coin_game_arena")
         self.assertEqual(g.num_players(), 4)
 
-    def test_simultaneous_dynamics(self):
+    def test_sequential_dynamics(self):
+        g = pyspiel.load_game("coin_game_arena")
+        self.assertEqual(g.get_type().dynamics, pyspiel.GameType.Dynamics.SEQUENTIAL)
         s = _new_state(seed=1)
-        self.assertEqual(s.current_player(), pyspiel.PlayerId.SIMULTANEOUS)
+        self.assertFalse(s.is_simultaneous_node())
+        self.assertEqual(s.current_player(), 0)
 
-    def test_only_two_seats_active_per_step(self):
+    def test_only_acting_player_has_legal_actions(self):
         s = _new_state(seed=1)
-        # Step 0: seats 0 (players 0, 2) active.
+        # Step 0: only player 0 acts.
         legal_counts = [len(s.legal_actions(p)) for p in range(4)]
-        self.assertEqual(legal_counts[0], 5)
-        self.assertEqual(legal_counts[1], 0)
-        self.assertEqual(legal_counts[2], 5)
-        self.assertEqual(legal_counts[3], 0)
+        self.assertEqual(legal_counts, [5, 0, 0, 0])
 
-    def test_active_seats_alternate_after_step(self):
+    def test_player_order_interleaves_teams(self):
         s = _new_state(seed=1)
-        s.apply_actions([4, pyspiel.INVALID_ACTION, 4, pyspiel.INVALID_ACTION])  # both stand
-        # Step 1: seats 1 (players 1, 3) active.
-        legal_counts = [len(s.legal_actions(p)) for p in range(4)]
-        self.assertEqual(legal_counts[0], 0)
-        self.assertEqual(legal_counts[1], 5)
-        self.assertEqual(legal_counts[2], 0)
-        self.assertEqual(legal_counts[3], 5)
+        observed = []
+        for _ in range(8):
+            observed.append(s.current_player())
+            s.apply_action(s.legal_actions()[0])  # stand-ish, just walk
+        # Two full cycles of [0, 2, 1, 3].
+        self.assertEqual(observed, _PLAYER_ORDER * 2)
 
 
 class ObservationTest(absltest.TestCase):
@@ -104,10 +104,12 @@ class TurnHistoryTest(absltest.TestCase):
 
     def test_history_includes_both_seats(self):
         s = _new_state(seed=2)
-        # Seat 0 plays "right" on both boards.
-        s.apply_actions([3, pyspiel.INVALID_ACTION, 3, pyspiel.INVALID_ACTION])
-        # Seat 1 plays "left" on both boards.
-        s.apply_actions([pyspiel.INVALID_ACTION, 2, pyspiel.INVALID_ACTION, 2])
+        # Sequential order is [0, 2, 1, 3]: seat 0 plays "right" on each
+        # board, then seat 1 plays "left" on each board.
+        s.apply_action(3)  # player 0: right
+        s.apply_action(3)  # player 2: right
+        s.apply_action(2)  # player 1: left
+        s.apply_action(2)  # player 3: left
 
         obs0 = json.loads(s.observation_string(0))  # team A view
         history = obs0["board"]["move_history"]
@@ -136,7 +138,7 @@ class DeterminismTest(absltest.TestCase):
 
 
 class TerminationTest(absltest.TestCase):
-    """Episode ends after exactly ``episode_length`` steps."""
+    """Episode ends after ``2 * episode_length`` steps (per-board moves)."""
 
     def test_terminates_on_episode_length(self):
         s = _new_state(seed=3, episode_length=4)
@@ -146,7 +148,8 @@ class TerminationTest(absltest.TestCase):
             _step_random(s, rng)
             steps += 1
         self.assertTrue(s.is_terminal())
-        self.assertEqual(steps, 4)
+        # 4 moves per board x 2 boards = 8 sequential steps.
+        self.assertEqual(steps, 8)
 
 
 class ScoringTest(absltest.TestCase):
@@ -154,9 +157,9 @@ class ScoringTest(absltest.TestCase):
 
     def test_zero_returns_when_no_coins_collected(self):
         s = _new_state(seed=1, episode_length=2)
-        # All players "stand" twice — collect nothing.
-        s.apply_actions([4, pyspiel.INVALID_ACTION, 4, pyspiel.INVALID_ACTION])
-        s.apply_actions([pyspiel.INVALID_ACTION, 4, pyspiel.INVALID_ACTION, 4])
+        # All four players "stand" once each (total moves = 2 * 2 = 4).
+        for _ in range(4):
+            s.apply_action(4)
         self.assertTrue(s.is_terminal())
         self.assertEqual(s.returns(), [0.0, 0.0, 0.0, 0.0])
 
@@ -217,8 +220,8 @@ class TerminalRevealTest(absltest.TestCase):
 
     def test_terminal_reveal(self):
         s = _new_state(seed=5, episode_length=2)
-        s.apply_actions([4, pyspiel.INVALID_ACTION, 4, pyspiel.INVALID_ACTION])
-        s.apply_actions([pyspiel.INVALID_ACTION, 4, pyspiel.INVALID_ACTION, 4])
+        for _ in range(4):
+            s.apply_action(4)  # stand
         obs0 = json.loads(s.observation_string(0))
         self.assertIn("boards", obs0)
         self.assertEqual(len(obs0["boards"]), 2)

--- a/tests/envs/open_spiel_env/games/coin_game_arena/harness_test.py
+++ b/tests/envs/open_spiel_env/games/coin_game_arena/harness_test.py
@@ -113,9 +113,11 @@ class GeneratePromptTest(absltest.TestCase):
         # state, then ensure player 0's prompt does not leak any of
         # team B's board info (and vice versa).
         s = _state(seed=7)
-        # Two full rounds: seat 0 then seat 1, on both boards.
-        s.apply_actions([3, pyspiel.INVALID_ACTION, 2, pyspiel.INVALID_ACTION])
-        s.apply_actions([pyspiel.INVALID_ACTION, 1, pyspiel.INVALID_ACTION, 0])
+        # Sequential order [0, 2, 1, 3]: seat 0 then seat 1, on each board.
+        s.apply_action(3)  # player 0
+        s.apply_action(2)  # player 2
+        s.apply_action(1)  # player 1
+        s.apply_action(0)  # player 3
 
         obs_a = _make_observation(s, 0)
         obs_b = _make_observation(s, 2)
@@ -169,9 +171,12 @@ class GeneratePromptTest(absltest.TestCase):
 
     def test_history_shows_partner_moves(self):
         s = _state(seed=7)
-        # Seat 0 plays right on each board, then seat 1 plays left.
-        s.apply_actions([3, pyspiel.INVALID_ACTION, 3, pyspiel.INVALID_ACTION])
-        s.apply_actions([pyspiel.INVALID_ACTION, 2, pyspiel.INVALID_ACTION, 2])
+        # Sequential order [0, 2, 1, 3]: seat 0 right, then seat 1 left
+        # on each board.
+        s.apply_action(3)  # player 0: right
+        s.apply_action(3)  # player 2: right
+        s.apply_action(2)  # player 1: left
+        s.apply_action(2)  # player 3: left
         # Now seat 0 (player 0) is up again; their prompt should include both.
         prompt = generate_prompt(_make_observation(s, 0), [])
         self.assertIn("seat 0", prompt)


### PR DESCRIPTION
The 2v2 arena was declared SIMULTANEOUS, which broke Kaggle's pairwise-scheduling validation episode: the validation harness expects exactly one agent active per step (the word_association pattern). Convert the env to SEQUENTIAL with player order [0, 2, 1, 3] repeating so teams interleave while each team's seats still alternate. episode_length keeps its "moves per board" meaning; total game length is now 2 * episode_length.

Also make the built-in random agent strict-mode compliant: omit the 'thoughts' field when strictMode is True, since the strict validator only accepts {'submission': int}.