### PR TITLE
Fix parser issues from Clobber harness audit

### DIFF
--- a/kaggle_environments/envs/open_spiel_env/games/clobber/harness.py
+++ b/kaggle_environments/envs/open_spiel_env/games/clobber/harness.py
@@ -211,11 +211,15 @@ def parse_response(
     legal_set = set(legal_action_strings)
 
     raw = _extract_move_from_json(response)
-    if raw is not None and raw in legal_set:
-        return ParseResult(legal_action=raw, raw_action=raw)
+    if raw is not None:
+        if raw in legal_set:
+            return ParseResult(legal_action=raw, raw_action=raw)
+        # Model committed to an illegal move in JSON; surface it for rethink
+        # rather than substituting an arbitrary legal coord from earlier prose.
+        return ParseResult(legal_action=None, raw_action=raw)
 
-    for token in _MOVE_RE.findall(response):
+    for token in reversed(_MOVE_RE.findall(response)):
         if token in legal_set:
-            return ParseResult(legal_action=token, raw_action=raw or token)
+            return ParseResult(legal_action=token, raw_action=token)
 
     return ParseResult(legal_action=None, raw_action=raw)

--- a/tests/envs/open_spiel_env/games/clobber/harness_test.py
+++ b/tests/envs/open_spiel_env/games/clobber/harness_test.py
@@ -78,6 +78,28 @@ class ParseResponseTest(absltest.TestCase):
         result = parse_response("After thinking, I'll play a1b9.", self.legal)
         self.assertIsNone(result.legal_action)
 
+    def test_parse_prose_picks_last_legal_token(self):
+        # When the model brainstorms multiple legal moves and then commits to
+        # the final one, the parser must prefer the final mention over earlier
+        # candidates.
+        response = (
+            "I considered a1b1, and also b2a2, but I will play c3d3."
+        )
+        result = parse_response(response, self.legal)
+        self.assertEqual(result.legal_action, "c3d3")
+
+    def test_parse_illegal_json_does_not_fall_through_to_prose(self):
+        # If the model commits to an illegal move in the JSON block, the
+        # parser must surface that as a parse failure (so the rethink loop
+        # fires) rather than silently substituting an earlier-mentioned
+        # legal coord from the prose.
+        response = (
+            "Candidates: a1b1, b2a2. ```json\n{\"move\": \"z9z9\"}\n```"
+        )
+        result = parse_response(response, self.legal)
+        self.assertIsNone(result.legal_action)
+        self.assertEqual(result.raw_action, "z9z9")
+
 
 # ---------------------------------------------------------------------------
 # generate_prompt


### PR DESCRIPTION
The regex fallback iterated forward and would pick the first legal coord mentioned in the model's reasoning rather than the last, surfacing brainstormed candidates instead of the model's final intent. Reverse the iteration so the last-mentioned legal coord wins.

When the JSON block parsed but contained an illegal move, the parser silently fell through to the prose scan and submitted whatever coord happened to appear earlier in the reasoning, denying the rethink loop a chance to fire. Return a parse failure with the illegal raw_action so the rethink prompt can show the model what it tried.

Add regression tests for both behaviors.