### PR TITLE
Fix coin_game_arena visualizer stacking both team boards at (0,0)

### DIFF
--- a/kaggle_environments/envs/open_spiel_env/games/coin_game_arena/visualizer/default/src/style.css
+++ b/kaggle_environments/envs/open_spiel_env/games/coin_game_arena/visualizer/default/src/style.css
@@ -126,6 +126,8 @@ body,
 }
 
 .board-column canvas {
+  /* Override .viewer canvas { position: absolute; ... } from web/core. */
+  position: relative;
   display: block;
   background: transparent;
 }


### PR DESCRIPTION
The .viewer canvas { position: absolute } rule from @kaggle-environments/core caused both team canvases to render on top of each other, hiding one board. Override to position: relative so the two boards lay out side-by-side, matching the y / clobber / dark_hex / amazons visualizers.