### PR TITLE
Snake: balance food spawns via 180° symmetric pairs + 10-turn respawn

### DIFF
--- a/kaggle_environments/envs/open_spiel_env/games/snake/harness.py
+++ b/kaggle_environments/envs/open_spiel_env/games/snake/harness.py
@@ -33,11 +33,15 @@ dies if its new head:
   - leaves the grid,
   - lands on any snake's post-move body (including its own), or
   - collides head-to-head with another snake (both die).
-A snake that moves onto the food ("*") grows by one and earns one point;
-a new food cell then appears on a random empty square. Snakes that do
-NOT eat lose their tail on the same turn. The game ends when at most one
-snake is alive (in a multi-player game) or after {max_turns} turns; the
-last snake standing wins, otherwise the highest score wins.
+A snake that moves onto a food cell ("*") grows by one and earns one
+point. Food spawns in 180°-rotationally-symmetric pairs (one cell and
+its mirror through the board center), so both starting positions are
+equidistant from the nearest food. Every {food_respawn_interval} turns
+a fresh pair is spawned and any uneaten food is removed — there is no
+respawn when food is eaten. Snakes that do NOT eat lose their tail on
+the same turn. The game ends when at most one snake is alive (in a
+multi-player game) or after {max_turns} turns; the last snake standing
+wins, otherwise the highest score wins.
 
 Coordinates are ``[row, column]`` with ``row=0`` at the top and
 ``column=0`` on the left. The board uses these characters:
@@ -50,6 +54,7 @@ The current game state is:
 
 You are player {player_id}. Your snake is at {your_body}{alive_note}.
 Your score: {your_score}. Food at: {food_str}.
+Next food respawn in {turns_until_respawn} turn(s).
 
 Moves you have played so far:
 {move_history}
@@ -174,8 +179,18 @@ def generate_prompt(
     alive = bool(your_snake.get("alive", True)) if your_snake else True
     alive_note = "" if alive else " (DEAD — you are out of the game)"
 
-    food = parsed.get("food")
-    food_str = f"{food}" if food else "(no food on board)"
+    foods = parsed.get("foods")
+    if foods is None:
+        # Back-compat: older proxies emitted a single "food" key.
+        single = parsed.get("food")
+        foods = [single] if single else []
+    food_str = ", ".join(str(f) for f in foods) if foods else "(no food on board)"
+
+    food_respawn_interval = int(parsed.get("food_respawn_interval") or 10)
+    turn = int(parsed.get("turn", 0))
+    turns_until_respawn = parsed.get("turns_until_respawn")
+    if turns_until_respawn is None and food_respawn_interval > 0:
+        turns_until_respawn = food_respawn_interval - (turn % food_respawn_interval)
 
     move_history_str = " ".join(move_history) if move_history else "None"
 
@@ -184,6 +199,8 @@ def generate_prompt(
         cols=cols,
         num_players=num_players,
         max_turns=max_turns,
+        food_respawn_interval=food_respawn_interval,
+        turns_until_respawn=turns_until_respawn,
         your_letter=your_letter,
         your_body_char=your_body_char,
         your_head_char=your_head_char,

--- a/kaggle_environments/envs/open_spiel_env/games/snake/snake_game.py
+++ b/kaggle_environments/envs/open_spiel_env/games/snake/snake_game.py
@@ -12,6 +12,7 @@ _MIN_PLAYERS = 1
 _MAX_PLAYERS = 4
 _NUM_ROWS = 10
 _NUM_COLS = 10
+_FOOD_RESPAWN_INTERVAL = 10
 _GAME_TYPE = pyspiel.GameType(
     short_name="snake",
     long_name="Snake",
@@ -30,6 +31,7 @@ _GAME_TYPE = pyspiel.GameType(
         "rows": _NUM_ROWS,
         "columns": _NUM_COLS,
         "players": _NUM_PLAYERS,
+        "food_respawn_interval": _FOOD_RESPAWN_INTERVAL,
     },
 )
 
@@ -58,6 +60,11 @@ class SnakeGame(pyspiel.Game):
         self.rows = params.get("rows", _NUM_ROWS) if params else _NUM_ROWS
         self.cols = params.get("columns", _NUM_COLS) if params else _NUM_COLS
         self._num_players = params.get("players", _NUM_PLAYERS) if params else _NUM_PLAYERS
+        self.food_respawn_interval = (
+            params.get("food_respawn_interval", _FOOD_RESPAWN_INTERVAL)
+            if params
+            else _FOOD_RESPAWN_INTERVAL
+        )
 
         # Update game info with dynamic player count
         game_info = pyspiel.GameInfo(
@@ -91,6 +98,7 @@ class SnakeState(pyspiel.State):
         self.rows = game.rows
         self.cols = game.cols
         self.num_players = game._num_players
+        self.food_respawn_interval = game.food_respawn_interval
         self._is_terminal = False
         self._game_over_reason = None
 
@@ -115,32 +123,51 @@ class SnakeState(pyspiel.State):
             start_r, start_c = start_positions[i % len(start_positions)]
             self.snakes.append([(start_r, start_c)])
 
-        self.food = None
-        self._place_food()
+        self.foods: List[Tuple[int, int]] = []
+        self._place_foods()
         self._steps = 0
         self._next_player = 0
         self._move_buffer = [None] * self.num_players
 
-    def _place_food(self):
-        """Places food in a random empty location."""
-        available_positions = []
+    def _place_foods(self):
+        """Places a 180°-rotationally-symmetric pair of food on empty cells.
+
+        Distance from snake i's start to its nearest food is equal across
+        snakes (when starts are themselves symmetric, e.g. the default 2-
+        and 4-player layouts). Any previously uneaten food is cleared first.
+        """
+        self.foods = []
+
+        occupied = set()
+        for snake in self.snakes:
+            for cell in snake:
+                occupied.add(cell)
+
+        # Iterate the half-board so each (cell, partner) pair is considered
+        # once. Exclude the board center (where cell == partner) so we
+        # always place two distinct foods.
+        candidates = []
         for r in range(self.rows):
             for c in range(self.cols):
-                occupied = False
-                for snake in self.snakes:
-                    if (r, c) in snake:
-                        occupied = True
-                        break
-                if not occupied:
-                    available_positions.append((r, c))
+                partner = (self.rows - 1 - r, self.cols - 1 - c)
+                if (r, c) >= partner:
+                    continue
+                if (r, c) in occupied or partner in occupied:
+                    continue
+                candidates.append(((r, c), partner))
 
-        if not available_positions:
-            # If board is full, game over.
-            self._is_terminal = True
-            self._game_over_reason = "Won (Board Full)"
+        if not candidates:
+            # Board too full to place a symmetric pair. Only flag terminal
+            # if literally no empty cell exists at all (matches the prior
+            # "Board Full" semantics).
+            total_cells = self.rows * self.cols
+            if len(occupied) >= total_cells:
+                self._is_terminal = True
+                self._game_over_reason = "Won (Board Full)"
             return
 
-        self.food = random.choice(available_positions)
+        a, b = random.choice(candidates)
+        self.foods = [a, b]
 
     def current_player(self):
         """Returns id of the next player to move."""
@@ -203,14 +230,13 @@ class SnakeState(pyspiel.State):
 
         # Determine which snakes eat food (simultaneous arrival allowed)
         eating = [False] * self.num_players
-        food_eaten = False
+        foods_set = set(self.foods)
 
         for i, head in enumerate(new_heads):
             if head is None:
                 continue
-            if head == self.food:
+            if head in foods_set:
                 eating[i] = True
-                food_eaten = True
 
         # Move snakes (tentatively)
         # If not eating, remove tail.
@@ -297,12 +323,17 @@ class SnakeState(pyspiel.State):
                 self.snakes[i] = next_snakes[i]
                 if eating[i]:
                     self.scores[i] += 1.0
+                    # Remove the eaten food cell (the snake's new head).
+                    head_cell = self.snakes[i][0]
+                    if head_cell in self.foods:
+                        self.foods.remove(head_cell)
             else:
                 self.snakes[i] = []  # Remove dead snakes
 
-        # Handle food
-        if food_eaten:
-            self._place_food()
+        # Timed food respawn: every food_respawn_interval turns, clear any
+        # uneaten food and place a fresh symmetric pair.
+        if self.food_respawn_interval > 0 and self._steps % self.food_respawn_interval == 0:
+            self._place_foods()
 
         # Check termination
         # Game ends if 0 or 1 player alive (if started with >1)
@@ -337,8 +368,8 @@ class SnakeState(pyspiel.State):
         """String representation of the state."""
         board = np.full((self.rows, self.cols), ".")
 
-        if self.food:
-            board[self.food] = "*"
+        for food in self.foods:
+            board[food] = "*"
 
         for i, snake in enumerate(self.snakes):
             if not self.is_alive[i]:
@@ -392,8 +423,7 @@ class SnakeObserver:
         obs.fill(0)
 
         # Food
-        if state.food:
-            fr, fc = state.food
+        for fr, fc in state.foods:
             obs[0, fr, fc] = 1.0
 
         for i in range(self.num_players):

--- a/kaggle_environments/envs/open_spiel_env/games/snake/snake_proxy.py
+++ b/kaggle_environments/envs/open_spiel_env/games/snake/snake_proxy.py
@@ -30,12 +30,11 @@ _EMPTY_CHAR = "."
 class SnakeState(proxy.State):
     """Snake state proxy with JSON observations."""
 
-    def _board(self, snakes: list[list[list[int]]], is_alive: list[bool], food: list[int] | None) -> list[list[str]]:
+    def _board(self, snakes: list[list[list[int]]], is_alive: list[bool], foods: list[list[int]]) -> list[list[str]]:
         rows = self.__wrapped__.rows
         cols = self.__wrapped__.cols
         board = [[_EMPTY_CHAR] * cols for _ in range(rows)]
-        if food is not None:
-            fr, fc = food
+        for fr, fc in foods:
             board[fr][fc] = _FOOD_CHAR
         for i, snake in enumerate(snakes):
             if not is_alive[i] or not snake:
@@ -54,7 +53,15 @@ class SnakeState(proxy.State):
         snakes = [[[int(r), int(c)] for r, c in snake] for snake in wrapped.snakes]
         is_alive = [bool(a) for a in wrapped.is_alive]
         scores = [float(s) for s in wrapped.scores]
-        food = [int(wrapped.food[0]), int(wrapped.food[1])] if wrapped.food is not None else None
+        foods = [[int(r), int(c)] for r, c in wrapped.foods]
+        # Back-compat: expose the first food under the old singular key too.
+        food = foods[0] if foods else None
+        food_respawn_interval = int(getattr(wrapped, "food_respawn_interval", 0))
+        turn = int(getattr(wrapped, "_steps", 0))
+        if food_respawn_interval > 0:
+            turns_until_respawn = food_respawn_interval - (turn % food_respawn_interval)
+        else:
+            turns_until_respawn = None
 
         is_terminal = self.is_terminal()
         winner: int | str | None = None
@@ -79,17 +86,20 @@ class SnakeState(proxy.State):
         pending = [i for i, a in enumerate(buffer) if a is not None]
 
         return {
-            "board": self._board(snakes, is_alive, food),
+            "board": self._board(snakes, is_alive, foods),
             "num_rows": int(wrapped.rows),
             "num_columns": int(wrapped.cols),
             "num_players": int(wrapped.num_players),
-            "food": food,
+            "foods": foods,
+            "food": food,  # deprecated, kept for back-compat
+            "food_respawn_interval": food_respawn_interval,
+            "turns_until_respawn": turns_until_respawn,
             "snakes": snake_objs,
             "scores": scores,
             "is_alive": is_alive,
             "current_player": self.current_player(),
             "pending_this_turn": pending,
-            "turn": int(getattr(wrapped, "_steps", 0)),
+            "turn": turn,
             "is_terminal": is_terminal,
             "winner": winner,
             "game_over_reason": getattr(wrapped, "_game_over_reason", None),

--- a/kaggle_environments/envs/open_spiel_env/games/snake/visualizer/default/src/renderer.ts
+++ b/kaggle_environments/envs/open_spiel_env/games/snake/visualizer/default/src/renderer.ts
@@ -12,7 +12,8 @@ type SnakeObservation = {
   num_rows: number;
   num_columns: number;
   num_players: number;
-  food: [number, number] | null;
+  foods?: [number, number][];
+  food?: [number, number] | null;
   snakes: {
     player: number;
     body: [number, number][];
@@ -81,8 +82,8 @@ function drawBoard(ctx: CanvasRenderingContext2D, width: number, height: number,
   }
 
   // Food.
-  if (obs.food) {
-    const [fr, fc] = obs.food;
+  const foods: [number, number][] = obs.foods ?? (obs.food ? [obs.food] : []);
+  for (const [fr, fc] of foods) {
     const cx = xOff + fc * cellSize + cellSize / 2;
     const cy = yOff + fr * cellSize + cellSize / 2;
     ctx.fillStyle = FOOD_COLOR;

--- a/tests/envs/open_spiel_env/games/snake/harness_test.py
+++ b/tests/envs/open_spiel_env/games/snake/harness_test.py
@@ -93,7 +93,10 @@ class GeneratePromptTest(absltest.TestCase):
                 "num_rows": 10,
                 "num_columns": 10,
                 "num_players": 2,
+                "foods": [[3, 4], [6, 5]],
                 "food": [3, 4],
+                "food_respawn_interval": 10,
+                "turns_until_respawn": 7,
                 "snakes": [
                     {"player": 0, "body": [[1, 1]], "alive": True, "score": 0},
                     {"player": 1, "body": [[8, 8]], "alive": True, "score": 0},
@@ -101,7 +104,7 @@ class GeneratePromptTest(absltest.TestCase):
                 "scores": [0, 0],
                 "is_alive": [True, True],
                 "current_player": player_id,
-                "turn": 0,
+                "turn": 3,
                 "is_terminal": False,
                 "winner": None,
             }
@@ -126,6 +129,7 @@ class GeneratePromptTest(absltest.TestCase):
     def test_prompt_includes_food_location(self):
         prompt = generate_prompt(self._obs(), [])
         self.assertIn("[3, 4]", prompt)
+        self.assertIn("[6, 5]", prompt)
 
     def test_prompt_includes_own_snake_body(self):
         prompt = generate_prompt(self._obs(player_id=1), [])

--- a/tests/envs/open_spiel_env/games/snake/snake_game_test.py
+++ b/tests/envs/open_spiel_env/games/snake/snake_game_test.py
@@ -37,6 +37,9 @@ class SnakeGameTest(absltest.TestCase):
         "snake", {"rows": 3, "columns": 3, "players": 1}
     )
     state = game.new_initial_state()
+    # Clear foods so the test only measures wall collision (random food may
+    # otherwise land on the snake's path and grant a point).
+    state.foods = []
     # Snake at 1, 1.
     # Move UP to 0, 1
     state.apply_action(0)
@@ -52,10 +55,11 @@ class SnakeGameTest(absltest.TestCase):
     )
     state = game.new_initial_state()
 
-    # Force food to be at specific location for testing
+    # Force food pair to known cells (one reachable, one far away).
     head_r, head_c = state.snakes[0][0]
     food_r, food_c = head_r - 1, head_c
-    state.food = (food_r, food_c)
+    partner = (state.rows - 1 - food_r, state.cols - 1 - food_c)
+    state.foods = [(food_r, food_c), partner]
 
     initial_len = len(state.snakes[0])
     # Move UP to eat
@@ -63,8 +67,69 @@ class SnakeGameTest(absltest.TestCase):
 
     self.assertLen(state.snakes[0], initial_len + 1)
     self.assertEqual(state.returns()[0], 1.0)
-    # Food should have moved
-    self.assertNotEqual(state.food, (food_r, food_c))
+    # Eaten food cell should be gone.
+    self.assertNotIn((food_r, food_c), state.foods)
+
+  def test_food_pair_symmetric(self):
+    game = pyspiel.load_game(
+        "snake", {"rows": 10, "columns": 10, "players": 2}
+    )
+    state = game.new_initial_state()
+
+    self.assertLen(state.foods, 2)
+    (r0, c0), (r1, c1) = state.foods
+    # 180° rotation about board center.
+    self.assertEqual(r0 + r1, state.rows - 1)
+    self.assertEqual(c0 + c1, state.cols - 1)
+
+    # Distance from each snake start to its nearest food is equal.
+    def manhattan(a, b):
+      return abs(a[0] - b[0]) + abs(a[1] - b[1])
+
+    p0_start = state.snakes[0][0]
+    p1_start = state.snakes[1][0]
+    d0 = min(manhattan(p0_start, f) for f in state.foods)
+    d1 = min(manhattan(p1_start, f) for f in state.foods)
+    self.assertEqual(d0, d1)
+
+  def test_food_respawn_timer(self):
+    game = pyspiel.load_game(
+        "snake",
+        {"rows": 10, "columns": 10, "players": 2, "food_respawn_interval": 3},
+    )
+    state = game.new_initial_state()
+
+    # Pin foods to cells far from either snake so neither can eat them.
+    state.foods = [(4, 0), (5, 9)]
+
+    # Step 3 turns of safe moves: P0 starts at (1,1) heads DOWN; P1 starts
+    # at (8,8) heads UP — both stay well clear of the walls and each other.
+    for _ in range(3):
+      state.apply_action(1)  # P0 DOWN
+      state.apply_action(0)  # P1 UP
+
+    # Old pinned cells must be gone (replaced by a fresh symmetric pair).
+    self.assertNotIn((4, 0), state.foods)
+    self.assertNotIn((5, 9), state.foods)
+    self.assertLen(state.foods, 2)
+    (r0, c0), (r1, c1) = state.foods
+    self.assertEqual(r0 + r1, state.rows - 1)
+    self.assertEqual(c0 + c1, state.cols - 1)
+
+  def test_uneaten_food_removed_on_respawn(self):
+    game = pyspiel.load_game(
+        "snake",
+        {"rows": 10, "columns": 10, "players": 2, "food_respawn_interval": 2},
+    )
+    state = game.new_initial_state()
+    state.foods = [(0, 0), (9, 9)]  # Out of reach in 2 turns.
+
+    for _ in range(2):
+      state.apply_action(1)  # P0 DOWN
+      state.apply_action(0)  # P1 UP
+
+    self.assertNotIn((0, 0), state.foods)
+    self.assertNotIn((9, 9), state.foods)
 
   def test_simultaneous_movement(self):
     game = pyspiel.load_game(


### PR DESCRIPTION
Food now spawns in pairs that are 180°-rotationally symmetric across the board center, so distance from each snake's start to the nearest food is identical. A new pair is placed every food_respawn_interval turns (default 10, exposed as a game parameter); any uneaten food is removed at that point. Eating food no longer triggers a respawn.

The proxy emits a new "foods" list plus "food_respawn_interval" and "turns_until_respawn"; the singular "food" key is kept (set to the first cell) for back-compat with existing replays. Harness prompt explains the new rules and reports the respawn countdown; renderer iterates the foods list (falling back to [food] for older replays).