### PR TITLE
Dots and boxes adjustments

### DIFF
--- a/kaggle_environments/envs/open_spiel_env/games/dots_and_boxes/harness.py
+++ b/kaggle_environments/envs/open_spiel_env/games/dots_and_boxes/harness.py
@@ -72,11 +72,13 @@ Score: Player 1 = {p1_score}, Player 2 = {p2_score}. Boxes remaining:
 {boxes_remaining}.
 
 You are Player {player_label}.
-Last move played: {last_move}
-Moves you have played so far: {move_history}
+{last_move_label}: {last_move}
 
-Action notation: ``<h|v> <row> <col>`` (e.g. ``h 0 1`` or ``v 2 0``). Only
-open edges (shown as ``.`` on the board) are legal.
+Legal moves you can play right now:
+{legal_moves}
+
+Action notation: ``<h|v> <row> <col>`` (e.g. ``h 0 1`` or ``v 2 0``). You
+must pick one of the legal moves listed above.
 
 Respond with your reasoning followed by your final move in a JSON block:
 
@@ -96,8 +98,8 @@ RETHINK_SUFFIX = """
 Your previous response was:
 {previous_response}
 
-You suggested move "{previous_action}" but it is not a legal move.
-Reconsider and pick a legal move (an open edge shown as ``.`` on the board).
+You suggested move "{previous_action}" but it is not in the legal moves
+list above. Reconsider and pick one of the listed legal moves.
 """
 
 
@@ -170,6 +172,26 @@ def _format_board_ascii(state: Mapping[str, Any]) -> str:
 def _boxes_remaining(state: Mapping[str, Any]) -> int:
     boxes = state.get("boxes") or []
     return sum(1 for row in boxes for cell in row if not cell)
+
+
+def _format_legal_moves(legal_action_strings: Sequence[str]) -> str:
+    """Render the legal action list as a grouped, sorted shorthand string."""
+    horizontal: list[tuple[int, int]] = []
+    vertical: list[tuple[int, int]] = []
+    for action_string in legal_action_strings:
+        m = _OPENSPIEL_LEGAL_RE.search(action_string or "")
+        if not m:
+            continue
+        coord = (int(m.group(2)), int(m.group(3)))
+        (horizontal if m.group(1).lower() == "h" else vertical).append(coord)
+    horizontal.sort()
+    vertical.sort()
+    lines: list[str] = []
+    if horizontal:
+        lines.append("  horizontal: " + ", ".join(f"h {r} {c}" for r, c in horizontal))
+    if vertical:
+        lines.append("  vertical: " + ", ".join(f"v {r} {c}" for r, c in vertical))
+    return "\n".join(lines) if lines else "  (none)"
 
 
 def _normalize_move(raw: str) -> str | None:
@@ -261,14 +283,19 @@ def generate_prompt(
     last_action = state.get("last_action")
     if last_action:
         last_move = (
-            f"P{last_action.get('player', '?')} "
             f"{last_action.get('orientation', '?')} "
             f"{last_action.get('row', '?')} {last_action.get('col', '?')}"
         )
+        last_move_label = (
+            "Your previous move (you completed a box, so it is your turn again)"
+            if str(last_action.get("player")) == str(player_label)
+            else "Opponent's last move"
+        )
     else:
         last_move = "(none yet)"
+        last_move_label = "Previous move"
 
-    move_history_str = ", ".join(move_history) if move_history else "None"
+    legal_moves = _format_legal_moves(list(get_legal_moves(observation).values()))
 
     prompt = DOTS_AND_BOXES_PROMPT_TEMPLATE.format(
         num_rows=num_rows,
@@ -282,8 +309,9 @@ def generate_prompt(
         p2_score=scores[1] if len(scores) > 1 else 0,
         boxes_remaining=_boxes_remaining(state),
         player_label=player_label,
+        last_move_label=last_move_label,
         last_move=last_move,
-        move_history=move_history_str,
+        legal_moves=legal_moves,
     )
 
     if previous_response is not None:

--- a/kaggle_environments/envs/open_spiel_env/games/dots_and_boxes/harness.py
+++ b/kaggle_environments/envs/open_spiel_env/games/dots_and_boxes/harness.py
@@ -73,12 +73,10 @@ Score: Player 1 = {p1_score}, Player 2 = {p2_score}. Boxes remaining:
 
 You are Player {player_label}.
 {last_move_label}: {last_move}
+Moves you have played so far: {move_history}
 
-Legal moves you can play right now:
-{legal_moves}
-
-Action notation: ``<h|v> <row> <col>`` (e.g. ``h 0 1`` or ``v 2 0``). You
-must pick one of the legal moves listed above.
+Action notation: ``<h|v> <row> <col>`` (e.g. ``h 0 1`` or ``v 2 0``). Only
+open edges (shown as ``.`` on the board) are legal.
 
 Respond with your reasoning followed by your final move in a JSON block:
 
@@ -98,8 +96,8 @@ RETHINK_SUFFIX = """
 Your previous response was:
 {previous_response}
 
-You suggested move "{previous_action}" but it is not in the legal moves
-list above. Reconsider and pick one of the listed legal moves.
+You suggested move "{previous_action}" but it is not a legal move.
+Reconsider and pick a legal move (an open edge shown as ``.`` on the board).
 """
 
 
@@ -172,26 +170,6 @@ def _format_board_ascii(state: Mapping[str, Any]) -> str:
 def _boxes_remaining(state: Mapping[str, Any]) -> int:
     boxes = state.get("boxes") or []
     return sum(1 for row in boxes for cell in row if not cell)
-
-
-def _format_legal_moves(legal_action_strings: Sequence[str]) -> str:
-    """Render the legal action list as a grouped, sorted shorthand string."""
-    horizontal: list[tuple[int, int]] = []
-    vertical: list[tuple[int, int]] = []
-    for action_string in legal_action_strings:
-        m = _OPENSPIEL_LEGAL_RE.search(action_string or "")
-        if not m:
-            continue
-        coord = (int(m.group(2)), int(m.group(3)))
-        (horizontal if m.group(1).lower() == "h" else vertical).append(coord)
-    horizontal.sort()
-    vertical.sort()
-    lines: list[str] = []
-    if horizontal:
-        lines.append("  horizontal: " + ", ".join(f"h {r} {c}" for r, c in horizontal))
-    if vertical:
-        lines.append("  vertical: " + ", ".join(f"v {r} {c}" for r, c in vertical))
-    return "\n".join(lines) if lines else "  (none)"
 
 
 def _normalize_move(raw: str) -> str | None:
@@ -295,7 +273,7 @@ def generate_prompt(
         last_move = "(none yet)"
         last_move_label = "Previous move"
 
-    legal_moves = _format_legal_moves(list(get_legal_moves(observation).values()))
+    move_history_str = ", ".join(move_history) if move_history else "None"
 
     prompt = DOTS_AND_BOXES_PROMPT_TEMPLATE.format(
         num_rows=num_rows,
@@ -311,7 +289,7 @@ def generate_prompt(
         player_label=player_label,
         last_move_label=last_move_label,
         last_move=last_move,
-        legal_moves=legal_moves,
+        move_history=move_history_str,
     )
 
     if previous_response is not None:

--- a/kaggle_environments/envs/open_spiel_env/open_spiel_env.py
+++ b/kaggle_environments/envs/open_spiel_env/open_spiel_env.py
@@ -989,7 +989,7 @@ GAMES_LIST = [
     "coin_game_arena",
     "connect_four",
     "dark_hex",
-    "dots_and_boxes(num_rows=9,num_cols=9)",
+    "dots_and_boxes(num_rows=8,num_cols=8)",
     "gin_rummy",
     "go(board_size=9)",
     "goofspiel(num_cards=4,points_order=descending,returns_type=total_points)",

--- a/kaggle_environments/envs/open_spiel_env/open_spiel_env.py
+++ b/kaggle_environments/envs/open_spiel_env/open_spiel_env.py
@@ -989,7 +989,7 @@ GAMES_LIST = [
     "coin_game_arena",
     "connect_four",
     "dark_hex",
-    "dots_and_boxes(num_rows=10,num_cols=10)",
+    "dots_and_boxes(num_rows=9,num_cols=9)",
     "gin_rummy",
     "go(board_size=9)",
     "goofspiel(num_cards=4,points_order=descending,returns_type=total_points)",

--- a/tests/envs/open_spiel_env/games/dots_and_boxes/harness_test.py
+++ b/tests/envs/open_spiel_env/games/dots_and_boxes/harness_test.py
@@ -118,33 +118,59 @@ class GeneratePromptTest(absltest.TestCase):
         self.assertIn("Player 1 = 0", prompt)
         self.assertIn("Player 2 = 0", prompt)
 
-    def test_last_move_rendered_after_play(self):
+    def test_last_move_rendered_after_opponent_play(self):
         self.state.apply_action(0)  # P1(h,0,0)
         obs1 = _make_observation(self.state, self.game, player_id=1)
         prompt = generate_prompt(obs1, [])
-        self.assertIn("Last move played: P1 h 0 0", prompt)
+        self.assertIn("Opponent's last move: h 0 0", prompt)
+
+    def test_last_move_labeled_as_own_after_box_completion(self):
+        # Drive the game so the same player completes the fourth edge of
+        # box (0,0), triggering a bonus turn — last_action.player should
+        # equal the current player.
+        def play(orient: str, row: int, col: int) -> None:
+            for action in self.state.legal_actions():
+                m = self.state.action_to_string(self.state.current_player(), action)
+                if f"({orient},{row},{col})" in m:
+                    self.state.apply_action(action)
+                    return
+            raise AssertionError(f"No legal action for {orient} {row} {col}")
+
+        play("h", 0, 0)  # P1
+        play("h", 0, 1)  # P2
+        play("v", 0, 0)  # P1
+        play("v", 0, 1)  # P2
+        play("h", 1, 0)  # P1 closes box (0,0); bonus turn
+        obs = _make_observation(self.state, self.game, player_id=int(self.state.current_player()))
+        prompt = generate_prompt(obs, [])
+        self.assertIn("Your previous move", prompt)
 
     def test_last_move_none_at_start(self):
         obs = _make_observation(self.state, self.game, player_id=0)
         prompt = generate_prompt(obs, [])
-        self.assertIn("Last move played: (none yet)", prompt)
+        self.assertIn("Previous move: (none yet)", prompt)
 
-    def test_move_history_rendered(self):
-        obs = _make_observation(self.state, self.game, player_id=0)
-        prompt = generate_prompt(obs, ["h 0 0", "v 0 0"])
-        self.assertIn("h 0 0, v 0 0", prompt)
-
-    def test_move_history_none_when_empty(self):
+    def test_legal_moves_list_rendered(self):
         obs = _make_observation(self.state, self.game, player_id=0)
         prompt = generate_prompt(obs, [])
-        self.assertIn("Moves you have played so far: None", prompt)
+        self.assertIn("Legal moves you can play", prompt)
+        self.assertIn("horizontal: h 0 0", prompt)
+        self.assertIn("vertical: v 0 0", prompt)
+
+    def test_legal_moves_list_excludes_played_edge(self):
+        self.state.apply_action(0)  # P1(h,0,0)
+        obs = _make_observation(self.state, self.game, player_id=1)
+        prompt = generate_prompt(obs, [])
+        legal_section = prompt.split("Legal moves you can play")[1]
+        self.assertNotIn("h 0 0,", legal_section)
+        self.assertNotIn("h 0 0\n", legal_section)
 
     def test_rethink_suffix(self):
         obs = _make_observation(self.state, self.game, player_id=0)
         prompt = generate_prompt(obs, [], previous_response="I'll play x 9 9", previous_action="x 9 9")
         self.assertIn("Your previous response was", prompt)
         self.assertIn("x 9 9", prompt)
-        self.assertIn("not a legal move", prompt)
+        self.assertIn("not in the legal moves", prompt)
 
     def test_no_rethink_on_first_attempt(self):
         obs = _make_observation(self.state, self.game, player_id=0)

--- a/tests/envs/open_spiel_env/games/dots_and_boxes/harness_test.py
+++ b/tests/envs/open_spiel_env/games/dots_and_boxes/harness_test.py
@@ -150,27 +150,22 @@ class GeneratePromptTest(absltest.TestCase):
         prompt = generate_prompt(obs, [])
         self.assertIn("Previous move: (none yet)", prompt)
 
-    def test_legal_moves_list_rendered(self):
+    def test_move_history_rendered(self):
+        obs = _make_observation(self.state, self.game, player_id=0)
+        prompt = generate_prompt(obs, ["h 0 0", "v 0 0"])
+        self.assertIn("h 0 0, v 0 0", prompt)
+
+    def test_move_history_none_when_empty(self):
         obs = _make_observation(self.state, self.game, player_id=0)
         prompt = generate_prompt(obs, [])
-        self.assertIn("Legal moves you can play", prompt)
-        self.assertIn("horizontal: h 0 0", prompt)
-        self.assertIn("vertical: v 0 0", prompt)
-
-    def test_legal_moves_list_excludes_played_edge(self):
-        self.state.apply_action(0)  # P1(h,0,0)
-        obs = _make_observation(self.state, self.game, player_id=1)
-        prompt = generate_prompt(obs, [])
-        legal_section = prompt.split("Legal moves you can play")[1]
-        self.assertNotIn("h 0 0,", legal_section)
-        self.assertNotIn("h 0 0\n", legal_section)
+        self.assertIn("Moves you have played so far: None", prompt)
 
     def test_rethink_suffix(self):
         obs = _make_observation(self.state, self.game, player_id=0)
         prompt = generate_prompt(obs, [], previous_response="I'll play x 9 9", previous_action="x 9 9")
         self.assertIn("Your previous response was", prompt)
         self.assertIn("x 9 9", prompt)
-        self.assertIn("not in the legal moves", prompt)
+        self.assertIn("not a legal move", prompt)
 
     def test_no_rethink_on_first_attempt(self):
         obs = _make_observation(self.state, self.game, player_id=0)


### PR DESCRIPTION
I threw some of the bad replays into claude and found that they often ignored the ASCII board entirely and treated the list of their own moves as the only moves that were played. So, they would pick moves that their opponent played because they weren't aware that those were taken. 

Changes made: 
- Bump board size down to 9x9
- Explicitly include the legal moves list in the prompt
- Drop the own-history list
- Renamed last move played to opponent's last move / your previous move 