### PR TITLE
Fix Word Association history tracking

### DIFF
--- a/kaggle_environments/envs/word_association/word_association.py
+++ b/kaggle_environments/envs/word_association/word_association.py
@@ -296,15 +296,19 @@ def interpreter(state, env):
                     s.observation.yellow_wins += 1
             
             window_size = env.configuration.get("memory_window_size", 0)
-            save_game_to_history(obs, winner, window_size)
-            
+            # Per-game memory lives on every agent's observation (track_turn
+            # writes to all four), so save/reset must touch all of them — not
+            # just state[0] — or subsequent prompts will leak prior-game turns.
+            for s in state:
+                save_game_to_history(s.observation, winner, window_size)
+
             if obs.current_game + 1 < games_per_episode:
-                # Continue to next game
-                obs.current_game += 1
-                obs.current_game_turns = []
-                obs._last_clue = ""
-                obs._last_revealed = [False] * len(obs.revealed)
-                
+                for s in state:
+                    s.observation.current_game += 1
+                    s.observation.current_game_turns = []
+                    s.observation._last_clue = ""
+                    s.observation._last_revealed = [False] * len(s.observation.revealed)
+
                 # Reset board (re-init)
                 initialize_game(state, env.configuration)
                 

--- a/kaggle_environments/envs/word_association/word_association.py
+++ b/kaggle_environments/envs/word_association/word_association.py
@@ -311,9 +311,13 @@ def interpreter(state, env):
 
                 # Reset board (re-init)
                 initialize_game(state, env.configuration)
-                
+
+                # initialize_game writes full roles to every agent; mask them
+                # again for the guessers before the new game's snapshot is
+                # returned, mirroring the first-game init path.
+                update_visibility(state)
+
                 # Reset agent statuses based on new current_turn
-                active_agent = state[0].observation.current_turn
                 for i in range(4):
                     state[i].status = "ACTIVE" if i == state[0].observation.current_turn else "INACTIVE"
                     

--- a/tests/envs/word_association/test_word_association.py
+++ b/tests/envs/word_association/test_word_association.py
@@ -185,6 +185,33 @@ def test_multi_game_memory_consistent_across_agents():
         assert oi.yellow_wins == obs0.yellow_wins
 
 
+def test_multi_game_guessers_dont_see_unmasked_roles_at_transition():
+    # After each per-episode game transition, guessers (agents 1 and 3) must
+    # see roles masked as "Unknown" — initialize_game writes full roles to
+    # every agent, so update_visibility must run before the snapshot is returned.
+    env = make("word_association", configuration={"games_per_episode": 5, "seed": 0})
+    env.reset()
+    prev_cg = env.state[0].observation.current_game
+    saw_transition = False
+    while not env.done:
+        env.step([None if env.state[i].status != "ACTIVE"
+                  else ({"clue": "ANIMAL", "number": 1} if i in (0, 2) else 0)
+                  for i in range(4)])
+        cg = env.state[0].observation.current_game
+        if cg != prev_cg:
+            saw_transition = True
+            for guesser in (1, 3):
+                roles = env.state[guesser].observation.roles
+                non_unknown = sum(1 for r in roles if r != "Unknown")
+                # All squares start unrevealed, so guessers should see 0 real roles.
+                assert non_unknown == 0, (
+                    f"guesser {guesser} saw {non_unknown} unmasked roles "
+                    f"at game-{cg} start"
+                )
+            prev_cg = cg
+    assert saw_transition, "test never observed a game transition"
+
+
 def test_multi_game_per_game_seed_uniqueness():
     # Different games within one episode must use different word boards.
     env = make("word_association", configuration={"games_per_episode": 2, "seed": 7})
@@ -215,5 +242,6 @@ if __name__ == "__main__":
     test_space_hyphen_validation()
     test_multi_game_cumulative_rewards()
     test_multi_game_memory_consistent_across_agents()
+    test_multi_game_guessers_dont_see_unmasked_roles_at_transition()
     test_multi_game_per_game_seed_uniqueness()
     print("All Word Association rule tests passed!")

--- a/tests/envs/word_association/test_word_association.py
+++ b/tests/envs/word_association/test_word_association.py
@@ -167,6 +167,44 @@ def test_multi_game_cumulative_rewards():
     # Sum of all 4 agent rewards should be 2 * (blue_wins + yellow_wins) = 6
     assert sum(rewards) == 6
 
+def test_multi_game_memory_consistent_across_agents():
+    # All 4 agents should see the same memory fields after multi-game runs;
+    # the per-game reset must update every agent, not only state[0].
+    env = make("word_association", configuration={"games_per_episode": 3, "seed": 7})
+    env.run(["random", "random", "random", "random"])
+
+    obs0 = env.state[0].observation
+    for i in range(1, 4):
+        oi = env.state[i].observation
+        assert oi.current_game == obs0.current_game, f"agent {i} current_game mismatch"
+        assert len(oi.history) == len(obs0.history), f"agent {i} history length mismatch"
+        assert len(oi.current_game_turns) == len(obs0.current_game_turns), (
+            f"agent {i} current_game_turns length mismatch"
+        )
+        assert oi.blue_wins == obs0.blue_wins
+        assert oi.yellow_wins == obs0.yellow_wins
+
+
+def test_multi_game_per_game_seed_uniqueness():
+    # Different games within one episode must use different word boards.
+    env = make("word_association", configuration={"games_per_episode": 2, "seed": 7})
+    env.reset()
+    words_game1 = list(env.state[0].observation.words)
+    env.run(["random", "random", "random", "random"])
+    words_game2 = list(env.state[0].observation.words)
+    assert words_game1 != words_game2
+
+    # First game must use the provided seed directly (matches a solo run).
+    solo = make("word_association", configuration={"games_per_episode": 1, "seed": 7})
+    solo.reset()
+    assert list(solo.state[0].observation.words) == words_game1
+
+    # Full episode is deterministic across runs.
+    env2 = make("word_association", configuration={"games_per_episode": 2, "seed": 7})
+    env2.run(["random", "random", "random", "random"])
+    assert list(env2.state[0].observation.words) == words_game2
+
+
 if __name__ == "__main__":
     test_word_association_completes()
     test_random_start_counts()
@@ -176,4 +214,6 @@ if __name__ == "__main__":
     test_clue_validation()
     test_space_hyphen_validation()
     test_multi_game_cumulative_rewards()
+    test_multi_game_memory_consistent_across_agents()
+    test_multi_game_per_game_seed_uniqueness()
     print("All Word Association rule tests passed!")


### PR DESCRIPTION
Only agent 0 was getting their observation updated correctly between games.
Also correctly update visibility between games.