### PR TITLE
kaggriculture: add DROP action to dump inventory into shed

### DIFF
--- a/kaggle_environments/envs/kaggriculture/AGENTS.md
+++ b/kaggle_environments/envs/kaggriculture/AGENTS.md
@@ -60,7 +60,7 @@ Your agent is a function that receives an observation and returns an action dict
 
 Farmer / hand ops:
 - Movement: `"NORTH"`, `"SOUTH"`, `"EAST"`, `"WEST"`, `"PASS"`
-- Shed / inventory: `"PICKUP" <item> [n]` (from shed), `"PLACE" <item> [n]` (places an animal on a matching structure when standing on it, or drops items into the shed when adjacent to it)
+- Shed / inventory: `"PICKUP" <item> [n]` (from shed), `"PLACE" <item> [n]` (places an animal on a matching structure when standing on it, or drops items into the shed when adjacent to it), `"DROP"` (when shed-adjacent, dumps entire inventory into shed; overflow past `shedCapacity` discarded)
 - Plants: `"PLANT" <crop>`, `"WATER"`, `"HARVEST"`, `"FERTILIZE"`
 - Animals: `"BUILD_COOP"`, `"BUILD_PASTURE"`, `"FEED"`, `"COLLECT_FERTILIZER"`, `"CARE"`
 - Terrain: `"DIG"` (removes a plant, weed, coop, or pasture from the current tile)

--- a/kaggle_environments/envs/kaggriculture/README.md
+++ b/kaggle_environments/envs/kaggriculture/README.md
@@ -39,6 +39,7 @@ Each Farmer / Farm Hand can be given an action every turn. Farmer/Farm Hand CAN 
 Picks up an item from the shed (must be orthogonally adjacent) into the inventory
 
 - PICKUP `<item>` `[n]` — move up to `n` of `<item>` (default 1) from the shed into the active farmer/hand's inventory. Any item present in the shed is valid (animals, fertilizer, harvested produce, etc.). Seeds live in a separate slot and are never picked up — `PLANT` consumes them directly.
+- DROP — orthogonally adjacent to the shed, dump the active farmer/hand's entire current inventory into the shed. Overflow past `shedCapacity` is discarded. No-op if not shed-adjacent.
 
 #### Plants
 

--- a/kaggle_environments/envs/kaggriculture/kaggriculture.py
+++ b/kaggle_environments/envs/kaggriculture/kaggriculture.py
@@ -332,6 +332,21 @@ def _apply_unit_action(farm, private, idx, action, board_size, day, turns_per_da
     if tile == "LOCKED":
         return
 
+    if op == "DROP":
+        if not _is_shed_adjacent((fx, fy), board_size):
+            return
+        shed = private["shed"]
+        for item, n in list(inv.items()):
+            if n <= 0:
+                del inv[item]
+                continue
+            room = max(0, shed_capacity - sum(shed.values()))
+            take = min(n, room)
+            if take > 0:
+                shed[item] = shed.get(item, 0) + take
+            del inv[item]
+        return
+
     if op == "PICKUP":
         if not _is_shed_adjacent((fx, fy), board_size):
             return

--- a/tests/envs/kaggriculture/test_kaggriculture.py
+++ b/tests/envs/kaggriculture/test_kaggriculture.py
@@ -164,6 +164,39 @@ def test_pickup_does_not_pull_from_seed_pool():
     assert private["inventories"][0].get("CARROT", 0) == 0
 
 
+def test_drop_action_dumps_inventory_when_shed_adjacent():
+    farm = _new_farm(10, 100)
+    private = _new_private()
+    # Farmer spawns at (4, 4) which is shed-adjacent.
+    private["inventories"][0] = {"WHEAT": 3, "CARROT": 2}
+    _apply_unit_action(farm, private, 0, ["DROP"], 10, 0, 24)
+    assert private["shed"]["WHEAT"] == 3
+    assert private["shed"]["CARROT"] == 2
+    assert private["inventories"][0] == {}
+
+
+def test_drop_action_noop_when_not_shed_adjacent():
+    farm = _new_farm(10, 100)
+    private = _new_private()
+    private["inventories"][0] = {"WHEAT": 3}
+    # Step west off the shed-adjacent spawn.
+    _apply_unit_action(farm, private, 0, ["WEST"], 10, 0, 24)
+    _apply_unit_action(farm, private, 0, ["DROP"], 10, 0, 24)
+    assert private["inventories"][0] == {"WHEAT": 3}
+    assert private["shed"].get("WHEAT", 0) == 0
+
+
+def test_drop_action_discards_overflow_past_shed_capacity():
+    farm = _new_farm(10, 100)
+    private = _new_private()
+    private["shed"]["WHEAT"] = 98
+    private["inventories"][0] = {"WHEAT": 5, "CARROT": 4}
+    _apply_unit_action(farm, private, 0, ["DROP"], 10, 0, 24, shed_capacity=100)
+    # Shed fills to capacity, overflow lost.
+    assert sum(private["shed"].values()) == 100
+    assert private["inventories"][0] == {}
+
+
 def test_drop_inventories_respects_shed_capacity():
     private = _new_private()
     # Pre-fill shed near capacity (capacity 100).


### PR DESCRIPTION
DROP, when shed-adjacent, drains the active farmer/hand's entire inventory into the shed; overflow past shedCapacity is discarded. No-op otherwise. This enables day 30 to be meaningful.