### PR TITLE
Extract a harness runner script from bespoke per-game ones

### DIFF
--- a/.agents/skills/create-harness/SKILL.md
+++ b/.agents/skills/create-harness/SKILL.md
@@ -417,11 +417,26 @@ Every harness should include a `test_llm_game.py` script that runs a
 full game locally with a real LLM — catches issues mocked unit tests
 miss (bad prompts, unparseable responses, env interaction bugs).
 
-Copy `kaggle_environments/envs/open_spiel_env/games/checkers/test_llm_game.py`
-verbatim and change two strings: the `make("open_spiel_checkers", ...)`
-env name and the docstring usage example. The script handles API-key
-discovery, env-var setup, game execution, per-step printing, and replay
-save. For non-OpenSpiel games use `word_association/test_llm_game.py`.
+Use `run_llm_game` from `kaggle_environments.local_harness_runner`. The
+helper handles API-key discovery, env-var defaults, `--model` /
+`--replay-path` CLI flags, game execution, per-step printing, and
+replay save. Per-game files are 3 lines plus a docstring:
+
+```python
+"""Run a full Checkers game with LLM agents for local integration testing."""
+from kaggle_environments.local_harness_runner import run_llm_game
+
+if __name__ == "__main__":
+    run_llm_game("open_spiel_checkers", caller_file=__file__)
+```
+
+For games that need extra config, pass `configuration=`,
+`replay_filename=`, `num_agents=`, or `agent_module=`. See
+`havannah/test_llm_game.py` (custom board size), `word_association/test_llm_game.py`
+(4 agents, packaged harness, custom post-run output), and
+`python_ant_foraging/test_llm_game.py` (custom replay filename) for
+real examples. Capture the returned `env` if you need to print
+game-specific results after the run.
 
 Place it next to the harness module:
 - OpenSpiel: `kaggle_environments/envs/open_spiel_env/games/<name>/test_llm_game.py`

--- a/kaggle_environments/envs/open_spiel_env/games/backgammon/test_llm_game.py
+++ b/kaggle_environments/envs/open_spiel_env/games/backgammon/test_llm_game.py
@@ -5,52 +5,11 @@ Usage:
         kaggle_environments.envs.open_spiel_env.games.backgammon.test_llm_game
 """
 
-import json
-import os
-
-from kaggle_environments import make
-
-
-def run_llm_game():
-    if not os.environ.get("GEMINI_API_KEY") and not os.environ.get("OPENAI_API_KEY"):
-        print("Set GEMINI_API_KEY or OPENAI_API_KEY to run this test.")
-        print("Example: export GEMINI_API_KEY=your_key")
-        return
-
-    if "MODEL_NAME" not in os.environ:
-        os.environ["MODEL_NAME"] = "gemini-2.5-flash"
-    if "MODEL_PROXY_KEY" not in os.environ:
-        os.environ["MODEL_PROXY_KEY"] = os.environ.get("GEMINI_API_KEY", os.environ.get("OPENAI_API_KEY", "dummy"))
-    if "MODEL_PROXY_URL" not in os.environ:
-        os.environ["MODEL_PROXY_URL"] = "dummy_url"
-
-    env = make("open_spiel_backgammon", configuration={"includeLegalActions": True, "seed": 7}, debug=True)
-
-    dir_path = os.path.dirname(os.path.abspath(__file__))
-    agent_path = os.path.join(dir_path, "harness.py")
-
-    print("Running Backgammon game with LLM agents...")
-    env.run([agent_path, agent_path])
-
-    print("\n=== GAME STEPS ===")
-    for idx, step in enumerate(env.steps):
-        print(f"--- Step {idx} ---")
-        for agent_idx, agent_state in enumerate(step):
-            action = agent_state.action
-            status = agent_state.status
-            print(f"  Agent {agent_idx} ({status}): {action}")
-
-    print("\n=== RESULTS ===")
-    for i, state in enumerate(env.state):
-        print(f"Agent {i}: status={state.status}, reward={state.reward}")
-
-    replay_dir = os.path.join(dir_path, "visualizer", "default", "replays")
-    os.makedirs(replay_dir, exist_ok=True)
-    replay_path = os.path.join(replay_dir, "test-replay.json")
-    with open(replay_path, "w") as f:
-        json.dump(env.toJSON(), f)
-    print(f"\nReplay saved to {replay_path}")
-
+from kaggle_environments.local_harness_runner import run_llm_game
 
 if __name__ == "__main__":
-    run_llm_game()
+    run_llm_game(
+        "open_spiel_backgammon",
+        caller_file=__file__,
+        configuration={"includeLegalActions": True, "seed": 7},
+    )

--- a/kaggle_environments/envs/open_spiel_env/games/checkers/test_llm_game.py
+++ b/kaggle_environments/envs/open_spiel_env/games/checkers/test_llm_game.py
@@ -5,52 +5,7 @@ Usage:
         kaggle_environments.envs.open_spiel_env.games.checkers.test_llm_game
 """
 
-import json
-import os
-
-from kaggle_environments import make
-
-
-def run_llm_game():
-    if not os.environ.get("GEMINI_API_KEY") and not os.environ.get("OPENAI_API_KEY"):
-        print("Set GEMINI_API_KEY or OPENAI_API_KEY to run this test.")
-        print("Example: export GEMINI_API_KEY=your_key")
-        return
-
-    if "MODEL_NAME" not in os.environ:
-        os.environ["MODEL_NAME"] = "gemini-2.5-flash"
-    if "MODEL_PROXY_KEY" not in os.environ:
-        os.environ["MODEL_PROXY_KEY"] = os.environ.get("GEMINI_API_KEY", os.environ.get("OPENAI_API_KEY", "dummy"))
-    if "MODEL_PROXY_URL" not in os.environ:
-        os.environ["MODEL_PROXY_URL"] = "dummy_url"
-
-    env = make("open_spiel_checkers", debug=True)
-
-    dir_path = os.path.dirname(os.path.abspath(__file__))
-    agent_path = os.path.join(dir_path, "harness.py")
-
-    print("Running Checkers game with LLM agents...")
-    env.run([agent_path, agent_path])
-
-    print("\n=== GAME STEPS ===")
-    for idx, step in enumerate(env.steps):
-        print(f"--- Step {idx} ---")
-        for agent_idx, agent_state in enumerate(step):
-            action = agent_state.action
-            status = agent_state.status
-            print(f"  Agent {agent_idx} ({status}): {action}")
-
-    print("\n=== RESULTS ===")
-    for i, state in enumerate(env.state):
-        print(f"Agent {i}: status={state.status}, reward={state.reward}")
-
-    replay_dir = os.path.join(dir_path, "visualizer", "default", "replays")
-    os.makedirs(replay_dir, exist_ok=True)
-    replay_path = os.path.join(replay_dir, "test-replay.json")
-    with open(replay_path, "w") as f:
-        json.dump(env.toJSON(), f)
-    print(f"\nReplay saved to {replay_path}")
-
+from kaggle_environments.local_harness_runner import run_llm_game
 
 if __name__ == "__main__":
-    run_llm_game()
+    run_llm_game("open_spiel_checkers", caller_file=__file__)

--- a/kaggle_environments/envs/open_spiel_env/games/chess/test_llm_game.py
+++ b/kaggle_environments/envs/open_spiel_env/games/chess/test_llm_game.py
@@ -1,86 +1,16 @@
-"""Run a full chess game with LLM agents for local integration testing.
+"""Run a full Chess game with LLM agents for local integration testing.
 
 Usage:
-    GEMINI_API_KEY=... python3 -m \\
+    GEMINI_API_KEY=... uv run python -m \\
         kaggle_environments.envs.open_spiel_env.games.chess.test_llm_game
-
-    # Or with a custom model and move limit:
-    GEMINI_API_KEY=... python3 -m \\
-        kaggle_environments.envs.open_spiel_env.games.chess.test_llm_game \\
-        --model gemini-2.5-flash --max-moves 20
 """
 
-import argparse
-import json
-import os
-
-from kaggle_environments import make
-
-
-def run_llm_game(model: str, max_moves: int) -> None:
-    if not os.environ.get("GEMINI_API_KEY") and not os.environ.get("OPENAI_API_KEY"):
-        print("Set GEMINI_API_KEY or OPENAI_API_KEY to run this test.")
-        print("Example: export GEMINI_API_KEY=your_key")
-        return
-
-    if "MODEL_NAME" not in os.environ:
-        os.environ["MODEL_NAME"] = model
-    if "MODEL_PROXY_KEY" not in os.environ:
-        os.environ["MODEL_PROXY_KEY"] = os.environ.get("GEMINI_API_KEY", os.environ.get("OPENAI_API_KEY", "dummy"))
-    if "MODEL_PROXY_URL" not in os.environ:
-        os.environ["MODEL_PROXY_URL"] = "dummy_url"
-
-    env = make(
-        "open_spiel_chess",
-        {"episodeSteps": max_moves * 2 + 100},
-        debug=True,
-    )
-
-    dir_path = os.path.dirname(os.path.abspath(__file__))
-    agent_path = os.path.join(dir_path, "harness.py")
-
-    print(f"Running chess game with LLM agents (model={os.environ['MODEL_NAME']}, max_moves={max_moves})...")
-    env.run([agent_path, agent_path])
-
-    print("\n=== GAME STEPS ===")
-    for idx, step in enumerate(env.steps):
-        for agent_idx, agent_state in enumerate(step):
-            action = agent_state.action
-            status = agent_state.status
-            action_str = action.get("actionString", "") if isinstance(action, dict) else ""
-            if status == "ACTIVE" and action_str:
-                player = "White" if agent_idx == 1 else "Black"
-                print(f"  Step {idx}: {player} plays {action_str}")
-
-    print("\n=== RESULTS ===")
-    for i, state in enumerate(env.state):
-        player = "White" if i == 1 else "Black"
-        print(f"  {player} (agent {i}): status={state.status}, reward={state.reward}")
-
-    replay_dir = os.path.join(dir_path, "visualizer", "default", "replays")
-    os.makedirs(replay_dir, exist_ok=True)
-    replay_path = os.path.join(replay_dir, "test-replay.json")
-    with open(replay_path, "w") as f:
-        json.dump(env.toJSON(), f)
-    print(f"\nReplay saved to {replay_path}")
-
-
-def main():
-    parser = argparse.ArgumentParser(description="Run a chess game with LLM agents")
-    parser.add_argument(
-        "--model",
-        default=os.environ.get("MODEL_NAME", "gemini-2.5-flash"),
-        help="LLM model name (default: gemini-2.5-flash)",
-    )
-    parser.add_argument(
-        "--max-moves",
-        type=int,
-        default=40,
-        help="Maximum number of moves per side (default: 40)",
-    )
-    args = parser.parse_args()
-    run_llm_game(args.model, args.max_moves)
-
+from kaggle_environments.local_harness_runner import run_llm_game
 
 if __name__ == "__main__":
-    main()
+    # Cap episode length so a stuck game doesn't run forever.
+    run_llm_game(
+        "open_spiel_chess",
+        caller_file=__file__,
+        configuration={"episodeSteps": 200},
+    )

--- a/kaggle_environments/envs/open_spiel_env/games/connect_four/debug_match_runner.py
+++ b/kaggle_environments/envs/open_spiel_env/games/connect_four/debug_match_runner.py
@@ -1,0 +1,122 @@
+"""Debug script: drive a short Connect Four match through the LLM harness.
+
+Unlike ``test_llm_game.py`` (which runs a full game via the standard
+``run_llm_game`` helper), this script uses a manual ``env.step()`` loop
+and wraps ``litellm.completion`` to print every prompt/response pair --
+handy when iterating on prompt wording or chasing a parsing bug.
+
+Usage:
+    GEMINI_API_KEY=... uv run python -m \
+        kaggle_environments.envs.open_spiel_env.games.connect_four.debug_match_runner \
+        --num-moves 10 --model gemini-2.5-flash
+"""
+
+import argparse
+import os
+import sys
+
+import litellm
+
+from kaggle_environments import make
+from kaggle_environments.core_harness import create_agent_fn
+from kaggle_environments.envs.open_spiel_env import open_spiel_env
+from kaggle_environments.envs.open_spiel_env.games.connect_four import harness
+
+
+class _C4Harness:
+    """Adapter wrapping module-level functions into the GameHarness protocol."""
+
+    def get_legal_moves(self, observation):
+        return harness.get_legal_moves(observation)
+
+    def make_prompt(self, observation, move_history, previous_response=None, previous_action=None):
+        return harness.generate_prompt(
+            observation,
+            move_history,
+            previous_response,
+            previous_action,
+        )
+
+    def parse_response(self, response, legal_action_strings):
+        return harness.parse_response(response, legal_action_strings)
+
+
+def _wrap_litellm_with_logging() -> None:
+    """Replace litellm.completion with a version that prints I/O."""
+    original = litellm.completion
+    call_idx = 0
+
+    def logged_completion(*args, **kwargs):
+        nonlocal call_idx
+        call_idx += 1
+        messages = kwargs.get("messages", [])
+        prompt = messages[-1]["content"] if messages else ""
+        print(f"\n----- LLM call #{call_idx}: prompt -----")
+        print(prompt)
+        resp = original(*args, **kwargs)
+        print(f"----- LLM call #{call_idx}: response -----")
+        print(resp.choices[0].message.content)
+        print("-" * 40)
+        return resp
+
+    litellm.completion = logged_completion
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--num-moves", type=int, default=10)
+    parser.add_argument(
+        "--model",
+        default=os.environ.get("MODEL_NAME", "gemini-2.5-flash"),
+    )
+    args = parser.parse_args()
+
+    if "GEMINI_API_KEY" not in os.environ:
+        sys.exit("GEMINI_API_KEY must be set in the environment.")
+
+    os.environ["MODEL_NAME"] = args.model
+    os.environ.setdefault("MODEL_PROXY_KEY", "unused")
+    os.environ.setdefault("MODEL_PROXY_URL", "dummy_url")
+
+    open_spiel_env._register_game_envs(["connect_four"])
+    env = make("open_spiel_connect_four", debug=True)
+    env.reset()
+    _wrap_litellm_with_logging()
+
+    agent_fn = create_agent_fn(_C4Harness())
+
+    moves_played = 0
+    last_action_string = None
+    while moves_played < args.num_moves:
+        is_setup_step = len(env.steps) == 1
+        submissions = []
+        for s in env.state:
+            if s["status"] == "ACTIVE":
+                result = agent_fn(s["observation"], {})
+                if result.get("submission") is not None:
+                    last_action_string = result.get("actionString")
+                submissions.append(result)
+            else:
+                submissions.append({"submission": -1})
+
+        if is_setup_step:
+            print("\n========== Setup step ==========")
+            print(f">>> Submissions: {submissions}")
+        else:
+            moves_played += 1
+            print(f"\n========== Move {moves_played}: {last_action_string or '?'} ==========")
+
+        env.step(submissions)
+        if env.done:
+            print("\nGame finished.")
+            break
+
+    print("\n========== Final board ==========")
+    print(env.state[0]["observation"].get("observationString", "(no observation)"))
+    print("\n========== Results ==========")
+    for i, s in enumerate(env.state):
+        print(f"Agent {i}: status={s['status']}, reward={s['reward']}")
+
+
+if __name__ == "__main__":
+    main()

--- a/kaggle_environments/envs/open_spiel_env/games/connect_four/test_llm_game.py
+++ b/kaggle_environments/envs/open_spiel_env/games/connect_four/test_llm_game.py
@@ -1,117 +1,14 @@
-"""Debug script: drive a short Connect Four match through the LLM harness.
+"""Run a full Connect Four game with LLM agents for local integration testing.
+
+For an interactive debug runner that logs every LLM prompt/response and lets
+you cap the number of moves, see ``debug_match_runner.py`` in the same dir.
 
 Usage:
-    GEMINI_API_KEY=... uv run python -m \
-        kaggle_environments.envs.open_spiel_env.games.connect_four.test_llm_game \
-        --num-moves 10 --model gemini-2.5-flash
+    GEMINI_API_KEY=... uv run python -m \\
+        kaggle_environments.envs.open_spiel_env.games.connect_four.test_llm_game
 """
 
-import argparse
-import os
-import sys
-
-import litellm
-
-from kaggle_environments import make
-from kaggle_environments.core_harness import create_agent_fn
-from kaggle_environments.envs.open_spiel_env import open_spiel_env
-from kaggle_environments.envs.open_spiel_env.games.connect_four import harness
-
-
-class _C4Harness:
-    """Adapter wrapping module-level functions into the GameHarness protocol."""
-
-    def get_legal_moves(self, observation):
-        return harness.get_legal_moves(observation)
-
-    def make_prompt(self, observation, move_history, previous_response=None, previous_action=None):
-        return harness.generate_prompt(
-            observation,
-            move_history,
-            previous_response,
-            previous_action,
-        )
-
-    def parse_response(self, response, legal_action_strings):
-        return harness.parse_response(response, legal_action_strings)
-
-
-def _wrap_litellm_with_logging() -> None:
-    """Replace litellm.completion with a version that prints I/O."""
-    original = litellm.completion
-    call_idx = 0
-
-    def logged_completion(*args, **kwargs):
-        nonlocal call_idx
-        call_idx += 1
-        messages = kwargs.get("messages", [])
-        prompt = messages[-1]["content"] if messages else ""
-        print(f"\n----- LLM call #{call_idx}: prompt -----")
-        print(prompt)
-        resp = original(*args, **kwargs)
-        print(f"----- LLM call #{call_idx}: response -----")
-        print(resp.choices[0].message.content)
-        print("-" * 40)
-        return resp
-
-    litellm.completion = logged_completion
-
-
-def main() -> None:
-    parser = argparse.ArgumentParser()
-    parser.add_argument("--num-moves", type=int, default=10)
-    parser.add_argument(
-        "--model",
-        default=os.environ.get("MODEL_NAME", "gemini-2.5-flash"),
-    )
-    args = parser.parse_args()
-
-    if "GEMINI_API_KEY" not in os.environ:
-        sys.exit("GEMINI_API_KEY must be set in the environment.")
-
-    os.environ["MODEL_NAME"] = args.model
-    os.environ.setdefault("MODEL_PROXY_KEY", "unused")
-    os.environ.setdefault("MODEL_PROXY_URL", "dummy_url")
-
-    open_spiel_env._register_game_envs(["connect_four"])
-    env = make("open_spiel_connect_four", debug=True)
-    env.reset()
-    _wrap_litellm_with_logging()
-
-    agent_fn = create_agent_fn(_C4Harness())
-
-    moves_played = 0
-    last_action_string = None
-    while moves_played < args.num_moves:
-        is_setup_step = len(env.steps) == 1
-        submissions = []
-        for s in env.state:
-            if s["status"] == "ACTIVE":
-                result = agent_fn(s["observation"], {})
-                if result.get("submission") is not None:
-                    last_action_string = result.get("actionString")
-                submissions.append(result)
-            else:
-                submissions.append({"submission": -1})
-
-        if is_setup_step:
-            print("\n========== Setup step ==========")
-            print(f">>> Submissions: {submissions}")
-        else:
-            moves_played += 1
-            print(f"\n========== Move {moves_played}: {last_action_string or '?'} ==========")
-
-        env.step(submissions)
-        if env.done:
-            print("\nGame finished.")
-            break
-
-    print("\n========== Final board ==========")
-    print(env.state[0]["observation"].get("observationString", "(no observation)"))
-    print("\n========== Results ==========")
-    for i, s in enumerate(env.state):
-        print(f"Agent {i}: status={s['status']}, reward={s['reward']}")
-
+from kaggle_environments.local_harness_runner import run_llm_game
 
 if __name__ == "__main__":
-    main()
+    run_llm_game("open_spiel_connect_four", caller_file=__file__)

--- a/kaggle_environments/envs/open_spiel_env/games/dots_and_boxes/test_llm_game.py
+++ b/kaggle_environments/envs/open_spiel_env/games/dots_and_boxes/test_llm_game.py
@@ -5,52 +5,7 @@ Usage:
         kaggle_environments.envs.open_spiel_env.games.dots_and_boxes.test_llm_game
 """
 
-import json
-import os
-
-from kaggle_environments import make
-
-
-def run_llm_game():
-    if not os.environ.get("GEMINI_API_KEY") and not os.environ.get("OPENAI_API_KEY"):
-        print("Set GEMINI_API_KEY or OPENAI_API_KEY to run this test.")
-        print("Example: export GEMINI_API_KEY=your_key")
-        return
-
-    if "MODEL_NAME" not in os.environ:
-        os.environ["MODEL_NAME"] = "gemini-2.5-flash"
-    if "MODEL_PROXY_KEY" not in os.environ:
-        os.environ["MODEL_PROXY_KEY"] = os.environ.get("GEMINI_API_KEY", os.environ.get("OPENAI_API_KEY", "dummy"))
-    if "MODEL_PROXY_URL" not in os.environ:
-        os.environ["MODEL_PROXY_URL"] = "dummy_url"
-
-    env = make("open_spiel_dots_and_boxes", debug=True)
-
-    dir_path = os.path.dirname(os.path.abspath(__file__))
-    agent_path = os.path.join(dir_path, "harness.py")
-
-    print("Running Dots and Boxes game with LLM agents...")
-    env.run([agent_path, agent_path])
-
-    print("\n=== GAME STEPS ===")
-    for idx, step in enumerate(env.steps):
-        print(f"--- Step {idx} ---")
-        for agent_idx, agent_state in enumerate(step):
-            action = agent_state.action
-            status = agent_state.status
-            print(f"  Agent {agent_idx} ({status}): {action}")
-
-    print("\n=== RESULTS ===")
-    for i, state in enumerate(env.state):
-        print(f"Agent {i}: status={state.status}, reward={state.reward}")
-
-    replay_dir = os.path.join(dir_path, "visualizer", "default", "replays")
-    os.makedirs(replay_dir, exist_ok=True)
-    replay_path = os.path.join(replay_dir, "test-replay.json")
-    with open(replay_path, "w") as f:
-        json.dump(env.toJSON(), f)
-    print(f"\nReplay saved to {replay_path}")
-
+from kaggle_environments.local_harness_runner import run_llm_game
 
 if __name__ == "__main__":
-    run_llm_game()
+    run_llm_game("open_spiel_dots_and_boxes", caller_file=__file__)

--- a/kaggle_environments/envs/open_spiel_env/games/havannah/test_llm_game.py
+++ b/kaggle_environments/envs/open_spiel_env/games/havannah/test_llm_game.py
@@ -5,60 +5,15 @@ Usage:
         kaggle_environments.envs.open_spiel_env.games.havannah.test_llm_game
 """
 
-import json
-import os
+from kaggle_environments.local_harness_runner import run_llm_game
 
-from kaggle_environments import make
-
-
-def run_llm_game():
-    if not os.environ.get("GEMINI_API_KEY") and not os.environ.get("OPENAI_API_KEY"):
-        print("Set GEMINI_API_KEY or OPENAI_API_KEY to run this test.")
-        print("Example: export GEMINI_API_KEY=your_key")
-        return
-
-    if "MODEL_NAME" not in os.environ:
-        os.environ["MODEL_NAME"] = "gemini-2.5-flash"
-    if "MODEL_PROXY_KEY" not in os.environ:
-        os.environ["MODEL_PROXY_KEY"] = os.environ.get("GEMINI_API_KEY", os.environ.get("OPENAI_API_KEY", "dummy"))
-    if "MODEL_PROXY_URL" not in os.environ:
-        os.environ["MODEL_PROXY_URL"] = "dummy_url"
-
-    # Use a smaller board for a quicker local test.
-    env = make(
+if __name__ == "__main__":
+    # Smaller board for a quicker local test.
+    run_llm_game(
         "open_spiel_havannah",
+        caller_file=__file__,
         configuration={
             "includeLegalActions": True,
             "openSpielGameParameters": {"board_size": 5},
         },
-        debug=True,
     )
-
-    dir_path = os.path.dirname(os.path.abspath(__file__))
-    agent_path = os.path.join(dir_path, "harness.py")
-
-    print("Running Havannah game with LLM agents...")
-    env.run([agent_path, agent_path])
-
-    print("\n=== GAME STEPS ===")
-    for idx, step in enumerate(env.steps):
-        print(f"--- Step {idx} ---")
-        for agent_idx, agent_state in enumerate(step):
-            action = agent_state.action
-            status = agent_state.status
-            print(f"  Agent {agent_idx} ({status}): {action}")
-
-    print("\n=== RESULTS ===")
-    for i, state in enumerate(env.state):
-        print(f"Agent {i}: status={state.status}, reward={state.reward}")
-
-    replay_dir = os.path.join(dir_path, "visualizer", "default", "replays")
-    os.makedirs(replay_dir, exist_ok=True)
-    replay_path = os.path.join(replay_dir, "test-replay.json")
-    with open(replay_path, "w") as f:
-        json.dump(env.toJSON(), f)
-    print(f"\nReplay saved to {replay_path}")
-
-
-if __name__ == "__main__":
-    run_llm_game()

--- a/kaggle_environments/envs/open_spiel_env/games/mancala/test_llm_game.py
+++ b/kaggle_environments/envs/open_spiel_env/games/mancala/test_llm_game.py
@@ -5,52 +5,7 @@ Usage:
         kaggle_environments.envs.open_spiel_env.games.mancala.test_llm_game
 """
 
-import json
-import os
-
-from kaggle_environments import make
-
-
-def run_llm_game():
-    if not os.environ.get("GEMINI_API_KEY") and not os.environ.get("OPENAI_API_KEY"):
-        print("Set GEMINI_API_KEY or OPENAI_API_KEY to run this test.")
-        print("Example: export GEMINI_API_KEY=your_key")
-        return
-
-    if "MODEL_NAME" not in os.environ:
-        os.environ["MODEL_NAME"] = "gemini-2.5-flash"
-    if "MODEL_PROXY_KEY" not in os.environ:
-        os.environ["MODEL_PROXY_KEY"] = os.environ.get("GEMINI_API_KEY", os.environ.get("OPENAI_API_KEY", "dummy"))
-    if "MODEL_PROXY_URL" not in os.environ:
-        os.environ["MODEL_PROXY_URL"] = "dummy_url"
-
-    env = make("open_spiel_mancala", debug=True)
-
-    dir_path = os.path.dirname(os.path.abspath(__file__))
-    agent_path = os.path.join(dir_path, "harness.py")
-
-    print("Running Mancala game with LLM agents...")
-    env.run([agent_path, agent_path])
-
-    print("\n=== GAME STEPS ===")
-    for idx, step in enumerate(env.steps):
-        print(f"--- Step {idx} ---")
-        for agent_idx, agent_state in enumerate(step):
-            action = agent_state.action
-            status = agent_state.status
-            print(f"  Agent {agent_idx} ({status}): {action}")
-
-    print("\n=== RESULTS ===")
-    for i, state in enumerate(env.state):
-        print(f"Agent {i}: status={state.status}, reward={state.reward}")
-
-    replay_dir = os.path.join(dir_path, "visualizer", "default", "replays")
-    os.makedirs(replay_dir, exist_ok=True)
-    replay_path = os.path.join(replay_dir, "test-replay.json")
-    with open(replay_path, "w") as f:
-        json.dump(env.toJSON(), f)
-    print(f"\nReplay saved to {replay_path}")
-
+from kaggle_environments.local_harness_runner import run_llm_game
 
 if __name__ == "__main__":
-    run_llm_game()
+    run_llm_game("open_spiel_mancala", caller_file=__file__)

--- a/kaggle_environments/envs/open_spiel_env/games/negotiation/test_llm_game.py
+++ b/kaggle_environments/envs/open_spiel_env/games/negotiation/test_llm_game.py
@@ -6,61 +6,21 @@ Usage:
 """
 
 import json
-import os
 
-from kaggle_environments import make
-
-
-def run_llm_game():
-    if not os.environ.get("GEMINI_API_KEY") and not os.environ.get("OPENAI_API_KEY"):
-        print("Set GEMINI_API_KEY or OPENAI_API_KEY to run this test.")
-        print("Example: export GEMINI_API_KEY=your_key")
-        return
-
-    if "MODEL_NAME" not in os.environ:
-        os.environ["MODEL_NAME"] = "gemini-2.5-flash"
-    if "MODEL_PROXY_KEY" not in os.environ:
-        os.environ["MODEL_PROXY_KEY"] = os.environ.get("GEMINI_API_KEY", os.environ.get("OPENAI_API_KEY", "dummy"))
-    if "MODEL_PROXY_URL" not in os.environ:
-        os.environ["MODEL_PROXY_URL"] = "dummy_url"
-
-    env = make(
-        "open_spiel_negotiation",
-        configuration={"includeLegalActions": True},
-        debug=True,
-    )
-
-    dir_path = os.path.dirname(os.path.abspath(__file__))
-    agent_path = os.path.join(dir_path, "harness.py")
-
-    print("Running Negotiation game with LLM agents...")
-    env.run([agent_path, agent_path])
-
-    print("\n=== GAME STEPS ===")
-    for idx, step in enumerate(env.steps):
-        print(f"--- Step {idx} ---")
-        for agent_idx, agent_state in enumerate(step):
-            action = agent_state.action
-            status = agent_state.status
-            print(f"  Agent {agent_idx} ({status}): {action}")
-
-    print("\n=== RESULTS ===")
-    for i, state in enumerate(env.state):
-        print(f"Agent {i}: status={state.status}, reward={state.reward}")
-    final_obs = env.state[0].observation.observationString
-    try:
-        parsed = json.loads(final_obs)
-        print(f"  agreement_reached={parsed.get('agreement_reached')} winner={parsed.get('winner')}")
-    except (TypeError, ValueError):
-        pass
-
-    replay_dir = os.path.join(dir_path, "visualizer", "default", "replays")
-    os.makedirs(replay_dir, exist_ok=True)
-    replay_path = os.path.join(replay_dir, "test-replay.json")
-    with open(replay_path, "w") as f:
-        json.dump(env.toJSON(), f)
-    print(f"\nReplay saved to {replay_path}")
-
+from kaggle_environments.local_harness_runner import run_llm_game
 
 if __name__ == "__main__":
-    run_llm_game()
+    env = run_llm_game(
+        "open_spiel_negotiation",
+        caller_file=__file__,
+        configuration={"includeLegalActions": True},
+    )
+    if env is not None:
+        try:
+            parsed = json.loads(env.state[0].observation.observationString)
+            print(
+                f"  agreement_reached={parsed.get('agreement_reached')} "
+                f"winner={parsed.get('winner')}"
+            )
+        except (TypeError, ValueError):
+            pass

--- a/kaggle_environments/envs/open_spiel_env/games/python_ant_foraging/test_llm_game.py
+++ b/kaggle_environments/envs/open_spiel_env/games/python_ant_foraging/test_llm_game.py
@@ -5,56 +5,12 @@ Usage:
         kaggle_environments.envs.open_spiel_env.games.python_ant_foraging.test_llm_game
 """
 
-import json
-import os
-
-from kaggle_environments import make
-
-
-def run_llm_game():
-    if not os.environ.get("GEMINI_API_KEY") and not os.environ.get("OPENAI_API_KEY"):
-        print("Set GEMINI_API_KEY or OPENAI_API_KEY to run this test.")
-        print("Example: export GEMINI_API_KEY=your_key")
-        return
-
-    if "MODEL_NAME" not in os.environ:
-        os.environ["MODEL_NAME"] = "gemini-2.5-flash"
-    if "MODEL_PROXY_KEY" not in os.environ:
-        os.environ["MODEL_PROXY_KEY"] = os.environ.get("GEMINI_API_KEY", os.environ.get("OPENAI_API_KEY", "dummy"))
-    if "MODEL_PROXY_URL" not in os.environ:
-        os.environ["MODEL_PROXY_URL"] = "dummy_url"
-
-    env = make(
-        "open_spiel_python_ant_foraging",
-        configuration={"includeLegalActions": True, "actTimeout": 120},
-        debug=True,
-    )
-
-    dir_path = os.path.dirname(os.path.abspath(__file__))
-    agent_path = os.path.join(dir_path, "harness.py")
-
-    print("Running game with LLM agents...")
-    env.run([agent_path, agent_path])
-
-    print("\n=== GAME STEPS ===")
-    for idx, step in enumerate(env.steps):
-        print(f"--- Step {idx} ---")
-        for agent_idx, agent_state in enumerate(step):
-            action = agent_state.action
-            status = agent_state.status
-            print(f"  Agent {agent_idx} ({status}): {action}")
-
-    print("\n=== RESULTS ===")
-    for i, state in enumerate(env.state):
-        print(f"Agent {i}: status={state.status}, reward={state.reward}")
-
-    replay_dir = os.path.join(dir_path, "visualizer", "default", "replays")
-    os.makedirs(replay_dir, exist_ok=True)
-    replay_path = os.path.join(replay_dir, "llm-replay.json")
-    with open(replay_path, "w") as f:
-        json.dump(env.toJSON(), f)
-    print(f"\nReplay saved to {replay_path}")
-
+from kaggle_environments.local_harness_runner import run_llm_game
 
 if __name__ == "__main__":
-    run_llm_game()
+    run_llm_game(
+        "open_spiel_python_ant_foraging",
+        caller_file=__file__,
+        configuration={"includeLegalActions": True, "actTimeout": 120},
+        replay_filename="llm-replay.json",
+    )

--- a/kaggle_environments/envs/open_spiel_env/games/snake/test_llm_game.py
+++ b/kaggle_environments/envs/open_spiel_env/games/snake/test_llm_game.py
@@ -5,56 +5,11 @@ Usage:
         kaggle_environments.envs.open_spiel_env.games.snake.test_llm_game
 """
 
-import json
-import os
-
-from kaggle_environments import make
-
-
-def run_llm_game():
-    if not os.environ.get("GEMINI_API_KEY") and not os.environ.get("OPENAI_API_KEY"):
-        print("Set GEMINI_API_KEY or OPENAI_API_KEY to run this test.")
-        print("Example: export GEMINI_API_KEY=your_key")
-        return
-
-    if "MODEL_NAME" not in os.environ:
-        os.environ["MODEL_NAME"] = "gemini-2.5-flash"
-    if "MODEL_PROXY_KEY" not in os.environ:
-        os.environ["MODEL_PROXY_KEY"] = os.environ.get("GEMINI_API_KEY", os.environ.get("OPENAI_API_KEY", "dummy"))
-    if "MODEL_PROXY_URL" not in os.environ:
-        os.environ["MODEL_PROXY_URL"] = "dummy_url"
-
-    env = make(
-        "open_spiel_snake",
-        configuration={"includeLegalActions": True, "actTimeout": 120},
-        debug=True,
-    )
-
-    dir_path = os.path.dirname(os.path.abspath(__file__))
-    agent_path = os.path.join(dir_path, "harness.py")
-
-    print("Running snake game with LLM agents...")
-    env.run([agent_path, agent_path])
-
-    print("\n=== GAME STEPS ===")
-    for idx, step in enumerate(env.steps):
-        print(f"--- Step {idx} ---")
-        for agent_idx, agent_state in enumerate(step):
-            action = agent_state.action
-            status = agent_state.status
-            print(f"  Agent {agent_idx} ({status}): {action}")
-
-    print("\n=== RESULTS ===")
-    for i, state in enumerate(env.state):
-        print(f"Agent {i}: status={state.status}, reward={state.reward}")
-
-    replay_dir = os.path.join(dir_path, "visualizer", "default", "replays")
-    os.makedirs(replay_dir, exist_ok=True)
-    replay_path = os.path.join(replay_dir, "test-replay.json")
-    with open(replay_path, "w") as f:
-        json.dump(env.toJSON(), f)
-    print(f"\nReplay saved to {replay_path}")
-
+from kaggle_environments.local_harness_runner import run_llm_game
 
 if __name__ == "__main__":
-    run_llm_game()
+    run_llm_game(
+        "open_spiel_snake",
+        caller_file=__file__,
+        configuration={"includeLegalActions": True, "actTimeout": 120},
+    )

--- a/kaggle_environments/envs/word_association/test_llm_game.py
+++ b/kaggle_environments/envs/word_association/test_llm_game.py
@@ -1,70 +1,34 @@
+"""Run a full Word Association game with LLM agents for local integration testing.
+
+Usage:
+    GEMINI_API_KEY=... uv run python -m \\
+        kaggle_environments.envs.word_association.test_llm_game
+"""
+
 import os
-import json
-from kaggle_environments import make
 
-def run_llm_game():
-    if not os.environ.get("GEMINI_API_KEY") and not os.environ.get("OPENAI_API_KEY"):
-        print("Please set GEMINI_API_KEY or OPENAI_API_KEY in your environment variables to run this test.")
-        print("Example: export GEMINI_API_KEY=your_key")
-        return
-        
-    # Inject dummy environment variables so local testing evaluates correctly against the required runner
-    if "MODEL_NAME" not in os.environ:
-        os.environ["MODEL_NAME"] = "gemini-3.1-flash-lite-preview"
-    if "MODEL_PROXY_KEY" not in os.environ:
-        # Pass the local api key in so that litellm can use it when it drops the dummy proxy url
-        os.environ["MODEL_PROXY_KEY"] = os.environ.get("GEMINI_API_KEY", os.environ.get("OPENAI_API_KEY", "dummy"))
-    if "MODEL_PROXY_URL" not in os.environ:
-        os.environ["MODEL_PROXY_URL"] = "dummy_url"
-
-    print("Initializing Word Association Game with LLM Agents...")
-    env = make("word_association", configuration={"games_per_episode": 1}, debug=True)
-    
-    # We use our litellm harness for all 4 slots.
-    # Kaggle environments requires an absolute or properly relative path
-    # relative to where the script is run from. Using absolute path here is safest.
-    dir_path = os.path.dirname(os.path.abspath(__file__))
-    agent_path = os.path.join(dir_path, "harness", "main.py")
-    
-    # Start the simulation. This will use API calls and may take a moment.
-    env.run([agent_path, agent_path, agent_path, agent_path])
-    
-    print("\n=== GAME STEPS ===")
-    for idx, step in enumerate(env.steps):
-        print(f"--- Step {idx} ---")
-        for agent_idx, agent_state in enumerate(step):
-            action = agent_state.action
-            status = agent_state.status
-            print(f"Agent {agent_idx} ({status}): {action}")
-    print("==================\n")
-    
-    print("Game Finished!")
-    
-    for i, state in enumerate(env.state):
-        print(f"Agent {i} Status: {state.status} | Reward: {state.reward}")
-        
-    rewards = [state.reward for state in env.state]
-    if rewards[0] > 0:
-        print("WINNER: Team Blue 🟦")
-    elif rewards[2] > 0:
-        print("WINNER: Team Yellow 🟨")
-    else:
-        print("Result: Tie or Error")
-
-    # Save replay data for the visualizer
-    replay_dir = os.path.join(dir_path, "visualizer", "default", "replays")
-    os.makedirs(replay_dir, exist_ok=True)
-    replay_path = os.path.join(replay_dir, "test-replay.json")
-    
-    with open(replay_path, "w") as f:
-        json.dump(env.toJSON(), f)
-    print(f"Saved replay to {replay_path}")
-
-    # Also save HTML render if needed
-    html = env.render(mode="html")
-    with open(os.path.join(dir_path, "word_association_replay.html"), "w") as f:
-        f.write(html)
-    print("Saved HTML render to word_association_replay.html")
+from kaggle_environments.local_harness_runner import run_llm_game
 
 if __name__ == "__main__":
-    run_llm_game()
+    env = run_llm_game(
+        "word_association",
+        caller_file=__file__,
+        agent_module="harness/main.py",
+        num_agents=4,
+        configuration={"games_per_episode": 1},
+    )
+    if env is not None:
+        rewards = [state.reward for state in env.state]
+        if rewards[0] > 0:
+            print("WINNER: Team Blue")
+        elif rewards[2] > 0:
+            print("WINNER: Team Yellow")
+        else:
+            print("Result: Tie or Error")
+
+        # Also save an HTML render for visual inspection.
+        dir_path = os.path.dirname(os.path.abspath(__file__))
+        html_path = os.path.join(dir_path, "word_association_replay.html")
+        with open(html_path, "w") as f:
+            f.write(env.render(mode="html"))
+        print(f"Saved HTML render to {html_path}")

--- a/kaggle_environments/local_harness_runner.py
+++ b/kaggle_environments/local_harness_runner.py
@@ -1,0 +1,143 @@
+"""Local-debug helper for running an LLM harness end-to-end against an env.
+
+Each game's ``test_llm_game.py`` collapses to a three-line wrapper:
+
+    \"\"\"Run a full Checkers game with LLM agents for local integration testing.\"\"\"
+    from kaggle_environments.local_harness_runner import run_llm_game
+
+    if __name__ == "__main__":
+        run_llm_game("open_spiel_checkers", caller_file=__file__)
+
+This module is for local development and integration testing only. It is NOT
+loaded by Kaggle in production -- the production loader uses the per-call
+``GameHarness`` protocol in ``core_harness.py``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from typing import Any
+
+from kaggle_environments import make
+
+
+_DEFAULT_MODEL = "gemini-2.5-flash"
+_REPLAY_SUBDIR = os.path.join("visualizer", "default", "replays")
+
+
+def _check_api_keys() -> bool:
+    if os.environ.get("GEMINI_API_KEY") or os.environ.get("OPENAI_API_KEY"):
+        return True
+    print("Set GEMINI_API_KEY or OPENAI_API_KEY to run this test.")
+    print("Example: export GEMINI_API_KEY=your_key")
+    return False
+
+
+def _set_env_defaults(model_override: str | None) -> None:
+    if model_override is not None:
+        os.environ["MODEL_NAME"] = model_override
+    elif "MODEL_NAME" not in os.environ:
+        os.environ["MODEL_NAME"] = _DEFAULT_MODEL
+    if "MODEL_PROXY_KEY" not in os.environ:
+        os.environ["MODEL_PROXY_KEY"] = os.environ.get(
+            "GEMINI_API_KEY", os.environ.get("OPENAI_API_KEY", "dummy")
+        )
+    if "MODEL_PROXY_URL" not in os.environ:
+        os.environ["MODEL_PROXY_URL"] = "dummy_url"
+
+
+def _parse_cli(argv: list[str] | None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Run an LLM harness end-to-end against a Kaggle environment.",
+    )
+    parser.add_argument(
+        "--model",
+        default=None,
+        help="Override MODEL_NAME for this run.",
+    )
+    parser.add_argument(
+        "--replay-path",
+        default=None,
+        help="Override the replay save path (default: <caller_dir>/visualizer/default/replays/<replay_filename>).",
+    )
+    return parser.parse_args(argv)
+
+
+def _print_steps_and_results(env: Any) -> None:
+    print("\n=== GAME STEPS ===")
+    for idx, step in enumerate(env.steps):
+        print(f"--- Step {idx} ---")
+        for agent_idx, agent_state in enumerate(step):
+            print(f"  Agent {agent_idx} ({agent_state.status}): {agent_state.action}")
+
+    print("\n=== RESULTS ===")
+    for i, state in enumerate(env.state):
+        print(f"Agent {i}: status={state.status}, reward={state.reward}")
+
+
+def _save_replay(env: Any, replay_path: str) -> None:
+    os.makedirs(os.path.dirname(replay_path), exist_ok=True)
+    with open(replay_path, "w") as f:
+        json.dump(env.toJSON(), f)
+    print(f"\nReplay saved to {replay_path}")
+
+
+def run_llm_game(
+    env_name: str,
+    *,
+    caller_file: str,
+    agent_module: str = "harness.py",
+    num_agents: int = 2,
+    configuration: dict[str, Any] | None = None,
+    replay_filename: str = "test-replay.json",
+    cli: bool = True,
+    argv: list[str] | None = None,
+) -> Any:
+    """Run a full game with LLM agents and save the replay.
+
+    Args:
+        env_name: Env to instantiate (e.g. ``"open_spiel_checkers"``).
+        caller_file: Pass ``__file__`` from the caller. The helper resolves
+            the agent path and the replay directory relative to this.
+        agent_module: Path to the harness module relative to the caller's
+            directory. Defaults to ``"harness.py"``; use ``"harness/main.py"``
+            for packaged harnesses like word_association.
+        num_agents: How many copies of the agent to pass to ``env.run``.
+            Defaults to 2; word_association uses 4.
+        configuration: Optional dict forwarded to ``make(configuration=...)``.
+        replay_filename: Filename for the saved replay; written to
+            ``<caller_dir>/visualizer/default/replays/<filename>`` by default.
+        cli: When True (default), parse ``--model`` and ``--replay-path`` from
+            ``sys.argv``. Set False to disable so the caller can bring its own
+            argparse.
+        argv: Optional override for ``sys.argv[1:]`` (test seam).
+
+    Returns:
+        The ``env`` after the run, so callers can do game-specific
+        post-processing (e.g. word_association's winner banner).
+        Returns ``None`` and prints a hint if no API key is present.
+    """
+    if not _check_api_keys():
+        return None
+
+    args = _parse_cli(argv if argv is not None else sys.argv[1:]) if cli else _parse_cli([])
+    _set_env_defaults(args.model)
+
+    env = make(env_name, configuration=configuration, debug=True)
+
+    caller_dir = os.path.dirname(os.path.abspath(caller_file))
+    agent_path = os.path.join(caller_dir, agent_module)
+    replay_path = args.replay_path or os.path.join(
+        caller_dir, _REPLAY_SUBDIR, replay_filename,
+    )
+
+    print(f"Running {env_name} with LLM agents (model={os.environ['MODEL_NAME']})...")
+    env.run([agent_path] * num_agents)
+
+    _print_steps_and_results(env)
+    _save_replay(env, replay_path)
+
+    return env

--- a/tests/local_harness_runner_test.py
+++ b/tests/local_harness_runner_test.py
@@ -1,0 +1,190 @@
+"""Tests for ``kaggle_environments.local_harness_runner.run_llm_game``."""
+
+import json
+import os
+import tempfile
+from unittest.mock import MagicMock, patch
+
+from absl.testing import absltest
+
+from kaggle_environments import local_harness_runner
+
+
+# Env vars the helper might consult; clear them per-test for determinism.
+_HARNESS_ENV_KEYS = (
+    "GEMINI_API_KEY",
+    "OPENAI_API_KEY",
+    "MODEL_NAME",
+    "MODEL_PROXY_KEY",
+    "MODEL_PROXY_URL",
+)
+
+
+def _make_fake_env() -> MagicMock:
+    """A fake env whose ``run`` returns nothing and ``toJSON`` returns a dict."""
+    env = MagicMock()
+    step = MagicMock()
+    step.status = "DONE"
+    step.action = {"submission": 0}
+    env.steps = [[step, step]]
+    state = MagicMock()
+    state.status = "DONE"
+    state.reward = 0
+    env.state = [state, state]
+    env.toJSON.return_value = {"name": "fake", "steps": []}
+    return env
+
+
+def _clear_env() -> dict[str, str | None]:
+    """Snapshot + clear the env vars the helper inspects. Returns the snapshot."""
+    snapshot = {k: os.environ.pop(k, None) for k in _HARNESS_ENV_KEYS}
+    return snapshot
+
+
+def _restore_env(snapshot: dict[str, str | None]) -> None:
+    for k, v in snapshot.items():
+        if v is None:
+            os.environ.pop(k, None)
+        else:
+            os.environ[k] = v
+
+
+class RunLlmGameTest(absltest.TestCase):
+    def setUp(self):
+        super().setUp()
+        self._env_snapshot = _clear_env()
+        self.addCleanup(_restore_env, self._env_snapshot)
+
+    def test_missing_api_key_returns_early(self):
+        with patch.object(local_harness_runner, "make") as mock_make:
+            result = local_harness_runner.run_llm_game(
+                "open_spiel_checkers", caller_file=__file__, cli=False,
+            )
+        self.assertIsNone(result)
+        mock_make.assert_not_called()
+
+    def test_env_vars_set_with_defaults(self):
+        os.environ["GEMINI_API_KEY"] = "test-key"
+        with patch.object(local_harness_runner, "make", return_value=_make_fake_env()):
+            with tempfile.TemporaryDirectory() as tmp:
+                local_harness_runner.run_llm_game(
+                    "open_spiel_checkers",
+                    caller_file=os.path.join(tmp, "test_llm_game.py"),
+                    cli=False,
+                )
+        # Defaults are populated.
+        self.assertEqual(os.environ.get("MODEL_NAME"), local_harness_runner._DEFAULT_MODEL)
+        self.assertEqual(os.environ.get("MODEL_PROXY_KEY"), "test-key")
+        self.assertEqual(os.environ.get("MODEL_PROXY_URL"), "dummy_url")
+
+    def test_preserves_existing_env_vars(self):
+        os.environ["GEMINI_API_KEY"] = "test-key"
+        os.environ["MODEL_NAME"] = "user-model"
+        os.environ["MODEL_PROXY_KEY"] = "user-proxy-key"
+        os.environ["MODEL_PROXY_URL"] = "https://user-proxy.example"
+        with patch.object(local_harness_runner, "make", return_value=_make_fake_env()):
+            with tempfile.TemporaryDirectory() as tmp:
+                local_harness_runner.run_llm_game(
+                    "open_spiel_checkers",
+                    caller_file=os.path.join(tmp, "test_llm_game.py"),
+                    cli=False,
+                )
+        self.assertEqual(os.environ["MODEL_NAME"], "user-model")
+        self.assertEqual(os.environ["MODEL_PROXY_KEY"], "user-proxy-key")
+        self.assertEqual(os.environ["MODEL_PROXY_URL"], "https://user-proxy.example")
+
+    def test_cli_model_override(self):
+        os.environ["GEMINI_API_KEY"] = "test-key"
+        with patch.object(local_harness_runner, "make", return_value=_make_fake_env()):
+            with tempfile.TemporaryDirectory() as tmp:
+                local_harness_runner.run_llm_game(
+                    "open_spiel_checkers",
+                    caller_file=os.path.join(tmp, "test_llm_game.py"),
+                    argv=["--model", "claude-opus-4-7"],
+                )
+        self.assertEqual(os.environ["MODEL_NAME"], "claude-opus-4-7")
+
+    def test_cli_replay_path_override(self):
+        os.environ["GEMINI_API_KEY"] = "test-key"
+        with tempfile.TemporaryDirectory() as tmp:
+            replay_path = os.path.join(tmp, "subdir", "custom-replay.json")
+            with patch.object(local_harness_runner, "make", return_value=_make_fake_env()):
+                local_harness_runner.run_llm_game(
+                    "open_spiel_checkers",
+                    caller_file=os.path.join(tmp, "test_llm_game.py"),
+                    argv=["--replay-path", replay_path],
+                )
+            self.assertTrue(os.path.exists(replay_path))
+            with open(replay_path) as f:
+                self.assertEqual(json.load(f), {"name": "fake", "steps": []})
+
+    def test_env_run_called_with_repeated_agent_path(self):
+        os.environ["GEMINI_API_KEY"] = "test-key"
+        fake_env = _make_fake_env()
+        with patch.object(local_harness_runner, "make", return_value=fake_env):
+            with tempfile.TemporaryDirectory() as tmp:
+                caller_file = os.path.join(tmp, "test_llm_game.py")
+                local_harness_runner.run_llm_game(
+                    "word_association",
+                    caller_file=caller_file,
+                    agent_module="harness/main.py",
+                    num_agents=4,
+                    cli=False,
+                )
+        fake_env.run.assert_called_once()
+        agents_arg = fake_env.run.call_args.args[0]
+        expected = os.path.join(tmp, "harness", "main.py")
+        self.assertEqual(agents_arg, [expected, expected, expected, expected])
+
+    def test_replay_saved_to_default_location(self):
+        os.environ["GEMINI_API_KEY"] = "test-key"
+        with tempfile.TemporaryDirectory() as tmp:
+            caller_file = os.path.join(tmp, "test_llm_game.py")
+            with patch.object(local_harness_runner, "make", return_value=_make_fake_env()):
+                local_harness_runner.run_llm_game(
+                    "open_spiel_checkers", caller_file=caller_file, cli=False,
+                )
+            expected = os.path.join(
+                tmp, "visualizer", "default", "replays", "test-replay.json",
+            )
+            self.assertTrue(os.path.exists(expected))
+            with open(expected) as f:
+                self.assertEqual(json.load(f), {"name": "fake", "steps": []})
+
+    def test_configuration_forwarded_to_make(self):
+        os.environ["GEMINI_API_KEY"] = "test-key"
+        with patch.object(local_harness_runner, "make", return_value=_make_fake_env()) as mock_make:
+            with tempfile.TemporaryDirectory() as tmp:
+                local_harness_runner.run_llm_game(
+                    "open_spiel_havannah",
+                    caller_file=os.path.join(tmp, "test_llm_game.py"),
+                    configuration={
+                        "includeLegalActions": True,
+                        "openSpielGameParameters": {"board_size": 5},
+                    },
+                    cli=False,
+                )
+        mock_make.assert_called_once_with(
+            "open_spiel_havannah",
+            configuration={
+                "includeLegalActions": True,
+                "openSpielGameParameters": {"board_size": 5},
+            },
+            debug=True,
+        )
+
+    def test_returns_env_for_post_processing(self):
+        os.environ["GEMINI_API_KEY"] = "test-key"
+        fake_env = _make_fake_env()
+        with patch.object(local_harness_runner, "make", return_value=fake_env):
+            with tempfile.TemporaryDirectory() as tmp:
+                returned = local_harness_runner.run_llm_game(
+                    "open_spiel_checkers",
+                    caller_file=os.path.join(tmp, "test_llm_game.py"),
+                    cli=False,
+                )
+        self.assertIs(returned, fake_env)
+
+
+if __name__ == "__main__":
+    absltest.main()


### PR DESCRIPTION
Reduces the per-game `test_llm_game` runner to just a few lines calling the common script.