### PR TITLE
Fix gameplay-impacting bugs in Oshi-Zumo harness

### DIFF
--- a/kaggle_environments/envs/open_spiel_env/games/oshi_zumo/harness.py
+++ b/kaggle_environments/envs/open_spiel_env/games/oshi_zumo/harness.py
@@ -36,26 +36,33 @@ Rules: Two wrestlers (you and the opponent) start with the same number of
 coins and try to push a token off either edge of a 1D field of length
 {field_size}. Each round both players SIMULTANEOUSLY choose an integer bid
 of at least {min_bid} coins, up to their current coin total. The higher
-bidder pushes the token one square toward the opponent's edge; equal bids
-leave it stationary. Both bids are deducted regardless of who won. The
-game ends when (a) the token is pushed off an edge — that side loses, or
-(b) both players run out of coins, or (c) the {horizon}-round horizon is
-reached. At the end, the side the token sits on loses; exactly center is
-a draw.
+bidder pushes the token one cell toward the opponent's edge; equal bids
+leave it stationary. Both bids are deducted regardless of who won.
+
+The game ends when (a) the token is pushed off either edge — the player
+whose edge it falls off LOSES, or (b) both players run out of coins, or
+(c) the {horizon}-round horizon is reached. If the game ends by (b) or
+(c), the player whose half of the field the token is currently on LOSES;
+if the token is exactly at the center, it is a draw.
 
 Field (W is the token, # are the off-edge cells):
   {field}
   index: {index_row}
 
-Token position:    {wrestler_position} (center is {center}; lower is your goal, higher is the opponent's)
+You are Player {player_label}.
+  - You WIN if the token is pushed off index {opp_edge_index} (the opponent's edge).
+  - You LOSE if the token is pushed off index {your_edge_index} (your edge).
+  - To push the token toward index {opp_edge_index}, you need to OUT-BID the opponent.
+
+Token position:    {wrestler_position} (center is {center})
 Your coins:        {my_coins}
 Opponent coins:    {opp_coins}
 Round:             {move_number}
 
-Your past bids:        {my_history}
+Your past bids:    {my_history}
 
-You are Player {player_label}. Choose your bid for this round (an integer
-at least {min_bid} and at most your current coin total).
+Choose your bid for this round (an integer at least {min_bid} and at
+most your current coin total).
 
 Respond with your reasoning followed by your final bid in a JSON block:
 
@@ -120,19 +127,21 @@ def _format_field_index_row(field_size: int) -> str:
 
 
 def _extract_bid_from_json(response: str) -> str | None:
-    """Pull the bid from a ```json``` block or a bare ``{"bid": N}``."""
-    match = _JSON_BLOCK_RE.search(response)
-    if match:
+    """Pull the bid from a ```json``` block or a bare ``{"bid": N}``.
+
+    Iterates in reverse so that when the model writes one answer, reconsiders,
+    and writes another, we take the last (final) answer rather than the
+    rejected first one.
+    """
+    for match in reversed(list(_JSON_BLOCK_RE.finditer(response))):
         try:
             data = json.loads(match.group(1))
-            bid = data.get("bid")
-            if bid is None:
-                return None
-            return str(bid).strip()
         except json.JSONDecodeError:
-            pass
-    bare = _BARE_JSON_RE.search(response)
-    if bare:
+            continue
+        bid = data.get("bid")
+        if bid is not None:
+            return str(bid).strip()
+    for bare in reversed(list(_BARE_JSON_RE.finditer(response))):
         return bare.group(1).strip()
     return None
 
@@ -182,9 +191,9 @@ def generate_prompt(
     """Build the LLM prompt for the current oshi-zumo state.
 
     ``move_history`` contains the agent's own past bids (one entry per round
-    it acted in). The opponent's past coin counts are encoded as a hidden
-    suffix on each entry so the prompt can show the opponent's bid history
-    too, since core_harness doesn't track per-round game state.
+    it acted in). The opponent's per-round bid history is not available to
+    the harness (core_harness only forwards this agent's own action history);
+    only the opponent's current coin total appears in the prompt.
     """
     state = _parse_observation_payload(observation)
     player_id = observation.get("playerId", 0)
@@ -200,6 +209,11 @@ def generate_prompt(
     move_number = state.get("move_number", 0)
     min_bid = int(params.get("min_bid", 0))
     horizon = int(params.get("horizon", 0))
+
+    # Engine: wrestler_pos == 0 -> P1 wins; wrestler_pos == field_size-1 -> P0 wins.
+    # So P0's losing edge is index 0 and winning edge is field_size-1; vice versa for P1.
+    your_edge_index = 0 if player_id == 0 else max(field_size - 1, 0)
+    opp_edge_index = max(field_size - 1, 0) if player_id == 0 else 0
 
     my_bids = [_bid_from_action_string(s) for s in move_history]
     my_history_str = (
@@ -220,6 +234,8 @@ def generate_prompt(
         move_number=move_number,
         my_history=my_history_str,
         player_label=player_id,
+        your_edge_index=your_edge_index,
+        opp_edge_index=opp_edge_index,
     )
 
     if previous_response is not None:
@@ -236,9 +252,14 @@ def parse_response(
 ) -> ParseResult:
     """Extract a legal bid from the LLM response.
 
-    Tries a ``json`` block first, then a bare ``{"bid": N}``, then falls
-    back to scanning for any legal ``[Pk]Bid: N`` substring or a standalone
-    integer that matches a legal bid.
+    Tries a ``json`` block first (last block wins on rethink), then a bare
+    ``{"bid": N}``, then falls back to scanning for a legal ``[Pk]Bid: N``
+    substring (last occurrence wins).
+
+    We intentionally do NOT fall back to a bare-integer scan: the largest
+    legal bid for this game is always the player's current coin total, which
+    the model echoes in nearly every response — that fallback silently
+    converts truncated/unparseable responses into all-in bids.
     """
     raw = _extract_bid_from_json(response)
     if raw is not None:
@@ -246,17 +267,12 @@ def parse_response(
         if matched is not None:
             return ParseResult(legal_action=matched, raw_action=raw)
 
+    last_pos, last_legal = -1, None
     for legal in legal_action_strings:
-        if legal in response:
-            return ParseResult(legal_action=legal, raw_action=raw or legal)
-
-    legal_bids = {
-        _bid_from_action_string(s): s for s in legal_action_strings
-    }
-    legal_bids.pop(None, None)
-    for n in sorted(legal_bids.keys(), reverse=True):
-        pattern = r"(?<!\d)" + re.escape(str(n)) + r"(?!\d)"
-        if re.search(pattern, response):
-            return ParseResult(legal_action=legal_bids[n], raw_action=raw or str(n))
+        idx = response.rfind(legal)
+        if idx > last_pos:
+            last_pos, last_legal = idx, legal
+    if last_legal is not None:
+        return ParseResult(legal_action=last_legal, raw_action=raw or last_legal)
 
     return ParseResult(legal_action=None, raw_action=raw)

--- a/tests/envs/open_spiel_env/games/oshi_zumo/harness_test.py
+++ b/tests/envs/open_spiel_env/games/oshi_zumo/harness_test.py
@@ -62,9 +62,13 @@ class ParseResponseTest(absltest.TestCase):
         )
         self.assertEqual(result.legal_action, "[P0]Bid: 3")
 
-    def test_parse_fallback_integer_in_text(self):
+    def test_parse_no_integer_substring_fallback(self):
+        # The largest legal bid equals the player's current coin total, which
+        # the prompt prints and the model nearly always echoes. A bare-integer
+        # fallback would silently convert any truncated response into an all-in
+        # bid. We require an explicit JSON or action-string mention instead.
         result = parse_response("After thinking I bid 2.", self.legal)
-        self.assertEqual(result.legal_action, "[P0]Bid: 2")
+        self.assertIsNone(result.legal_action)
 
     def test_parse_illegal_bid_returns_raw(self):
         result = parse_response('```json\n{"bid": 99}\n```', self.legal)
@@ -80,15 +84,27 @@ class ParseResponseTest(absltest.TestCase):
         result = parse_response('```json\n{"bid": 0}\n```', self.legal)
         self.assertIsInstance(result, ParseResult)
 
-    def test_parse_prefers_largest_legal_match(self):
-        """A response containing '12' should NOT pick '1' or '2' — but if
-        only single-digit bids are legal, it must pick the largest match."""
-        legal = ["[P0]Bid: 1", "[P0]Bid: 2"]
-        result = parse_response("after deliberation I'll bid 2.", legal)
-        self.assertEqual(result.legal_action, "[P0]Bid: 2")
-        # The substring '12' inside a larger number should not match either bid.
-        result2 = parse_response("the score was 121-99.", legal)
-        self.assertIsNone(result2.legal_action)
+    def test_parse_rethink_takes_last_json_block(self):
+        # On rethink the model writes one answer, reconsiders, writes another.
+        # Take the last block, not the first.
+        response = (
+            '```json\n{"bid": 0}\n```\n'
+            'Wait, actually:\n'
+            '```json\n{"bid": 3}\n```'
+        )
+        result = parse_response(response, self.legal)
+        self.assertEqual(result.legal_action, "[P0]Bid: 3")
+
+    def test_parse_rethink_takes_last_bare_json(self):
+        response = '{"bid": 1} ... reconsidering ... {"bid": 3}'
+        result = parse_response(response, self.legal)
+        self.assertEqual(result.legal_action, "[P0]Bid: 3")
+
+    def test_parse_action_string_takes_last_occurrence(self):
+        # Model cites past round before declaring this round's choice.
+        response = "Last round was [P0]Bid: 2, this round [P0]Bid: 3 looks good."
+        result = parse_response(response, self.legal)
+        self.assertEqual(result.legal_action, "[P0]Bid: 3")
 
 
 # ---------------------------------------------------------------------------
@@ -133,10 +149,25 @@ class GeneratePromptTest(absltest.TestCase):
         self.assertIn("Your coins:        10", p1_prompt)
         self.assertIn("Opponent coins:    8", p1_prompt)
 
+    def test_per_player_edge_indices(self):
+        # Engine: wrestler_pos==0 -> P1 wins, wrestler_pos==field_size-1 -> P0 wins.
+        # So P0's WIN edge is index 8 (= 2*size+2 with size=3); P1's is 0.
+        obs0 = _make_observation(self.state, self.game, player_id=0)
+        obs1 = _make_observation(self.state, self.game, player_id=1)
+        p0_prompt = generate_prompt(obs0, [])
+        p1_prompt = generate_prompt(obs1, [])
+        self.assertIn("pushed off index 8 (the opponent's edge)", p0_prompt)
+        self.assertIn("pushed off index 0 (your edge)", p0_prompt)
+        self.assertIn("pushed off index 0 (the opponent's edge)", p1_prompt)
+        self.assertIn("pushed off index 8 (your edge)", p1_prompt)
+        # And the old buggy "lower is your goal" line must not reappear.
+        self.assertNotIn("lower is your goal", p0_prompt)
+        self.assertNotIn("lower is your goal", p1_prompt)
+
     def test_my_history_rendered(self):
         obs = _make_observation(self.state, self.game, player_id=0)
         prompt = generate_prompt(obs, ["[P0]Bid: 4", "[P0]Bid: 2"])
-        self.assertIn("Your past bids:        4, 2", prompt)
+        self.assertIn("Your past bids:    4, 2", prompt)
 
     def test_no_history_fallback(self):
         obs = _make_observation(self.state, self.game, player_id=0)


### PR DESCRIPTION
A harness audit (review-harness skill) against 2,030 production replays surfaced six issues:

1. The prompt always said "lower is your goal, higher is the opponent's", which is correct only for Player 1. Player 0 wins at the high-index edge (engine: winner_=0 when wrestler_pos == 2*size+2). 7.7% of P0 turns in the replay archive contained language explicitly stating the wrong direction; 735 stated it without later correction. Make the direction text player-aware and label the winning/losing indices.

2. The integer-substring fallback in parse_response walked legal bids in decreasing order, so the largest legal number anywhere in the text won -- and the largest legal bid equals the player's current coin total, which the prompt prints and the model echoes. In the archive, 45/46 (97.8%) no-JSON turns resulted in a silent all-in bid. Remove this fallback; let the rethink loop handle truly unparseable responses.

3. _JSON_BLOCK_RE.search / _BARE_JSON_RE.search picked the first JSON block, so a model that wrote one bid, reconsidered, and wrote another submitted the rejected first answer. Iterate in reverse and take the last successful parse. (Same anti-pattern as in connect_four et al.)

4. The action-string substring fallback picked the first occurrence, so "Last round was [P0]Bid: 2, this round [P0]Bid: 3" submitted 2. Scan for the last (rightmost) occurrence instead.

5. The generate_prompt docstring claimed opponent past coin counts were "encoded as a hidden suffix" of each move_history entry and surfaced in the prompt, but no code path implemented that and the prompt only ever rendered the agent's own bids. Drop the misleading claim.

6. Rules wording made the horizon-tie / coin-exhaustion outcome a reading puzzle ("the side the token sits on loses"). Restate explicitly which player loses in each terminal case.

Tests: the two tests that codified the buggy behaviors (test_parse_fallback_integer_in_text, test_parse_prefers_largest_legal_match) are replaced with tests for the new semantics (no integer fallback, last-wins JSON, last-wins action-string), plus a per-player-edge-index test for the new prompt.