### PR TITLE
Snake: add proxy, harness, visualizer, and tests

### DIFF
--- a/kaggle_environments/envs/open_spiel_env/games/snake/harness.py
+++ b/kaggle_environments/envs/open_spiel_env/games/snake/harness.py
@@ -1,0 +1,229 @@
+"""LLM harness for the OpenSpiel Snake game.
+
+Drop the body of this file into the notebook attached to the competition via
+HarnessKernelId. The auto-generated ``main.py`` calls these three module-level
+functions: ``get_legal_moves``, ``generate_prompt``, ``parse_response``.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from typing import Any, Mapping, Sequence
+
+import pyspiel
+
+from kaggle_environments.core_harness import ParseResult
+
+_JSON_BLOCK_RE = re.compile(r"```json\s*(\{.*?\})\s*```", re.DOTALL)
+_BARE_JSON_RE = re.compile(r'\{[^{}]*"move"\s*:\s*"([^"]+)"[^{}]*\}', re.DOTALL)
+# Snake action names are uppercase: UP | DOWN | LEFT | RIGHT.
+_MOVE_RE = re.compile(r"\b(up|down|left|right)\b", re.IGNORECASE)
+
+
+# --- Prompt -----------------------------------------------------------------
+
+
+SNAKE_PROMPT_TEMPLATE = """Let's play Snake.
+
+Rules: {rows}x{cols} grid with {num_players} snakes moving simultaneously.
+Each turn every snake picks one of {{UP, DOWN, LEFT, RIGHT}} and all
+snakes move one cell in the chosen direction at the same time. A snake
+dies if its new head:
+  - leaves the grid,
+  - lands on any snake's post-move body (including its own), or
+  - collides head-to-head with another snake (both die).
+A snake that moves onto the food ("*") grows by one and earns one point;
+a new food cell then appears on a random empty square. Snakes that do
+NOT eat lose their tail on the same turn. The game ends when at most one
+snake is alive (in a multi-player game) or after {max_turns} turns; the
+last snake standing wins, otherwise the highest score wins.
+
+Coordinates are ``[row, column]`` with ``row=0`` at the top and
+``column=0`` on the left. The board uses these characters:
+  ``.`` empty, ``*`` food, lowercase letter ({your_body_char}/etc.) snake
+  body, uppercase letter ({your_head_char}/etc.) snake head. Your snake
+  uses letter "{your_letter}".
+
+The current game state is:
+{state_str}
+
+You are player {player_id}. Your snake is at {your_body}{alive_note}.
+Your score: {your_score}. Food at: {food_str}.
+
+Moves you have played so far:
+{move_history}
+
+It is now your turn. Choose your move.
+The move MUST be one of: UP, DOWN, LEFT, RIGHT.
+Your response should include the reasoning that led you to your move,
+and conclude with your final move as a JSON formatted as follows:
+
+```json
+{{
+  "move": "<UP|DOWN|LEFT|RIGHT>"
+}}
+```
+
+Failure to output your final answer in the specified format will result
+in a loss.
+Begin!
+"""
+
+
+RETHINK_SUFFIX = """
+
+Your previous response was:
+{previous_response}
+
+You suggested move "{previous_action}" but this is not in the legal
+moves list. Reconsider and play a legal move from {{UP, DOWN, LEFT,
+RIGHT}}.
+"""
+
+
+# --- Helpers ----------------------------------------------------------------
+
+
+def _normalize(move: str) -> str:
+    return re.sub(r"\s+", "", move).upper()
+
+
+def _extract_move_from_json(response: str) -> str | None:
+    match = _JSON_BLOCK_RE.search(response)
+    if match:
+        try:
+            data = json.loads(match.group(1))
+            move = str(data.get("move", "")).strip()
+            if move:
+                return move
+        except json.JSONDecodeError:
+            pass
+
+    bare = _BARE_JSON_RE.search(response)
+    if bare:
+        return bare.group(1).strip()
+
+    return None
+
+
+def _match_move_to_legal(move: str, legal_moves: Sequence[str]) -> str | None:
+    """Match ``move`` against the legal-move list, ignoring case/whitespace."""
+    target = _normalize(move)
+    if not target:
+        return None
+    legal_normalized = {_normalize(legal): legal for legal in legal_moves}
+    return legal_normalized.get(target)
+
+
+def _parse_observation(observation: Mapping[str, Any]) -> dict[str, Any]:
+    """Parse the snake proxy's JSON observation, returning ``{}`` on error."""
+    obs_str = observation.get("observationString", "")
+    if not obs_str:
+        return {}
+    try:
+        return json.loads(obs_str)
+    except (json.JSONDecodeError, TypeError):
+        return {}
+
+
+# --- Public functions (called by main.py) -----------------------------------
+
+
+def get_legal_moves(observation: Mapping[str, Any]) -> dict[int, str]:
+    """Return ``{action_id: action_string}`` for the current state."""
+    legal_actions = observation.get("legalActions")
+    legal_action_strings = observation.get("legalActionStrings")
+    if legal_actions and legal_action_strings:
+        return dict(zip(legal_actions, legal_action_strings))
+
+    serialized = observation.get("serializedGameAndState", "")
+    if not serialized:
+        return {}
+    _, state = pyspiel.deserialize_game_and_state(serialized)
+    actions = state.legal_actions()
+    return {a: state.action_to_string(a) for a in actions}
+
+
+def generate_prompt(
+    observation: Mapping[str, Any],
+    move_history: list[str],
+    previous_response: str | None = None,
+    previous_action: str | None = None,
+) -> str:
+    """Build the LLM prompt for the current snake game state."""
+    obs_string = observation.get("observationString", "")
+    player_id = int(observation.get("playerId", 0))
+    parsed = _parse_observation(observation)
+
+    rows = int(parsed.get("num_rows", 10))
+    cols = int(parsed.get("num_columns", 10))
+    num_players = int(parsed.get("num_players", 2))
+    max_turns = rows * cols * 2
+
+    body_chars = ["a", "b", "c", "d"]
+    head_chars = ["A", "B", "C", "D"]
+    your_letter = body_chars[player_id % len(body_chars)]
+    your_body_char = body_chars[player_id % len(body_chars)]
+    your_head_char = head_chars[player_id % len(head_chars)]
+
+    snakes = parsed.get("snakes") or []
+    your_snake = next((s for s in snakes if int(s.get("player", -1)) == player_id), None)
+    your_body = your_snake["body"] if your_snake else "(unknown)"
+    your_score = your_snake["score"] if your_snake else 0
+    alive = bool(your_snake.get("alive", True)) if your_snake else True
+    alive_note = "" if alive else " (DEAD — you are out of the game)"
+
+    food = parsed.get("food")
+    food_str = f"{food}" if food else "(no food on board)"
+
+    move_history_str = " ".join(move_history) if move_history else "None"
+
+    prompt = SNAKE_PROMPT_TEMPLATE.format(
+        rows=rows,
+        cols=cols,
+        num_players=num_players,
+        max_turns=max_turns,
+        your_letter=your_letter,
+        your_body_char=your_body_char,
+        your_head_char=your_head_char,
+        state_str=obs_string,
+        player_id=player_id,
+        your_body=your_body,
+        your_score=your_score,
+        alive_note=alive_note,
+        food_str=food_str,
+        move_history=move_history_str,
+    )
+
+    if previous_response is not None:
+        prompt += RETHINK_SUFFIX.format(
+            previous_response=previous_response[:500],
+            previous_action=previous_action or "(could not parse)",
+        )
+
+    return prompt
+
+
+def parse_response(
+    response: str,
+    legal_action_strings: Sequence[str],
+) -> ParseResult:
+    """Extract a legal Snake move from the model response.
+
+    Tries to extract the move from a JSON block first, then falls back to
+    scanning the response text for the first direction keyword.
+    """
+    raw = _extract_move_from_json(response)
+    if raw is not None:
+        matched = _match_move_to_legal(raw, legal_action_strings)
+        if matched is not None:
+            return ParseResult(legal_action=matched, raw_action=raw)
+
+    for m in _MOVE_RE.finditer(response):
+        candidate = m.group(0)
+        matched = _match_move_to_legal(candidate, legal_action_strings)
+        if matched is not None:
+            return ParseResult(legal_action=matched, raw_action=raw or candidate)
+
+    return ParseResult(legal_action=None, raw_action=raw)

--- a/kaggle_environments/envs/open_spiel_env/games/snake/snake_game.py
+++ b/kaggle_environments/envs/open_spiel_env/games/snake/snake_game.py
@@ -5,7 +5,6 @@ import random
 from typing import List, Tuple
 
 import numpy as np
-
 import pyspiel
 
 _NUM_PLAYERS = 2  # Default to 2 players for head-to-head
@@ -46,368 +45,371 @@ _GAME_INFO = pyspiel.GameInfo(
 
 
 class Action(enum.IntEnum):
-  UP = 0
-  DOWN = 1
-  LEFT = 2
-  RIGHT = 3
+    UP = 0
+    DOWN = 1
+    LEFT = 2
+    RIGHT = 3
 
 
 class SnakeGame(pyspiel.Game):
-  """A Python version of the Snake game."""
+    """A Python version of the Snake game."""
 
-  def __init__(self, params=None):
-    self.rows = params.get("rows", _NUM_ROWS) if params else _NUM_ROWS
-    self.cols = params.get("columns", _NUM_COLS) if params else _NUM_COLS
-    self.num_players = (
-        params.get("players", _NUM_PLAYERS) if params else _NUM_PLAYERS
-    )
+    def __init__(self, params=None):
+        self.rows = params.get("rows", _NUM_ROWS) if params else _NUM_ROWS
+        self.cols = params.get("columns", _NUM_COLS) if params else _NUM_COLS
+        self._num_players = params.get("players", _NUM_PLAYERS) if params else _NUM_PLAYERS
 
-    # Update game info with dynamic player count
-    game_info = pyspiel.GameInfo(
-        num_distinct_actions=4,
-        max_chance_outcomes=0,
-        num_players=self.num_players,
-        min_utility=-1.0,
-        max_utility=100.0,
-        utility_sum=0.0,
-        max_game_length=self.rows * self.cols * 2,
-    )
-    super().__init__(_GAME_TYPE, game_info, params or dict())
+        # Update game info with dynamic player count
+        game_info = pyspiel.GameInfo(
+            num_distinct_actions=4,
+            max_chance_outcomes=0,
+            num_players=self._num_players,
+            min_utility=-1.0,
+            max_utility=100.0,
+            utility_sum=0.0,
+            max_game_length=self.rows * self.cols * 2,
+        )
+        super().__init__(_GAME_TYPE, game_info, params or dict())
 
-  def new_initial_state(self):
-    """Returns a state corresponding to the start of a game."""
-    return SnakeState(self)
+    def new_initial_state(self):
+        """Returns a state corresponding to the start of a game."""
+        return SnakeState(self)
 
-  def make_py_observer(self, params=None):
-    """Returns an object used for observing game state."""
-    return SnakeObserver(params, self.rows, self.cols)
+    def make_py_observer(self, iig_obs_type=None, params=None):
+        """Returns an object used for observing game state."""
+        del iig_obs_type, params
+        return SnakeObserver(self.rows, self.cols, self._num_players)
 
 
 class SnakeState(pyspiel.State):
-  """A python version of the Snake state."""
+    """A python version of the Snake state."""
 
-  def __init__(self, game):
-    """Constructor; should only be called by Game.new_initial_state."""
-    super().__init__(game)
-    self._game = game
-    self.rows = game.rows
-    self.cols = game.cols
-    self.num_players = game.num_players
-    self._is_terminal = False
-    self._game_over_reason = None
+    def __init__(self, game):
+        """Constructor; should only be called by Game.new_initial_state."""
+        super().__init__(game)
+        self._game = game
+        self.rows = game.rows
+        self.cols = game.cols
+        self.num_players = game._num_players
+        self._is_terminal = False
+        self._game_over_reason = None
 
-    # Initialize snakes
-    # Starting positions: corners/edges depending on player count
-    # 2 players: (1,1) and (R-2, C-2)
-    # 3 players: + (1, C-2)
-    # 4 players: + (R-2, 1)
+        # Initialize snakes
+        # Starting positions: corners/edges depending on player count
+        # 2 players: (1,1) and (R-2, C-2)
+        # 3 players: + (1, C-2)
+        # 4 players: + (R-2, 1)
 
-    start_positions = [
-        (1, 1),
-        (self.rows - 2, self.cols - 2),
-        (1, self.cols - 2),
-        (self.rows - 2, 1),
-    ]
+        start_positions = [
+            (1, 1),
+            (self.rows - 2, self.cols - 2),
+            (1, self.cols - 2),
+            (self.rows - 2, 1),
+        ]
 
-    self.snakes: List[List[Tuple[int, int]]] = []  # List of lists of coords
-    self.scores = [0.0] * self.num_players
-    self.is_alive = [True] * self.num_players
+        self.snakes: List[List[Tuple[int, int]]] = []  # List of lists of coords
+        self.scores = [0.0] * self.num_players
+        self.is_alive = [True] * self.num_players
 
-    for i in range(self.num_players):
-      start_r, start_c = start_positions[i % len(start_positions)]
-      self.snakes.append([(start_r, start_c)])
+        for i in range(self.num_players):
+            start_r, start_c = start_positions[i % len(start_positions)]
+            self.snakes.append([(start_r, start_c)])
 
-    self.food = None
-    self._place_food()
-    self._steps = 0
-    self._next_player = 0
-    self._move_buffer = [None] * self.num_players
+        self.food = None
+        self._place_food()
+        self._steps = 0
+        self._next_player = 0
+        self._move_buffer = [None] * self.num_players
 
-  def _place_food(self):
-    """Places food in a random empty location."""
-    available_positions = []
-    for r in range(self.rows):
-      for c in range(self.cols):
-        occupied = False
-        for snake in self.snakes:
-          if (r, c) in snake:
-            occupied = True
-            break
-        if not occupied:
-          available_positions.append((r, c))
+    def _place_food(self):
+        """Places food in a random empty location."""
+        available_positions = []
+        for r in range(self.rows):
+            for c in range(self.cols):
+                occupied = False
+                for snake in self.snakes:
+                    if (r, c) in snake:
+                        occupied = True
+                        break
+                if not occupied:
+                    available_positions.append((r, c))
 
-    if not available_positions:
-      # If board is full, game over.
-      self._is_terminal = True
-      self._game_over_reason = "Won (Board Full)"
-      return
+        if not available_positions:
+            # If board is full, game over.
+            self._is_terminal = True
+            self._game_over_reason = "Won (Board Full)"
+            return
 
-    self.food = random.choice(available_positions)
+        self.food = random.choice(available_positions)
 
-  def current_player(self):
-    """Returns id of the next player to move."""
-    if self._is_terminal:
-      return pyspiel.PlayerId.TERMINAL
-    return self._next_player
+    def current_player(self):
+        """Returns id of the next player to move."""
+        if self._is_terminal:
+            return pyspiel.PlayerId.TERMINAL
+        return self._next_player
 
-  def _legal_actions(self):
-    """Returns a list of legal actions."""
-    if self._is_terminal:
-      return []
-    # If player is dead, their only action is pass/nothing,
-    # but OpenSpiel doesn't have PASS for simultaneous easily wrapped in
-    # sequential.
-    # We'll just allow any action and ignore it if dead.
-    return [a.value for a in Action]
+    def _legal_actions(self, player=None):
+        """Returns a list of legal actions."""
+        del player
+        if self._is_terminal:
+            return []
+        # If player is dead, their only action is pass/nothing,
+        # but OpenSpiel doesn't have PASS for simultaneous easily wrapped in
+        # sequential.
+        # We'll just allow any action and ignore it if dead.
+        return [a.value for a in Action]
 
-  def _apply_action(self, action):
-    """Applies the specified action to the state."""
-    # Store move
-    self._move_buffer[self._next_player] = action
+    def _apply_action(self, action):
+        """Applies the specified action to the state."""
+        # Store move
+        self._move_buffer[self._next_player] = action
 
-    # Move to next player
-    self._next_player += 1
+        # Move to next player
+        self._next_player += 1
 
-    # If all players have moved, process the turn
-    if self._next_player >= self.num_players:
-      self._process_simultaneous_turn()
-      self._next_player = 0
-      self._move_buffer = [None] * self.num_players
+        # If all players have moved, process the turn
+        if self._next_player >= self.num_players:
+            self._process_simultaneous_turn()
+            self._next_player = 0
+            self._move_buffer = [None] * self.num_players
 
-  def _process_simultaneous_turn(self):
-    self._steps += 1
+    def _process_simultaneous_turn(self):
+        self._steps += 1
 
-    # Calculate new heads
-    new_heads = []
-    for i in range(self.num_players):
-      if not self.is_alive[i]:
-        new_heads.append(None)
-        continue
+        # Calculate new heads
+        new_heads = []
+        for i in range(self.num_players):
+            if not self.is_alive[i]:
+                new_heads.append(None)
+                continue
 
-      action = self._move_buffer[i]
-      if not self.snakes[i]:
-        new_heads.append(None)
-        continue
+            action = self._move_buffer[i]
+            if not self.snakes[i]:
+                new_heads.append(None)
+                continue
 
-      head_r, head_c = self.snakes[i][0]
+            head_r, head_c = self.snakes[i][0]
 
-      if action == Action.UP:
-        head_r -= 1
-      elif action == Action.DOWN:
-        head_r += 1
-      elif action == Action.LEFT:
-        head_c -= 1
-      elif action == Action.RIGHT:
-        head_c += 1
+            if action == Action.UP:
+                head_r -= 1
+            elif action == Action.DOWN:
+                head_r += 1
+            elif action == Action.LEFT:
+                head_c -= 1
+            elif action == Action.RIGHT:
+                head_c += 1
 
-      new_heads.append((head_r, head_c))
+            new_heads.append((head_r, head_c))
 
-    # Determine which snakes eat food (simultaneous arrival allowed)
-    eating = [False] * self.num_players
-    food_eaten = False
+        # Determine which snakes eat food (simultaneous arrival allowed)
+        eating = [False] * self.num_players
+        food_eaten = False
 
-    for i, head in enumerate(new_heads):
-      if head is None:
-        continue
-      if head == self.food:
-        eating[i] = True
-        food_eaten = True
+        for i, head in enumerate(new_heads):
+            if head is None:
+                continue
+            if head == self.food:
+                eating[i] = True
+                food_eaten = True
 
-    # Move snakes (tentatively)
-    # If not eating, remove tail.
-    # Add new head.
+        # Move snakes (tentatively)
+        # If not eating, remove tail.
+        # Add new head.
 
-    # Conflict resolution:
-    # 1. Wall collision -> die
-    # 2. Self collision -> die
-    # 3. Other snake collision -> die
-    # 4. Head-to-Head collision -> both die
+        # Conflict resolution:
+        # 1. Wall collision -> die
+        # 2. Self collision -> die
+        # 3. Other snake collision -> die
+        # 4. Head-to-Head collision -> both die
 
-    next_snakes = []
-    temp_alive = list(self.is_alive)
+        next_snakes = []
+        temp_alive = list(self.is_alive)
 
-    for i in range(self.num_players):
-      if not self.is_alive[i]:
-        next_snakes.append(self.snakes[i])  # Dead snake body stays? Or removed?
-        # Standard snake: dead snake is removed.
-        # Let's say dead snake is cleared from board immediately.
-        # So next_snakes[i] should be empty.
-        # But currently self.snakes[i] might still have body.
-        # Let's verify: if I died last turn, I am already empty?
-        continue
+        for i in range(self.num_players):
+            if not self.is_alive[i]:
+                next_snakes.append(self.snakes[i])  # Dead snake body stays? Or removed?
+                # Standard snake: dead snake is removed.
+                # Let's say dead snake is cleared from board immediately.
+                # So next_snakes[i] should be empty.
+                # But currently self.snakes[i] might still have body.
+                # Let's verify: if I died last turn, I am already empty?
+                continue
 
-      # Calculate new body
-      current_snake = list(self.snakes[i])
-      head = new_heads[i]
+            # Calculate new body
+            current_snake = list(self.snakes[i])
+            head = new_heads[i]
 
-      # Check Wall
-      if not (0 <= head[0] < self.rows and 0 <= head[1] < self.cols):
-        temp_alive[i] = False
-        next_snakes.append([])  # Removed
-        continue
+            # Check Wall
+            if not (0 <= head[0] < self.rows and 0 <= head[1] < self.cols):
+                temp_alive[i] = False
+                next_snakes.append([])  # Removed
+                continue
 
-      # Update body
-      current_snake.insert(0, head)
-      if not eating[i]:
-        current_snake.pop()
-      next_snakes.append(current_snake)
+            # Update body
+            current_snake.insert(0, head)
+            if not eating[i]:
+                current_snake.pop()
+            next_snakes.append(current_snake)
 
-    # Check collisions
-    # We need to check collisions against ALL snakes'
-    # bodies as they are *after* the move.
-    # Note: Head-to-Head is a special case of hitting a body (another head).
+        # Check collisions
+        # We need to check collisions against ALL snakes'
+        # bodies as they are *after* the move.
+        # Note: Head-to-Head is a special case of hitting a body (another head).
 
-    # Create a set of all body parts for fast lookup,
-    # mapping pos -> list of player_ids
-    # But wait, Head-to-Head means both die.
-    # Head-to-Body means Head dies.
+        # Create a set of all body parts for fast lookup,
+        # mapping pos -> list of player_ids
+        # But wait, Head-to-Head means both die.
+        # Head-to-Body means Head dies.
 
-    # Let's iterate all alive players and check valid conditions.
-    final_alive = list(temp_alive)
+        # Let's iterate all alive players and check valid conditions.
+        final_alive = list(temp_alive)
 
-    for i in range(self.num_players):
-      if not temp_alive[i]:
-        continue
+        for i in range(self.num_players):
+            if not temp_alive[i]:
+                continue
 
-      head = next_snakes[i][0]
+            head = next_snakes[i][0]
 
-      # Check against all snakes
-      for j in range(self.num_players):
-        if not temp_alive[j]:
-          continue  # Don't collide with already dead snakes (removed)
+            # Check against all snakes
+            for j in range(self.num_players):
+                if not temp_alive[j]:
+                    continue  # Don't collide with already dead snakes (removed)
 
-        snake_body = next_snakes[j]
-        # collision with self: check if head in body[1:]
-        # collision with other: check if head in body
+                snake_body = next_snakes[j]
+                # collision with self: check if head in body[1:]
+                # collision with other: check if head in body
 
-        start_index = 1 if i == j else 0
-        if head in snake_body[start_index:]:
-          # Collision!
-          # If head-to-head (i.e. head == snake_body[0] and i != j), both die?
-          # The loop will catch j colliding with i later (or earlier).
-          # So we just mark i as dead.
-          final_alive[i] = False
-          break
+                start_index = 1 if i == j else 0
+                if head in snake_body[start_index:]:
+                    # Collision!
+                    # If head-to-head (i.e. head == snake_body[0] and i != j), both die?
+                    # The loop will catch j colliding with i later (or earlier).
+                    # So we just mark i as dead.
+                    final_alive[i] = False
+                    break
 
-    # Update state
-    self.is_alive = final_alive
+        # Update state
+        self.is_alive = final_alive
 
-    # Update scores and bodies
-    for i in range(self.num_players):
-      if self.is_alive[i]:
-        self.snakes[i] = next_snakes[i]
-        if eating[i]:
-          self.scores[i] += 1.0
-      else:
-        self.snakes[i] = []  # Remove dead snakes
+        # Update scores and bodies
+        for i in range(self.num_players):
+            if self.is_alive[i]:
+                self.snakes[i] = next_snakes[i]
+                if eating[i]:
+                    self.scores[i] += 1.0
+            else:
+                self.snakes[i] = []  # Remove dead snakes
 
-    # Handle food
-    if food_eaten:
-      self._place_food()
+        # Handle food
+        if food_eaten:
+            self._place_food()
 
-    # Check termination
-    # Game ends if 0 or 1 player alive (if started with >1)
-    # If single player mode, end if dead.
-    num_alive = sum(self.is_alive)
-    if self.num_players > 1:
-      if num_alive <= 1:
-        self._is_terminal = True
-        # If 1 alive, they win. +Bonus?
-        # Returns are just scores.
-    else:
-      if num_alive == 0:
-        self._is_terminal = True
+        # Check termination
+        # Game ends if 0 or 1 player alive (if started with >1)
+        # If single player mode, end if dead.
+        num_alive = sum(self.is_alive)
+        if self.num_players > 1:
+            if num_alive <= 1:
+                self._is_terminal = True
+                # If 1 alive, they win. +Bonus?
+                # Returns are just scores.
+        else:
+            if num_alive == 0:
+                self._is_terminal = True
 
-  def _action_to_string(self, action):
-    """Action -> string."""
-    return Action(action).name
+    def _action_to_string(self, player, action=None):
+        """Action -> string."""
+        # OpenSpiel calls this as _action_to_string(player, action); some
+        # internal paths pass only the action. Accept both.
+        if action is None:
+            action = player
+        return Action(action).name
 
-  def is_terminal(self):
-    """Returns True if the game is over."""
-    return self._is_terminal
+    def is_terminal(self):
+        """Returns True if the game is over."""
+        return self._is_terminal
 
-  def returns(self):
-    """Total reward for each player over the course of the game so far."""
-    return self.scores
+    def returns(self):
+        """Total reward for each player over the course of the game so far."""
+        return self.scores
 
-  def __str__(self):
-    """String representation of the state."""
-    board = np.full((self.rows, self.cols), ".")
+    def __str__(self):
+        """String representation of the state."""
+        board = np.full((self.rows, self.cols), ".")
 
-    if self.food:
-      board[self.food] = "*"
+        if self.food:
+            board[self.food] = "*"
 
-    for i, snake in enumerate(self.snakes):
-      if not self.is_alive[i]:
-        continue
+        for i, snake in enumerate(self.snakes):
+            if not self.is_alive[i]:
+                continue
 
-      # Symbol for player: 0, 1, 2, 3
-      # Head is H0, H1? Or just id.
-      # Let's use digit for body, Upper char for head?
-      # 0: a, A
-      # 1: b, B
-      # ...
+            # Symbol for player: 0, 1, 2, 3
+            # Head is H0, H1? Or just id.
+            # Let's use digit for body, Upper char for head?
+            # 0: a, A
+            # 1: b, B
+            # ...
 
-      chars = [("a", "A"), ("b", "B"), ("c", "C"), ("d", "D")]
-      body_char, head_char = chars[i % 4]
+            chars = [("a", "A"), ("b", "B"), ("c", "C"), ("d", "D")]
+            body_char, head_char = chars[i % 4]
 
-      for r, c in snake:
-        board[r, c] = body_char
+            for r, c in snake:
+                board[r, c] = body_char
 
-      if snake:
-        hr, hc = snake[0]
-        board[hr, hc] = head_char
+            if snake:
+                hr, hc = snake[0]
+                board[hr, hc] = head_char
 
-    return "\n".join("".join(row) for row in board)
+        return "\n".join("".join(row) for row in board)
 
 
 class SnakeObserver:
-  """Observer for Snake."""
+    """Observer for Snake."""
 
-  def __init__(self, rows, cols, num_players):
-    self.rows = rows
-    self.cols = cols
-    self.num_players = num_players
-    # Channels:
-    # 0: Food
-    # 1..N: Snake i Body
-    # N+1..2N: Snake i Head
-    shape = (1 + 2 * num_players, self.rows, self.cols)
-    self.tensor = np.zeros(np.prod(shape), np.float32)
-    self.dict = {"observation": np.reshape(self.tensor, shape)}
+    def __init__(self, rows, cols, num_players):
+        self.rows = rows
+        self.cols = cols
+        self.num_players = num_players
+        # Channels:
+        # 0: Food
+        # 1..N: Snake i Body
+        # N+1..2N: Snake i Head
+        shape = (1 + 2 * num_players, self.rows, self.cols)
+        self.tensor = np.zeros(np.prod(shape), np.float32)
+        self.dict = {"observation": np.reshape(self.tensor, shape)}
 
-  def set_from(self, state):
-    """Sets the observer's tensor representation from the game state.
+    def set_from(self, state, player):
+        """Sets the observer's tensor representation from the game state.
 
-    The observation tensor has the following channels:
-    - Channel 0: Food position.
-    - Channels 1 to N: Body of snake i.
-    - Channels N+1 to 2N: Head of snake i.
+        The observation tensor has the following channels:
+        - Channel 0: Food position.
+        - Channels 1 to N: Body of snake i.
+        - Channels N+1 to 2N: Head of snake i.
+        """
+        del player
+        obs = self.dict["observation"]
+        obs.fill(0)
 
-    Args:
-      state: The current game state (SnakeState).
-    """
-    obs = self.dict["observation"]
-    obs.fill(0)
+        # Food
+        if state.food:
+            fr, fc = state.food
+            obs[0, fr, fc] = 1.0
 
-    # Food
-    if state.food:
-      fr, fc = state.food
-      obs[0, fr, fc] = 1.0
+        for i in range(self.num_players):
+            # Body
+            if state.is_alive[i]:
+                for r, c in state.snakes[i]:
+                    obs[1 + i, r, c] = 1.0
 
-    for i in range(self.num_players):
-      # Body
-      if state.is_alive[i]:
-        for r, c in state.snakes[i]:
-          obs[1 + i, r, c] = 1.0
+                # Head
+                if state.snakes[i]:
+                    hr, hc = state.snakes[i][0]
+                    obs[1 + self.num_players + i, hr, hc] = 1.0
 
-        # Head
-        if state.snakes[i]:
-          hr, hc = state.snakes[i][0]
-          obs[1 + self.num_players + i, hr, hc] = 1.0
-
-  def string_from(self, state):
-    return str(state)
+    def string_from(self, state, player):
+        del player
+        return str(state)
 
 
 # Register the game with the OpenSpiel library

--- a/kaggle_environments/envs/open_spiel_env/games/snake/snake_proxy.py
+++ b/kaggle_environments/envs/open_spiel_env/games/snake/snake_proxy.py
@@ -1,0 +1,127 @@
+"""Structured JSON observations for the custom Snake game.
+
+The Snake game (see ``snake_game.py``) is a multi-snake grid game with
+simultaneous-move semantics implemented sequentially: each turn cycles
+through players 0..N-1, buffering their actions, and on player N-1's
+move the buffered actions are applied together. Actions are
+``0=UP, 1=DOWN, 2=LEFT, 3=RIGHT``.
+
+This proxy exposes the state as structured JSON so agents and the
+visualizer don't have to parse the ASCII board produced by
+``SnakeState.__str__``.
+"""
+
+import json
+from typing import Any
+
+import pyspiel
+
+from ... import proxy
+
+# Ensure the underlying custom game is registered before we try to load it.
+from . import snake_game  # noqa: F401
+
+_BODY_CHARS = ["a", "b", "c", "d"]
+_HEAD_CHARS = ["A", "B", "C", "D"]
+_FOOD_CHAR = "*"
+_EMPTY_CHAR = "."
+
+
+class SnakeState(proxy.State):
+    """Snake state proxy with JSON observations."""
+
+    def _board(self, snakes: list[list[list[int]]], is_alive: list[bool], food: list[int] | None) -> list[list[str]]:
+        rows = self.__wrapped__.rows
+        cols = self.__wrapped__.cols
+        board = [[_EMPTY_CHAR] * cols for _ in range(rows)]
+        if food is not None:
+            fr, fc = food
+            board[fr][fc] = _FOOD_CHAR
+        for i, snake in enumerate(snakes):
+            if not is_alive[i] or not snake:
+                continue
+            body_char = _BODY_CHARS[i % len(_BODY_CHARS)]
+            head_char = _HEAD_CHARS[i % len(_HEAD_CHARS)]
+            for r, c in snake:
+                board[r][c] = body_char
+            hr, hc = snake[0]
+            board[hr][hc] = head_char
+        return board
+
+    def state_dict(self, player: int | None = None) -> dict[str, Any]:
+        del player  # Snake is perfect-information; same view for everyone.
+        wrapped = self.__wrapped__
+        snakes = [[[int(r), int(c)] for r, c in snake] for snake in wrapped.snakes]
+        is_alive = [bool(a) for a in wrapped.is_alive]
+        scores = [float(s) for s in wrapped.scores]
+        food = [int(wrapped.food[0]), int(wrapped.food[1])] if wrapped.food is not None else None
+
+        is_terminal = self.is_terminal()
+        winner: int | str | None = None
+        if is_terminal:
+            alive_ids = [i for i, a in enumerate(is_alive) if a]
+            if len(alive_ids) == 1:
+                winner = alive_ids[0]
+            else:
+                top_score = max(scores)
+                top = [i for i, s in enumerate(scores) if s == top_score]
+                winner = top[0] if len(top) == 1 else "draw"
+
+        snake_objs = [
+            {"player": i, "body": snakes[i], "alive": is_alive[i], "score": scores[i]}
+            for i in range(wrapped.num_players)
+        ]
+
+        # While players are buffering moves for the current turn (sequential
+        # implementation of simultaneous play), expose who is acting next and
+        # which players have already submitted this turn.
+        buffer = [a for a in getattr(wrapped, "_move_buffer", [])]
+        pending = [i for i, a in enumerate(buffer) if a is not None]
+
+        return {
+            "board": self._board(snakes, is_alive, food),
+            "num_rows": int(wrapped.rows),
+            "num_columns": int(wrapped.cols),
+            "num_players": int(wrapped.num_players),
+            "food": food,
+            "snakes": snake_objs,
+            "scores": scores,
+            "is_alive": is_alive,
+            "current_player": self.current_player(),
+            "pending_this_turn": pending,
+            "turn": int(getattr(wrapped, "_steps", 0)),
+            "is_terminal": is_terminal,
+            "winner": winner,
+            "game_over_reason": getattr(wrapped, "_game_over_reason", None),
+        }
+
+    def to_json(self, player: int | None = None) -> str:
+        return json.dumps(self.state_dict(player))
+
+    def observation_string(self, player: int) -> str:
+        return self.to_json(player)
+
+    def information_state_string(self, player: int) -> str:
+        return self.to_json(player)
+
+    def __str__(self) -> str:
+        return self.to_json()
+
+
+class SnakeGame(proxy.Game):
+    """Snake game proxy."""
+
+    def __init__(self, params: Any | None = None):
+        params = params or {}
+        wrapped = pyspiel.load_game("snake", params)
+        super().__init__(
+            wrapped,
+            short_name="snake_proxy",
+            long_name="Snake (proxy)",
+        )
+
+    def new_initial_state(self, *args) -> SnakeState:
+        return SnakeState(self.__wrapped__.new_initial_state(*args), game=self)
+
+
+pyspiel.register_game(SnakeGame().get_type(), SnakeGame)

--- a/kaggle_environments/envs/open_spiel_env/games/snake/test_llm_game.py
+++ b/kaggle_environments/envs/open_spiel_env/games/snake/test_llm_game.py
@@ -1,0 +1,60 @@
+"""Run a full snake game with LLM agents for local integration testing.
+
+Usage:
+    GEMINI_API_KEY=... uv run python -m \\
+        kaggle_environments.envs.open_spiel_env.games.snake.test_llm_game
+"""
+
+import json
+import os
+
+from kaggle_environments import make
+
+
+def run_llm_game():
+    if not os.environ.get("GEMINI_API_KEY") and not os.environ.get("OPENAI_API_KEY"):
+        print("Set GEMINI_API_KEY or OPENAI_API_KEY to run this test.")
+        print("Example: export GEMINI_API_KEY=your_key")
+        return
+
+    if "MODEL_NAME" not in os.environ:
+        os.environ["MODEL_NAME"] = "gemini-2.5-flash"
+    if "MODEL_PROXY_KEY" not in os.environ:
+        os.environ["MODEL_PROXY_KEY"] = os.environ.get("GEMINI_API_KEY", os.environ.get("OPENAI_API_KEY", "dummy"))
+    if "MODEL_PROXY_URL" not in os.environ:
+        os.environ["MODEL_PROXY_URL"] = "dummy_url"
+
+    env = make(
+        "open_spiel_snake",
+        configuration={"includeLegalActions": True, "actTimeout": 120},
+        debug=True,
+    )
+
+    dir_path = os.path.dirname(os.path.abspath(__file__))
+    agent_path = os.path.join(dir_path, "harness.py")
+
+    print("Running snake game with LLM agents...")
+    env.run([agent_path, agent_path])
+
+    print("\n=== GAME STEPS ===")
+    for idx, step in enumerate(env.steps):
+        print(f"--- Step {idx} ---")
+        for agent_idx, agent_state in enumerate(step):
+            action = agent_state.action
+            status = agent_state.status
+            print(f"  Agent {agent_idx} ({status}): {action}")
+
+    print("\n=== RESULTS ===")
+    for i, state in enumerate(env.state):
+        print(f"Agent {i}: status={state.status}, reward={state.reward}")
+
+    replay_dir = os.path.join(dir_path, "visualizer", "default", "replays")
+    os.makedirs(replay_dir, exist_ok=True)
+    replay_path = os.path.join(replay_dir, "test-replay.json")
+    with open(replay_path, "w") as f:
+        json.dump(env.toJSON(), f)
+    print(f"\nReplay saved to {replay_path}")
+
+
+if __name__ == "__main__":
+    run_llm_game()

--- a/kaggle_environments/envs/open_spiel_env/games/snake/visualizer/default/index.html
+++ b/kaggle_environments/envs/open_spiel_env/games/snake/visualizer/default/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Snake Visualizer</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="/src/main.ts"></script>
+  </body>
+</html>

--- a/kaggle_environments/envs/open_spiel_env/games/snake/visualizer/default/package.json
+++ b/kaggle_environments/envs/open_spiel_env/games/snake/visualizer/default/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@kaggle-environments/open-spiel-snake-visualizer",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "dev-with-replay": "cross-env VITE_REPLAY_FILE=./replays/test-replay.json vite",
+    "build": "tsc && vite build",
+    "preview": "vite preview"
+  },
+  "devDependencies": {
+    "cross-env": "^10.1.0",
+    "typescript": "^5.0.0",
+    "vite": "^5.0.0"
+  },
+  "dependencies": {
+    "@kaggle-environments/core": "workspace:*"
+  }
+}

--- a/kaggle_environments/envs/open_spiel_env/games/snake/visualizer/default/replays/test-replay.json
+++ b/kaggle_environments/envs/open_spiel_env/games/snake/visualizer/default/replays/test-replay.json
@@ -1,0 +1,584 @@
+{
+  "id": "b93ea0ce-552d-11f1-8652-bae7cb43ed0b",
+  "name": "open_spiel_snake",
+  "title": "Open Spiel: snake",
+  "description": "Kaggle environment wrapper for OpenSpiel games.\nFor game implementation details see:\nhttps://github.com/google-deepmind/open_spiel/tree/master/open_spiel/games",
+  "version": "0.1.0",
+  "module_version": "1.18.0",
+  "configuration": {
+    "includeLegalActions": true,
+    "episodeSteps": 300,
+    "actTimeout": 3600,
+    "runTimeout": 172800,
+    "openSpielGameString": "snake_proxy(columns=10,players=2,rows=10)",
+    "openSpielGameName": "snake",
+    "openSpielGameParameters": {
+      "columns": 10,
+      "players": 2,
+      "rows": 10
+    },
+    "observationType": "observation",
+    "useOpenings": false,
+    "useImage": false,
+    "loadPresetHands": false,
+    "metadata": {},
+    "strictMode": false,
+    "savePrompt": true,
+    "freeForm": false,
+    "includeGenerateReturns": false,
+    "illegalMoveForfeit": true
+  },
+  "specification": {
+    "action": {
+      "description": "Action object MUST contain a field `submission`, and MAY contain arbitrary additional information.",
+      "type": "object",
+      "default": {
+        "submission": -1
+      }
+    },
+    "agents": [2],
+    "configuration": {
+      "episodeSteps": {
+        "description": "Maximum number of steps in the episode.",
+        "type": "integer",
+        "minimum": 1,
+        "default": 300
+      },
+      "actTimeout": {
+        "description": "Maximum runtime (seconds) to obtain an action from an agent.",
+        "type": "number",
+        "minimum": 0,
+        "default": 3600
+      },
+      "runTimeout": {
+        "description": "Maximum runtime (seconds) of an episode (not necessarily DONE).",
+        "type": "number",
+        "minimum": 0,
+        "default": 172800
+      },
+      "openSpielGameString": {
+        "description": "The full game string including parameters.",
+        "type": "string",
+        "default": "snake_proxy(columns=10,players=2,rows=10)"
+      },
+      "openSpielGameName": {
+        "description": "The short_name of the OpenSpiel game to load.",
+        "type": "string",
+        "default": "snake"
+      },
+      "openSpielGameParameters": {
+        "description": "Game parameters for Open Spiel game.",
+        "type": "object",
+        "default": {
+          "columns": 10,
+          "players": 2,
+          "rows": 10
+        },
+        "properties": {}
+      },
+      "observationType": {
+        "description": "Type of observation string: 'observation' or 'information_state'.",
+        "type": "string",
+        "default": "observation"
+      },
+      "useOpenings": {
+        "description": "Whether to start from a position in an opening book.",
+        "type": "boolean",
+        "default": false
+      },
+      "useImage": {
+        "description": "If true, indicates the observation is intended to be rendered as an image. Note that currently the agent harness is responsible for the actual rendering; no image is passed in the observation.",
+        "type": "boolean",
+        "default": false
+      },
+      "includeLegalActions": {
+        "description": "If true, include legalActions and legalActionStrings in observations. Defaults to false since these can be derived from serializedGameAndState.",
+        "type": "boolean",
+        "default": false
+      },
+      "seed": {
+        "description": "Integer used to select a starting position (when useOpenings is true) and to seed chance-node sampling so episodes are reproducible.",
+        "type": "number"
+      },
+      "initialActions": {
+        "description": "Actions applied to initial state before play begins to set up starting position.",
+        "type": "array"
+      },
+      "loadPresetHands": {
+        "description": "Repeated poker only. Load preset hand chance actions from preset_hands.jsonl.",
+        "type": "boolean",
+        "default": false
+      },
+      "presetHands": {
+        "description": "Repeated poker only. List of per-hand chance action sequences to use instead of random chance.",
+        "type": "array"
+      },
+      "metadata": {
+        "description": "Arbitrary metadata.",
+        "type": "object",
+        "default": {},
+        "properties": {}
+      },
+      "strictMode": {
+        "description": "If true, agents must return only {'submission': int} (no extra fields like 'thoughts'), and per-agent TIMEOUT/ERROR/INVALID counts as a loss for the offending agent only \u2014 other agents are marked DONE with a winning reward. The offender keeps its natural ERROR or TIMEOUT status (matching how every other Kaggle competition reports per-player failures). If false (default), any agent error halts and voids the entire episode, matching the lenient research-mode behavior.",
+        "type": "boolean",
+        "default": false
+      },
+      "savePrompt": {
+        "description": "If disabled, skip logging LLM prompts in the replay file.",
+        "type": "boolean",
+        "default": true
+      },
+      "freeForm": {
+        "description": "If true, the core harness allows free-form actions (get_legal_moves may return None) on turns where the action space is not enumerable. Defaults to false for OpenSpiel games.",
+        "type": "boolean",
+        "default": false
+      },
+      "includeGenerateReturns": {
+        "description": "If true, include a legacy generate_returns field on each action with per-LLM-call metadata (model, token counts, finish reason, duration). Useful for cost tracking and visualization pipelines.",
+        "type": "boolean",
+        "default": false
+      },
+      "illegalMoveForfeit": {
+        "description": "If true (default), when an LLM harness exhausts its retries without producing a legal move, it submits an invalid action so this player forfeits via the env's INVALID path (matching the game_arena convention). If false, the harness re-raises the parse failure, which voids the whole episode. Only affects exhaustion from illegal/unparsable moves; uncaught exceptions still propagate either way.",
+        "type": "boolean",
+        "default": true
+      }
+    },
+    "info": {},
+    "observation": {
+      "remainingOverageTime": {
+        "description": "Total remaining banked time (seconds) that can be used in excess of per-step actTimeouts -- agent is disqualified with TIMEOUT status when this drops below 0.",
+        "shared": false,
+        "type": "number",
+        "minimum": 0,
+        "default": 12
+      },
+      "step": {
+        "description": "Current step within the episode.",
+        "type": "integer",
+        "shared": true,
+        "minimum": 0,
+        "default": 0
+      },
+      "properties": {
+        "openSpielGameString": {
+          "description": "Full game string including parameters.",
+          "type": "string",
+          "default": "snake_proxy(columns=10,players=2,rows=10)"
+        },
+        "openSpielGameName": {
+          "description": "Short name of the OpenSpiel game.",
+          "type": "string",
+          "default": "snake"
+        },
+        "observationString": {
+          "description": "String representation of state.",
+          "type": "string"
+        },
+        "legalActions": {
+          "description": "List of OpenSpiel legal action integers. Only included if includeLegalActions is true.",
+          "type": "array"
+        },
+        "legalActionStrings": {
+          "description": "List of OpenSpiel legal action strings. Only included if includeLegalActions is true.",
+          "type": "array"
+        },
+        "currentPlayer": {
+          "description": "ID of player whose turn it is.",
+          "type": "integer"
+        },
+        "playerId": {
+          "description": "ID of the agent receiving this observation.",
+          "type": "integer"
+        },
+        "isTerminal": {
+          "description": "Boolean indicating game end.",
+          "type": "boolean"
+        },
+        "serializedGameAndState": {
+          "description": "Enables reconstructing the Game and State objects.",
+          "type": "string"
+        },
+        "remainingOverageTime": 60,
+        "step": 0
+      },
+      "default": {}
+    },
+    "reward": {
+      "type": ["number", "null"],
+      "default": 0.0
+    }
+  },
+  "steps": [
+    [
+      {
+        "action": {
+          "submission": -1
+        },
+        "reward": 0.0,
+        "info": {},
+        "observation": {
+          "remainingOverageTime": 12,
+          "step": 0
+        },
+        "status": "ACTIVE"
+      },
+      {
+        "action": {
+          "submission": -1
+        },
+        "reward": 0.0,
+        "info": {},
+        "observation": {
+          "remainingOverageTime": 12
+        },
+        "status": "ACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "submission": -1
+        },
+        "reward": null,
+        "info": {
+          "actionSubmitted": null,
+          "actionSubmittedToString": null,
+          "actionApplied": null,
+          "timeTaken": null,
+          "agentSelfReportedStatus": null
+        },
+        "observation": {
+          "remainingOverageTime": 12,
+          "step": 1,
+          "observationString": "{\"board\": [[\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \"A\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \"*\", \".\", \".\", \".\", \".\", \".\", \"B\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"]], \"num_rows\": 10, \"num_columns\": 10, \"num_players\": 2, \"food\": [8, 2], \"snakes\": [{\"player\": 0, \"body\": [[1, 1]], \"alive\": true, \"score\": 0.0}, {\"player\": 1, \"body\": [[8, 8]], \"alive\": true, \"score\": 0.0}], \"scores\": [0.0, 0.0], \"is_alive\": [true, true], \"current_player\": 0, \"pending_this_turn\": [], \"turn\": 0, \"is_terminal\": false, \"winner\": null, \"game_over_reason\": null}",
+          "currentPlayer": 0,
+          "playerId": 0,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nsnake_proxy(columns=10,players=2,rows=10)\n[State]\nhistory=\nmove_number=0\n__dict__=gASV7AIAAAAAAAB9lIwLX193cmFwcGVkX1+UjD5rYWdnbGVfZW52aXJvbm1lbnRzLmVudnMub3Blbl9zcGllbF9lbnYuZ2FtZXMuc25ha2Uuc25ha2VfZ2FtZZSMClNuYWtlU3RhdGWUk5QpgZRYgAIAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCnNuYWtlKGNvbHVtbnM9MTAscGxheWVycz0yLHJvd3M9MTApCltTdGF0ZV0KaGlzdG9yeT0KbW92ZV9udW1iZXI9MApfX2RpY3RfXz1nQVNWV2dFQUFBQUFBQUI5bENpTUJWOW5ZVzFsbEl3K2EyRm5aMnhsWDJWdWRtbHliMjV0Wlc1MGN5NWxiblp6TG05d1pXNWZjM0JwWld4ZlpXNTJMbWRoYldWekxuTnVZV3RsTG5OdVlXdGxYMmRoYldXVWpBbFRibUZyWlVkaGJXV1VrNVFwZ1pTTUkzTnVZV3RsS0dOdmJIVnRibk05TVRBc2NHeGhlV1Z5Y3oweUxISnZkM005TVRBcGxHS01CSEp2ZDNPVVN3cU1CR052YkhPVVN3cU1DMjUxYlY5d2JHRjVaWEp6bEVzQ2pBeGZhWE5mZEdWeWJXbHVZV3lVaVl3UlgyZGhiV1ZmYjNabGNsOXlaV0Z6YjI2VVRvd0djMjVoYTJWemxGMlVLRjJVU3dGTEFZYVVZVjJVU3doTENJYVVZV1dNQm5OamIzSmxjNVJkbENoSEFBQUFBQUFBQUFCSEFBQUFBQUFBQUFCbGpBaHBjMTloYkdsMlpaUmRsQ2lJaUdXTUJHWnZiMlNVU3doTEFvYVVqQVpmYzNSbGNIT1VTd0NNREY5dVpYaDBYM0JzWVhsbGNwUkxBSXdNWDIxdmRtVmZZblZtWm1WeWxGMlVLRTVPWlhVdQqUYnMu\n",
+          "legalActions": [0, 1, 2, 3],
+          "legalActionStrings": ["UP", "DOWN", "LEFT", "RIGHT"]
+        },
+        "status": "ACTIVE"
+      },
+      {
+        "action": {
+          "submission": -1
+        },
+        "reward": null,
+        "info": {},
+        "observation": {
+          "remainingOverageTime": 12,
+          "observationString": "{\"board\": [[\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \"A\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \"*\", \".\", \".\", \".\", \".\", \".\", \"B\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"]], \"num_rows\": 10, \"num_columns\": 10, \"num_players\": 2, \"food\": [8, 2], \"snakes\": [{\"player\": 0, \"body\": [[1, 1]], \"alive\": true, \"score\": 0.0}, {\"player\": 1, \"body\": [[8, 8]], \"alive\": true, \"score\": 0.0}], \"scores\": [0.0, 0.0], \"is_alive\": [true, true], \"current_player\": 0, \"pending_this_turn\": [], \"turn\": 0, \"is_terminal\": false, \"winner\": null, \"game_over_reason\": null}",
+          "currentPlayer": 0,
+          "playerId": 1,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nsnake_proxy(columns=10,players=2,rows=10)\n[State]\nhistory=\nmove_number=0\n__dict__=gASV7AIAAAAAAAB9lIwLX193cmFwcGVkX1+UjD5rYWdnbGVfZW52aXJvbm1lbnRzLmVudnMub3Blbl9zcGllbF9lbnYuZ2FtZXMuc25ha2Uuc25ha2VfZ2FtZZSMClNuYWtlU3RhdGWUk5QpgZRYgAIAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCnNuYWtlKGNvbHVtbnM9MTAscGxheWVycz0yLHJvd3M9MTApCltTdGF0ZV0KaGlzdG9yeT0KbW92ZV9udW1iZXI9MApfX2RpY3RfXz1nQVNWV2dFQUFBQUFBQUI5bENpTUJWOW5ZVzFsbEl3K2EyRm5aMnhsWDJWdWRtbHliMjV0Wlc1MGN5NWxiblp6TG05d1pXNWZjM0JwWld4ZlpXNTJMbWRoYldWekxuTnVZV3RsTG5OdVlXdGxYMmRoYldXVWpBbFRibUZyWlVkaGJXV1VrNVFwZ1pTTUkzTnVZV3RsS0dOdmJIVnRibk05TVRBc2NHeGhlV1Z5Y3oweUxISnZkM005TVRBcGxHS01CSEp2ZDNPVVN3cU1CR052YkhPVVN3cU1DMjUxYlY5d2JHRjVaWEp6bEVzQ2pBeGZhWE5mZEdWeWJXbHVZV3lVaVl3UlgyZGhiV1ZmYjNabGNsOXlaV0Z6YjI2VVRvd0djMjVoYTJWemxGMlVLRjJVU3dGTEFZYVVZVjJVU3doTENJYVVZV1dNQm5OamIzSmxjNVJkbENoSEFBQUFBQUFBQUFCSEFBQUFBQUFBQUFCbGpBaHBjMTloYkdsMlpaUmRsQ2lJaUdXTUJHWnZiMlNVU3doTEFvYVVqQVpmYzNSbGNIT1VTd0NNREY5dVpYaDBYM0JzWVhsbGNwUkxBSXdNWDIxdmRtVmZZblZtWm1WeWxGMlVLRTVPWlhVdQqUYnMu\n",
+          "legalActions": [],
+          "legalActionStrings": []
+        },
+        "status": "INACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "submission": 0,
+          "thoughts": "beta mu iota imagine consider shadow delta rho",
+          "actionString": "UP"
+        },
+        "reward": null,
+        "info": {
+          "actionSubmitted": 0,
+          "actionSubmittedToString": "UP",
+          "actionApplied": 0,
+          "timeTaken": 0.0,
+          "agentSelfReportedStatus": null
+        },
+        "observation": {
+          "remainingOverageTime": 12,
+          "step": 2,
+          "observationString": "{\"board\": [[\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \"A\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \"*\", \".\", \".\", \".\", \".\", \".\", \"B\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"]], \"num_rows\": 10, \"num_columns\": 10, \"num_players\": 2, \"food\": [8, 2], \"snakes\": [{\"player\": 0, \"body\": [[1, 1]], \"alive\": true, \"score\": 0.0}, {\"player\": 1, \"body\": [[8, 8]], \"alive\": true, \"score\": 0.0}], \"scores\": [0.0, 0.0], \"is_alive\": [true, true], \"current_player\": 1, \"pending_this_turn\": [0], \"turn\": 0, \"is_terminal\": false, \"winner\": null, \"game_over_reason\": null}",
+          "currentPlayer": 1,
+          "playerId": 0,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nsnake_proxy(columns=10,players=2,rows=10)\n[State]\nhistory=0:0\nmove_number=1\n__dict__=gASV8wIAAAAAAAB9lIwLX193cmFwcGVkX1+UjD5rYWdnbGVfZW52aXJvbm1lbnRzLmVudnMub3Blbl9zcGllbF9lbnYuZ2FtZXMuc25ha2Uuc25ha2VfZ2FtZZSMClNuYWtlU3RhdGWUk5QpgZRYhwIAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCnNuYWtlKGNvbHVtbnM9MTAscGxheWVycz0yLHJvd3M9MTApCltTdGF0ZV0KaGlzdG9yeT0wOjAKbW92ZV9udW1iZXI9MQpfX2RpY3RfXz1nQVNWV3dFQUFBQUFBQUI5bENpTUJWOW5ZVzFsbEl3K2EyRm5aMnhsWDJWdWRtbHliMjV0Wlc1MGN5NWxiblp6TG05d1pXNWZjM0JwWld4ZlpXNTJMbWRoYldWekxuTnVZV3RsTG5OdVlXdGxYMmRoYldXVWpBbFRibUZyWlVkaGJXV1VrNVFwZ1pTTUkzTnVZV3RsS0dOdmJIVnRibk05TVRBc2NHeGhlV1Z5Y3oweUxISnZkM005TVRBcGxHS01CSEp2ZDNPVVN3cU1CR052YkhPVVN3cU1DMjUxYlY5d2JHRjVaWEp6bEVzQ2pBeGZhWE5mZEdWeWJXbHVZV3lVaVl3UlgyZGhiV1ZmYjNabGNsOXlaV0Z6YjI2VVRvd0djMjVoYTJWemxGMlVLRjJVU3dGTEFZYVVZVjJVU3doTENJYVVZV1dNQm5OamIzSmxjNVJkbENoSEFBQUFBQUFBQUFCSEFBQUFBQUFBQUFCbGpBaHBjMTloYkdsMlpaUmRsQ2lJaUdXTUJHWnZiMlNVU3doTEFvYVVqQVpmYzNSbGNIT1VTd0NNREY5dVpYaDBYM0JzWVhsbGNwUkxBWXdNWDIxdmRtVmZZblZtWm1WeWxGMlVLRXNBVG1WMUxnPT0KlGJzLg==\n",
+          "legalActions": [],
+          "legalActionStrings": []
+        },
+        "status": "INACTIVE"
+      },
+      {
+        "action": {
+          "submission": -1
+        },
+        "reward": null,
+        "info": {},
+        "observation": {
+          "remainingOverageTime": 12,
+          "observationString": "{\"board\": [[\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \"A\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \"*\", \".\", \".\", \".\", \".\", \".\", \"B\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"]], \"num_rows\": 10, \"num_columns\": 10, \"num_players\": 2, \"food\": [8, 2], \"snakes\": [{\"player\": 0, \"body\": [[1, 1]], \"alive\": true, \"score\": 0.0}, {\"player\": 1, \"body\": [[8, 8]], \"alive\": true, \"score\": 0.0}], \"scores\": [0.0, 0.0], \"is_alive\": [true, true], \"current_player\": 1, \"pending_this_turn\": [0], \"turn\": 0, \"is_terminal\": false, \"winner\": null, \"game_over_reason\": null}",
+          "currentPlayer": 1,
+          "playerId": 1,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nsnake_proxy(columns=10,players=2,rows=10)\n[State]\nhistory=0:0\nmove_number=1\n__dict__=gASV8wIAAAAAAAB9lIwLX193cmFwcGVkX1+UjD5rYWdnbGVfZW52aXJvbm1lbnRzLmVudnMub3Blbl9zcGllbF9lbnYuZ2FtZXMuc25ha2Uuc25ha2VfZ2FtZZSMClNuYWtlU3RhdGWUk5QpgZRYhwIAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCnNuYWtlKGNvbHVtbnM9MTAscGxheWVycz0yLHJvd3M9MTApCltTdGF0ZV0KaGlzdG9yeT0wOjAKbW92ZV9udW1iZXI9MQpfX2RpY3RfXz1nQVNWV3dFQUFBQUFBQUI5bENpTUJWOW5ZVzFsbEl3K2EyRm5aMnhsWDJWdWRtbHliMjV0Wlc1MGN5NWxiblp6TG05d1pXNWZjM0JwWld4ZlpXNTJMbWRoYldWekxuTnVZV3RsTG5OdVlXdGxYMmRoYldXVWpBbFRibUZyWlVkaGJXV1VrNVFwZ1pTTUkzTnVZV3RsS0dOdmJIVnRibk05TVRBc2NHeGhlV1Z5Y3oweUxISnZkM005TVRBcGxHS01CSEp2ZDNPVVN3cU1CR052YkhPVVN3cU1DMjUxYlY5d2JHRjVaWEp6bEVzQ2pBeGZhWE5mZEdWeWJXbHVZV3lVaVl3UlgyZGhiV1ZmYjNabGNsOXlaV0Z6YjI2VVRvd0djMjVoYTJWemxGMlVLRjJVU3dGTEFZYVVZVjJVU3doTENJYVVZV1dNQm5OamIzSmxjNVJkbENoSEFBQUFBQUFBQUFCSEFBQUFBQUFBQUFCbGpBaHBjMTloYkdsMlpaUmRsQ2lJaUdXTUJHWnZiMlNVU3doTEFvYVVqQVpmYzNSbGNIT1VTd0NNREY5dVpYaDBYM0JzWVhsbGNwUkxBWXdNWDIxdmRtVmZZblZtWm1WeWxGMlVLRXNBVG1WMUxnPT0KlGJzLg==\n",
+          "legalActions": [0, 1, 2, 3],
+          "legalActionStrings": ["UP", "DOWN", "LEFT", "RIGHT"]
+        },
+        "status": "ACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "submission": -1
+        },
+        "reward": null,
+        "info": {},
+        "observation": {
+          "remainingOverageTime": 12,
+          "step": 3,
+          "observationString": "{\"board\": [[\".\", \"A\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \"B\", \".\"], [\".\", \".\", \"*\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"]], \"num_rows\": 10, \"num_columns\": 10, \"num_players\": 2, \"food\": [8, 2], \"snakes\": [{\"player\": 0, \"body\": [[0, 1]], \"alive\": true, \"score\": 0.0}, {\"player\": 1, \"body\": [[7, 8]], \"alive\": true, \"score\": 0.0}], \"scores\": [0.0, 0.0], \"is_alive\": [true, true], \"current_player\": 0, \"pending_this_turn\": [], \"turn\": 1, \"is_terminal\": false, \"winner\": null, \"game_over_reason\": null}",
+          "currentPlayer": 0,
+          "playerId": 0,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nsnake_proxy(columns=10,players=2,rows=10)\n[State]\nhistory=0:0,1:0\nmove_number=2\n__dict__=gASV8wIAAAAAAAB9lIwLX193cmFwcGVkX1+UjD5rYWdnbGVfZW52aXJvbm1lbnRzLmVudnMub3Blbl9zcGllbF9lbnYuZ2FtZXMuc25ha2Uuc25ha2VfZ2FtZZSMClNuYWtlU3RhdGWUk5QpgZRYhwIAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCnNuYWtlKGNvbHVtbnM9MTAscGxheWVycz0yLHJvd3M9MTApCltTdGF0ZV0KaGlzdG9yeT0wOjAsMTowCm1vdmVfbnVtYmVyPTIKX19kaWN0X189Z0FTVldnRUFBQUFBQUFCOWxDaU1CVjluWVcxbGxJdythMkZuWjJ4bFgyVnVkbWx5YjI1dFpXNTBjeTVsYm5aekxtOXdaVzVmYzNCcFpXeGZaVzUyTG1kaGJXVnpMbk51WVd0bExuTnVZV3RsWDJkaGJXV1VqQWxUYm1GclpVZGhiV1dVazVRcGdaU01JM051WVd0bEtHTnZiSFZ0Ym5NOU1UQXNjR3hoZVdWeWN6MHlMSEp2ZDNNOU1UQXBsR0tNQkhKdmQzT1VTd3FNQkdOdmJIT1VTd3FNQzI1MWJWOXdiR0Y1WlhKemxFc0NqQXhmYVhOZmRHVnliV2x1WVd5VWlZd1JYMmRoYldWZmIzWmxjbDl5WldGemIyNlVUb3dHYzI1aGEyVnpsRjJVS0YyVVN3QkxBWWFVWVYyVVN3ZExDSWFVWVdXTUJuTmpiM0psYzVSZGxDaEhBQUFBQUFBQUFBQkhBQUFBQUFBQUFBQmxqQWhwYzE5aGJHbDJaWlJkbENpSWlHV01CR1p2YjJTVVN3aExBb2FVakFaZmMzUmxjSE9VU3dHTURGOXVaWGgwWDNCc1lYbGxjcFJMQUl3TVgyMXZkbVZmWW5WbVptVnlsRjJVS0U1T1pYVXUKlGJzLg==\n",
+          "legalActions": [0, 1, 2, 3],
+          "legalActionStrings": ["UP", "DOWN", "LEFT", "RIGHT"]
+        },
+        "status": "ACTIVE"
+      },
+      {
+        "action": {
+          "submission": 0,
+          "thoughts": "delta kappa ponder psi reflect reflect rho sigma",
+          "actionString": "UP"
+        },
+        "reward": null,
+        "info": {
+          "actionSubmitted": 0,
+          "actionSubmittedToString": "UP",
+          "actionApplied": 0,
+          "timeTaken": 0.0,
+          "agentSelfReportedStatus": null
+        },
+        "observation": {
+          "remainingOverageTime": 12,
+          "observationString": "{\"board\": [[\".\", \"A\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \"B\", \".\"], [\".\", \".\", \"*\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"]], \"num_rows\": 10, \"num_columns\": 10, \"num_players\": 2, \"food\": [8, 2], \"snakes\": [{\"player\": 0, \"body\": [[0, 1]], \"alive\": true, \"score\": 0.0}, {\"player\": 1, \"body\": [[7, 8]], \"alive\": true, \"score\": 0.0}], \"scores\": [0.0, 0.0], \"is_alive\": [true, true], \"current_player\": 0, \"pending_this_turn\": [], \"turn\": 1, \"is_terminal\": false, \"winner\": null, \"game_over_reason\": null}",
+          "currentPlayer": 0,
+          "playerId": 1,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nsnake_proxy(columns=10,players=2,rows=10)\n[State]\nhistory=0:0,1:0\nmove_number=2\n__dict__=gASV8wIAAAAAAAB9lIwLX193cmFwcGVkX1+UjD5rYWdnbGVfZW52aXJvbm1lbnRzLmVudnMub3Blbl9zcGllbF9lbnYuZ2FtZXMuc25ha2Uuc25ha2VfZ2FtZZSMClNuYWtlU3RhdGWUk5QpgZRYhwIAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCnNuYWtlKGNvbHVtbnM9MTAscGxheWVycz0yLHJvd3M9MTApCltTdGF0ZV0KaGlzdG9yeT0wOjAsMTowCm1vdmVfbnVtYmVyPTIKX19kaWN0X189Z0FTVldnRUFBQUFBQUFCOWxDaU1CVjluWVcxbGxJdythMkZuWjJ4bFgyVnVkbWx5YjI1dFpXNTBjeTVsYm5aekxtOXdaVzVmYzNCcFpXeGZaVzUyTG1kaGJXVnpMbk51WVd0bExuTnVZV3RsWDJkaGJXV1VqQWxUYm1GclpVZGhiV1dVazVRcGdaU01JM051WVd0bEtHTnZiSFZ0Ym5NOU1UQXNjR3hoZVdWeWN6MHlMSEp2ZDNNOU1UQXBsR0tNQkhKdmQzT1VTd3FNQkdOdmJIT1VTd3FNQzI1MWJWOXdiR0Y1WlhKemxFc0NqQXhmYVhOZmRHVnliV2x1WVd5VWlZd1JYMmRoYldWZmIzWmxjbDl5WldGemIyNlVUb3dHYzI1aGEyVnpsRjJVS0YyVVN3QkxBWWFVWVYyVVN3ZExDSWFVWVdXTUJuTmpiM0psYzVSZGxDaEhBQUFBQUFBQUFBQkhBQUFBQUFBQUFBQmxqQWhwYzE5aGJHbDJaWlJkbENpSWlHV01CR1p2YjJTVVN3aExBb2FVakFaZmMzUmxjSE9VU3dHTURGOXVaWGgwWDNCc1lYbGxjcFJMQUl3TVgyMXZkbVZmWW5WbVptVnlsRjJVS0U1T1pYVXUKlGJzLg==\n",
+          "legalActions": [],
+          "legalActionStrings": []
+        },
+        "status": "INACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "submission": 2,
+          "thoughts": "spark alpha spark consider xi eta cascade xi",
+          "actionString": "LEFT"
+        },
+        "reward": null,
+        "info": {
+          "actionSubmitted": 2,
+          "actionSubmittedToString": "LEFT",
+          "actionApplied": 2,
+          "timeTaken": 0.0,
+          "agentSelfReportedStatus": null
+        },
+        "observation": {
+          "remainingOverageTime": 12,
+          "step": 4,
+          "observationString": "{\"board\": [[\".\", \"A\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \"B\", \".\"], [\".\", \".\", \"*\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"]], \"num_rows\": 10, \"num_columns\": 10, \"num_players\": 2, \"food\": [8, 2], \"snakes\": [{\"player\": 0, \"body\": [[0, 1]], \"alive\": true, \"score\": 0.0}, {\"player\": 1, \"body\": [[7, 8]], \"alive\": true, \"score\": 0.0}], \"scores\": [0.0, 0.0], \"is_alive\": [true, true], \"current_player\": 1, \"pending_this_turn\": [0], \"turn\": 1, \"is_terminal\": false, \"winner\": null, \"game_over_reason\": null}",
+          "currentPlayer": 1,
+          "playerId": 0,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nsnake_proxy(columns=10,players=2,rows=10)\n[State]\nhistory=0:0,1:0,0:2\nmove_number=3\n__dict__=gASV+wIAAAAAAAB9lIwLX193cmFwcGVkX1+UjD5rYWdnbGVfZW52aXJvbm1lbnRzLmVudnMub3Blbl9zcGllbF9lbnYuZ2FtZXMuc25ha2Uuc25ha2VfZ2FtZZSMClNuYWtlU3RhdGWUk5QpgZRYjwIAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCnNuYWtlKGNvbHVtbnM9MTAscGxheWVycz0yLHJvd3M9MTApCltTdGF0ZV0KaGlzdG9yeT0wOjAsMTowLDA6Mgptb3ZlX251bWJlcj0zCl9fZGljdF9fPWdBU1ZXd0VBQUFBQUFBQjlsQ2lNQlY5bllXMWxsSXcrYTJGbloyeGxYMlZ1ZG1seWIyNXRaVzUwY3k1bGJuWnpMbTl3Wlc1ZmMzQnBaV3hmWlc1MkxtZGhiV1Z6TG5OdVlXdGxMbk51WVd0bFgyZGhiV1dVakFsVGJtRnJaVWRoYldXVWs1UXBnWlNNSTNOdVlXdGxLR052YkhWdGJuTTlNVEFzY0d4aGVXVnljejB5TEhKdmQzTTlNVEFwbEdLTUJISnZkM09VU3dxTUJHTnZiSE9VU3dxTUMyNTFiVjl3YkdGNVpYSnpsRXNDakF4ZmFYTmZkR1Z5YldsdVlXeVVpWXdSWDJkaGJXVmZiM1psY2w5eVpXRnpiMjZVVG93R2MyNWhhMlZ6bEYyVUtGMlVTd0JMQVlhVVlWMlVTd2RMQ0lhVVlXV01Cbk5qYjNKbGM1UmRsQ2hIQUFBQUFBQUFBQUJIQUFBQUFBQUFBQUJsakFocGMxOWhiR2wyWlpSZGxDaUlpR1dNQkdadmIyU1VTd2hMQW9hVWpBWmZjM1JsY0hPVVN3R01ERjl1WlhoMFgzQnNZWGxsY3BSTEFZd01YMjF2ZG1WZlluVm1abVZ5bEYyVUtFc0NUbVYxTGc9PQqUYnMu\n",
+          "legalActions": [],
+          "legalActionStrings": []
+        },
+        "status": "INACTIVE"
+      },
+      {
+        "action": {
+          "submission": -1
+        },
+        "reward": null,
+        "info": {},
+        "observation": {
+          "remainingOverageTime": 12,
+          "observationString": "{\"board\": [[\".\", \"A\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \"B\", \".\"], [\".\", \".\", \"*\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"]], \"num_rows\": 10, \"num_columns\": 10, \"num_players\": 2, \"food\": [8, 2], \"snakes\": [{\"player\": 0, \"body\": [[0, 1]], \"alive\": true, \"score\": 0.0}, {\"player\": 1, \"body\": [[7, 8]], \"alive\": true, \"score\": 0.0}], \"scores\": [0.0, 0.0], \"is_alive\": [true, true], \"current_player\": 1, \"pending_this_turn\": [0], \"turn\": 1, \"is_terminal\": false, \"winner\": null, \"game_over_reason\": null}",
+          "currentPlayer": 1,
+          "playerId": 1,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nsnake_proxy(columns=10,players=2,rows=10)\n[State]\nhistory=0:0,1:0,0:2\nmove_number=3\n__dict__=gASV+wIAAAAAAAB9lIwLX193cmFwcGVkX1+UjD5rYWdnbGVfZW52aXJvbm1lbnRzLmVudnMub3Blbl9zcGllbF9lbnYuZ2FtZXMuc25ha2Uuc25ha2VfZ2FtZZSMClNuYWtlU3RhdGWUk5QpgZRYjwIAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCnNuYWtlKGNvbHVtbnM9MTAscGxheWVycz0yLHJvd3M9MTApCltTdGF0ZV0KaGlzdG9yeT0wOjAsMTowLDA6Mgptb3ZlX251bWJlcj0zCl9fZGljdF9fPWdBU1ZXd0VBQUFBQUFBQjlsQ2lNQlY5bllXMWxsSXcrYTJGbloyeGxYMlZ1ZG1seWIyNXRaVzUwY3k1bGJuWnpMbTl3Wlc1ZmMzQnBaV3hmWlc1MkxtZGhiV1Z6TG5OdVlXdGxMbk51WVd0bFgyZGhiV1dVakFsVGJtRnJaVWRoYldXVWs1UXBnWlNNSTNOdVlXdGxLR052YkhWdGJuTTlNVEFzY0d4aGVXVnljejB5TEhKdmQzTTlNVEFwbEdLTUJISnZkM09VU3dxTUJHTnZiSE9VU3dxTUMyNTFiVjl3YkdGNVpYSnpsRXNDakF4ZmFYTmZkR1Z5YldsdVlXeVVpWXdSWDJkaGJXVmZiM1psY2w5eVpXRnpiMjZVVG93R2MyNWhhMlZ6bEYyVUtGMlVTd0JMQVlhVVlWMlVTd2RMQ0lhVVlXV01Cbk5qYjNKbGM1UmRsQ2hIQUFBQUFBQUFBQUJIQUFBQUFBQUFBQUJsakFocGMxOWhiR2wyWlpSZGxDaUlpR1dNQkdadmIyU1VTd2hMQW9hVWpBWmZjM1JsY0hPVVN3R01ERjl1WlhoMFgzQnNZWGxsY3BSTEFZd01YMjF2ZG1WZlluVm1abVZ5bEYyVUtFc0NUbVYxTGc9PQqUYnMu\n",
+          "legalActions": [0, 1, 2, 3],
+          "legalActionStrings": ["UP", "DOWN", "LEFT", "RIGHT"]
+        },
+        "status": "ACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "submission": -1
+        },
+        "reward": null,
+        "info": {},
+        "observation": {
+          "remainingOverageTime": 12,
+          "step": 5,
+          "observationString": "{\"board\": [[\"A\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \"B\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \"*\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"]], \"num_rows\": 10, \"num_columns\": 10, \"num_players\": 2, \"food\": [8, 2], \"snakes\": [{\"player\": 0, \"body\": [[0, 0]], \"alive\": true, \"score\": 0.0}, {\"player\": 1, \"body\": [[6, 8]], \"alive\": true, \"score\": 0.0}], \"scores\": [0.0, 0.0], \"is_alive\": [true, true], \"current_player\": 0, \"pending_this_turn\": [], \"turn\": 2, \"is_terminal\": false, \"winner\": null, \"game_over_reason\": null}",
+          "currentPlayer": 0,
+          "playerId": 0,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nsnake_proxy(columns=10,players=2,rows=10)\n[State]\nhistory=0:0,1:0,0:2,1:0\nmove_number=4\n__dict__=gASV+wIAAAAAAAB9lIwLX193cmFwcGVkX1+UjD5rYWdnbGVfZW52aXJvbm1lbnRzLmVudnMub3Blbl9zcGllbF9lbnYuZ2FtZXMuc25ha2Uuc25ha2VfZ2FtZZSMClNuYWtlU3RhdGWUk5QpgZRYjwIAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCnNuYWtlKGNvbHVtbnM9MTAscGxheWVycz0yLHJvd3M9MTApCltTdGF0ZV0KaGlzdG9yeT0wOjAsMTowLDA6MiwxOjAKbW92ZV9udW1iZXI9NApfX2RpY3RfXz1nQVNWV2dFQUFBQUFBQUI5bENpTUJWOW5ZVzFsbEl3K2EyRm5aMnhsWDJWdWRtbHliMjV0Wlc1MGN5NWxiblp6TG05d1pXNWZjM0JwWld4ZlpXNTJMbWRoYldWekxuTnVZV3RsTG5OdVlXdGxYMmRoYldXVWpBbFRibUZyWlVkaGJXV1VrNVFwZ1pTTUkzTnVZV3RsS0dOdmJIVnRibk05TVRBc2NHeGhlV1Z5Y3oweUxISnZkM005TVRBcGxHS01CSEp2ZDNPVVN3cU1CR052YkhPVVN3cU1DMjUxYlY5d2JHRjVaWEp6bEVzQ2pBeGZhWE5mZEdWeWJXbHVZV3lVaVl3UlgyZGhiV1ZmYjNabGNsOXlaV0Z6YjI2VVRvd0djMjVoYTJWemxGMlVLRjJVU3dCTEFJYVVZVjJVU3daTENJYVVZV1dNQm5OamIzSmxjNVJkbENoSEFBQUFBQUFBQUFCSEFBQUFBQUFBQUFCbGpBaHBjMTloYkdsMlpaUmRsQ2lJaUdXTUJHWnZiMlNVU3doTEFvYVVqQVpmYzNSbGNIT1VTd0tNREY5dVpYaDBYM0JzWVhsbGNwUkxBSXdNWDIxdmRtVmZZblZtWm1WeWxGMlVLRTVPWlhVdQqUYnMu\n",
+          "legalActions": [0, 1, 2, 3],
+          "legalActionStrings": ["UP", "DOWN", "LEFT", "RIGHT"]
+        },
+        "status": "ACTIVE"
+      },
+      {
+        "action": {
+          "submission": 0,
+          "thoughts": "pi omicron xi lambda beta tau epsilon horizon",
+          "actionString": "UP"
+        },
+        "reward": null,
+        "info": {
+          "actionSubmitted": 0,
+          "actionSubmittedToString": "UP",
+          "actionApplied": 0,
+          "timeTaken": 0.0,
+          "agentSelfReportedStatus": null
+        },
+        "observation": {
+          "remainingOverageTime": 12,
+          "observationString": "{\"board\": [[\"A\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \"B\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \"*\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"]], \"num_rows\": 10, \"num_columns\": 10, \"num_players\": 2, \"food\": [8, 2], \"snakes\": [{\"player\": 0, \"body\": [[0, 0]], \"alive\": true, \"score\": 0.0}, {\"player\": 1, \"body\": [[6, 8]], \"alive\": true, \"score\": 0.0}], \"scores\": [0.0, 0.0], \"is_alive\": [true, true], \"current_player\": 0, \"pending_this_turn\": [], \"turn\": 2, \"is_terminal\": false, \"winner\": null, \"game_over_reason\": null}",
+          "currentPlayer": 0,
+          "playerId": 1,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nsnake_proxy(columns=10,players=2,rows=10)\n[State]\nhistory=0:0,1:0,0:2,1:0\nmove_number=4\n__dict__=gASV+wIAAAAAAAB9lIwLX193cmFwcGVkX1+UjD5rYWdnbGVfZW52aXJvbm1lbnRzLmVudnMub3Blbl9zcGllbF9lbnYuZ2FtZXMuc25ha2Uuc25ha2VfZ2FtZZSMClNuYWtlU3RhdGWUk5QpgZRYjwIAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCnNuYWtlKGNvbHVtbnM9MTAscGxheWVycz0yLHJvd3M9MTApCltTdGF0ZV0KaGlzdG9yeT0wOjAsMTowLDA6MiwxOjAKbW92ZV9udW1iZXI9NApfX2RpY3RfXz1nQVNWV2dFQUFBQUFBQUI5bENpTUJWOW5ZVzFsbEl3K2EyRm5aMnhsWDJWdWRtbHliMjV0Wlc1MGN5NWxiblp6TG05d1pXNWZjM0JwWld4ZlpXNTJMbWRoYldWekxuTnVZV3RsTG5OdVlXdGxYMmRoYldXVWpBbFRibUZyWlVkaGJXV1VrNVFwZ1pTTUkzTnVZV3RsS0dOdmJIVnRibk05TVRBc2NHeGhlV1Z5Y3oweUxISnZkM005TVRBcGxHS01CSEp2ZDNPVVN3cU1CR052YkhPVVN3cU1DMjUxYlY5d2JHRjVaWEp6bEVzQ2pBeGZhWE5mZEdWeWJXbHVZV3lVaVl3UlgyZGhiV1ZmYjNabGNsOXlaV0Z6YjI2VVRvd0djMjVoYTJWemxGMlVLRjJVU3dCTEFJYVVZVjJVU3daTENJYVVZV1dNQm5OamIzSmxjNVJkbENoSEFBQUFBQUFBQUFCSEFBQUFBQUFBQUFCbGpBaHBjMTloYkdsMlpaUmRsQ2lJaUdXTUJHWnZiMlNVU3doTEFvYVVqQVpmYzNSbGNIT1VTd0tNREY5dVpYaDBYM0JzWVhsbGNwUkxBSXdNWDIxdmRtVmZZblZtWm1WeWxGMlVLRTVPWlhVdQqUYnMu\n",
+          "legalActions": [],
+          "legalActionStrings": []
+        },
+        "status": "INACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "submission": 0,
+          "thoughts": "psi ripple ponder echo omega reflect beta kappa",
+          "actionString": "UP"
+        },
+        "reward": null,
+        "info": {
+          "actionSubmitted": 0,
+          "actionSubmittedToString": "UP",
+          "actionApplied": 0,
+          "timeTaken": 0.0,
+          "agentSelfReportedStatus": null
+        },
+        "observation": {
+          "remainingOverageTime": 12,
+          "step": 6,
+          "observationString": "{\"board\": [[\"A\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \"B\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \"*\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"]], \"num_rows\": 10, \"num_columns\": 10, \"num_players\": 2, \"food\": [8, 2], \"snakes\": [{\"player\": 0, \"body\": [[0, 0]], \"alive\": true, \"score\": 0.0}, {\"player\": 1, \"body\": [[6, 8]], \"alive\": true, \"score\": 0.0}], \"scores\": [0.0, 0.0], \"is_alive\": [true, true], \"current_player\": 1, \"pending_this_turn\": [0], \"turn\": 2, \"is_terminal\": false, \"winner\": null, \"game_over_reason\": null}",
+          "currentPlayer": 1,
+          "playerId": 0,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nsnake_proxy(columns=10,players=2,rows=10)\n[State]\nhistory=0:0,1:0,0:2,1:0,0:0\nmove_number=5\n__dict__=gASVAwMAAAAAAAB9lIwLX193cmFwcGVkX1+UjD5rYWdnbGVfZW52aXJvbm1lbnRzLmVudnMub3Blbl9zcGllbF9lbnYuZ2FtZXMuc25ha2Uuc25ha2VfZ2FtZZSMClNuYWtlU3RhdGWUk5QpgZRYlwIAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCnNuYWtlKGNvbHVtbnM9MTAscGxheWVycz0yLHJvd3M9MTApCltTdGF0ZV0KaGlzdG9yeT0wOjAsMTowLDA6MiwxOjAsMDowCm1vdmVfbnVtYmVyPTUKX19kaWN0X189Z0FTVld3RUFBQUFBQUFCOWxDaU1CVjluWVcxbGxJdythMkZuWjJ4bFgyVnVkbWx5YjI1dFpXNTBjeTVsYm5aekxtOXdaVzVmYzNCcFpXeGZaVzUyTG1kaGJXVnpMbk51WVd0bExuTnVZV3RsWDJkaGJXV1VqQWxUYm1GclpVZGhiV1dVazVRcGdaU01JM051WVd0bEtHTnZiSFZ0Ym5NOU1UQXNjR3hoZVdWeWN6MHlMSEp2ZDNNOU1UQXBsR0tNQkhKdmQzT1VTd3FNQkdOdmJIT1VTd3FNQzI1MWJWOXdiR0Y1WlhKemxFc0NqQXhmYVhOZmRHVnliV2x1WVd5VWlZd1JYMmRoYldWZmIzWmxjbDl5WldGemIyNlVUb3dHYzI1aGEyVnpsRjJVS0YyVVN3QkxBSWFVWVYyVVN3WkxDSWFVWVdXTUJuTmpiM0psYzVSZGxDaEhBQUFBQUFBQUFBQkhBQUFBQUFBQUFBQmxqQWhwYzE5aGJHbDJaWlJkbENpSWlHV01CR1p2YjJTVVN3aExBb2FVakFaZmMzUmxjSE9VU3dLTURGOXVaWGgwWDNCc1lYbGxjcFJMQVl3TVgyMXZkbVZmWW5WbVptVnlsRjJVS0VzQVRtVjFMZz09CpRicy4=\n",
+          "legalActions": [],
+          "legalActionStrings": []
+        },
+        "status": "INACTIVE"
+      },
+      {
+        "action": {
+          "submission": -1
+        },
+        "reward": null,
+        "info": {},
+        "observation": {
+          "remainingOverageTime": 12,
+          "observationString": "{\"board\": [[\"A\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \"B\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \"*\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"]], \"num_rows\": 10, \"num_columns\": 10, \"num_players\": 2, \"food\": [8, 2], \"snakes\": [{\"player\": 0, \"body\": [[0, 0]], \"alive\": true, \"score\": 0.0}, {\"player\": 1, \"body\": [[6, 8]], \"alive\": true, \"score\": 0.0}], \"scores\": [0.0, 0.0], \"is_alive\": [true, true], \"current_player\": 1, \"pending_this_turn\": [0], \"turn\": 2, \"is_terminal\": false, \"winner\": null, \"game_over_reason\": null}",
+          "currentPlayer": 1,
+          "playerId": 1,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nsnake_proxy(columns=10,players=2,rows=10)\n[State]\nhistory=0:0,1:0,0:2,1:0,0:0\nmove_number=5\n__dict__=gASVAwMAAAAAAAB9lIwLX193cmFwcGVkX1+UjD5rYWdnbGVfZW52aXJvbm1lbnRzLmVudnMub3Blbl9zcGllbF9lbnYuZ2FtZXMuc25ha2Uuc25ha2VfZ2FtZZSMClNuYWtlU3RhdGWUk5QpgZRYlwIAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCnNuYWtlKGNvbHVtbnM9MTAscGxheWVycz0yLHJvd3M9MTApCltTdGF0ZV0KaGlzdG9yeT0wOjAsMTowLDA6MiwxOjAsMDowCm1vdmVfbnVtYmVyPTUKX19kaWN0X189Z0FTVld3RUFBQUFBQUFCOWxDaU1CVjluWVcxbGxJdythMkZuWjJ4bFgyVnVkbWx5YjI1dFpXNTBjeTVsYm5aekxtOXdaVzVmYzNCcFpXeGZaVzUyTG1kaGJXVnpMbk51WVd0bExuTnVZV3RsWDJkaGJXV1VqQWxUYm1GclpVZGhiV1dVazVRcGdaU01JM051WVd0bEtHTnZiSFZ0Ym5NOU1UQXNjR3hoZVdWeWN6MHlMSEp2ZDNNOU1UQXBsR0tNQkhKdmQzT1VTd3FNQkdOdmJIT1VTd3FNQzI1MWJWOXdiR0Y1WlhKemxFc0NqQXhmYVhOZmRHVnliV2x1WVd5VWlZd1JYMmRoYldWZmIzWmxjbDl5WldGemIyNlVUb3dHYzI1aGEyVnpsRjJVS0YyVVN3QkxBSWFVWVYyVVN3WkxDSWFVWVdXTUJuTmpiM0psYzVSZGxDaEhBQUFBQUFBQUFBQkhBQUFBQUFBQUFBQmxqQWhwYzE5aGJHbDJaWlJkbENpSWlHV01CR1p2YjJTVVN3aExBb2FVakFaZmMzUmxjSE9VU3dLTURGOXVaWGgwWDNCc1lYbGxjcFJMQVl3TVgyMXZkbVZmWW5WbVptVnlsRjJVS0VzQVRtVjFMZz09CpRicy4=\n",
+          "legalActions": [0, 1, 2, 3],
+          "legalActionStrings": ["UP", "DOWN", "LEFT", "RIGHT"]
+        },
+        "status": "ACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "submission": -1
+        },
+        "reward": 0.0,
+        "info": {},
+        "observation": {
+          "remainingOverageTime": 12,
+          "step": 7,
+          "observationString": "{\"board\": [[\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \"B\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \"*\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"]], \"num_rows\": 10, \"num_columns\": 10, \"num_players\": 2, \"food\": [8, 2], \"snakes\": [{\"player\": 0, \"body\": [], \"alive\": false, \"score\": 0.0}, {\"player\": 1, \"body\": [[6, 7]], \"alive\": true, \"score\": 0.0}], \"scores\": [0.0, 0.0], \"is_alive\": [false, true], \"current_player\": -4, \"pending_this_turn\": [], \"turn\": 3, \"is_terminal\": true, \"winner\": 1, \"game_over_reason\": null}",
+          "currentPlayer": -4,
+          "playerId": 0,
+          "isTerminal": true,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nsnake_proxy(columns=10,players=2,rows=10)\n[State]\nhistory=0:0,1:0,0:2,1:0,0:0,1:2\nmove_number=6\n__dict__=gASV+wIAAAAAAAB9lIwLX193cmFwcGVkX1+UjD5rYWdnbGVfZW52aXJvbm1lbnRzLmVudnMub3Blbl9zcGllbF9lbnYuZ2FtZXMuc25ha2Uuc25ha2VfZ2FtZZSMClNuYWtlU3RhdGWUk5QpgZRYjwIAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCnNuYWtlKGNvbHVtbnM9MTAscGxheWVycz0yLHJvd3M9MTApCltTdGF0ZV0KaGlzdG9yeT0wOjAsMTowLDA6MiwxOjAsMDowLDE6Mgptb3ZlX251bWJlcj02Cl9fZGljdF9fPWdBU1ZVd0VBQUFBQUFBQjlsQ2lNQlY5bllXMWxsSXcrYTJGbloyeGxYMlZ1ZG1seWIyNXRaVzUwY3k1bGJuWnpMbTl3Wlc1ZmMzQnBaV3hmWlc1MkxtZGhiV1Z6TG5OdVlXdGxMbk51WVd0bFgyZGhiV1dVakFsVGJtRnJaVWRoYldXVWs1UXBnWlNNSTNOdVlXdGxLR052YkhWdGJuTTlNVEFzY0d4aGVXVnljejB5TEhKdmQzTTlNVEFwbEdLTUJISnZkM09VU3dxTUJHTnZiSE9VU3dxTUMyNTFiVjl3YkdGNVpYSnpsRXNDakF4ZmFYTmZkR1Z5YldsdVlXeVVpSXdSWDJkaGJXVmZiM1psY2w5eVpXRnpiMjZVVG93R2MyNWhhMlZ6bEYyVUtGMlVYWlJMQmtzSGhwUmhaWXdHYzJOdmNtVnpsRjJVS0VjQUFBQUFBQUFBQUVjQUFBQUFBQUFBQUdXTUNHbHpYMkZzYVhabGxGMlVLSW1JWll3RVptOXZaSlJMQ0VzQ2hwU01CbDl6ZEdWd2M1UkxBNHdNWDI1bGVIUmZjR3hoZVdWeWxFc0FqQXhmYlc5MlpWOWlkV1ptWlhLVVhaUW9UazVsZFM0PQqUYnMu\n",
+          "legalActions": [],
+          "legalActionStrings": []
+        },
+        "status": "DONE"
+      },
+      {
+        "action": {
+          "submission": 2,
+          "thoughts": "ember echo echo pi tau ripple eta omicron",
+          "actionString": "LEFT"
+        },
+        "reward": 0.0,
+        "info": {
+          "actionSubmitted": 2,
+          "actionSubmittedToString": "LEFT",
+          "actionApplied": 2,
+          "timeTaken": 0.0,
+          "agentSelfReportedStatus": null
+        },
+        "observation": {
+          "remainingOverageTime": 12,
+          "observationString": "{\"board\": [[\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \"B\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \"*\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"]], \"num_rows\": 10, \"num_columns\": 10, \"num_players\": 2, \"food\": [8, 2], \"snakes\": [{\"player\": 0, \"body\": [], \"alive\": false, \"score\": 0.0}, {\"player\": 1, \"body\": [[6, 7]], \"alive\": true, \"score\": 0.0}], \"scores\": [0.0, 0.0], \"is_alive\": [false, true], \"current_player\": -4, \"pending_this_turn\": [], \"turn\": 3, \"is_terminal\": true, \"winner\": 1, \"game_over_reason\": null}",
+          "currentPlayer": -4,
+          "playerId": 1,
+          "isTerminal": true,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nsnake_proxy(columns=10,players=2,rows=10)\n[State]\nhistory=0:0,1:0,0:2,1:0,0:0,1:2\nmove_number=6\n__dict__=gASV+wIAAAAAAAB9lIwLX193cmFwcGVkX1+UjD5rYWdnbGVfZW52aXJvbm1lbnRzLmVudnMub3Blbl9zcGllbF9lbnYuZ2FtZXMuc25ha2Uuc25ha2VfZ2FtZZSMClNuYWtlU3RhdGWUk5QpgZRYjwIAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCnNuYWtlKGNvbHVtbnM9MTAscGxheWVycz0yLHJvd3M9MTApCltTdGF0ZV0KaGlzdG9yeT0wOjAsMTowLDA6MiwxOjAsMDowLDE6Mgptb3ZlX251bWJlcj02Cl9fZGljdF9fPWdBU1ZVd0VBQUFBQUFBQjlsQ2lNQlY5bllXMWxsSXcrYTJGbloyeGxYMlZ1ZG1seWIyNXRaVzUwY3k1bGJuWnpMbTl3Wlc1ZmMzQnBaV3hmWlc1MkxtZGhiV1Z6TG5OdVlXdGxMbk51WVd0bFgyZGhiV1dVakFsVGJtRnJaVWRoYldXVWs1UXBnWlNNSTNOdVlXdGxLR052YkhWdGJuTTlNVEFzY0d4aGVXVnljejB5TEhKdmQzTTlNVEFwbEdLTUJISnZkM09VU3dxTUJHTnZiSE9VU3dxTUMyNTFiVjl3YkdGNVpYSnpsRXNDakF4ZmFYTmZkR1Z5YldsdVlXeVVpSXdSWDJkaGJXVmZiM1psY2w5eVpXRnpiMjZVVG93R2MyNWhhMlZ6bEYyVUtGMlVYWlJMQmtzSGhwUmhaWXdHYzJOdmNtVnpsRjJVS0VjQUFBQUFBQUFBQUVjQUFBQUFBQUFBQUdXTUNHbHpYMkZzYVhabGxGMlVLSW1JWll3RVptOXZaSlJMQ0VzQ2hwU01CbDl6ZEdWd2M1UkxBNHdNWDI1bGVIUmZjR3hoZVdWeWxFc0FqQXhmYlc5MlpWOWlkV1ptWlhLVVhaUW9UazVsZFM0PQqUYnMu\n",
+          "legalActions": [],
+          "legalActionStrings": []
+        },
+        "status": "DONE"
+      }
+    ]
+  ],
+  "rewards": [0.0, 0.0],
+  "statuses": ["DONE", "DONE"],
+  "schema_version": 1,
+  "info": {
+    "openSpielGameStringResolved": "snake_proxy(columns=10,players=2,rows=10)",
+    "stateHistory": [
+      "{\"board\": [[\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \"A\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \"*\", \".\", \".\", \".\", \".\", \".\", \"B\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"]], \"num_rows\": 10, \"num_columns\": 10, \"num_players\": 2, \"food\": [8, 2], \"snakes\": [{\"player\": 0, \"body\": [[1, 1]], \"alive\": true, \"score\": 0.0}, {\"player\": 1, \"body\": [[8, 8]], \"alive\": true, \"score\": 0.0}], \"scores\": [0.0, 0.0], \"is_alive\": [true, true], \"current_player\": 0, \"pending_this_turn\": [], \"turn\": 0, \"is_terminal\": false, \"winner\": null, \"game_over_reason\": null}",
+      "{\"board\": [[\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \"A\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \"*\", \".\", \".\", \".\", \".\", \".\", \"B\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"]], \"num_rows\": 10, \"num_columns\": 10, \"num_players\": 2, \"food\": [8, 2], \"snakes\": [{\"player\": 0, \"body\": [[1, 1]], \"alive\": true, \"score\": 0.0}, {\"player\": 1, \"body\": [[8, 8]], \"alive\": true, \"score\": 0.0}], \"scores\": [0.0, 0.0], \"is_alive\": [true, true], \"current_player\": 1, \"pending_this_turn\": [0], \"turn\": 0, \"is_terminal\": false, \"winner\": null, \"game_over_reason\": null}",
+      "{\"board\": [[\".\", \"A\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \"B\", \".\"], [\".\", \".\", \"*\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"]], \"num_rows\": 10, \"num_columns\": 10, \"num_players\": 2, \"food\": [8, 2], \"snakes\": [{\"player\": 0, \"body\": [[0, 1]], \"alive\": true, \"score\": 0.0}, {\"player\": 1, \"body\": [[7, 8]], \"alive\": true, \"score\": 0.0}], \"scores\": [0.0, 0.0], \"is_alive\": [true, true], \"current_player\": 0, \"pending_this_turn\": [], \"turn\": 1, \"is_terminal\": false, \"winner\": null, \"game_over_reason\": null}",
+      "{\"board\": [[\".\", \"A\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \"B\", \".\"], [\".\", \".\", \"*\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"]], \"num_rows\": 10, \"num_columns\": 10, \"num_players\": 2, \"food\": [8, 2], \"snakes\": [{\"player\": 0, \"body\": [[0, 1]], \"alive\": true, \"score\": 0.0}, {\"player\": 1, \"body\": [[7, 8]], \"alive\": true, \"score\": 0.0}], \"scores\": [0.0, 0.0], \"is_alive\": [true, true], \"current_player\": 1, \"pending_this_turn\": [0], \"turn\": 1, \"is_terminal\": false, \"winner\": null, \"game_over_reason\": null}",
+      "{\"board\": [[\"A\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \"B\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \"*\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"]], \"num_rows\": 10, \"num_columns\": 10, \"num_players\": 2, \"food\": [8, 2], \"snakes\": [{\"player\": 0, \"body\": [[0, 0]], \"alive\": true, \"score\": 0.0}, {\"player\": 1, \"body\": [[6, 8]], \"alive\": true, \"score\": 0.0}], \"scores\": [0.0, 0.0], \"is_alive\": [true, true], \"current_player\": 0, \"pending_this_turn\": [], \"turn\": 2, \"is_terminal\": false, \"winner\": null, \"game_over_reason\": null}",
+      "{\"board\": [[\"A\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \"B\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \"*\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"]], \"num_rows\": 10, \"num_columns\": 10, \"num_players\": 2, \"food\": [8, 2], \"snakes\": [{\"player\": 0, \"body\": [[0, 0]], \"alive\": true, \"score\": 0.0}, {\"player\": 1, \"body\": [[6, 8]], \"alive\": true, \"score\": 0.0}], \"scores\": [0.0, 0.0], \"is_alive\": [true, true], \"current_player\": 1, \"pending_this_turn\": [0], \"turn\": 2, \"is_terminal\": false, \"winner\": null, \"game_over_reason\": null}",
+      "{\"board\": [[\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \"B\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \"*\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"]], \"num_rows\": 10, \"num_columns\": 10, \"num_players\": 2, \"food\": [8, 2], \"snakes\": [{\"player\": 0, \"body\": [], \"alive\": false, \"score\": 0.0}, {\"player\": 1, \"body\": [[6, 7]], \"alive\": true, \"score\": 0.0}], \"scores\": [0.0, 0.0], \"is_alive\": [false, true], \"current_player\": -4, \"pending_this_turn\": [], \"turn\": 3, \"is_terminal\": true, \"winner\": 1, \"game_over_reason\": null}"
+    ],
+    "actionHistory": ["0", "0", "2", "0", "0", "2"],
+    "moveDurations": [0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+  }
+}

--- a/kaggle_environments/envs/open_spiel_env/games/snake/visualizer/default/src/main.ts
+++ b/kaggle_environments/envs/open_spiel_env/games/snake/visualizer/default/src/main.ts
@@ -1,0 +1,21 @@
+import { createReplayVisualizer, ReplayAdapter } from '@kaggle-environments/core';
+import { renderer } from './renderer';
+import './style.css';
+
+const app = document.getElementById('app');
+if (!app) {
+  throw new Error('Could not find app element');
+}
+
+if (import.meta.env?.DEV && import.meta.hot) {
+  import.meta.hot.accept();
+}
+
+createReplayVisualizer(
+  app,
+  new ReplayAdapter({
+    gameName: 'open_spiel_snake',
+    renderer: renderer as any,
+    ui: 'side-panel',
+  })
+);

--- a/kaggle_environments/envs/open_spiel_env/games/snake/visualizer/default/src/renderer.ts
+++ b/kaggle_environments/envs/open_spiel_env/games/snake/visualizer/default/src/renderer.ts
@@ -1,0 +1,200 @@
+import type { RendererOptions } from '@kaggle-environments/core';
+
+const PLAYER_COLORS = ['#1f4f8b', '#9a3324', '#2e7d32', '#7b1fa2'];
+const HEAD_COLORS = ['#4a90e2', '#e74c3c', '#4caf50', '#ab47bc'];
+const FOOD_COLOR = '#e6a23c';
+const GRID_LINE = '#d6cfb0';
+const CELL_FILL = '#fbf7e8';
+const INK = '#050001';
+
+type SnakeObservation = {
+  board: string[][];
+  num_rows: number;
+  num_columns: number;
+  num_players: number;
+  food: [number, number] | null;
+  snakes: {
+    player: number;
+    body: [number, number][];
+    alive: boolean;
+    score: number;
+  }[];
+  scores: number[];
+  is_alive: boolean[];
+  current_player: number;
+  pending_this_turn: number[];
+  turn: number;
+  is_terminal: boolean;
+  winner: number | string | null;
+  game_over_reason: string | null;
+};
+
+function getPlayerName(replay: any, idx: number): string {
+  const team = replay?.info?.TeamNames?.[idx];
+  if (team) return team;
+  const agent = replay?.agents?.[idx]?.name;
+  if (agent) return agent;
+  return `Player ${idx}`;
+}
+
+function parseObservation(step: any): SnakeObservation | null {
+  const raw = step?.[0]?.observation?.observationString;
+  if (!raw) return null;
+  try {
+    return JSON.parse(raw) as SnakeObservation;
+  } catch {
+    return null;
+  }
+}
+
+function drawBoard(ctx: CanvasRenderingContext2D, width: number, height: number, obs: SnakeObservation) {
+  ctx.clearRect(0, 0, width, height);
+
+  const rows = obs.num_rows;
+  const cols = obs.num_columns;
+  const padding = 8;
+  const cellSize = Math.floor(Math.min((width - padding * 2) / cols, (height - padding * 2) / rows));
+  const boardW = cellSize * cols;
+  const boardH = cellSize * rows;
+  const xOff = Math.floor((width - boardW) / 2);
+  const yOff = Math.floor((height - boardH) / 2);
+
+  // Cells.
+  ctx.fillStyle = CELL_FILL;
+  ctx.fillRect(xOff, yOff, boardW, boardH);
+
+  ctx.strokeStyle = GRID_LINE;
+  ctx.lineWidth = 1;
+  for (let r = 0; r <= rows; r++) {
+    const y = yOff + r * cellSize + 0.5;
+    ctx.beginPath();
+    ctx.moveTo(xOff, y);
+    ctx.lineTo(xOff + boardW, y);
+    ctx.stroke();
+  }
+  for (let c = 0; c <= cols; c++) {
+    const x = xOff + c * cellSize + 0.5;
+    ctx.beginPath();
+    ctx.moveTo(x, yOff);
+    ctx.lineTo(x, yOff + boardH);
+    ctx.stroke();
+  }
+
+  // Food.
+  if (obs.food) {
+    const [fr, fc] = obs.food;
+    const cx = xOff + fc * cellSize + cellSize / 2;
+    const cy = yOff + fr * cellSize + cellSize / 2;
+    ctx.fillStyle = FOOD_COLOR;
+    ctx.beginPath();
+    ctx.arc(cx, cy, cellSize * 0.32, 0, Math.PI * 2);
+    ctx.fill();
+    ctx.strokeStyle = INK;
+    ctx.lineWidth = 1.2;
+    ctx.stroke();
+  }
+
+  // Snakes.
+  for (const snake of obs.snakes) {
+    if (!snake.alive || snake.body.length === 0) continue;
+    const bodyColor = PLAYER_COLORS[snake.player % PLAYER_COLORS.length];
+    const headColor = HEAD_COLORS[snake.player % HEAD_COLORS.length];
+    // Body segments.
+    for (let i = 0; i < snake.body.length; i++) {
+      const [r, c] = snake.body[i];
+      const x = xOff + c * cellSize;
+      const y = yOff + r * cellSize;
+      const inset = i === 0 ? 1 : 2;
+      ctx.fillStyle = i === 0 ? headColor : bodyColor;
+      ctx.fillRect(x + inset, y + inset, cellSize - inset * 2, cellSize - inset * 2);
+    }
+    // Head outline.
+    const [hr, hc] = snake.body[0];
+    ctx.strokeStyle = INK;
+    ctx.lineWidth = 1.5;
+    ctx.strokeRect(xOff + hc * cellSize + 1, yOff + hr * cellSize + 1, cellSize - 2, cellSize - 2);
+  }
+}
+
+export function renderer(options: RendererOptions) {
+  const { parent, replay, step } = options;
+  const steps = replay?.steps ?? [];
+  if (!steps.length) {
+    parent.innerHTML = '<div>No replay data.</div>';
+    return;
+  }
+  const obs = parseObservation(steps[step]);
+  if (!obs) {
+    parent.innerHTML = '<div>Waiting for first observation...</div>';
+    return;
+  }
+
+  parent.innerHTML = `
+    <div class="snake-container">
+      <div class="snake-header"></div>
+      <div class="snake-board-wrap"><canvas></canvas></div>
+      <div class="snake-status"></div>
+    </div>
+  `;
+  const header = parent.querySelector('.snake-header') as HTMLDivElement;
+  const wrap = parent.querySelector('.snake-board-wrap') as HTMLDivElement;
+  const canvas = wrap.querySelector('canvas') as HTMLCanvasElement;
+  const statusEl = parent.querySelector('.snake-status') as HTMLDivElement;
+
+  // Header: one card per player.
+  const headerHtml = obs.snakes
+    .map((snake) => {
+      const name = getPlayerName(replay, snake.player);
+      const color = PLAYER_COLORS[snake.player % PLAYER_COLORS.length];
+      const isActive = !obs.is_terminal && obs.current_player === snake.player;
+      const classes = ['snake-player-card', snake.alive ? 'alive' : 'dead', isActive ? 'active' : ''].join(' ');
+      return `
+        <div class="${classes}" style="color: ${color};">
+          <div class="snake-player-name">${name}</div>
+          <div class="snake-player-score">${snake.score.toFixed(0)}</div>
+        </div>
+      `;
+    })
+    .join('');
+  header.innerHTML = headerHtml;
+
+  // Status line.
+  let status = '';
+  if (obs.is_terminal) {
+    if (obs.winner === 'draw' || obs.winner === null) {
+      status = `Game over — draw (turn ${obs.turn})`;
+    } else {
+      const wname = getPlayerName(replay, obs.winner as number);
+      const wcolor = PLAYER_COLORS[(obs.winner as number) % PLAYER_COLORS.length];
+      status = `Game over — winner: <span style="color: ${wcolor}; font-weight: 700;">${wname}</span> (turn ${obs.turn})`;
+    }
+    if (obs.game_over_reason) status += ` — ${obs.game_over_reason}`;
+  } else {
+    const aname = getPlayerName(replay, obs.current_player);
+    const acolor = PLAYER_COLORS[obs.current_player % PLAYER_COLORS.length];
+    status = `Turn ${obs.turn} — acting: <span style="color: ${acolor}; font-weight: 700;">${aname}</span>`;
+    if (obs.pending_this_turn.length > 0) {
+      status += ` (pending: ${obs.pending_this_turn.join(', ')})`;
+    }
+  }
+  statusEl.innerHTML = status;
+
+  // Canvas sizing + draw.
+  const aspect = obs.num_columns / obs.num_rows;
+  const sizeAndDraw = () => {
+    const rect = wrap.getBoundingClientRect();
+    if (rect.width <= 0 || rect.height <= 0) return;
+    let cssW = Math.min(rect.width, rect.height * aspect);
+    let cssH = cssW / aspect;
+    cssW = Math.max(1, Math.floor(cssW));
+    cssH = Math.max(1, Math.floor(cssH));
+    canvas.style.width = `${cssW}px`;
+    canvas.style.height = `${cssH}px`;
+    canvas.width = cssW;
+    canvas.height = cssH;
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return;
+    drawBoard(ctx, cssW, cssH, obs);
+  };
+  requestAnimationFrame(sizeAndDraw);
+}

--- a/kaggle_environments/envs/open_spiel_env/games/snake/visualizer/default/src/style.css
+++ b/kaggle_environments/envs/open_spiel_env/games/snake/visualizer/default/src/style.css
@@ -1,0 +1,80 @@
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap');
+
+html, body, #app {
+  width: 100%;
+  height: 100%;
+  margin: 0;
+  padding: 0;
+  overflow: hidden;
+}
+
+.snake-container {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  width: 100%;
+  height: 100%;
+  min-height: 0;
+  background-color: #f5f1e2;
+  overflow: hidden;
+  font-family: 'Inter', sans-serif;
+  box-sizing: border-box;
+  padding: 12px;
+  color: #050001;
+  gap: 10px;
+}
+
+.snake-header {
+  display: flex;
+  justify-content: center;
+  align-items: stretch;
+  width: 100%;
+  gap: 10px;
+  flex-shrink: 0;
+}
+
+.snake-player-card {
+  padding: 6px 14px;
+  background-color: white;
+  font-weight: 700;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 2px;
+  min-width: 110px;
+  border: 1px dashed #3c3b37;
+  opacity: 0.55;
+  transition: opacity 200ms;
+}
+
+.snake-player-card.alive { opacity: 1; }
+.snake-player-card.dead { text-decoration: line-through; }
+.snake-player-card.active { box-shadow: 0 0 0 2px #050001 inset; }
+
+.snake-player-name { font-size: 0.95rem; }
+.snake-player-score { font-size: 1.3rem; font-weight: 800; }
+
+.snake-board-wrap {
+  flex: 1 1 0;
+  width: 100%;
+  min-height: 0;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.snake-board-wrap canvas {
+  display: block;
+  max-width: 100%;
+  max-height: 100%;
+}
+
+.snake-status {
+  width: 100%;
+  text-align: center;
+  font-size: 0.9rem;
+  padding: 6px 10px;
+  border: 1px dashed #3c3b37;
+  background-color: white;
+  flex-shrink: 0;
+}

--- a/kaggle_environments/envs/open_spiel_env/games/snake/visualizer/default/tsconfig.json
+++ b/kaggle_environments/envs/open_spiel_env/games/snake/visualizer/default/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../../../../../../web/tsconfig.base.json",
+  "include": ["src"],
+  "compilerOptions": {
+    "allowJs": true
+  }
+}

--- a/kaggle_environments/envs/open_spiel_env/games/snake/visualizer/default/vite.config.ts
+++ b/kaggle_environments/envs/open_spiel_env/games/snake/visualizer/default/vite.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig, mergeConfig } from 'vite';
+import baseConfig from '../../../../../../../web/vite.config.base';
+
+export default mergeConfig(
+  baseConfig,
+  defineConfig({
+    publicDir: 'replays',
+  })
+);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -703,6 +703,22 @@ importers:
         specifier: ^5.0.0
         version: 5.4.21(@types/node@25.2.1)
 
+  kaggle_environments/envs/open_spiel_env/games/snake/visualizer/default:
+    dependencies:
+      '@kaggle-environments/core':
+        specifier: workspace:*
+        version: link:../../../../../../../web/core
+    devDependencies:
+      cross-env:
+        specifier: ^10.1.0
+        version: 10.1.0
+      typescript:
+        specifier: ^5.0.0
+        version: 5.9.3
+      vite:
+        specifier: ^5.0.0
+        version: 5.4.21(@types/node@25.2.1)
+
   kaggle_environments/envs/open_spiel_env/games/y/visualizer/default:
     dependencies:
       '@kaggle-environments/core':

--- a/tests/envs/open_spiel_env/games/snake/harness_test.py
+++ b/tests/envs/open_spiel_env/games/snake/harness_test.py
@@ -1,0 +1,355 @@
+"""Tests for Snake LLM harness."""
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pyspiel
+from absl.testing import absltest
+
+from kaggle_environments.core_harness import ParseResult, create_agent_fn
+from kaggle_environments.envs.open_spiel_env.games.snake import snake_proxy
+from kaggle_environments.envs.open_spiel_env.games.snake.harness import (
+    generate_prompt,
+    get_legal_moves,
+    parse_response,
+)
+
+_LEGAL = ["UP", "DOWN", "LEFT", "RIGHT"]
+
+
+def _make_observation(state, game, player_id=0):
+    """Build a harness-style observation dict from a snake state."""
+    return {
+        "observationString": state.observation_string(player_id),
+        "playerId": player_id,
+        "currentPlayer": state.current_player(),
+        "isTerminal": state.is_terminal(),
+        "serializedGameAndState": pyspiel.serialize_game_and_state(
+            game.__wrapped__,
+            state.__wrapped__,
+        ),
+    }
+
+
+class ParseResponseTest(absltest.TestCase):
+    def test_parse_json_move(self):
+        response = '```json\n{"move": "UP"}\n```'
+        result = parse_response(response, _LEGAL)
+        self.assertEqual(result.legal_action, "UP")
+        self.assertEqual(result.raw_action, "UP")
+
+    def test_parse_each_action(self):
+        for action in _LEGAL:
+            response = f'```json\n{{"move": "{action}"}}\n```'
+            result = parse_response(response, _LEGAL)
+            self.assertEqual(result.legal_action, action)
+
+    def test_parse_case_insensitive(self):
+        response = '```json\n{"move": "up"}\n```'
+        result = parse_response(response, _LEGAL)
+        self.assertEqual(result.legal_action, "UP")
+
+    def test_parse_with_whitespace(self):
+        response = '```json\n{"move": "  down  "}\n```'
+        result = parse_response(response, _LEGAL)
+        self.assertEqual(result.legal_action, "DOWN")
+
+    def test_parse_fallback_keyword_in_text(self):
+        response = "Food is to my right, so I will go right toward it."
+        result = parse_response(response, _LEGAL)
+        self.assertEqual(result.legal_action, "RIGHT")
+
+    def test_parse_no_match_returns_none(self):
+        response = '```json\n{"move": "diagonal"}\n```'
+        result = parse_response(response, _LEGAL)
+        self.assertIsNone(result.legal_action)
+        self.assertEqual(result.raw_action, "diagonal")
+
+    def test_parse_malformed_json_falls_back(self):
+        response = "```json\n{bad json}\n```\nI'll go LEFT."
+        result = parse_response(response, _LEGAL)
+        self.assertEqual(result.legal_action, "LEFT")
+
+    def test_parse_no_move_returns_none(self):
+        response = "I have no idea what to do."
+        result = parse_response(response, _LEGAL)
+        self.assertIsNone(result.legal_action)
+        self.assertIsNone(result.raw_action)
+
+    def test_parse_bare_json(self):
+        response = 'I think {"move": "DOWN"} is best.'
+        result = parse_response(response, _LEGAL)
+        self.assertEqual(result.legal_action, "DOWN")
+
+    def test_parse_returns_parse_result(self):
+        result = parse_response('```json\n{"move": "UP"}\n```', _LEGAL)
+        self.assertIsInstance(result, ParseResult)
+
+
+class GeneratePromptTest(absltest.TestCase):
+    def _obs(self, player_id=0):
+        state = json.dumps(
+            {
+                "num_rows": 10,
+                "num_columns": 10,
+                "num_players": 2,
+                "food": [3, 4],
+                "snakes": [
+                    {"player": 0, "body": [[1, 1]], "alive": True, "score": 0},
+                    {"player": 1, "body": [[8, 8]], "alive": True, "score": 0},
+                ],
+                "scores": [0, 0],
+                "is_alive": [True, True],
+                "current_player": player_id,
+                "turn": 0,
+                "is_terminal": False,
+                "winner": None,
+            }
+        )
+        return {"observationString": state, "playerId": player_id}
+
+    def test_basic_prompt_contains_rules(self):
+        prompt = generate_prompt(self._obs(), [])
+        self.assertIn("Snake", prompt)
+        self.assertIn("UP, DOWN, LEFT, RIGHT", prompt)
+        self.assertIn("simultaneously", prompt)
+        self.assertIn("food", prompt.lower())
+
+    def test_prompt_includes_player_id(self):
+        prompt = generate_prompt(self._obs(player_id=1), [])
+        self.assertIn("player 1", prompt)
+
+    def test_prompt_includes_dimensions(self):
+        prompt = generate_prompt(self._obs(), [])
+        self.assertIn("10x10", prompt)
+
+    def test_prompt_includes_food_location(self):
+        prompt = generate_prompt(self._obs(), [])
+        self.assertIn("[3, 4]", prompt)
+
+    def test_prompt_includes_own_snake_body(self):
+        prompt = generate_prompt(self._obs(player_id=1), [])
+        self.assertIn("[8, 8]", prompt)
+
+    def test_move_history_included(self):
+        prompt = generate_prompt(self._obs(), ["UP", "RIGHT", "DOWN"])
+        self.assertIn("UP RIGHT DOWN", prompt)
+
+    def test_rethink_suffix(self):
+        prompt = generate_prompt(
+            self._obs(),
+            [],
+            previous_response="I move diagonally",
+            previous_action="diagonal",
+        )
+        self.assertIn("Your previous response was", prompt)
+        self.assertIn("diagonal", prompt)
+        self.assertIn("not in the legal", prompt)
+
+    def test_no_rethink_on_first_attempt(self):
+        prompt = generate_prompt(self._obs(), [])
+        self.assertNotIn("Your previous response was", prompt)
+
+    def test_handles_dead_snake(self):
+        state = json.dumps(
+            {
+                "num_rows": 10,
+                "num_columns": 10,
+                "num_players": 2,
+                "food": [3, 4],
+                "snakes": [
+                    {"player": 0, "body": [], "alive": False, "score": 1},
+                    {"player": 1, "body": [[5, 5]], "alive": True, "score": 0},
+                ],
+                "is_terminal": False,
+                "winner": None,
+            }
+        )
+        prompt = generate_prompt({"observationString": state, "playerId": 0}, [])
+        self.assertIn("DEAD", prompt)
+
+    def test_handles_missing_observation(self):
+        prompt = generate_prompt({"observationString": "", "playerId": 0}, [])
+        # Should not crash; falls back to defaults.
+        self.assertIn("Snake", prompt)
+
+
+class GetLegalMovesTest(absltest.TestCase):
+    def test_from_provided_actions(self):
+        observation = {
+            "legalActions": [0, 1, 2, 3],
+            "legalActionStrings": ["UP", "DOWN", "LEFT", "RIGHT"],
+        }
+        result = get_legal_moves(observation)
+        self.assertEqual(result, {0: "UP", 1: "DOWN", 2: "LEFT", 3: "RIGHT"})
+
+    def test_from_serialized_state(self):
+        game = snake_proxy.SnakeGame()
+        state = game.new_initial_state()
+        observation = {
+            "serializedGameAndState": pyspiel.serialize_game_and_state(
+                game.__wrapped__,
+                state.__wrapped__,
+            ),
+        }
+        result = get_legal_moves(observation)
+        self.assertEqual(sorted(result.values()), ["DOWN", "LEFT", "RIGHT", "UP"])
+
+    def test_empty_serialized(self):
+        observation = {"serializedGameAndState": ""}
+        result = get_legal_moves(observation)
+        self.assertEqual(result, {})
+
+    def test_returns_dict(self):
+        observation = {
+            "legalActions": [0, 3],
+            "legalActionStrings": ["UP", "RIGHT"],
+        }
+        result = get_legal_moves(observation)
+        self.assertIsInstance(result, dict)
+        for k, v in result.items():
+            self.assertIsInstance(k, int)
+            self.assertIsInstance(v, str)
+
+
+class _StreamDelta:
+    def __init__(self, content):
+        self.content = content
+
+
+class _StreamChoice:
+    def __init__(self, content, finish_reason=None):
+        self.delta = _StreamDelta(content)
+        self.finish_reason = finish_reason
+
+
+class _StreamChunk:
+    def __init__(self, choices, usage=None):
+        self.choices = choices
+        self.usage = usage
+
+
+def _make_mock_response(content):
+    """Build a streaming-style mock LLM response (a re-iterable chunk list)."""
+    usage = MagicMock(
+        prompt_tokens=10,
+        completion_tokens=20,
+        total_tokens=30,
+        completion_tokens_details=None,
+    )
+    return [
+        _StreamChunk([_StreamChoice(content)]),
+        _StreamChunk([_StreamChoice("", finish_reason="stop")]),
+        _StreamChunk([], usage=usage),
+    ]
+
+
+class _SnakeHarness:
+    """Adapter wrapping module-level functions in the GameHarness protocol."""
+
+    def get_legal_moves(self, observation):
+        return get_legal_moves(observation)
+
+    def make_prompt(
+        self,
+        observation,
+        move_history,
+        previous_response=None,
+        previous_action=None,
+    ):
+        return generate_prompt(
+            observation,
+            move_history,
+            previous_response=previous_response,
+            previous_action=previous_action,
+        )
+
+    def parse_response(self, response, legal_action_strings):
+        return parse_response(response, legal_action_strings)
+
+
+_ENV = {
+    "MODEL_NAME": "test-model",
+    "MODEL_PROXY_KEY": "test-key",
+    "MODEL_PROXY_URL": "dummy_url",
+}
+
+
+class AgentIntegrationTest(absltest.TestCase):
+    """Test the snake harness through ``create_agent_fn``."""
+
+    @patch.dict("os.environ", _ENV)
+    @patch("kaggle_environments.core_harness.litellm")
+    def test_setup_step_returns_inactive(self, mock_litellm):
+        mock_litellm.drop_params = True
+        agent = create_agent_fn(_SnakeHarness())
+        result = agent({"step": 0, "remainingOverageTime": 60}, {})
+        self.assertIsNone(result["submission"])
+        self.assertEqual(result["status"], "INACTIVE")
+        mock_litellm.completion.assert_not_called()
+
+    @patch.dict("os.environ", _ENV)
+    @patch("kaggle_environments.core_harness.litellm")
+    def test_successful_move(self, mock_litellm):
+        mock_litellm.drop_params = True
+        mock_litellm.completion.return_value = _make_mock_response(
+            '```json\n{"move": "UP"}\n```',
+        )
+        agent = create_agent_fn(_SnakeHarness())
+
+        game = snake_proxy.SnakeGame()
+        state = game.new_initial_state()
+        observation = _make_observation(state, game, state.current_player())
+
+        result = agent(observation, {})
+
+        self.assertEqual(result["status"], "OK")
+        self.assertEqual(result["actionString"], "UP")
+        self.assertEqual(
+            state.__wrapped__.action_to_string(
+                state.current_player(),
+                result["submission"],
+            ),
+            "UP",
+        )
+
+    @patch.dict("os.environ", _ENV)
+    @patch("kaggle_environments.core_harness.litellm")
+    def test_retry_on_bad_parse(self, mock_litellm):
+        mock_litellm.drop_params = True
+        mock_litellm.completion.side_effect = [
+            _make_mock_response('```json\n{"move": "diagonal"}\n```'),
+            _make_mock_response('```json\n{"move": "LEFT"}\n```'),
+        ]
+        agent = create_agent_fn(_SnakeHarness())
+
+        game = snake_proxy.SnakeGame()
+        state = game.new_initial_state()
+        observation = _make_observation(state, game, state.current_player())
+
+        result = agent(observation, {})
+
+        self.assertEqual(result["actionString"], "LEFT")
+        self.assertEqual(mock_litellm.completion.call_count, 2)
+
+    @patch.dict("os.environ", _ENV)
+    @patch("kaggle_environments.core_harness.litellm")
+    def test_raises_after_two_failures(self, mock_litellm):
+        mock_litellm.drop_params = True
+        mock_litellm.completion.return_value = _make_mock_response(
+            "I have no idea what to do",
+        )
+        agent = create_agent_fn(_SnakeHarness())
+
+        game = snake_proxy.SnakeGame()
+        state = game.new_initial_state()
+        observation = _make_observation(state, game, state.current_player())
+
+        with self.assertRaises(ValueError):
+            agent(observation, {})
+
+        self.assertEqual(mock_litellm.completion.call_count, 2)
+
+
+if __name__ == "__main__":
+    absltest.main()

--- a/tests/envs/open_spiel_env/test_open_spiel_env.py
+++ b/tests/envs/open_spiel_env/test_open_spiel_env.py
@@ -1375,6 +1375,83 @@ class OpenSpielEnvTest(absltest.TestCase):
         self.assertEqual(json_out["rewards"][0], open_spiel_env.DEFAULT_INVALID_ACTION_REWARD)
         self.assertEqual(json_out["rewards"][1], -open_spiel_env.DEFAULT_INVALID_ACTION_REWARD)
 
+    def test_snake_agent_playthrough(self):
+        env = make(
+            "open_spiel_snake",
+            configuration={"includeLegalActions": True},
+            debug=True,
+        )
+        env.run(["random", "random"])
+        json_out = env.toJSON()
+        self.assertEqual(json_out["name"], "open_spiel_snake")
+        self.assertTrue(all(status == "DONE" for status in json_out["statuses"]))
+
+    def test_snake_observation_is_json(self):
+        env = make(
+            "open_spiel_snake",
+            configuration={"includeLegalActions": True},
+            debug=True,
+        )
+        env.reset()
+        env.step([{"submission": -1}, {"submission": -1}])  # Setup step.
+        obs = json.loads(env.state[0]["observation"]["observationString"])
+        self.assertEqual(obs["num_rows"], 10)
+        self.assertEqual(obs["num_columns"], 10)
+        self.assertEqual(obs["num_players"], 2)
+        self.assertEqual(len(obs["board"]), 10)
+        self.assertTrue(all(len(row) == 10 for row in obs["board"]))
+        self.assertEqual(obs["snakes"][0]["body"], [[1, 1]])
+        self.assertEqual(obs["snakes"][1]["body"], [[8, 8]])
+        self.assertTrue(obs["snakes"][0]["alive"])
+        self.assertTrue(obs["snakes"][1]["alive"])
+        self.assertEqual(obs["scores"], [0.0, 0.0])
+        self.assertEqual(obs["current_player"], 0)
+        self.assertFalse(obs["is_terminal"])
+        self.assertIsNone(obs["winner"])
+        self.assertEqual(obs["turn"], 0)
+        # Food is placed on an empty square.
+        self.assertIsNotNone(obs["food"])
+        fr, fc = obs["food"]
+        self.assertEqual(obs["board"][fr][fc], "*")
+
+    def test_snake_manual_playthrough(self):
+        # Sequential implementation of simultaneous play: each player submits
+        # in turn, then the buffered moves are applied together. Drive both
+        # snakes off the board on the first round so both die and the game
+        # terminates immediately.
+        env = make("open_spiel_snake", debug=True)
+        env.reset()
+        env.step([{"submission": -1}, {"submission": -1}])  # Setup step.
+        # P0 at (1,1): UP -> (0,1)? still on board. Send LEFT (2) twice to die.
+        # First round: both submit a move; resolution moves snakes and may kill.
+        # P0 LEFT from (1,1) -> (1,0) (alive). P1 RIGHT from (8,8) -> (8,9) (alive).
+        # Second round: P0 LEFT from (1,0) -> (1,-1) (wall, dies).
+        # P1 RIGHT from (8,9) -> (8,10) (wall, dies).
+        env.step([{"submission": 2}, {"submission": -1}])  # P0 LEFT
+        env.step([{"submission": -1}, {"submission": 3}])  # P1 RIGHT
+        env.step([{"submission": 2}, {"submission": -1}])  # P0 LEFT (off board)
+        env.step([{"submission": -1}, {"submission": 3}])  # P1 RIGHT (off board)
+        self.assertTrue(env.done)
+        obs = json.loads(env.state[0]["observation"]["observationString"])
+        self.assertTrue(obs["is_terminal"])
+        self.assertFalse(obs["snakes"][0]["alive"])
+        self.assertFalse(obs["snakes"][1]["alive"])
+
+    def test_snake_invalid_action(self):
+        env = make("open_spiel_snake", debug=True)
+        env.reset()
+        env.step([{"submission": -1}, {"submission": -1}])  # Setup step.
+        env.step([{"submission": 999}, {"submission": -1}])  # Invalid action.
+        self.assertTrue(env.done)
+        json_out = env.toJSON()
+        self.assertEqual(
+            json_out["rewards"],
+            [
+                open_spiel_env.DEFAULT_INVALID_ACTION_REWARD,
+                -open_spiel_env.DEFAULT_INVALID_ACTION_REWARD,
+            ],
+        )
+
     def test_simultaneous_agent_error(self):
         open_spiel_env._register_game_envs(["goofspiel(num_cards=4,points_order=descending,returns_type=total_points)"])
         env = make("open_spiel_goofspiel", debug=True)


### PR DESCRIPTION
The custom Snake port (snake_game.py) was registered in GAMES_LIST but silently skipped at env build time because SnakeGame.num_players shadowed the inherited method. Fixed that and a handful of related signature mismatches (_legal_actions, _action_to_string, the observer factory and set_from/string_from), then added:

- snake_proxy.py for structured JSON observations
- harness.py with rules, board snapshot, food location, own-snake position, and a UP/DOWN/LEFT/RIGHT JSON output spec; multi-stage parser with case-insensitive fallback
- A Vite/TS canvas visualizer (per-player score cards, food, head/body colours, turn/winner status)
- 28 harness tests + 4 env-level tests (playthrough, JSON observation shape, manual play, invalid action)
- A local LLM driver (test_llm_game.py)