### PR TITLE
ant_foraging_arena: only end on matching-move boundaries

### DIFF
--- a/kaggle_environments/envs/open_spiel_env/games/ant_foraging_arena/ant_foraging_arena_game.py
+++ b/kaggle_environments/envs/open_spiel_env/games/ant_foraging_arena/ant_foraging_arena_game.py
@@ -15,7 +15,10 @@ Dynamics are SEQUENTIAL — exactly one player is active per step. The
 game terminates when either board has delivered all food (that team
 locks in its food race win) or after ``max_turns`` rounds elapse, where
 a "round" is one move per ant per team (``num_ants_per_team *
-NUM_TEAMS`` interleaved steps).
+NUM_TEAMS`` interleaved steps). Food-completion terminations are only
+applied at boundaries where every team has had a matching number of
+moves, so the opposing team always gets its corresponding move before
+the game can end.
 
 Both teams' boards are seeded identically from the ``seed`` parameter:
 same nest, food, and ant start positions. This makes any AA-vs-BB
@@ -272,9 +275,16 @@ class AntForagingArenaState(pyspiel.State):
                 board["pheromone_to_nest"] *= self._game.pheromone_decay
 
         # Terminal: any board has delivered all food, OR we hit the cap.
+        # Food-completion can only end the game once every team has had a
+        # matching number of moves — i.e. on boundaries where each team
+        # has played the same number of times. Otherwise team A finishing
+        # mid-step would deny team B its corresponding move.
         if self._move_number >= self._game.total_moves:
             self._is_terminal = True
-        elif any(b["food_collected"] >= self._game.num_food for b in self._boards):
+        elif (
+            self._move_number % _NUM_TEAMS == 0
+            and any(b["food_collected"] >= self._game.num_food for b in self._boards)
+        ):
             self._is_terminal = True
 
     def _step_player(self, team: int, seat: int, action: Action) -> None:

--- a/tests/envs/open_spiel_env/games/ant_foraging_arena/env_test.py
+++ b/tests/envs/open_spiel_env/games/ant_foraging_arena/env_test.py
@@ -198,6 +198,47 @@ class TerminationTest(absltest.TestCase):
         )
 
 
+    def test_food_completion_waits_for_opposing_team_move(self):
+        # If team A delivers its last food on player 0's move, the game
+        # must NOT terminate until team B's matching move (player 2) has
+        # been applied — i.e. only at move_number % NUM_TEAMS == 0.
+        s = _new_state(seed=1, num_food=1, max_turns=100, grid_size=8)
+        obs0 = json.loads(s.observation_string(0))
+        food_r, food_c = obs0["board"]["food_positions"][0]
+        nest_r, nest_c = obs0["board"]["nest_position"]
+        ant_r, ant_c = obs0["board"]["ant_positions"]["0"]
+
+        def _step_for_p0(action_value):
+            s.apply_action(action_value)  # P0
+            # After P0's move team A may have just finished — but the
+            # game must still let P2 play before terminating.
+            if s._boards[0]["food_collected"] >= 1:
+                self.assertFalse(s.is_terminal())
+                self.assertEqual(s.current_player(), 2)
+            s.apply_action(0)  # P2 stay
+            if s.is_terminal():
+                return
+            s.apply_action(0)  # P1 stay
+            s.apply_action(0)  # P3 stay
+
+        def _walk(r0, c0, r1, c1):
+            while r0 != r1 and not s.is_terminal():
+                action = 2 if r1 > r0 else 1
+                _step_for_p0(action)
+                r0 += 1 if r1 > r0 else -1
+            while c0 != c1 and not s.is_terminal():
+                action = 4 if c1 > c0 else 3
+                _step_for_p0(action)
+                c0 += 1 if c1 > c0 else -1
+
+        _walk(ant_r, ant_c, food_r, food_c)
+        if not s.is_terminal():
+            _walk(food_r, food_c, nest_r, nest_c)
+        self.assertTrue(s.is_terminal())
+        # Terminal only on a matching-move boundary.
+        self.assertEqual(s._move_number % 2, 0)
+
+
 class ScoringTest(absltest.TestCase):
     """Cooperative reward: both teammates get the team's food count."""
 


### PR DESCRIPTION
Food-completion termination is now gated on move_number % NUM_TEAMS == 0 so the opposing team always gets its corresponding move before the game ends. The max-turns cap is unchanged.