### PR TITLE
Fix misleading move format examples in main prompts

### DIFF
--- a/kaggle_environments/envs/open_spiel_env/games/amazons/harness.py
+++ b/kaggle_environments/envs/open_spiel_env/games/amazons/harness.py
@@ -164,9 +164,11 @@ Respond with your reasoning followed by your final answer in a JSON block:
 
 ```json
 {{
-  "move": "<square in algebraic notation, e.g. a1>"
+  "move": "<square in algebraic notation>"
 }}
 ```
+
+For example: `{{"move": "a1"}}`
 
 Failure to output your final answer in the specified format, or selecting an
 illegal square, will result in a loss.

--- a/kaggle_environments/envs/open_spiel_env/games/backgammon/harness.py
+++ b/kaggle_environments/envs/open_spiel_env/games/backgammon/harness.py
@@ -126,9 +126,11 @@ Respond with your reasoning followed by your move in a JSON block:
 
 ```json
 {{
-  "move": "<notation>, e.g. 24/23 24/22"
+  "move": "<notation>"
 }}
 ```
+
+For example: `{{"move": "24/23 24/22"}}`
 
 Failure to output your final answer in the specified format, or selecting
 an illegal move, will result in a loss.

--- a/kaggle_environments/envs/open_spiel_env/games/checkers/harness.py
+++ b/kaggle_environments/envs/open_spiel_env/games/checkers/harness.py
@@ -90,9 +90,11 @@ Respond with your reasoning followed by your final move in a JSON block:
 
 ```json
 {{
-  "move": "<from><to>, e.g. a3b4"
+  "move": "<from><to>"
 }}
 ```
+
+For example: `{{"move": "a3b4"}}`
 
 Failure to output your final answer in the specified format, or selecting
 an illegal move, will result in a loss.

--- a/kaggle_environments/envs/open_spiel_env/games/clobber/harness.py
+++ b/kaggle_environments/envs/open_spiel_env/games/clobber/harness.py
@@ -55,9 +55,11 @@ Respond with your reasoning followed by your final move in a JSON block:
 
 ```json
 {{
-  "move": "<from><to>, e.g. a1b1"
+  "move": "<from><to>"
 }}
 ```
+
+For example: `{{"move": "a1b1"}}`
 
 Failure to output your final answer in the specified format, or selecting an
 illegal move, will result in a loss.

--- a/kaggle_environments/envs/open_spiel_env/games/dark_hex/harness.py
+++ b/kaggle_environments/envs/open_spiel_env/games/dark_hex/harness.py
@@ -68,9 +68,11 @@ Respond with your reasoning followed by your final move in a JSON block:
 
 ```json
 {{
-  "move": "<coordinate, e.g. a1, b3, d2>"
+  "move": "<coordinate>"
 }}
 ```
+
+For example: `{{"move": "a1"}}`
 
 Failure to output your final answer in the specified format, or selecting a
 cell that is not a legal move, will result in a loss.

--- a/kaggle_environments/envs/open_spiel_env/games/mancala/harness.py
+++ b/kaggle_environments/envs/open_spiel_env/games/mancala/harness.py
@@ -87,9 +87,11 @@ block:
 
 ```json
 {{
-  "move": "<pit index, e.g. 3>"
+  "move": "<pit index>"
 }}
 ```
+
+For example: `{{"move": "3"}}`
 
 Failure to output your final answer in the specified format, or choosing
 an illegal pit, will result in a loss.


### PR DESCRIPTION
The last change addressed this in rethink prompts, but not the main prompts.