### PR TITLE
Wire built visualizers into html_renderer() and bundle them in the wheel

### DIFF
--- a/cicd/cloudbuild.yaml
+++ b/cicd/cloudbuild.yaml
@@ -67,12 +67,16 @@ steps:
         pnpm build-ci
     waitFor: ["build-cpu-image"]
 
-  # Step 5: Publish to PyPI (after tests pass)
+  # Step 5: Publish to PyPI (after tests pass and visualizers are built)
+  # Waits for build-all-visualizers so each env's
+  # `visualizer/<variant>/dist/index.html` exists on disk before the publish
+  # script prunes the trees and runs `flit publish`. Without this, the wheel
+  # would race the visualizer build and ship without the bundled visualizer.
   - id: "publish-to-pypi"
     name: "python:3.11-slim"
     entrypoint: "bash"
     args: ["docker/cicd-publish-to-pypi.sh"]
-    waitFor: ["run-tests"]
+    waitFor: ["run-tests", "build-all-visualizers"]
     secretEnv: ["PYPI_TOKEN"]
 
   # Step 6: Deploy visualizers to GCS (after visualizers built)

--- a/docker/cicd-publish-to-pypi.sh
+++ b/docker/cicd-publish-to-pypi.sh
@@ -42,6 +42,29 @@ if [ "$VERSION_EXISTS" = "true" ]; then
   echo "⏩ Version $VERSION_FROM_PYPROJECT already exists on PyPI. Skipping publish."
 else
   echo "🚀 Version $VERSION_FROM_PYPROJECT not found on PyPI. Publishing..."
+
+  # Prune visualizer trees to keep only `dist/index.html` (the self-contained
+  # bundle produced by vite-plugin-singlefile). flit_core's wheel builder does
+  # not apply [tool.flit.sdist] excludes, so we have to physically remove
+  # node_modules / src / e2e / etc. before `flit publish` or they end up in
+  # the wheel. The `build-all-visualizers` step must run before this.
+  echo "Pruning visualizer trees to dist/index.html only..."
+  find kaggle_environments -type d -name visualizer | while read -r viz_dir; do
+    find "$viz_dir" -mindepth 1 -maxdepth 1 -type d | while read -r variant; do
+      keep="$variant/dist/index.html"
+      if [ -f "$keep" ]; then
+        tmp=$(mktemp)
+        cp "$keep" "$tmp"
+        rm -rf "$variant"
+        mkdir -p "$variant/dist"
+        mv "$tmp" "$keep"
+      else
+        echo "  ⚠️  No dist/index.html for $variant — removing entirely."
+        rm -rf "$variant"
+      fi
+    done
+  done
+
   pip install flit --quiet
   export FLIT_USERNAME=__token__
   export FLIT_PASSWORD=$PYPI_TOKEN

--- a/kaggle_environments/envs/cabt/cabt.py
+++ b/kaggle_environments/envs/cabt/cabt.py
@@ -193,9 +193,16 @@ def renderer(state, env):
 
 
 def html_renderer():
-    jspath = os.path.abspath(os.path.join(os.path.dirname(__file__), "cabt.js"))
-    with open(jspath, encoding="utf-8") as f:
-        return f.read()
+    dir_path = os.path.dirname(__file__)
+    htmlpath = os.path.join(dir_path, "visualizer", "default", "dist", "index.html")
+    if os.path.exists(htmlpath):
+        with open(htmlpath, encoding="utf-8") as f:
+            return f.read()
+    jspath = os.path.abspath(os.path.join(dir_path, "cabt.js"))
+    if os.path.exists(jspath):
+        with open(jspath, encoding="utf-8") as f:
+            return f.read()
+    return ""
 
 
 jsonpath = os.path.abspath(os.path.join(os.path.dirname(__file__), "cabt.json"))

--- a/kaggle_environments/envs/connectx/connectx.py
+++ b/kaggle_environments/envs/connectx/connectx.py
@@ -190,6 +190,12 @@ with open(jsonpath) as f:
 
 
 def html_renderer():
+    htmlpath = path.join(dirpath, "visualizer", "default", "dist", "index.html")
+    if path.exists(htmlpath):
+        with open(htmlpath, encoding="utf-8") as f:
+            return f.read()
     jspath = path.abspath(path.join(dirpath, "connectx.js"))
-    with open(jspath, encoding="utf-8") as f:
-        return f.read()
+    if path.exists(jspath):
+        with open(jspath, encoding="utf-8") as f:
+            return f.read()
+    return ""

--- a/kaggle_environments/envs/halite/halite.py
+++ b/kaggle_environments/envs/halite/halite.py
@@ -259,6 +259,12 @@ with open(json_path) as json_file:
 
 
 def html_renderer():
+    html_path = path.join(dir_path, "visualizer", "default", "dist", "index.html")
+    if path.exists(html_path):
+        with open(html_path, encoding="utf-8") as f:
+            return f.read()
     js_path = path.abspath(path.join(dir_path, "halite.js"))
-    with open(js_path, encoding="utf-8") as js_file:
-        return js_file.read()
+    if path.exists(js_path):
+        with open(js_path, encoding="utf-8") as js_file:
+            return js_file.read()
+    return ""

--- a/kaggle_environments/envs/hungry_geese/hungry_geese.py
+++ b/kaggle_environments/envs/hungry_geese/hungry_geese.py
@@ -311,6 +311,12 @@ with open(jsonpath) as f:
 
 
 def html_renderer():
+    htmlpath = path.join(dirpath, "visualizer", "default", "dist", "index.html")
+    if path.exists(htmlpath):
+        with open(htmlpath, encoding="utf-8") as f:
+            return f.read()
     jspath = path.abspath(path.join(dirpath, "hungry_geese.js"))
-    with open(jspath, encoding="utf-8") as f:
-        return f.read()
+    if path.exists(jspath):
+        with open(jspath, encoding="utf-8") as f:
+            return f.read()
+    return ""

--- a/kaggle_environments/envs/kore_fleets/kore_fleets.py
+++ b/kaggle_environments/envs/kore_fleets/kore_fleets.py
@@ -550,6 +550,12 @@ with open(json_path) as json_file:
 
 
 def html_renderer():
+    html_path = path.join(dir_path, "visualizer", "default", "dist", "index.html")
+    if path.exists(html_path):
+        with open(html_path, encoding="utf-8") as f:
+            return f.read()
     js_path = path.abspath(path.join(dir_path, "kore_fleets.js"))
-    with open(js_path, encoding="utf-8") as js_file:
-        return js_file.read()
+    if path.exists(js_path):
+        with open(js_path, encoding="utf-8") as js_file:
+            return js_file.read()
+    return ""

--- a/kaggle_environments/envs/mab/mab.py
+++ b/kaggle_environments/envs/mab/mab.py
@@ -138,9 +138,15 @@ with open(json_path) as json_file:
 
 
 def html_renderer():
+    html_path = path.join(dir_path, "visualizer", "default", "dist", "index.html")
+    if path.exists(html_path):
+        with open(html_path, encoding="utf-8") as f:
+            return f.read()
     js_path = path.abspath(path.join(dir_path, "mab.js"))
-    with open(js_path, encoding="utf-8") as js_file:
-        return js_file.read()
+    if path.exists(js_path):
+        with open(js_path, encoding="utf-8") as js_file:
+            return js_file.read()
+    return ""
 
 
 agents = all_agents

--- a/kaggle_environments/envs/open_spiel_env/open_spiel_env.py
+++ b/kaggle_environments/envs/open_spiel_env/open_spiel_env.py
@@ -774,7 +774,25 @@ function renderer(context) {
 def _get_html_renderer_content(
     open_spiel_short_name: str, base_path_for_custom_renderers: pathlib.Path, default_renderer_func: Callable[[], str]
 ) -> str:
-    """Tries to load a custom JS renderer for the game, falls back to default."""
+    """Tries to load a custom HTML/JS renderer for the game, falls back to default."""
+    # Prefer the built Vite visualizer at games/<name>/visualizer/default/dist/index.html
+    dist_index_path = pathlib.Path(
+        base_path_for_custom_renderers,
+        open_spiel_short_name,
+        "visualizer",
+        "default",
+        "dist",
+        "index.html",
+    )
+    if dist_index_path.is_file():
+        try:
+            with open(dist_index_path, "r", encoding="utf-8") as f:
+                content = f.read()
+            _log.debug(f"Using built HTML visualizer for {open_spiel_short_name} from {dist_index_path}")
+            return content
+        except Exception as e:  # pylint: disable=broad-exception-caught
+            _log.debug(e)
+    # Fallback to legacy single-file JS renderer at games/<name>/<name>.js
     custom_renderer_js_path = pathlib.Path(
         base_path_for_custom_renderers,
         open_spiel_short_name,

--- a/kaggle_environments/envs/rps/rps.py
+++ b/kaggle_environments/envs/rps/rps.py
@@ -82,9 +82,15 @@ with open(json_path) as json_file:
 
 
 def html_renderer():
+    html_path = path.join(dir_path, "visualizer", "default", "dist", "index.html")
+    if path.exists(html_path):
+        with open(html_path, encoding="utf-8") as f:
+            return f.read()
     js_path = path.abspath(path.join(dir_path, "rps.js"))
-    with open(js_path, encoding="utf-8") as js_file:
-        return js_file.read()
+    if path.exists(js_path):
+        with open(js_path, encoding="utf-8") as js_file:
+            return js_file.read()
+    return ""
 
 
 agents = all_agents

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "vite": "^5.0.0",
     "vite-plugin-checker": "^0.11.0",
     "vite-plugin-css-injected-by-js": "^3.5.2",
+    "vite-plugin-singlefile": "^2.0.0",
     "vite-tsconfig-paths": "^5.1.4"
   },
   "dependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -93,6 +93,9 @@ importers:
       vite-plugin-css-injected-by-js:
         specifier: ^3.5.2
         version: 3.5.2(vite@5.4.21(@types/node@25.2.1))
+      vite-plugin-singlefile:
+        specifier: ^2.0.0
+        version: 2.3.3(vite@5.4.21(@types/node@25.2.1))
       vite-tsconfig-paths:
         specifier: ^5.1.4
         version: 5.1.4(typescript@5.9.3)(vite@5.4.21(@types/node@25.2.1))
@@ -4085,6 +4088,16 @@ packages:
       vite:
         optional: true
 
+  vite-plugin-singlefile@2.3.3:
+    resolution: {integrity: sha512-XVnGH0QzbOa8fxRSsHdCarVN1BSBXNi7uLMQYlrGRN5apdHkk62XQWRJhVever0lnfuyBkwn+kvVChdm/OoOUg==}
+    engines: {node: '>18.0.0'}
+    peerDependencies:
+      rollup: ^4.59.0
+      vite: ^5.4.21 || ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      rollup:
+        optional: true
+
   vite-plugin-static-copy@3.2.0:
     resolution: {integrity: sha512-g2k9z8B/1Bx7D4wnFjPLx9dyYGrqWMLTpwTtPHhcU+ElNZP2O4+4OsyaficiDClus0dzVhdGvoGFYMJxoXZ12Q==}
     engines: {node: ^18.0.0 || >=20.0.0}
@@ -7861,6 +7874,11 @@ snapshots:
       - '@types/node'
       - rollup
       - supports-color
+
+  vite-plugin-singlefile@2.3.3(vite@5.4.21(@types/node@25.2.1)):
+    dependencies:
+      micromatch: 4.0.8
+      vite: 5.4.21(@types/node@25.2.1)
 
   vite-plugin-static-copy@3.2.0(vite@5.4.21(@types/node@25.2.1)):
     dependencies:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "kaggle-environments"
-version = "1.29.3"
+version = "1.30.0"
 description = "Kaggle Environments"
 authors = [
     {name = "Kaggle", email = "support@kaggle.com"},
@@ -62,6 +62,14 @@ name = "kaggle_environments"
 # Flit specific options (files to exclude from the PyPI package).
 # If using another build backend (setuptools, poetry), you can remove this
 # section.
+#
+# NOTE: these patterns only apply to the sdist. flit_core's wheel builder
+# ignores them and ships everything under the module directory. The CI
+# `publish-to-pypi` step (docker/cicd-publish-to-pypi.sh) prunes each
+# `visualizer/<variant>/` to just `dist/index.html` before `flit publish`
+# so that the wheel ships the self-contained bundle without node_modules
+# or build sources. The shipped `dist/index.html` is what `html_renderer()`
+# returns in notebook / iframe srcdoc contexts.
 [tool.flit.sdist]
 exclude = [
   # Do not release tests files on PyPI

--- a/web/vite.config.base.ts
+++ b/web/vite.config.base.ts
@@ -2,6 +2,7 @@ import { defineConfig } from 'vite';
 import checker from 'vite-plugin-checker';
 import tsconfigPaths from 'vite-tsconfig-paths';
 import cssInjectedByJsPlugin from 'vite-plugin-css-injected-by-js';
+import { viteSingleFile } from 'vite-plugin-singlefile';
 
 // Support custom port via environment variable (used by Playwright tests)
 const port = process.env.VITE_PORT ? parseInt(process.env.VITE_PORT, 10) : 5173;
@@ -38,6 +39,10 @@ export default defineConfig({
     process.env.NODE_ENV !== 'production' && checker({ typescript: true }),
     // Inject CSS into JS bundle in production builds (matches dev behavior)
     cssInjectedByJsPlugin(),
+    // Inline all JS/CSS into a single self-contained dist/index.html so it can
+    // be served from an iframe srcdoc (Kaggle notebook html_renderer path) and
+    // shipped inside the PyPI wheel without needing a co-located assets dir.
+    viteSingleFile(),
     {
       name: 'custom-header-plugin',
       configureServer(server) {


### PR DESCRIPTION
[Thread](https://chat.kaggle.net/kaggle/pl/iijydia9e3yjzk8awkenm1pmbw)

@bovard - can you share how you were using orbit_wars.js in an interactive notebook context? I'm hoping that this fix will allow us to make it 'just work' for all environments, but not 100% sure. 

PR #708 deleted the per-env single-file JS visualizers (connectx.js, halite.js, etc.) but left html_renderer() functions that still tried to read those paths, breaking notebook rendering for every affected env.

Update each html_renderer() to read the vite-built `visualizer/default/dist/index.html` first and fall back to the legacy `<env>.js` for any env that still hand-maintains one (orbit_wars-style). Same change applied to open_spiel_env's shared resolver so chess, connect_four, go, and repeated_poker pick up their dist artifacts.

For the artifact to actually reach Kaggle notebook users, three plumbing fixes were needed:

* `web/vite.config.base.ts` — add vite-plugin-singlefile so every `vite build` inlines JS/CSS into a self-contained `dist/index.html`. Required because notebook rendering uses `<iframe srcdoc=...>`, which has no base URL and can't resolve `./assets/index-*.js` references. The same self-contained file also works from `<iframe src=URL>` for the GCS-served path, so one artifact serves both contexts.

* `cicd/cloudbuild.yaml` — make publish-to-pypi wait on build-all-visualizers so the dist files exist before `flit publish` runs. Previously these steps ran in parallel; the publish step happened to win the race and shipped wheels without any visualizer.

* `docker/cicd-publish-to-pypi.sh` — prune each `visualizer/<variant>/` to just `dist/index.html` before publishing. flit_core's wheel builder ignores `[tool.flit.sdist]` excludes entirely, so a physical prune is the only way to keep node_modules / src / e2e out of the wheel once we stop racing the visualizer build.

Verified end-to-end on connectx: built singlefile serves correctly from both a static HTTP URL (GCS path) and an iframe srcdoc (notebook path), postMessage protocol intact, playback controls functional. All 42 visualizer variants build successfully with the singlefile plugin (largest: kaggriculture 11.3MB, mancala 6.9MB, go 3.9MB). Estimated wheel size goes from ~13MB to ~27MB.