### PR TITLE
Fix issues from Snake harness audit

### DIFF
--- a/kaggle_environments/envs/open_spiel_env/games/snake/harness.py
+++ b/kaggle_environments/envs/open_spiel_env/games/snake/harness.py
@@ -29,13 +29,15 @@ dies if its new head:
   - collides head-to-head with another snake (both die).
 A snake that moves onto a food cell ("*") grows by one and earns one
 point. Food spawns in 180°-rotationally-symmetric pairs (one cell and
-its mirror through the board center), so both starting positions are
-equidistant from the nearest food. Every {food_respawn_interval} turns
-a fresh pair is spawned and any uneaten food is removed — there is no
-respawn when food is eaten. Snakes that do NOT eat lose their tail on
-the same turn. The game ends when at most one snake is alive (in a
-multi-player game) or after {max_turns} turns; the last snake standing
-wins, otherwise the highest score wins.
+its mirror through the board center). Every {food_respawn_interval}
+turns a fresh pair is spawned and any uneaten food on the board is
+removed -- there is NO respawn when food is eaten. Snakes that do NOT
+eat lose their tail on the same turn. The game ends when at most one
+snake is alive, or when the board has no room left for a new food pair.
+
+Your goal is to maximize your food score (1 point per food eaten).
+There is NO bonus for being the last snake standing -- surviving only
+ends the game; it does not boost your score.
 
 Coordinates are ``[row, column]`` with ``row=0`` at the top and
 ``column=0`` on the left. The board uses these characters:
@@ -43,15 +45,16 @@ Coordinates are ``[row, column]`` with ``row=0`` at the top and
   body, uppercase letter ({your_head_char}/etc.) snake head. Your snake
   uses letter "{your_letter}".
 
-The current game state is:
-{state_str}
+Current board:
+{board_str}
 
-You are player {player_id}. Your snake is at {your_body}{alive_note}.
+You are player {player_id}. Your snake body is at {your_body}{alive_note}
+(the first coordinate is your head).
 Your score: {your_score}. Food at: {food_str}.
 Next food respawn in {turns_until_respawn} turn(s).
 
-Moves you have played so far:
-{move_history}
+Recent rounds (most recent last; one line per simultaneous round):
+{round_history_str}
 
 It is now your turn. Choose your move.
 The move MUST be one of: UP, DOWN, LEFT, RIGHT.
@@ -100,6 +103,9 @@ The move you choose must also be legal in the current state.
 # --- Helpers ----------------------------------------------------------------
 
 
+_RECENT_ROUNDS_LIMIT = 10
+
+
 def _parse_observation(observation: Mapping[str, Any]) -> dict[str, Any]:
     """Parse the snake proxy's JSON observation, returning ``{}`` on error."""
     obs_str = observation.get("observationString", "")
@@ -109,6 +115,40 @@ def _parse_observation(observation: Mapping[str, Any]) -> dict[str, Any]:
         return json.loads(obs_str)
     except (json.JSONDecodeError, TypeError):
         return {}
+
+
+def _render_board(board: list[list[str]] | None) -> str:
+    """Render the proxy's 2D board array as a single ASCII grid."""
+    if not board:
+        return "(no board)"
+    return "\n".join("".join(row) for row in board)
+
+
+def _render_round_history(
+    round_history: list[list[str | None]] | None,
+    num_players: int,
+) -> str:
+    """Render the per-round action log shared by all players.
+
+    Lines are 1-indexed by round number, capped at the most recent
+    ``_RECENT_ROUNDS_LIMIT`` rounds so the prompt doesn't grow without
+    bound. ``None`` in a slot means the player didn't supply a move that
+    round (e.g. they were already dead).
+    """
+    if not round_history:
+        return "(no moves yet)"
+    total = len(round_history)
+    recent = round_history[-_RECENT_ROUNDS_LIMIT:]
+    start_idx = total - len(recent) + 1
+    lines = []
+    for i, round_moves in enumerate(recent):
+        round_num = start_idx + i
+        parts = [
+            f"P{p}={(round_moves[p] if p < len(round_moves) else None) or '-'}"
+            for p in range(num_players)
+        ]
+        lines.append(f"Round {round_num}: " + ", ".join(parts))
+    return "\n".join(lines)
 
 
 # --- Public functions (called by main.py) -----------------------------------
@@ -136,14 +176,13 @@ def generate_prompt(
     previous_action: str | None = None,
 ) -> str:
     """Build the LLM prompt for the current snake game state."""
-    obs_string = observation.get("observationString", "")
+    del move_history  # We render the proxy's full per-round history instead.
     player_id = int(observation.get("playerId", 0))
     parsed = _parse_observation(observation)
 
     rows = int(parsed.get("num_rows", 10))
     cols = int(parsed.get("num_columns", 10))
     num_players = int(parsed.get("num_players", 2))
-    max_turns = rows * cols * 2
 
     body_chars = ["a", "b", "c", "d"]
     head_chars = ["A", "B", "C", "D"]
@@ -156,7 +195,7 @@ def generate_prompt(
     your_body = your_snake["body"] if your_snake else "(unknown)"
     your_score = your_snake["score"] if your_snake else 0
     alive = bool(your_snake.get("alive", True)) if your_snake else True
-    alive_note = "" if alive else " (DEAD — you are out of the game)"
+    alive_note = "" if alive else " (DEAD -- you are out of the game)"
 
     foods = parsed.get("foods")
     if foods is None:
@@ -171,25 +210,27 @@ def generate_prompt(
     if turns_until_respawn is None and food_respawn_interval > 0:
         turns_until_respawn = food_respawn_interval - (turn % food_respawn_interval)
 
-    move_history_str = " ".join(move_history) if move_history else "None"
+    board_str = _render_board(parsed.get("board"))
+    round_history_str = _render_round_history(
+        parsed.get("round_history"), num_players,
+    )
 
     prompt = SNAKE_PROMPT_TEMPLATE.format(
         rows=rows,
         cols=cols,
         num_players=num_players,
-        max_turns=max_turns,
         food_respawn_interval=food_respawn_interval,
         turns_until_respawn=turns_until_respawn,
         your_letter=your_letter,
         your_body_char=your_body_char,
         your_head_char=your_head_char,
-        state_str=obs_string,
+        board_str=board_str,
         player_id=player_id,
         your_body=your_body,
         your_score=your_score,
         alive_note=alive_note,
         food_str=food_str,
-        move_history=move_history_str,
+        round_history_str=round_history_str,
     )
 
     prompt += render_rethink_suffix(

--- a/kaggle_environments/envs/open_spiel_env/games/snake/snake_game.py
+++ b/kaggle_environments/envs/open_spiel_env/games/snake/snake_game.py
@@ -128,6 +128,10 @@ class SnakeState(pyspiel.State):
         self._steps = 0
         self._next_player = 0
         self._move_buffer = [None] * self.num_players
+        # Per-round log of applied actions (one inner list per simultaneous
+        # round). Lets the harness expose opponent moves to each player; in
+        # simultaneous-move snake this is otherwise invisible.
+        self._round_history: List[List[int | None]] = []
 
     def _place_foods(self):
         """Places a 180°-rotationally-symmetric pair of food on empty cells.
@@ -202,6 +206,7 @@ class SnakeState(pyspiel.State):
 
     def _process_simultaneous_turn(self):
         self._steps += 1
+        self._round_history.append(list(self._move_buffer))
 
         # Calculate new heads
         new_heads = []

--- a/kaggle_environments/envs/open_spiel_env/games/snake/snake_proxy.py
+++ b/kaggle_environments/envs/open_spiel_env/games/snake/snake_proxy.py
@@ -20,6 +20,7 @@ from ... import proxy
 
 # Ensure the underlying custom game is registered before we try to load it.
 from . import snake_game  # noqa: F401
+from .snake_game import Action as _Action
 
 _BODY_CHARS = ["a", "b", "c", "d"]
 _HEAD_CHARS = ["A", "B", "C", "D"]
@@ -85,6 +86,14 @@ class SnakeState(proxy.State):
         buffer = [a for a in getattr(wrapped, "_move_buffer", [])]
         pending = [i for i, a in enumerate(buffer) if a is not None]
 
+        round_history = [
+            [
+                _Action(a).name if a is not None and 0 <= a < len(_Action) else None
+                for a in round_moves
+            ]
+            for round_moves in getattr(wrapped, "_round_history", [])
+        ]
+
         return {
             "board": self._board(snakes, is_alive, foods),
             "num_rows": int(wrapped.rows),
@@ -99,6 +108,7 @@ class SnakeState(proxy.State):
             "is_alive": is_alive,
             "current_player": self.current_player(),
             "pending_this_turn": pending,
+            "round_history": round_history,
             "turn": turn,
             "is_terminal": is_terminal,
             "winner": winner,

--- a/tests/envs/open_spiel_env/games/snake/harness_test.py
+++ b/tests/envs/open_spiel_env/games/snake/harness_test.py
@@ -107,9 +107,16 @@ class ParseResponseTest(absltest.TestCase):
 
 
 class GeneratePromptTest(absltest.TestCase):
-    def _obs(self, player_id=0):
+    def _obs(self, player_id=0, round_history=None):
+        # Minimal 10x10 board with P0 head at (1,1) and P1 head at (8,8).
+        board = [["." for _ in range(10)] for _ in range(10)]
+        board[1][1] = "A"
+        board[8][8] = "B"
+        board[3][4] = "*"
+        board[6][5] = "*"
         state = json.dumps(
             {
+                "board": board,
                 "num_rows": 10,
                 "num_columns": 10,
                 "num_players": 2,
@@ -124,6 +131,7 @@ class GeneratePromptTest(absltest.TestCase):
                 "scores": [0, 0],
                 "is_alive": [True, True],
                 "current_player": player_id,
+                "round_history": round_history or [],
                 "turn": 3,
                 "is_terminal": False,
                 "winner": None,
@@ -155,9 +163,36 @@ class GeneratePromptTest(absltest.TestCase):
         prompt = generate_prompt(self._obs(player_id=1), [])
         self.assertIn("[8, 8]", prompt)
 
-    def test_move_history_included(self):
+    def test_board_rendered_as_ascii_grid(self):
+        # The board must be a multi-line ASCII grid (not a raw JSON blob),
+        # so the model can read spatial structure directly.
+        prompt = generate_prompt(self._obs(), [])
+        # P0 head 'A' at (1,1) in our test obs.
+        self.assertIn(".A........", prompt)
+        # Multi-line: at least one bare row of '.' between markers.
+        self.assertIn("\n..........\n", prompt)
+        # And the raw JSON board array must NOT appear.
+        self.assertNotIn('"board":', prompt)
+
+    def test_round_history_renders_opponent_moves(self):
+        # The proxy's round_history is a list of per-round action lists,
+        # one entry per player. The prompt must surface BOTH players' moves
+        # so each side can see what the opponent did.
+        rounds = [["UP", "LEFT"], ["UP", "DOWN"]]
+        prompt = generate_prompt(self._obs(round_history=rounds), [])
+        self.assertIn("Round 1: P0=UP, P1=LEFT", prompt)
+        self.assertIn("Round 2: P0=UP, P1=DOWN", prompt)
+
+    def test_round_history_empty(self):
+        prompt = generate_prompt(self._obs(), [])
+        self.assertIn("(no moves yet)", prompt)
+
+    def test_ignores_framework_move_history(self):
+        # The harness reads round_history from the proxy, not the
+        # framework-supplied per-agent move_history (which has no
+        # opponent moves and would mislead in a simultaneous game).
         prompt = generate_prompt(self._obs(), ["UP", "RIGHT", "DOWN"])
-        self.assertIn("UP RIGHT DOWN", prompt)
+        self.assertNotIn("UP RIGHT DOWN", prompt)
 
     def test_rethink_suffix(self):
         prompt = generate_prompt(


### PR DESCRIPTION
- `snake_game.py`: added `self._round_history` list; appended `list(self._move_buffer)` at the top of `_process_simultaneous_turn` to log each completed simultaneous round.
- `snake_proxy.py`: imported `Action`, decoded `_round_history` ints to direction names, and exposed as a new `round_history` field in `state_dict`.
-  `harness.py` — board rendering: added `_render_board` helper; replaced the raw JSON dump (`state_str=obs_string`) with an ASCII grid.
- `harness.py` — opponent moves: added `_render_round_history` helper that reads the proxy's `round_history` and renders both players' moves per round (capped at last 10 rounds).
- `harness.py `— prompt rewrite: dropped the false `max_turns` claim; added the "board full" termination path; reworded "last snake standing wins" to "goal is to maximize food score, no survival bonus"; annotated `your_body` with "(the first coordinate is your head)"; dropped the 2-player-only "both starting positions equidistant" clause.
