### PR TITLE
Remove legal-moves list from open_spiel harness prompts

### DIFF
--- a/kaggle_environments/envs/open_spiel_env/games/amazons/harness.py
+++ b/kaggle_environments/envs/open_spiel_env/games/amazons/harness.py
@@ -125,8 +125,8 @@ def _board_dims(state: Mapping[str, Any]) -> tuple[int, int]:
 
 _PHASE_INSTRUCTION = {
     "from": (
-        "Choose which of your amazons to move. Each legal move below names a "
-        "square that currently holds one of your amazons."
+        "Choose which of your amazons to move (one of your pieces on the "
+        "board)."
     ),
     "to": (
         "You picked up an amazon. Choose where to move it. Amazons move like "
@@ -159,22 +159,19 @@ Move history (last {history_max}):
 
 {phase_instruction}
 
-Legal moves you may play (algebraic, column letter + row number):
-{legal_moves}
-
 It is your turn. Think briefly about the position, then choose your move.
-The move MUST be exactly one of the legal squares listed above.
+Use algebraic notation: column letter + row number, e.g. ``a1`` or ``j10``.
 
 Respond with your reasoning followed by your final answer in a JSON block:
 
 ```json
 {{
-  "move": "<square from the legal list, e.g. a1>"
+  "move": "<square in algebraic notation, e.g. a1>"
 }}
 ```
 
-Failure to output your final answer in the specified format, or selecting a
-square that is not in the legal list, will result in a loss.
+Failure to output your final answer in the specified format, or selecting an
+illegal square, will result in a loss.
 """
 
 
@@ -183,8 +180,8 @@ RETHINK_SUFFIX = """
 Your previous response was:
 {previous_response}
 
-You suggested move "{previous_action}" but it is NOT in the legal list above.
-Reconsider and pick a square that appears verbatim in the legal moves list.
+You suggested move "{previous_action}" but it is not a legal move.
+Reconsider the position and pick a legal square.
 """
 
 
@@ -243,9 +240,6 @@ def generate_prompt(
     player_name = "Black" if current == "x" else "White"
     player_glyph = "X" if current == "x" else "O"
 
-    legal_moves = get_legal_moves(observation)
-    legal_strings = list(legal_moves.values())
-
     prompt = AMAZONS_PROMPT_TEMPLATE.format(
         num_rows=num_rows,
         num_cols=num_cols,
@@ -256,7 +250,6 @@ def generate_prompt(
         history_max=_HISTORY_MAX,
         move_history=_format_history(move_history),
         phase_instruction=_PHASE_INSTRUCTION.get(phase, _PHASE_INSTRUCTION["from"]),
-        legal_moves=", ".join(legal_strings) if legal_strings else "(none)",
     )
 
     if previous_response is not None:

--- a/kaggle_environments/envs/open_spiel_env/games/clobber/harness.py
+++ b/kaggle_environments/envs/open_spiel_env/games/clobber/harness.py
@@ -54,18 +54,19 @@ You are Player {player_label} ('{my_piece}').
 Move number: {move_number}
 Last move played: {last_move}
 
-You MUST pick one of the legal moves: {legal_moves}.
+Choose your move. It must move one of your pieces onto an orthogonally
+adjacent square that holds an opponent's piece.
 
 Respond with your reasoning followed by your final move in a JSON block:
 
 ```json
 {{
-  "move": "<one of the legal moves>"
+  "move": "<from><to>, e.g. a1b1"
 }}
 ```
 
-Failure to output your final answer in the specified format, or selecting a
-move that is not in the legal list, will result in a loss.
+Failure to output your final answer in the specified format, or selecting an
+illegal move, will result in a loss.
 """
 
 
@@ -74,8 +75,8 @@ RETHINK_SUFFIX = """
 Your previous response was:
 {previous_response}
 
-You suggested move "{previous_action}" but it is NOT in the legal move list.
-Reconsider and pick one of the legal moves exactly.
+You suggested move "{previous_action}" but it is not a legal move.
+Reconsider the board and pick a legal move.
 """
 
 
@@ -178,11 +179,6 @@ def generate_prompt(
     my_piece = "o" if player_id == 0 else "x"
     last_file = chr(ord("a") + max(0, columns - 1))
 
-    legal_action_strings = observation.get("legalActionStrings") or []
-    if not legal_action_strings:
-        legal_action_strings = list(get_legal_moves(observation).values())
-    legal_moves_str = ", ".join(sorted(legal_action_strings)) or "(none)"
-
     prompt = CLOBBER_PROMPT_TEMPLATE.format(
         rows=rows,
         columns=columns,
@@ -192,7 +188,6 @@ def generate_prompt(
         my_piece=my_piece,
         move_number=move_number,
         last_move=last_move,
-        legal_moves=legal_moves_str,
     )
 
     if previous_response is not None:

--- a/kaggle_environments/envs/open_spiel_env/games/gin_rummy/harness.py
+++ b/kaggle_environments/envs/open_spiel_env/games/gin_rummy/harness.py
@@ -160,8 +160,8 @@ def _instruction_for_phase(phase: str | None, legal_strings: Sequence[str]) -> s
     if "Pass" in legals and "Draw upcard" not in legals:
         return _PHASE_INSTRUCTION["Layoff"]
     return (
-        "Choose one of the legal actions listed below. Your move MUST be "
-        "exactly one of those strings."
+        "Choose a legal action for this phase. Use an exact OpenSpiel "
+        "action string."
     )
 
 
@@ -194,23 +194,20 @@ Move history (oldest -> newest):
 
 {phase_instruction}
 
-Legal moves you may play:
-{legal_moves}
-
 It is your turn. Think briefly about the position, then choose your move.
-The move MUST be exactly one of the legal moves listed above (use the exact
-string, e.g. 'Draw upcard', 'Knock', '7h', 'As2s3s').
+Use the exact OpenSpiel action string (e.g. 'Draw upcard', 'Knock', '7h',
+'As2s3s').
 
 Respond with your reasoning followed by your final answer in a JSON block:
 
 ```json
 {{
-  "move": "<one of the legal moves above>"
+  "move": "<exact OpenSpiel action string>"
 }}
 ```
 
-Failure to output your final answer in the specified format, or selecting a
-move that is not in the legal list, will result in a loss.
+Failure to output your final answer in the specified format, or selecting an
+illegal move, will result in a loss.
 """
 
 
@@ -219,8 +216,8 @@ RETHINK_SUFFIX = """
 Your previous response was:
 {previous_response}
 
-You suggested move "{previous_action}" but it is NOT in the legal moves list.
-Reconsider and pick a move that appears verbatim in the legal moves above.
+You suggested move "{previous_action}" but it is not a legal move.
+Reconsider the position and pick a legal action for this phase.
 """
 
 
@@ -282,7 +279,6 @@ def generate_prompt(
         deadwood=deadwood if deadwood is not None else "?",
         move_history=_format_history(move_history),
         phase_instruction=_instruction_for_phase(phase, legal_strings),
-        legal_moves=", ".join(legal_strings) if legal_strings else "(none)",
     )
 
     if previous_response is not None:

--- a/kaggle_environments/envs/open_spiel_env/games/oshi_zumo/harness.py
+++ b/kaggle_environments/envs/open_spiel_env/games/oshi_zumo/harness.py
@@ -54,19 +54,19 @@ Round:             {move_number}
 
 Your past bids:        {my_history}
 
-You are Player {player_label}. Choose your bid for this round.
-You MUST pick one of the legal bids: {legal_bids}.
+You are Player {player_label}. Choose your bid for this round (an integer
+at least {min_bid} and at most your current coin total).
 
 Respond with your reasoning followed by your final bid in a JSON block:
 
 ```json
 {{
-  "bid": <integer from the legal list>
+  "bid": <integer>
 }}
 ```
 
-Failure to output your final answer in the specified format, or selecting a
-bid that is not in the legal list, will result in a loss.
+Failure to output your final answer in the specified format, or selecting an
+illegal bid, will result in a loss.
 """
 
 
@@ -75,8 +75,8 @@ RETHINK_SUFFIX = """
 Your previous response was:
 {previous_response}
 
-You suggested bid "{previous_action}" but it is NOT in the legal bid list.
-Reconsider and pick one of the legal bids exactly.
+You suggested bid "{previous_action}" but it is not a legal bid.
+Reconsider your coin total and the minimum bid, then pick a legal integer bid.
 """
 
 
@@ -201,14 +201,6 @@ def generate_prompt(
     min_bid = int(params.get("min_bid", 0))
     horizon = int(params.get("horizon", 0))
 
-    legal_action_strings = observation.get("legalActionStrings") or []
-    if not legal_action_strings:
-        legal_action_strings = list(get_legal_moves(observation).values())
-    legal_bids = sorted(
-        {b for b in (_bid_from_action_string(s) for s in legal_action_strings) if b is not None}
-    )
-    legal_bids_str = ", ".join(str(b) for b in legal_bids) or "(none)"
-
     my_bids = [_bid_from_action_string(s) for s in move_history]
     my_history_str = (
         ", ".join(str(b) for b in my_bids if b is not None)
@@ -228,7 +220,6 @@ def generate_prompt(
         move_number=move_number,
         my_history=my_history_str,
         player_label=player_id,
-        legal_bids=legal_bids_str,
     )
 
     if previous_response is not None:

--- a/tests/envs/open_spiel_env/games/clobber/harness_test.py
+++ b/tests/envs/open_spiel_env/games/clobber/harness_test.py
@@ -107,12 +107,6 @@ class GeneratePromptTest(absltest.TestCase):
         self.assertIn("Player 1", prompt)
         self.assertIn("'x'", prompt)
 
-    def test_legal_moves_listed(self):
-        obs = _make_observation(self.state, self.game, player_id=0)
-        prompt = generate_prompt(obs, [])
-        for legal in obs["legalActionStrings"]:
-            self.assertIn(legal, prompt)
-
     def test_board_ascii_includes_files_and_ranks(self):
         obs = _make_observation(self.state, self.game, player_id=0)
         prompt = generate_prompt(obs, [])
@@ -136,7 +130,7 @@ class GeneratePromptTest(absltest.TestCase):
         )
         self.assertIn("Your previous response was", prompt)
         self.assertIn("z9z9", prompt)
-        self.assertIn("NOT in the legal move list", prompt)
+        self.assertIn("not a legal move", prompt)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/envs/open_spiel_env/games/oshi_zumo/harness_test.py
+++ b/tests/envs/open_spiel_env/games/oshi_zumo/harness_test.py
@@ -114,13 +114,6 @@ class GeneratePromptTest(absltest.TestCase):
         # Initial state is centered with all 12 coins each.
         self.assertIn("12", prompt)
 
-    def test_legal_bids_listed(self):
-        obs = _make_observation(self.state, self.game, player_id=0)
-        prompt = generate_prompt(obs, [])
-        # Initial bids 0..12 are all legal.
-        for n in range(13):
-            self.assertIn(str(n), prompt)
-
     def test_player_label_swap(self):
         obs0 = _make_observation(self.state, self.game, player_id=0)
         obs1 = _make_observation(self.state, self.game, player_id=1)
@@ -157,7 +150,7 @@ class GeneratePromptTest(absltest.TestCase):
         )
         self.assertIn("Your previous response was", prompt)
         self.assertIn("99", prompt)
-        self.assertIn("NOT in the legal bid list", prompt)
+        self.assertIn("not a legal bid", prompt)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Drop the enumerated legal-moves list from the Amazons, Clobber, Gin Rummy, and Oshi-Zumo prompts (and the matching wording in their rethink suffixes). Models must derive legal moves from the rules and board state shown in the prompt. Update the two harness tests that asserted the list was present.