### PR TITLE
Fix issues from Coin Game Arena audit

### DIFF
--- a/kaggle_environments/envs/open_spiel_env/games/coin_game_arena/harness.py
+++ b/kaggle_environments/envs/open_spiel_env/games/coin_game_arena/harness.py
@@ -46,7 +46,9 @@ preferred coin colour and your seat (and therefore the order in which
 you move).
 
 Actions: {{up, down, left, right, stand}}. Moving onto a coin collects
-it. The episode runs for {episode_length} moves total per board.
+it. Moves that would leave the board, or move onto your teammate's
+cell, are no-ops — you stay in place (this is not illegal). The
+episode runs for {episode_length} moves total per board.
 
 Scoring (per player on YOUR board, summed across the team):
 
@@ -63,9 +65,9 @@ preference for them, and AVOID coins of unowned colours (each one
 collected hurts both of you quadratically). You don't know your
 teammate's preference up front — infer it from what they pick up.
 
-Cells are ``"."`` for empty, digits for players (your seats), lowercase
-letters for coin colours. Coordinates are ``[row, column]`` with
-``row=0`` at the top.
+Cells are ``"."`` for empty, digits for players (the player ids shown
+below, not the seat indices), lowercase letters for coin colours.
+Coordinates are ``[row, column]`` with ``row=0`` at the top.
 
 Your team id is {team_id}. You are player {player_id} (seat {seat} on
 your team's board). Your teammate is player {teammate_id} (seat
@@ -113,18 +115,21 @@ def _normalize(move: str) -> str:
 
 
 def _extract_move_from_json(response: str) -> str | None:
-    match = _JSON_BLOCK_RE.search(response)
-    if match:
+    # Iterate in reverse so a self-correcting model (writes one JSON
+    # answer, reconsiders, writes another) gets credit for the LAST
+    # block, not the rejected first one.
+    for match in reversed(list(_JSON_BLOCK_RE.finditer(response))):
         try:
             data = json.loads(match.group(1))
             move = str(data.get("move", "")).strip()
             if move:
                 return move
         except json.JSONDecodeError:
-            pass
-    bare = _BARE_JSON_RE.search(response)
-    if bare:
-        return bare.group(1).strip()
+            continue
+    for bare in reversed(list(_BARE_JSON_RE.finditer(response))):
+        candidate = bare.group(1).strip()
+        if candidate:
+            return candidate
     return None
 
 

--- a/tests/envs/open_spiel_env/games/coin_game_arena/harness_test.py
+++ b/tests/envs/open_spiel_env/games/coin_game_arena/harness_test.py
@@ -64,6 +64,25 @@ class ParseResponseTest(absltest.TestCase):
         result = parse_response('```json\n{"move": "diagonal"}\n```', legal)
         self.assertIsNone(result.legal_action)
 
+    def test_parse_picks_last_json_block_on_self_correction(self):
+        # Model writes one answer, then reconsiders and writes another.
+        # The harness must submit the final answer, not the rejected one.
+        legal = ["up", "down", "left", "right", "stand"]
+        response = (
+            '```json\n{"move":"up"}\n```\n'
+            'Wait, let me reconsider.\n'
+            '```json\n{"move":"down"}\n```'
+        )
+        result = parse_response(response, legal)
+        self.assertEqual(result.legal_action, "down")
+
+    def test_parse_picks_last_bare_json_on_self_correction(self):
+        legal = ["up", "down", "left", "right", "stand"]
+        result = parse_response(
+            '{"move":"up"} ... actually {"move":"down"}', legal,
+        )
+        self.assertEqual(result.legal_action, "down")
+
     def test_returns_parse_result(self):
         legal = ["up", "down", "left", "right", "stand"]
         self.assertIsInstance(


### PR DESCRIPTION
- Parser: pick the last JSON block (not the first) on self-correction; matches the existing reverse-iter behaviour of the keyword fallback. Replay scan over 217,600 turns found 18 model self-correction cases where the first JSON differed from the last and the harness submitted the rejected first move.
- Prompt: clarify that board digits are player ids (not seat indices), which had been misleading for team B (digits 2/3 vs seats 0/1).
- Prompt: state that off-board and onto-teammate moves are no-ops, rather than leaving the model to infer. Replay scan showed 3,434 turns mentioning out-of-bounds and 12,271 mentioning teammate blocking, all spent reasoning about an undocumented rule.
- Tests: add regressions for fenced and bare self-correction parses.