### PR TITLE
kaggriculture: quadruple glut-crash slope for premium resources, drop  cow cost to 400

### DIFF
--- a/kaggle_environments/envs/kaggriculture/README.md
+++ b/kaggle_environments/envs/kaggriculture/README.md
@@ -16,7 +16,7 @@ Each player starts with an empty farm and a small amount of income (seed money, 
 | **Strawberry** | Ongoing | 100 | 120 | 10 days | NA | every other day | 4 | 1 | 2 |
 | **Melon** | One-time | 80 | 250 | 10 days | 12 days | none | 6 | 1 | .5 |
 | **Goose/Egg** | Ongoing | 200 | 80 | 3 days | NA | every day | 4 | 1 \+ 1 (build coop) | 2 |
-| **Cow/Milk** | Ongoing | 500 | 240 | 6 days | NA | every two days | 6 | 1 \+ 1 (build pasture) | 1 |
+| **Cow/Milk** | Ongoing | 400 | 240 | 6 days | NA | every two days | 6 | 1 \+ 1 (build pasture) | 1 |
 | **Sheep/Wool** | Ongoing | 400 | 300 | 5 days | NA | every three days | 6 | 1 \+ 1 (build pasture) | .67 |
 | **Fertilizer** | NA | 100 | X |  | X | X |  | 1 |  |
 
@@ -200,18 +200,18 @@ price(inv) = base + sign · amp · f(|inv − I0|)
 
 Floored at `$1` and rounded to the nearest dollar.
 
-`T` is the production capacity of a single 5×5 field over a 24-day game at optimal watering with no fertilizer (animal totals are pre-discounted by 30% to account for wheat-feed overhead). `target` says "moving `T` units past `I0` shifts the price by `target × base`." Picking different `f` and `target` on each side lets resources with similar production profiles play very differently strategically — wheat panics on scarcity but absorbs gluts, carrot is the opposite; melon barely reacts to scarcity but crashes hard on overproduction; wool mirrors melon at a smaller scale.
+`T` is the production capacity of a single 5×5 field over a 24-day game at optimal watering with no fertilizer (animal totals are pre-discounted by 30% to account for wheat-feed overhead). `target` says "moving `T` units past `I0` shifts the price by `target × base`." Picking different `f` and `target` on each side lets resources with similar production profiles play very differently strategically — wheat panics on scarcity but absorbs gluts, carrot is the opposite; melon barely reacts to scarcity but crashes hard on overproduction; wool mirrors melon at a smaller scale. Premium resources (base > $100: strawberry, melon, milk, wool) use `above_target > 1`, so even modest gluts drive them straight to the $1 floor — bundling and timing sales matters more for these than for staples.
 
 | Resource | Base | I0 | T | Below func | Below target | Above func | Above target | P(I0−T) | P(I0+T) | P(I0+2T) |
 | ----- | ----- | ----- | ----- | ----- | ----- | ----- | ----- | ----- | ----- | ----- |
 | **Wheat** | 25 | 10,000 | 400 | sqrt | 0.80 | log | 0.20 | $45 | $20 | $19 |
 | **Carrot** | 35 | 10,000 | 450 | log | 0.20 | sqrt | 0.70 | $42 | $10 | $1 |
 | **Tomato** | 60 | 10,000 | 200 | linear | 0.40 | sqrt | 0.60 | $84 | $24 | $9 |
-| **Strawberry** | 120 | 10,000 | 100 | sqrt | 0.70 | linear | 0.40 | $204 | $72 | $24 |
-| **Melon** | 250 | 10,000 | 300 | log | 0.20 | sq | 0.90 | $300 | $25 | $1 |
+| **Strawberry** | 120 | 10,000 | 100 | sqrt | 0.70 | linear | 1.60 | $204 | $1 | $1 |
+| **Melon** | 250 | 10,000 | 300 | log | 0.20 | sq | 3.60 | $300 | $1 | $1 |
 | **Egg** | 50 | 10,000 | 332 | linear | 0.40 | log | 0.20 | $70 | $40 | $39 |
-| **Milk** | 160 | 10,000 | 122 | sqrt | 0.60 | linear | 0.40 | $256 | $96 | $32 |
-| **Wool** | 200 | 10,000 | 105 | log | 0.20 | sq | 0.80 | $240 | $40 | $1 |
+| **Milk** | 160 | 10,000 | 122 | sqrt | 0.60 | linear | 1.60 | $256 | $1 | $1 |
+| **Wool** | 200 | 10,000 | 105 | log | 0.20 | sq | 3.20 | $240 | $1 | $1 |
 | **Fertilizer** | 100 | 10,000 | 200 | linear | 0.40 | linear | 0.40 | $140 | $60 | $20 |
 
 The defaults live in `MARKET_PARAMS` in `kaggriculture.py`. Per-resource overrides (sparse: any subset of `base`, `I0`, `T`, `below_func`, `below_target`, `above_func`, `above_target`) can be supplied at episode creation via `env.configuration["marketParams"]` without touching code, e.g. `{"WOOL": {"above_target": 0.95}}`.

--- a/kaggle_environments/envs/kaggriculture/kaggriculture.py
+++ b/kaggle_environments/envs/kaggriculture/kaggriculture.py
@@ -16,7 +16,7 @@ CROPS = {
 
 ANIMALS = {
     "GOOSE": {"cost": 300, "structure": "COOP",    "first_yield_day": 4, "interval": 1, "max_held": 4, "product": "EGG"},
-    "COW":   {"cost": 600, "structure": "PASTURE", "first_yield_day": 8, "interval": 2, "max_held": 6, "product": "MILK"},
+    "COW":   {"cost": 400, "structure": "PASTURE", "first_yield_day": 8, "interval": 2, "max_held": 6, "product": "MILK"},
     "SHEEP": {"cost": 500, "structure": "PASTURE", "first_yield_day": 6, "interval": 3, "max_held": 6, "product": "WOOL"},
 }
 
@@ -39,11 +39,11 @@ MARKET_PARAMS = {
     "WHEAT":      {"base":  25, "I0": MARKET_I0, "T": 400, "below_func": "sqrt",   "below_target": 0.80, "above_func": "log",    "above_target": 0.20},
     "CARROT":     {"base":  35, "I0": MARKET_I0, "T": 450, "below_func": "log",    "below_target": 0.20, "above_func": "sqrt",   "above_target": 0.70},
     "TOMATO":     {"base":  60, "I0": MARKET_I0, "T": 200, "below_func": "linear", "below_target": 0.40, "above_func": "sqrt",   "above_target": 0.60},
-    "STRAWBERRY": {"base": 120, "I0": MARKET_I0, "T": 100, "below_func": "sqrt",   "below_target": 0.70, "above_func": "linear", "above_target": 0.40},
-    "MELON":      {"base": 250, "I0": MARKET_I0, "T": 300, "below_func": "log",    "below_target": 0.20, "above_func": "sq",     "above_target": 0.90},
+    "STRAWBERRY": {"base": 120, "I0": MARKET_I0, "T": 100, "below_func": "sqrt",   "below_target": 0.70, "above_func": "linear", "above_target": 1.60},
+    "MELON":      {"base": 250, "I0": MARKET_I0, "T": 300, "below_func": "log",    "below_target": 0.20, "above_func": "sq",     "above_target": 3.60},
     "EGG":        {"base":  50, "I0": MARKET_I0, "T": 332, "below_func": "linear", "below_target": 0.40, "above_func": "log",    "above_target": 0.20},
-    "MILK":       {"base": 160, "I0": MARKET_I0, "T": 122, "below_func": "sqrt",   "below_target": 0.60, "above_func": "linear", "above_target": 0.40},
-    "WOOL":       {"base": 200, "I0": MARKET_I0, "T": 105, "below_func": "log",    "below_target": 0.20, "above_func": "sq",     "above_target": 0.80},
+    "MILK":       {"base": 160, "I0": MARKET_I0, "T": 122, "below_func": "sqrt",   "below_target": 0.60, "above_func": "linear", "above_target": 1.60},
+    "WOOL":       {"base": 200, "I0": MARKET_I0, "T": 105, "below_func": "log",    "below_target": 0.20, "above_func": "sq",     "above_target": 3.20},
     "FERTILIZER": {"base": 100, "I0": MARKET_I0, "T": 200, "below_func": "linear", "below_target": 0.40, "above_func": "linear", "above_target": 0.40},
 }
 

--- a/kaggle_environments/envs/kaggriculture/visualizer/playable/src/engine/constants.ts
+++ b/kaggle_environments/envs/kaggriculture/visualizer/playable/src/engine/constants.ts
@@ -27,7 +27,7 @@ export const CROPS: Record<CropId, CropSpec> = {
 
 export const ANIMALS: Record<AnimalId, AnimalSpec> = {
   GOOSE: { cost: 300, structure: 'COOP', first_yield_day: 4, interval: 1, max_held: 4, product: 'EGG' },
-  COW: { cost: 600, structure: 'PASTURE', first_yield_day: 8, interval: 2, max_held: 6, product: 'MILK' },
+  COW: { cost: 400, structure: 'PASTURE', first_yield_day: 8, interval: 2, max_held: 6, product: 'MILK' },
   SHEEP: { cost: 500, structure: 'PASTURE', first_yield_day: 6, interval: 3, max_held: 6, product: 'WOOL' },
 };
 
@@ -81,7 +81,7 @@ export const MARKET_PARAMS: Record<ProductId, MarketParam> = {
     below_func: 'sqrt',
     below_target: 0.7,
     above_func: 'linear',
-    above_target: 0.4,
+    above_target: 1.6,
   },
   MELON: {
     base: 250,
@@ -90,7 +90,7 @@ export const MARKET_PARAMS: Record<ProductId, MarketParam> = {
     below_func: 'log',
     below_target: 0.2,
     above_func: 'sq',
-    above_target: 0.9,
+    above_target: 3.6,
   },
   EGG: {
     base: 50,
@@ -108,9 +108,9 @@ export const MARKET_PARAMS: Record<ProductId, MarketParam> = {
     below_func: 'sqrt',
     below_target: 0.6,
     above_func: 'linear',
-    above_target: 0.4,
+    above_target: 1.6,
   },
-  WOOL: { base: 200, I0: MARKET_I0, T: 105, below_func: 'log', below_target: 0.2, above_func: 'sq', above_target: 0.8 },
+  WOOL: { base: 200, I0: MARKET_I0, T: 105, below_func: 'log', below_target: 0.2, above_func: 'sq', above_target: 3.2 },
   FERTILIZER: {
     base: 100,
     I0: MARKET_I0,


### PR DESCRIPTION


Multiply `above_target` by 4 for resources with base > $100 (Strawberry, Melon, Milk, Wool) so prices crash 4x faster once inventory exceeds I0. Mirror the change in the visualizer engine constants. Reduce cow cost from 600 to 400 (~33% off). Refresh the README pricing table and add a note that premium resources now floor out well before T excess units.