### PR TITLE
Gin Rummy visualizer: hand grid, mini discard grid, stable center row

### DIFF
--- a/kaggle_environments/envs/open_spiel_env/games/gin_rummy/visualizer/default/src/renderer.ts
+++ b/kaggle_environments/envs/open_spiel_env/games/gin_rummy/visualizer/default/src/renderer.ts
@@ -222,22 +222,33 @@ function buildPile(visual: HTMLElement, label: string, modifier?: string): HTMLD
   return pile;
 }
 
+function buildPileSlot(): HTMLDivElement {
+  const slot = document.createElement('div');
+  slot.className = 'card-slot--pile';
+  return slot;
+}
+
 function buildStockPile(stockSize: number): HTMLDivElement {
   const stack = document.createElement('div');
   stack.className = 'pile-stack';
-  // Decorative offset stack of up to 3 face-down cards.
-  for (let i = 0; i < Math.min(stockSize, 3); i++) {
-    stack.appendChild(buildCard(null, { faceDown: true }));
+  if (stockSize === 0) {
+    stack.appendChild(buildPileSlot());
+  } else {
+    // Decorative offset stack of up to 3 face-down cards.
+    for (let i = 0; i < Math.min(stockSize, 3); i++) {
+      stack.appendChild(buildCard(null, { faceDown: true }));
+    }
   }
   return buildPile(stack, `Stock (${stockSize})`);
 }
 
 function buildUpcardPile(upcard: string | null): HTMLDivElement {
-  // Wrap the upcard in a pile-stack so the empty and non-empty states have
-  // the same 64x90 footprint as the Stock pile.
+  // Wrap in a pile-stack so the empty and non-empty states have the same
+  // 64x90 footprint as the Stock pile; when empty, render a dashed
+  // card-shaped slot so the slot stays visible.
   const stack = document.createElement('div');
   stack.className = 'pile-stack';
-  if (upcard) stack.appendChild(buildCard(upcard));
+  stack.appendChild(upcard ? buildCard(upcard) : buildPileSlot());
   return buildPile(stack, 'Upcard');
 }
 

--- a/kaggle_environments/envs/open_spiel_env/games/gin_rummy/visualizer/default/src/renderer.ts
+++ b/kaggle_environments/envs/open_spiel_env/games/gin_rummy/visualizer/default/src/renderer.ts
@@ -29,6 +29,14 @@ const RANK_DISPLAY: Record<string, string> = {
   K: 'K',
 };
 
+// Grid layout: rows = suits (♠♥♦♣), cols = ranks (A..K). Used by both the
+// player hand grid and the discard mini-grid so cards line up by suit/rank.
+const GRID_SUITS = ['s', 'h', 'd', 'c'] as const;
+const GRID_RANKS = ['A', '2', '3', '4', '5', '6', '7', '8', '9', 'T', 'J', 'Q', 'K'] as const;
+
+const ALL_RANKS: readonly string[] = ['A', '2', '3', '4', '5', '6', '7', '8', '9', 'T', 'J', 'Q', 'K'];
+const ALL_SUITS: readonly string[] = ['s', 'c', 'd', 'h'];
+
 function rankOf(card: string): string {
   const r = card[0];
   return RANK_DISPLAY[r] ?? r;
@@ -36,32 +44,6 @@ function rankOf(card: string): string {
 
 function suitOf(card: string): string {
   return card[1];
-}
-
-const RANK_ORDER: Record<string, number> = {
-  A: 1,
-  '2': 2,
-  '3': 3,
-  '4': 4,
-  '5': 5,
-  '6': 6,
-  '7': 7,
-  '8': 8,
-  '9': 9,
-  T: 10,
-  J: 11,
-  Q: 12,
-  K: 13,
-};
-const SUIT_ORDER: Record<string, number> = { s: 0, h: 1, d: 2, c: 3 };
-
-function sortHand(hand: string[]): string[] {
-  return [...hand].sort((a, b) => {
-    const sa = SUIT_ORDER[suitOf(a)] ?? 9;
-    const sb = SUIT_ORDER[suitOf(b)] ?? 9;
-    if (sa !== sb) return sa - sb;
-    return (RANK_ORDER[a[0]] ?? 99) - (RANK_ORDER[b[0]] ?? 99);
-  });
 }
 
 function parseObservation(step: any, playerIdx: number): GinRummyObservation | null {
@@ -74,22 +56,9 @@ function parseObservation(step: any, playerIdx: number): GinRummyObservation | n
   }
 }
 
-function findInitialUpcard(steps: GinRummyStep[]): string | null {
-  // In Oklahoma the initial upcard is the knock card; its rank-value sets the
-  // deadwood limit. Look only at the FirstUpcard phase since the upcard slot
-  // can be empty once play continues.
-  for (const s of steps) {
-    const obs = mergedObservation(s.rawStep);
-    if (!obs) continue;
-    if (obs.phase === 'FirstUpcard') return obs.upcard;
-    return obs.upcard ?? null;
-  }
-  return null;
-}
-
 function mergedObservation(step: any): GinRummyObservation | null {
-  // Player 0's observation has player 0's hand visible; player 1's observation
-  // has player 1's hand visible. Merge so the spectator view shows both.
+  // Each player's observation only reveals their own hand; merge so the
+  // spectator view shows both hands at once.
   const o0 = parseObservation(step, 0);
   const o1 = parseObservation(step, 1);
   const base = o0 ?? o1;
@@ -106,12 +75,19 @@ function mergedObservation(step: any): GinRummyObservation | null {
   return merged;
 }
 
+function findInitialUpcard(steps: GinRummyStep[]): string | null {
+  // In Oklahoma the initial upcard sets the deadwood limit for knocking.
+  for (const s of steps) {
+    const obs = mergedObservation(s.rawStep);
+    if (!obs) continue;
+    if (obs.phase === 'FirstUpcard') return obs.upcard;
+    return obs.upcard ?? null;
+  }
+  return null;
+}
+
 function getPlayerName(replay: any, idx: number): string {
-  const info = replay?.info?.TeamNames?.[idx];
-  if (info) return info;
-  const fromAgent = replay?.agents?.[idx]?.name;
-  if (fromAgent) return fromAgent;
-  return idx === 0 ? 'Player 1' : 'Player 2';
+  return replay?.info?.TeamNames?.[idx] ?? replay?.agents?.[idx]?.name ?? (idx === 0 ? 'Player 1' : 'Player 2');
 }
 
 function buildCard(
@@ -124,8 +100,7 @@ function buildCard(
   if (options.faceDown || !card) {
     classes.push('face-down');
   } else {
-    const suit = suitOf(card);
-    classes.push(SUIT_COLOR[suit]);
+    classes.push(SUIT_COLOR[suitOf(card)]);
   }
   if (options.highlight) classes.push('highlight');
   if (options.dim) classes.push('dim');
@@ -135,10 +110,6 @@ function buildCard(
     const glyph = SUIT_GLYPH[suitOf(card)] ?? '?';
     el.innerHTML = `
       <div class="corner top">
-        <span>${rank}</span>
-        <span class="suit">${glyph}</span>
-      </div>
-      <div class="corner bottom">
         <span>${rank}</span>
         <span class="suit">${glyph}</span>
       </div>
@@ -153,14 +124,9 @@ function actionLabel(submission: number, hand: string[] | null): string {
   if (submission === 54) return 'Pass';
   if (submission === 55) return 'Knock';
   if (submission >= 0 && submission < 52) {
-    // Single card action: drawn-card index 0..51 maps to a specific card.
-    // We don't know the exact card from the action alone in all phases;
-    // best effort: derive card string from action index using OpenSpiel's
-    // canonical ordering: rank-major within suit (s, c, d, h).
-    const ranks = ['A', '2', '3', '4', '5', '6', '7', '8', '9', 'T', 'J', 'Q', 'K'];
-    const suits = ['s', 'c', 'd', 'h'];
-    const suit = suits[Math.floor(submission / 13)];
-    const rank = ranks[submission % 13];
+    // OpenSpiel canonical ordering: rank-major within suit (s, c, d, h).
+    const suit = ALL_SUITS[Math.floor(submission / 13)];
+    const rank = ALL_RANKS[submission % 13];
     const card = `${rank}${suit}`;
     if (hand && hand.includes(card)) return `Discard ${rank}${SUIT_GLYPH[suit]}`;
     return `${rank}${SUIT_GLYPH[suit]}`;
@@ -180,8 +146,43 @@ function findLastAction(step: any): { actor: number; submission: number } | null
 
 function phaseLabel(phase: string | null): string {
   if (!phase) return '';
-  // Make camel-case phases more readable.
   return phase.replace(/([a-z])([A-Z])/g, '$1 $2');
+}
+
+function buildHandGrid(hand: string[], highlightCard: string | null): HTMLDivElement {
+  // 4x13 grid (rows = suits, cols = ranks). Empty cells render a card-slot
+  // placeholder so swapping a slot for a card produces zero layout shift.
+  const handSet = new Set(hand);
+  const grid = document.createElement('div');
+  grid.className = 'hand-grid';
+  for (const suit of GRID_SUITS) {
+    const row = document.createElement('div');
+    row.className = 'hand-grid__row';
+    for (const rank of GRID_RANKS) {
+      const card = `${rank}${suit}`;
+      if (handSet.has(card)) {
+        row.appendChild(buildCard(card, { highlight: !!highlightCard && card === highlightCard }));
+      } else {
+        const slot = document.createElement('div');
+        slot.className = 'card-slot';
+        row.appendChild(slot);
+      }
+    }
+    grid.appendChild(row);
+  }
+  return grid;
+}
+
+function buildFaceDownHand(handLength: number): HTMLDivElement {
+  // Opponent hand placeholder: a flat overlapping row of face-down cards.
+  // We can't lay these out by suit/rank because the opponent's hand is hidden.
+  const el = document.createElement('div');
+  el.className = 'hand';
+  const count = handLength || 10;
+  for (let i = 0; i < count; i++) {
+    el.appendChild(buildCard(null, { faceDown: true }));
+  }
+  return el;
 }
 
 function renderPlayerRow(
@@ -207,22 +208,123 @@ function renderPlayerRow(
     <span class="deadwood sketched-border">Cards: ${hand.length}</span>
   `;
   container.appendChild(meta);
+  container.appendChild(showFaceDown ? buildFaceDownHand(hand.length) : buildHandGrid(hand, highlightCard));
+}
 
-  const handEl = document.createElement('div');
-  handEl.className = 'hand';
-  const sorted = showFaceDown ? hand : sortHand(hand);
-  // If hand empty and showFaceDown, render placeholder face-down cards.
-  const cardsToRender = sorted.length ? sorted : showFaceDown ? new Array(10).fill('XX') : [];
-  for (const card of cardsToRender) {
-    const isHighlight = !!highlightCard && card === highlightCard && !showFaceDown;
-    handEl.appendChild(
-      buildCard(card === 'XX' ? null : card, {
-        faceDown: showFaceDown,
-        highlight: isHighlight,
-      })
-    );
+function buildPile(visual: HTMLElement, label: string, modifier?: string): HTMLDivElement {
+  const pile = document.createElement('div');
+  pile.className = modifier ? `pile ${modifier}` : 'pile';
+  pile.appendChild(visual);
+  const lbl = document.createElement('div');
+  lbl.className = 'pile-label';
+  lbl.textContent = label;
+  pile.appendChild(lbl);
+  return pile;
+}
+
+function buildStockPile(stockSize: number): HTMLDivElement {
+  const stack = document.createElement('div');
+  stack.className = 'pile-stack';
+  // Decorative offset stack of up to 3 face-down cards.
+  for (let i = 0; i < Math.min(stockSize, 3); i++) {
+    stack.appendChild(buildCard(null, { faceDown: true }));
   }
-  container.appendChild(handEl);
+  return buildPile(stack, `Stock (${stockSize})`);
+}
+
+function buildUpcardPile(upcard: string | null): HTMLDivElement {
+  // Wrap the upcard in a pile-stack so the empty and non-empty states have
+  // the same 64x90 footprint as the Stock pile.
+  const stack = document.createElement('div');
+  stack.className = 'pile-stack';
+  if (upcard) stack.appendChild(buildCard(upcard));
+  return buildPile(stack, 'Upcard');
+}
+
+function buildKnockCardPile(initialUpcard: string | null, knockLimit: number | null): HTMLDivElement {
+  let visual: HTMLElement;
+  if (initialUpcard) {
+    visual = buildCard(initialUpcard);
+  } else {
+    visual = document.createElement('div');
+    visual.className = 'pile-empty';
+    visual.textContent = '?';
+  }
+  const label = knockLimit !== null ? `Knock Card (≤${knockLimit})` : 'Knock Card';
+  return buildPile(visual, label);
+}
+
+function buildDiscardPile(discardPile: string[]): HTMLDivElement {
+  // Mini 4x13 grid showing every discarded card; top card outlined.
+  const topCard = discardPile.length ? discardPile[discardPile.length - 1] : null;
+  const discardSet = new Set(discardPile);
+  const grid = document.createElement('div');
+  grid.className = 'discard-grid';
+  for (const suit of GRID_SUITS) {
+    const row = document.createElement('div');
+    row.className = 'discard-grid__row';
+    for (const rank of GRID_RANKS) {
+      const code = `${rank}${suit}`;
+      const cell = document.createElement('div');
+      cell.className = 'discard-cell';
+      if (discardSet.has(code)) {
+        cell.classList.add(SUIT_COLOR[suit]);
+        if (code === topCard) cell.classList.add('top');
+        cell.innerHTML =
+          `<span class="dc-rank">${RANK_DISPLAY[rank] ?? rank}</span>` +
+          `<span class="dc-suit">${SUIT_GLYPH[suit] ?? ''}</span>`;
+      }
+      row.appendChild(cell);
+    }
+    grid.appendChild(row);
+  }
+  return buildPile(grid, `Discards (${discardPile.length})`, 'pile--discard');
+}
+
+function buildStatus(
+  observation: GinRummyObservation,
+  lastAction: { actor: number; submission: number } | null,
+  playerNames: string[],
+  activeIdx: number,
+  winnerIdx: number,
+  isTerminal: boolean
+): string {
+  const parts: string[] = [];
+  if (observation.phase) {
+    parts.push(`<span class="phase-pill">${phaseLabel(observation.phase)}</span>`);
+  }
+  if (observation.knock_card !== null) {
+    parts.push(`<span class="annotation">knock card: ${observation.knock_card}</span>`);
+  }
+  if (lastAction) {
+    const { actor, submission } = lastAction;
+    const color = actor === 0 ? PLAYER_0_COLOR : PLAYER_1_COLOR;
+    const hand = observation.hands[String(actor) as '0' | '1'] ?? [];
+    const lbl = actionLabel(submission, hand);
+    parts.push(
+      `<span class="annotation">last move:</span> ` +
+        `<span style="color:${color};font-weight:700;">${playerNames[actor]} \u2192 ${lbl}</span>`
+    );
+  } else if (!isTerminal && activeIdx >= 0) {
+    const color = activeIdx === 0 ? PLAYER_0_COLOR : PLAYER_1_COLOR;
+    parts.push(`<span>Turn: <span style="color:${color};font-weight:700;">${playerNames[activeIdx]}</span></span>`);
+  }
+  if (isTerminal) {
+    let html: string;
+    if (winnerIdx === 0) {
+      html = `<span style="color:${PLAYER_0_COLOR};font-weight:700;">${playerNames[0]} wins</span>`;
+    } else if (winnerIdx === 1) {
+      html = `<span style="color:${PLAYER_1_COLOR};font-weight:700;">${playerNames[1]} wins</span>`;
+    } else {
+      html = `<span>Game over: ${observation.winner ?? 'draw'}</span>`;
+    }
+    const ret = observation.returns;
+    if (ret && ret.length === 2) {
+      html += ` <span class="annotation">(score ${ret[0]} : ${ret[1]})</span>`;
+    }
+    parts.push(html);
+  }
+  return parts.join(' ');
 }
 
 export function renderer(options: RendererOptions<GinRummyStep[]>) {
@@ -259,7 +361,6 @@ export function renderer(options: RendererOptions<GinRummyStep[]>) {
   const activeIdx = isTerminal ? -1 : observation.current_player;
   const winnerIdx = typeof observation.winner === 'number' ? observation.winner : -1;
 
-  // Header
   header.innerHTML = `
     <span class="player sketched-border ${activeIdx === 0 ? 'active' : ''}" style="color: ${PLAYER_0_COLOR};">
       ${playerNames[0]}
@@ -270,29 +371,18 @@ export function renderer(options: RendererOptions<GinRummyStep[]>) {
     </span>
   `;
 
-  // Detect the action that produced this state (if any).
+  // Highlight the just-discarded card inside the actor's hand. The status bar
+  // already names the move, so we don't highlight stock/upcard/discard piles.
   const lastAction = findLastAction(currentStep);
-  let highlightDiscard: string | null = null;
-  let highlightTakenUpcard = false;
-  let highlightDrawStock = false;
   let highlightCardP0: string | null = null;
   let highlightCardP1: string | null = null;
-  if (lastAction) {
-    const { actor, submission } = lastAction;
-    if (submission === 52) highlightTakenUpcard = true;
-    else if (submission === 53) highlightDrawStock = true;
-    else if (submission >= 0 && submission < 52) {
-      // Single-card action: top card of discard pile is the just-discarded card
-      // (in Discard / Knock phases). Highlight it as the move.
-      const discard = observation.discard_pile;
-      if (discard.length) highlightDiscard = discard[discard.length - 1];
-      // If knock, highlight that card in the actor's hand as well.
-      if (actor === 0) highlightCardP0 = discard.length ? discard[discard.length - 1] : null;
-      if (actor === 1) highlightCardP1 = discard.length ? discard[discard.length - 1] : null;
-    }
+  if (lastAction && lastAction.submission >= 0 && lastAction.submission < 52) {
+    const dp = observation.discard_pile;
+    const top = dp.length ? dp[dp.length - 1] : null;
+    if (lastAction.actor === 0) highlightCardP0 = top;
+    if (lastAction.actor === 1) highlightCardP1 = top;
   }
 
-  // Top: player 1
   renderPlayerRow(
     topRow,
     playerNames[1],
@@ -305,112 +395,15 @@ export function renderer(options: RendererOptions<GinRummyStep[]>) {
     highlightCardP1
   );
 
-  // Center: [knock card] | stock | discard | (recent action info)
   centerRow.innerHTML = '';
-
-  // Knock card (Oklahoma rules only): the initial upcard determines the
-  // deadwood limit for knocking, so surface it persistently in the table.
   const oklahoma = !!replay?.configuration?.openSpielGameParameters?.oklahoma;
   if (oklahoma) {
-    const knockCardPile = document.createElement('div');
-    knockCardPile.className = 'pile';
-    const initialUpcard = findInitialUpcard(steps);
-    if (initialUpcard) {
-      knockCardPile.appendChild(buildCard(initialUpcard));
-    } else {
-      const empty = document.createElement('div');
-      empty.className = 'pile-empty';
-      empty.textContent = '?';
-      knockCardPile.appendChild(empty);
-    }
-    const lbl = document.createElement('div');
-    const limit = observation.knock_card;
-    lbl.textContent = limit !== null ? `Knock Card (≤${limit})` : 'Knock Card';
-    knockCardPile.appendChild(lbl);
-    centerRow.appendChild(knockCardPile);
+    centerRow.appendChild(buildKnockCardPile(findInitialUpcard(steps), observation.knock_card));
   }
+  centerRow.appendChild(buildStockPile(observation.stock_size));
+  centerRow.appendChild(buildUpcardPile(observation.upcard));
+  centerRow.appendChild(buildDiscardPile(observation.discard_pile));
 
-  // Stock pile (face-down stack)
-  const stockPile = document.createElement('div');
-  stockPile.className = 'pile';
-  const stockStack = document.createElement('div');
-  stockStack.className = 'pile-stack';
-  const stockCardCount = Math.min(observation.stock_size, 3);
-  if (stockCardCount === 0) {
-    const empty = document.createElement('div');
-    empty.className = 'pile-empty';
-    empty.textContent = 'empty';
-    stockPile.appendChild(empty);
-  } else {
-    for (let i = 0; i < stockCardCount; i++) {
-      stockStack.appendChild(
-        buildCard(null, { faceDown: true, highlight: i === stockCardCount - 1 && highlightDrawStock })
-      );
-    }
-    stockPile.appendChild(stockStack);
-  }
-  const stockLabel = document.createElement('div');
-  stockLabel.textContent = `Stock (${observation.stock_size})`;
-  stockPile.appendChild(stockLabel);
-  centerRow.appendChild(stockPile);
-
-  // Upcard / discard top -- in OpenSpiel gin_rummy, the upcard is the visible
-  // top of the discard pile during draw phases; once drawn or after a discard,
-  // the discard pile's last card is the visible top. We render the upcard slot
-  // separately when present (Draw phase) and the rest of the pile beneath.
-  const upcardPile = document.createElement('div');
-  upcardPile.className = 'pile';
-  if (observation.upcard) {
-    upcardPile.appendChild(
-      buildCard(observation.upcard, {
-        highlight: highlightTakenUpcard || (highlightDiscard !== null && highlightDiscard === observation.upcard),
-      })
-    );
-    const lbl = document.createElement('div');
-    lbl.textContent = 'Upcard';
-    upcardPile.appendChild(lbl);
-  } else {
-    const empty = document.createElement('div');
-    empty.className = 'pile-empty';
-    empty.textContent = 'no upcard';
-    upcardPile.appendChild(empty);
-    const lbl = document.createElement('div');
-    lbl.textContent = 'Upcard';
-    upcardPile.appendChild(lbl);
-  }
-  centerRow.appendChild(upcardPile);
-
-  // Discard pile beneath the upcard slot. The OpenSpiel discard_pile and
-  // upcard are disjoint (the upcard is reported on its own line and is not
-  // included in the discard pile).
-  const discardPile = document.createElement('div');
-  discardPile.className = 'pile';
-  const discardStack = document.createElement('div');
-  discardStack.className = 'pile-stack';
-  const dp = observation.discard_pile;
-  const visible = dp.slice(-3);
-  if (visible.length === 0) {
-    const empty = document.createElement('div');
-    empty.className = 'pile-empty';
-    empty.textContent = 'empty';
-    discardPile.appendChild(empty);
-  } else {
-    visible.forEach((card, i) => {
-      const isTop = i === visible.length - 1;
-      discardStack.appendChild(
-        buildCard(card, {
-          highlight: isTop && highlightDiscard !== null && card === highlightDiscard,
-        })
-      );
-    });
-    discardPile.appendChild(discardStack);
-  }
-  const dpLabel = document.createElement('div');
-  dpLabel.textContent = `Discard (${dp.length})`;
-  discardPile.appendChild(dpLabel);
-  centerRow.appendChild(discardPile);
-
-  // Bottom: player 0
   renderPlayerRow(
     bottomRow,
     playerNames[0],
@@ -423,45 +416,5 @@ export function renderer(options: RendererOptions<GinRummyStep[]>) {
     highlightCardP0
   );
 
-  // Status: phase, last action, terminal result
-  const parts: string[] = [];
-  if (observation.phase) {
-    parts.push(`<span class="phase-pill">${phaseLabel(observation.phase)}</span>`);
-  }
-  if (observation.knock_card !== null) {
-    parts.push(`<span class="annotation">knock card: ${observation.knock_card}</span>`);
-  }
-  if (lastAction) {
-    const { actor, submission } = lastAction;
-    const moverColor = actor === 0 ? PLAYER_0_COLOR : PLAYER_1_COLOR;
-    const moverHand = observation.hands[String(actor) as '0' | '1'] ?? [];
-    const lbl = actionLabel(submission, moverHand);
-    parts.push(
-      `<span class="annotation">last move:</span> <span style="color:${moverColor};font-weight:700;">${playerNames[actor]} \u2192 ${lbl}</span>`
-    );
-  } else if (!isTerminal) {
-    const turnColor = activeIdx === 0 ? PLAYER_0_COLOR : PLAYER_1_COLOR;
-    const turnName = activeIdx >= 0 ? playerNames[activeIdx] : '';
-    if (turnName) {
-      parts.push(`<span>Turn: <span style="color:${turnColor};font-weight:700;">${turnName}</span></span>`);
-    }
-  }
-
-  if (isTerminal) {
-    let resultHTML = '';
-    if (winnerIdx === 0) {
-      resultHTML = `<span style="color:${PLAYER_0_COLOR};font-weight:700;">${playerNames[0]} wins</span>`;
-    } else if (winnerIdx === 1) {
-      resultHTML = `<span style="color:${PLAYER_1_COLOR};font-weight:700;">${playerNames[1]} wins</span>`;
-    } else {
-      resultHTML = `<span>Game over: ${observation.winner ?? 'draw'}</span>`;
-    }
-    const ret = observation.returns;
-    if (ret && ret.length === 2) {
-      resultHTML += ` <span class="annotation">(score ${ret[0]} : ${ret[1]})</span>`;
-    }
-    parts.push(resultHTML);
-  }
-
-  statusContainer.innerHTML = parts.join(' ');
+  statusContainer.innerHTML = buildStatus(observation, lastAction, playerNames, activeIdx, winnerIdx, isTerminal);
 }

--- a/kaggle_environments/envs/open_spiel_env/games/gin_rummy/visualizer/default/src/style.css
+++ b/kaggle_environments/envs/open_spiel_env/games/gin_rummy/visualizer/default/src/style.css
@@ -45,8 +45,13 @@ body,
   flex-shrink: 0;
 }
 
-.header .player {
+/* Doubled `.player.player` selector raises specificity to 0,3,0 so the
+   kaggle core's `.game-renderer-isolation` reset can't expand the pill to
+   fill the flex row. */
+.header .player.player {
   display: inline-flex;
+  flex: none;
+  width: max-content;
   flex-direction: row;
   align-items: center;
   padding: 4px 12px;
@@ -279,6 +284,21 @@ body,
 .pile-stack .card:nth-child(3) {
   left: 8px;
   top: 0;
+}
+
+/* Card-shaped slot used when the upcard or stock pile is empty — keeps a
+   visible 56x80 dashed outline in place of the missing card. */
+.pile-stack .card-slot--pile {
+  position: absolute;
+  left: 0;
+  top: 6px;
+  box-sizing: border-box;
+  width: 56px;
+  height: 80px;
+  margin: 0;
+  border: 1px dashed #9a9684;
+  border-radius: 6px;
+  background: transparent;
 }
 
 /* Empty card slot inside a .pile (used by knock-card pile in Oklahoma mode). */

--- a/kaggle_environments/envs/open_spiel_env/games/gin_rummy/visualizer/default/src/style.css
+++ b/kaggle_environments/envs/open_spiel_env/games/gin_rummy/visualizer/default/src/style.css
@@ -1,5 +1,9 @@
 @import url('https://fonts.googleapis.com/css2?family=Inter:ital,opsz,wght@0,14..32,100..900;1,14..32,100..900&display=swap');
 
+/* ---------------------------------------------------------------------------
+ * Layout
+ * ------------------------------------------------------------------------- */
+
 html,
 body,
 #app {
@@ -45,11 +49,8 @@ body,
   display: inline-flex;
   flex-direction: row;
   align-items: center;
-  width: auto;
-  height: auto;
   padding: 4px 12px;
   background-color: white;
-  background: white;
   transition: scale 300ms, background-color 300ms;
   white-space: nowrap;
 }
@@ -98,58 +99,31 @@ body,
   padding: 2px 10px;
 }
 
-.hand {
-  display: flex;
-  flex-direction: row;
-  flex-wrap: nowrap;
-  align-items: center;
-  justify-content: center;
-  gap: 0;
-  flex: 0 1 auto;
-  min-height: 0;
-  padding: 4px;
-}
+/* ---------------------------------------------------------------------------
+ * Cards
+ *
+ * The kaggle-environments core wraps the visualizer in `.game-renderer-isolation`
+ * which forces `box-sizing: content-box` via `.game-renderer-isolation *`
+ * (specificity 0,1,1). That beats a plain `.card` rule and silently inflates
+ * every card by its padding + border. The doubled `.card.card` selector below
+ * raises specificity to 0,2,0 so border-box sticks.
+ * ------------------------------------------------------------------------- */
 
-.center-row {
-  display: flex;
-  flex-direction: row;
-  align-items: center;
-  justify-content: center;
-  gap: 18px;
-  flex-shrink: 0;
-  padding: 6px 0;
-}
-
-.pile {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 4px;
-  font-size: 0.78rem;
-  font-weight: 600;
-  color: #444343;
-}
-
-.pile-stack {
-  position: relative;
-  width: 64px;
-  height: 90px;
-}
-
-.card {
+.card,
+.card.card {
   position: relative;
   display: inline-flex;
   flex-direction: column;
   align-items: center;
-  justify-content: space-between;
+  justify-content: center;
+  box-sizing: border-box;
   width: 56px;
   height: 80px;
+  padding: 4px 6px;
+  margin-left: -16px;
   border: 1px dashed #3c3b37;
   border-radius: 6px;
   background-color: white;
-  padding: 4px 6px;
-  margin-left: -16px;
-  box-sizing: border-box;
   font-family: 'Inter', sans-serif;
   font-weight: 700;
   color: #050001;
@@ -162,54 +136,30 @@ body,
   margin-left: 0;
 }
 
-.card.compact {
-  width: 44px;
-  height: 64px;
-  padding: 3px 4px;
-  margin-left: -12px;
-  font-size: 0.78rem;
-}
-
-.card.compact:first-child {
-  margin-left: 0;
-}
-
 .card .corner {
   display: flex;
   flex-direction: column;
-  align-items: flex-start;
-  font-size: 1.05rem;
-  line-height: 1;
-}
-
-.card.compact .corner {
-  font-size: 0.85rem;
-}
-
-.card .corner.bottom {
-  align-items: flex-end;
-  transform: rotate(180deg);
+  align-items: center;
+  justify-content: center;
+  font-size: 1.4rem;
+  line-height: 1.05;
+  gap: 2px;
 }
 
 .card .suit {
-  font-size: 1rem;
+  font-size: 1.15rem;
   line-height: 1;
-}
-
-.card.compact .suit {
-  font-size: 0.78rem;
 }
 
 .card.face-down {
   background-color: #fbf7e8;
-  background-image:
-    repeating-linear-gradient(
-      45deg,
-      #d9d3bf 0,
-      #d9d3bf 2px,
-      transparent 2px,
-      transparent 6px
-    );
+  background-image: repeating-linear-gradient(
+    45deg,
+    #d9d3bf 0,
+    #d9d3bf 2px,
+    transparent 2px,
+    transparent 6px
+  );
 }
 
 .card.face-down .corner,
@@ -236,6 +186,79 @@ body,
   opacity: 0.55;
 }
 
+/* ---------------------------------------------------------------------------
+ * Opponent's overlapping face-down hand row
+ * ------------------------------------------------------------------------- */
+
+.hand {
+  display: flex;
+  flex-direction: row;
+  flex-wrap: nowrap;
+  align-items: center;
+  justify-content: center;
+  padding: 4px;
+}
+
+/* ---------------------------------------------------------------------------
+ * Centre row: stock + upcard + (right-aligned) discard mini-grid
+ *
+ * The row width matches the hand-grid outer width
+ * (13 cards * 44px + 12 gaps * 4px + 2 * 6px padding = 632px) so the
+ * absolutely-positioned discard's right edge lines up with the right edge of
+ * the player hand grids above and below.
+ * ------------------------------------------------------------------------- */
+
+.center-row {
+  position: relative;
+  display: flex;
+  flex-direction: row;
+  align-items: flex-end;
+  justify-content: center;
+  gap: 18px;
+  flex-shrink: 0;
+  padding: 6px 0;
+  width: 632px;
+  margin: 0 auto;
+}
+
+.center-row > .pile--discard {
+  position: absolute;
+  right: 0;
+  bottom: 6px;
+  margin: 0;
+}
+
+.pile {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: flex-end;
+  width: 72px;
+  flex: none;
+  font-size: 0.78rem;
+  font-weight: 600;
+  color: #444343;
+}
+
+.pile-label,
+.pile > div:last-child {
+  white-space: nowrap;
+  text-align: center;
+}
+
+.pile--discard {
+  width: auto;
+}
+
+.pile-stack {
+  position: relative;
+  box-sizing: border-box;
+  width: 64px;
+  height: 90px;
+  margin: 0;
+  flex: none;
+}
+
 .pile-stack .card {
   position: absolute;
   margin-left: 0;
@@ -247,18 +270,24 @@ body,
   left: 0;
   top: 6px;
 }
+
 .pile-stack .card:nth-child(2) {
   left: 4px;
   top: 3px;
 }
+
 .pile-stack .card:nth-child(3) {
   left: 8px;
   top: 0;
 }
 
-.pile-empty {
+/* Empty card slot inside a .pile (used by knock-card pile in Oklahoma mode). */
+.pile > .pile-empty {
+  box-sizing: border-box;
   width: 56px;
   height: 80px;
+  margin: 0;
+  flex: none;
   border: 1px dashed #9a9684;
   border-radius: 6px;
   background-color: transparent;
@@ -269,6 +298,151 @@ body,
   color: #9a9684;
   font-style: italic;
 }
+
+.pile > .card {
+  margin: 0;
+  flex: none;
+}
+
+/* ---------------------------------------------------------------------------
+ * Player hand: 4x13 grid (rows = suits, cols = ranks)
+ *
+ * Empty cells render a `.card-slot` of identical dimensions to a card so
+ * swapping slot <-> card produces zero layout shift between steps.
+ * ------------------------------------------------------------------------- */
+
+.hand-grid {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 6px;
+  align-self: center;
+}
+
+.hand-grid__row {
+  display: grid;
+  grid-template-columns: repeat(13, 44px);
+  gap: 4px;
+  align-items: center;
+}
+
+.hand-grid .card,
+.hand-grid .card-slot {
+  box-sizing: border-box;
+  width: 44px;
+  height: 62px;
+  margin: 0;
+  padding: 0;
+  border: 1px dashed #3c3b37;
+  border-radius: 6px;
+  transition: none;
+  transform: none;
+  animation: none;
+  flex: none;
+}
+
+.hand-grid .card-slot {
+  background: transparent;
+  border-color: rgba(60, 59, 55, 0.18);
+}
+
+.hand-grid .card .corner {
+  font-size: 0.95rem;
+  padding: 0;
+  gap: 1px;
+}
+
+.hand-grid .card .suit {
+  font-size: 0.9rem;
+}
+
+.hand-grid .card.highlight {
+  /* Stable outline only — no translate that pops the row. */
+  outline: 2.5px solid #f5b400;
+  outline-offset: -1px;
+  transform: none;
+  z-index: 2;
+}
+
+.card-slot {
+  box-sizing: border-box;
+  width: 44px;
+  height: 62px;
+  border: 1px dashed rgba(60, 59, 55, 0.25);
+  border-radius: 6px;
+  background: rgba(255, 255, 255, 0.04);
+}
+
+/* ---------------------------------------------------------------------------
+ * Discard pile: mini 4x13 grid showing every discarded card
+ * ------------------------------------------------------------------------- */
+
+.discard-grid {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  padding: 4px;
+  box-sizing: border-box;
+  border: 1px dashed rgba(60, 59, 55, 0.18);
+  border-radius: 6px;
+  background: rgba(255, 255, 255, 0.4);
+}
+
+.discard-grid__row {
+  display: grid;
+  grid-template-columns: repeat(13, 14px);
+  gap: 1px;
+}
+
+.discard-cell {
+  box-sizing: border-box;
+  width: 14px;
+  height: 18px;
+  border: 1px solid transparent;
+  border-radius: 2px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.55rem;
+  font-weight: 700;
+  line-height: 1;
+  background: transparent;
+}
+
+.discard-cell.red,
+.discard-cell.black {
+  background: white;
+  border-color: #d8d4c4;
+}
+
+.discard-cell.red {
+  color: #c0392b;
+}
+
+.discard-cell.black {
+  color: #1a1a1a;
+}
+
+.discard-cell.top {
+  outline: 1.5px solid #f5b400;
+  outline-offset: -1px;
+  z-index: 1;
+}
+
+.discard-cell .dc-rank,
+.discard-cell .dc-suit {
+  display: block;
+  line-height: 1;
+}
+
+.discard-cell .dc-suit {
+  font-size: 0.55rem;
+}
+
+/* ---------------------------------------------------------------------------
+ * Status bar
+ * ------------------------------------------------------------------------- */
 
 .status-container {
   display: flex;
@@ -301,8 +475,13 @@ body,
   font-weight: 700;
 }
 
+/* ---------------------------------------------------------------------------
+ * Narrow-container fallback (used for very small embedded views)
+ * ------------------------------------------------------------------------- */
+
 @container (max-width: 520px) {
-  .card {
+  .card,
+  .card.card {
     width: 44px;
     height: 64px;
     margin-left: -12px;
@@ -318,8 +497,20 @@ body,
     width: 52px;
     height: 72px;
   }
-  .pile-empty {
+  .pile > .pile-empty {
     width: 44px;
     height: 64px;
+  }
+}
+
+@media (max-width: 900px) {
+  .hand-grid__row {
+    grid-template-columns: repeat(13, 32px);
+    gap: 3px;
+  }
+  .hand-grid .card,
+  .card-slot {
+    width: 32px;
+    height: 46px;
   }
 }


### PR DESCRIPTION
Reworks the OpenSpiel Gin Rummy replay visualizer:

- **Player hands** render as a 4x13 grid (rows = suits, cols = ranks) with fixed-size slots so cards swap in/out without layout shift.
- **Center row** holds Stock (decorative offset stack), Upcard (single card in a matching 64x90 frame), and a right-aligned **Discards mini-grid** showing every discarded card with the top card outlined.
- All pile labels share a single baseline. The center row width matches the hand-grid outer width so the Discards block right-aligns with the player hands.
- Cards show a single centered rank+suit (the rotated-180deg duplicate was removed). The pile-level "what just happened" highlights were dropped — the status bar already names the move; only the just-discarded card stays highlighted in the actor's hand.
- Re-asserts `box-sizing: border-box` for `.card` with a doubled-class selector — `.game-renderer-isolation *` (from the core) has specificity 0,1,1 and silently overrides the single-class declaration, otherwise inflating every card by its padding + border.

Code paths touched:
- `kaggle_environments/envs/open_spiel_env/games/gin_rummy/visualizer/default/src/renderer.ts`
- `kaggle_environments/envs/open_spiel_env/games/gin_rummy/visualizer/default/src/style.css`

## Test plan

- [x] `pnpm exec tsc --noEmit` clean
- [x] `pnpm dev` with `VITE_REPLAY_FILE` pointing at a random playthrough renders without visible layout shift across all 100+ steps
- [x] Stock and Upcard piles are identical 64x90 footprints; labels for Stock / Upcard / Discards share a single baseline
- [x] Card and slot dimensions are identical (44x62 border-box) inside the hand grid; no card-resize pop when a slot fills