### PR TITLE
ant_foraging_arena: filter OOB moves from legal_actions; harness fixes

### DIFF
--- a/kaggle_environments/envs/open_spiel_env/games/ant_foraging_arena/ant_foraging_arena_game.py
+++ b/kaggle_environments/envs/open_spiel_env/games/ant_foraging_arena/ant_foraging_arena_game.py
@@ -234,7 +234,23 @@ class AntForagingArenaState(pyspiel.State):
             return []
         if player != self._current_player_id():
             return []
-        return [a.value for a in Action]
+        # Mirror upstream ant_foraging: STAY is always legal; directions
+        # are only legal when they keep the ant on the board.
+        seat = _seat_of(player, self._players_per_team)
+        team = _team_of(player, self._players_per_team)
+        board = self._boards[team]
+        r, c = board["ant_positions"][seat]
+        # Read grid_size from the board itself so this also works on
+        # states reconstructed via pyspiel.deserialize_game_and_state
+        # (where ``self._game`` may not retain Python attributes).
+        grid_size = len(board["grid"])
+        actions = [Action.STAY.value]
+        for action in (Action.UP, Action.DOWN, Action.LEFT, Action.RIGHT):
+            dr, dc = _ACTION_DELTAS[action]
+            nr, nc = r + dr, c + dc
+            if 0 <= nr < grid_size and 0 <= nc < grid_size:
+                actions.append(action.value)
+        return sorted(actions)
 
     def _apply_action(self, action_value):
         if self._is_terminal:
@@ -267,7 +283,8 @@ class AntForagingArenaState(pyspiel.State):
         r, c = board["ant_positions"][seat]
         dr, dc = _ACTION_DELTAS[action]
         nr, nc = r + dr, c + dc
-        # Out-of-bounds moves stay put (mirrors upstream ant_foraging).
+        # _legal_actions filters off-board moves, so this is defensive
+        # only (e.g. callers that bypass legal_actions).
         if not (0 <= nr < grid_size and 0 <= nc < grid_size):
             nr, nc = r, c
         board["ant_positions"][seat] = (nr, nc)

--- a/kaggle_environments/envs/open_spiel_env/games/ant_foraging_arena/harness.py
+++ b/kaggle_environments/envs/open_spiel_env/games/ant_foraging_arena/harness.py
@@ -113,18 +113,20 @@ def _normalize(move: str) -> str:
 
 
 def _extract_move_from_json(response: str) -> str | None:
-    match = _JSON_BLOCK_RE.search(response)
-    if match:
+    # Prefer the LAST JSON block — the prompt asks the model to put its
+    # final answer at the end, after any reasoning that may itself
+    # contain JSON snippets.
+    for match in reversed(_JSON_BLOCK_RE.findall(response)):
         try:
-            data = json.loads(match.group(1))
+            data = json.loads(match)
             move = str(data.get("move", "")).strip()
             if move:
                 return move
         except json.JSONDecodeError:
-            pass
-    bare = _BARE_JSON_RE.search(response)
-    if bare:
-        return bare.group(1).strip()
+            continue
+    bare_matches = list(_BARE_JSON_RE.finditer(response))
+    if bare_matches:
+        return bare_matches[-1].group(1).strip()
     return None
 
 
@@ -265,7 +267,10 @@ def parse_response(
         if matched is not None:
             return ParseResult(legal_action=matched, raw_action=raw)
 
-    for m in _MOVE_RE.finditer(response):
+    # Scan from the end: the prompt asks the model to put its final
+    # answer at the end of the response, so the last direction word is
+    # the right one to pick when the JSON parse failed.
+    for m in reversed(list(_MOVE_RE.finditer(response))):
         candidate = m.group(0)
         matched = _match_move_to_legal(candidate, legal_action_strings)
         if matched is not None:

--- a/kaggle_environments/envs/open_spiel_env/games/python_ant_foraging/harness.py
+++ b/kaggle_environments/envs/open_spiel_env/games/python_ant_foraging/harness.py
@@ -118,19 +118,21 @@ def _normalize(move: str) -> str:
 
 
 def _extract_move_from_json(response: str) -> str | None:
-    match = _JSON_BLOCK_RE.search(response)
-    if match:
+    # Prefer the LAST JSON block — the prompt asks the model to put its
+    # final answer at the end, after any reasoning that may itself
+    # contain JSON snippets.
+    for match in reversed(_JSON_BLOCK_RE.findall(response)):
         try:
-            data = json.loads(match.group(1))
+            data = json.loads(match)
             move = str(data.get("move", "")).strip()
             if move:
                 return move
         except json.JSONDecodeError:
-            pass
+            continue
 
-    bare = _BARE_JSON_RE.search(response)
-    if bare:
-        return bare.group(1).strip()
+    bare_matches = list(_BARE_JSON_RE.finditer(response))
+    if bare_matches:
+        return bare_matches[-1].group(1).strip()
 
     return None
 
@@ -244,9 +246,10 @@ def parse_response(
         if matched is not None:
             return ParseResult(legal_action=matched, raw_action=raw)
 
-    # Fallback: scan the response text for any direction keyword that
-    # corresponds to a legal action.
-    for m in _DIRECTION_RE.finditer(response):
+    # Fallback: scan from the end of the response — the prompt asks the
+    # model to put its final answer last, so the last direction word is
+    # more likely to be the real choice than the first.
+    for m in reversed(list(_DIRECTION_RE.finditer(response))):
         candidate = m.group(0)
         matched = _match_move_to_legal(candidate, legal_action_strings)
         if matched is not None:

--- a/tests/envs/open_spiel_env/games/ant_foraging_arena/harness_test.py
+++ b/tests/envs/open_spiel_env/games/ant_foraging_arena/harness_test.py
@@ -1,0 +1,195 @@
+"""Tests for the Ant Foraging Arena LLM harness."""
+
+import json
+
+import pyspiel
+from absl.testing import absltest
+
+from kaggle_environments.core_harness import ParseResult
+from kaggle_environments.envs.open_spiel_env.games.ant_foraging_arena import (
+    ant_foraging_arena_game,  # noqa: F401  (registers the game)
+)
+from kaggle_environments.envs.open_spiel_env.games.ant_foraging_arena.harness import (
+    generate_prompt,
+    get_legal_moves,
+    parse_response,
+)
+
+
+_DIRECTIONS = ("stay", "up", "down", "left", "right")
+
+
+def _make_arena_observation(player_id=0, seed=1):
+    game = pyspiel.load_game("ant_foraging_arena", {"seed": seed})
+    state = game.new_initial_state()
+    return {
+        "observationString": state.observation_string(player_id),
+        "playerId": player_id,
+        "currentPlayer": state.current_player(),
+        "isTerminal": state.is_terminal(),
+        "legalActions": list(state.legal_actions(player_id)),
+        "legalActionStrings": [
+            state.action_to_string(player_id, a) for a in state.legal_actions(player_id)
+        ],
+        "serializedGameAndState": pyspiel.serialize_game_and_state(game, state),
+    }
+
+
+class ParseResponseTest(absltest.TestCase):
+    def test_parse_json_direction(self):
+        result = parse_response('```json\n{"move": "up"}\n```', list(_DIRECTIONS))
+        self.assertEqual(result.legal_action, "up")
+        self.assertEqual(result.raw_action, "up")
+
+    def test_parse_case_insensitive(self):
+        result = parse_response('```json\n{"move": "LEFT"}\n```', list(_DIRECTIONS))
+        self.assertEqual(result.legal_action, "left")
+
+    def test_parse_each_direction(self):
+        for direction in _DIRECTIONS:
+            result = parse_response(
+                f'```json\n{{"move": "{direction}"}}\n```', list(_DIRECTIONS)
+            )
+            self.assertEqual(result.legal_action, direction)
+
+    def test_parse_bare_json(self):
+        result = parse_response(
+            'Thinking… {"move": "down"} that is my choice.', list(_DIRECTIONS)
+        )
+        self.assertEqual(result.legal_action, "down")
+
+    def test_parse_fallback_picks_last_direction(self):
+        # Reasoning mentions "up" first but the model lands on "down" as
+        # its final answer; we should pick the trailing word.
+        response = "I considered going up but ended up choosing down"
+        result = parse_response(response, list(_DIRECTIONS))
+        self.assertEqual(result.legal_action, "down")
+
+    def test_parse_prefers_last_json_block(self):
+        # Two JSON blocks: a draft in the reasoning and a final answer.
+        response = (
+            'First draft: ```json\n{"move": "up"}\n```\n'
+            'Reconsidering, final: ```json\n{"move": "right"}\n```'
+        )
+        result = parse_response(response, list(_DIRECTIONS))
+        self.assertEqual(result.legal_action, "right")
+
+    def test_parse_no_match_returns_none(self):
+        result = parse_response('```json\n{"move": "diagonal"}\n```', list(_DIRECTIONS))
+        self.assertIsNone(result.legal_action)
+        self.assertEqual(result.raw_action, "diagonal")
+
+    def test_parse_no_direction_returns_none(self):
+        result = parse_response("I have no idea what to do.", list(_DIRECTIONS))
+        self.assertIsNone(result.legal_action)
+        self.assertIsNone(result.raw_action)
+
+    def test_parse_skips_directions_not_legal(self):
+        # If only "stay" is legal, mentioning "up" should not match.
+        result = parse_response("Maybe up?", ["stay"])
+        self.assertIsNone(result.legal_action)
+
+    def test_parse_malformed_json_falls_back(self):
+        # Bad JSON block, but reasoning includes a direction word.
+        response = "```json\n{bad}\n```\nFinal answer: stay"
+        result = parse_response(response, list(_DIRECTIONS))
+        self.assertEqual(result.legal_action, "stay")
+
+    def test_parse_returns_parse_result(self):
+        result = parse_response('```json\n{"move": "up"}\n```', list(_DIRECTIONS))
+        self.assertIsInstance(result, ParseResult)
+
+
+class GeneratePromptTest(absltest.TestCase):
+    def test_includes_core_rules(self):
+        obs = _make_arena_observation(player_id=0)
+        prompt = generate_prompt(obs, [])
+        self.assertIn("Ant Foraging Arena", prompt)
+        self.assertIn("2v2", prompt)
+        self.assertIn("stay, up, down, left, right", prompt)
+
+    def test_includes_player_team_and_seat(self):
+        obs0 = _make_arena_observation(player_id=0)
+        prompt0 = generate_prompt(obs0, [])
+        self.assertIn("team id is 0", prompt0)
+        self.assertIn("player 0", prompt0)
+        self.assertIn("seat 0", prompt0)
+
+        obs2 = _make_arena_observation(player_id=2)
+        prompt2 = generate_prompt(obs2, [])
+        self.assertIn("team id is 1", prompt2)
+        self.assertIn("player 2", prompt2)
+
+    def test_includes_grid_and_food_count(self):
+        prompt = generate_prompt(_make_arena_observation(player_id=0), [])
+        self.assertIn("8x8", prompt)
+        self.assertIn("3 food", prompt)
+
+    def test_other_team_board_hidden(self):
+        # The per-player observation must not leak the opposing board.
+        obs2 = _make_arena_observation(player_id=2)
+        prompt = generate_prompt(obs2, [])
+        parsed = json.loads(obs2["observationString"])
+        # Team B's view exposes board team_id == 1 only.
+        self.assertEqual(parsed["board"]["team_id"], 1)
+        self.assertNotIn('"team_id": 0', prompt)
+
+    def test_rethink_suffix_appended(self):
+        prompt = generate_prompt(
+            _make_arena_observation(player_id=0),
+            [],
+            previous_response="I'll go diagonal",
+            previous_action="diagonal",
+        )
+        self.assertIn("Your previous response was", prompt)
+        self.assertIn("diagonal", prompt)
+        self.assertIn("not in the legal", prompt)
+
+    def test_no_rethink_on_first_attempt(self):
+        prompt = generate_prompt(_make_arena_observation(player_id=0), [])
+        self.assertNotIn("Your previous response was", prompt)
+
+    def test_empty_move_history(self):
+        prompt = generate_prompt(_make_arena_observation(player_id=0), [])
+        self.assertIn("(no moves yet)", prompt)
+
+
+class GetLegalMovesTest(absltest.TestCase):
+    def test_from_provided_actions(self):
+        observation = {
+            "legalActions": [0, 1, 4],
+            "legalActionStrings": ["stay", "up", "right"],
+        }
+        result = get_legal_moves(observation)
+        self.assertEqual(result, {0: "stay", 1: "up", 4: "right"})
+
+    def test_empty_when_off_turn(self):
+        # Inactive players get no actions.
+        observation = {"legalActions": [], "legalActionStrings": []}
+        self.assertEqual(get_legal_moves(observation), {})
+
+    def test_from_serialized_state(self):
+        # Player 0 starts at the nest centre, all 5 actions legal.
+        obs = _make_arena_observation(player_id=0)
+        # Drop the helpful pre-computed fields to force the fallback path.
+        obs.pop("legalActions")
+        obs.pop("legalActionStrings")
+        result = get_legal_moves(obs)
+        self.assertEqual(
+            sorted(result.values()),
+            ["down", "left", "right", "stay", "up"],
+        )
+
+    def test_off_turn_player_via_serialized_state(self):
+        # Step 0 belongs to player 0; player 2 has no legal actions.
+        obs = _make_arena_observation(player_id=2)
+        obs.pop("legalActions")
+        obs.pop("legalActionStrings")
+        self.assertEqual(get_legal_moves(obs), {})
+
+    def test_empty_serialized(self):
+        self.assertEqual(get_legal_moves({"serializedGameAndState": ""}), {})
+
+
+if __name__ == "__main__":
+    absltest.main()


### PR DESCRIPTION
Address review feedback on the merged ant_foraging_arena PR:

- _legal_actions now filters out-of-bounds directions to match upstream ant_foraging. Previously the arena returned all 5 actions and silently no-op'd OOB moves, burning an LLM's turn (e.g. an ant at row 0 picking "up"). The defensive OOB clamp in _step_player is kept for callers that bypass legal_actions. Read grid_size from the board itself so this still works on states reconstructed via deserialize_game_and_state.

- parse_response now prefers the LAST JSON block and the LAST direction word in fallback text scanning, since the prompt asks the model to put its final answer at the end. The previous first-match bias meant reasoning like "I considered up but ended up choosing down" parsed as "up". Applied the same fix to python_ant_foraging/harness.py, which has the same bug.

- Add harness unit tests for ant_foraging_arena covering parse_response, generate_prompt, and get_legal_moves (including the prefer-last-answer behaviour and the off-turn empty-actions path).