### PR TITLE
Fix issues from Amazons audit

### DIFF
--- a/kaggle_environments/envs/open_spiel_env/games/amazons/amazons_proxy.py
+++ b/kaggle_environments/envs/open_spiel_env/games/amazons/amazons_proxy.py
@@ -50,6 +50,34 @@ class AmazonsState(proxy.State):
             return None
         return _PHASES[self.move_number() % 3]
 
+    def _sub_turn_actions(
+        self, phase: str | None,
+    ) -> tuple[int | None, int | None]:
+        """Return ``(from_action, to_action)`` for the current sub-turn.
+
+        OpenSpiel keeps the in-progress turn's ``from_``/``to_`` private, but
+        they're recoverable from the action history: the actions belonging to
+        the current sub-turn are the trailing entries since the last shoot.
+
+        - ``from`` phase: nothing chosen yet -> ``(None, None)``.
+        - ``to`` phase: ``from`` already played -> ``(history[-1], None)``.
+        - ``shoot`` phase: ``from`` and ``to`` already played ->
+          ``(history[-2], history[-1])``.
+
+        TO/SHOOT prompts need these so the model can be told which queen it
+        picked up; without them the source square is invisible (the engine
+        empties the ``from_`` cell as soon as it's selected).
+        """
+        if phase == "to":
+            history = self.history()
+            if history:
+                return history[-1], None
+        elif phase == "shoot":
+            history = self.history()
+            if len(history) >= 2:
+                return history[-2], history[-1]
+        return None, None
+
     def state_dict(self) -> dict[str, Any]:
         winner: str | None = None
         if self.is_terminal():
@@ -61,12 +89,16 @@ class AmazonsState(proxy.State):
             else:
                 winner = "draw"
         board = self._board()
+        phase = self._phase()
+        from_action, to_action = self._sub_turn_actions(phase)
         return {
             "board": board,
             "num_rows": len(board),
             "num_cols": len(board[0]) if board else 0,
             "current_player": self._player_string(self.current_player()),
-            "phase": self._phase(),
+            "phase": phase,
+            "from_action": from_action,
+            "to_action": to_action,
             "move_number": self.move_number(),
             "is_terminal": self.is_terminal(),
             "winner": winner,

--- a/kaggle_environments/envs/open_spiel_env/games/amazons/harness.py
+++ b/kaggle_environments/envs/open_spiel_env/games/amazons/harness.py
@@ -173,15 +173,19 @@ def _phase_instruction(
                 f"and is now sitting at {to_sq}. Place a barrier on any "
                 f"empty square reachable from {to_sq} by a queen-move "
                 "(any number of empty squares in a straight or diagonal "
-                "line). The chosen square is then permanently blocked "
-                "for the rest of the game: no piece may enter or cross "
-                "it."
+                f"line). This INCLUDES {from_sq}, the square the queen "
+                "just vacated -- it is empty again and reachable, so it "
+                "is a legal barrier target. The chosen square is then "
+                "permanently blocked for the rest of the game: no piece "
+                "may enter or cross it."
             )
         return (
             "Place a barrier from the queen you just moved. The barrier "
             "travels any number of empty squares from that queen's new "
             "square in a straight or diagonal line; the square it lands "
-            "on is permanently blocked for the rest of the game."
+            "on is permanently blocked for the rest of the game. The "
+            "square the queen just vacated this turn is empty again and "
+            "is a legal barrier target."
         )
     # FROM phase
     return (

--- a/kaggle_environments/envs/open_spiel_env/games/amazons/harness.py
+++ b/kaggle_environments/envs/open_spiel_env/games/amazons/harness.py
@@ -4,10 +4,16 @@ Drop the body of this file into the notebook attached to the competition via
 HarnessKernelId. The auto-generated ``main.py`` calls these three module-level
 functions: ``get_legal_moves``, ``generate_prompt``, ``parse_response``.
 
-Amazons turns decompose into three sub-actions: pick an amazon (``from``),
-move it like a queen (``to``), then shoot an arrow from the new square
-(``shoot``). Each sub-action is one LLM call. The proxy exposes the current
-phase and board in ``observationString`` as JSON.
+Amazons turns decompose into three sub-actions: pick a queen (``from``),
+move it like a chess queen (``to``), then place a barrier reachable from the
+new square (``shoot`` in the engine, presented to the model as a barrier
+placement). Each sub-action is one LLM call. The proxy exposes the current
+phase, board, and (for in-progress turns) the queen's source/destination in
+``observationString`` as JSON.
+
+The prompt avoids weapon-adjacent vocabulary so that model APIs with strict
+safety filters don't refuse to play: queens move, then place a barrier on a
+square that becomes blocked. The game mechanics are unchanged.
 """
 
 from __future__ import annotations
@@ -121,38 +127,86 @@ def _board_dims(state: Mapping[str, Any]) -> tuple[int, int]:
 # --- Prompt -----------------------------------------------------------------
 
 
-_PHASE_INSTRUCTION = {
-    "from": (
-        "Choose which of your amazons to move (one of your pieces on the "
-        "board)."
-    ),
-    "to": (
-        "You picked up an amazon. Choose where to move it. Amazons move like "
-        "chess queens (any number of empty squares in a straight or diagonal "
-        "line) and cannot pass through arrows or other pieces."
-    ),
-    "shoot": (
-        "Now shoot an arrow from your amazon's new square. The arrow flies "
-        "like a queen's move from that square. The square it lands on is "
-        "burned for the rest of the game and no piece may enter or cross it."
-    ),
+# Phase labels shown to the model. Sterilized from the engine's internal
+# names so safety filters don't flag the prompt ("shoot" -> "place barrier").
+_PHASE_LABEL = {
+    "from": "PICK QUEEN",
+    "to": "MOVE QUEEN",
+    "shoot": "PLACE BARRIER",
 }
 
 
-AMAZONS_PROMPT_TEMPLATE = """Let's play the Game of the Amazons on a {num_rows}x{num_cols} board.
+def _phase_instruction(
+    phase: str,
+    from_sq: str | None,
+    to_sq: str | None,
+) -> str:
+    """Per-phase instruction text. Names the in-progress squares when known.
 
-Pieces: X = Black amazons, O = White amazons, # = burned (arrow) squares,
-. = empty. Each turn has three steps: move one of your amazons like a chess
-queen (from -> to), then shoot an arrow from its new square (also like a
-queen). A player who cannot move on their turn loses.
+    The TO/SHOOT phases are the high-stakes ones: the engine has already
+    cleared the queen's source cell, so the board no longer reveals which
+    queen the player picked up. Without telling the model, it has to infer
+    the source from the move-history list -- which it usually gets wrong,
+    burning retries. We name ``from_sq`` / ``to_sq`` explicitly here.
+    """
+    if phase == "to":
+        if from_sq is not None:
+            return (
+                f"You picked up the queen previously at {from_sq} -- that "
+                f"square is now empty on the board. Choose where to move "
+                f"it: any empty square reachable from {from_sq} by a "
+                "queen-move (any number of empty squares in a straight or "
+                "diagonal line; the path may not cross another queen or a "
+                "blocked square)."
+            )
+        return (
+            "You picked up one of your queens earlier this turn -- its "
+            "previous square is now empty on the board. Choose where to "
+            "move it: queens move any number of empty squares in a "
+            "straight or diagonal line and cannot pass through other "
+            "pieces or blocked squares."
+        )
+    if phase == "shoot":
+        if from_sq is not None and to_sq is not None:
+            return (
+                f"Your queen moved from {from_sq} to {to_sq} this turn "
+                f"and is now sitting at {to_sq}. Place a barrier on any "
+                f"empty square reachable from {to_sq} by a queen-move "
+                "(any number of empty squares in a straight or diagonal "
+                "line). The chosen square is then permanently blocked "
+                "for the rest of the game: no piece may enter or cross "
+                "it."
+            )
+        return (
+            "Place a barrier from the queen you just moved. The barrier "
+            "travels any number of empty squares from that queen's new "
+            "square in a straight or diagonal line; the square it lands "
+            "on is permanently blocked for the rest of the game."
+        )
+    # FROM phase
+    return (
+        "Choose which of your queens to move. You may only pick a queen "
+        "that has at least one empty neighbouring square -- a queen with "
+        "no empty neighbour cannot move and is not a legal selection."
+    )
+
+
+AMAZONS_PROMPT_TEMPLATE = """Let's play a strategy game on a {num_rows}x{num_cols} grid.
+
+Pieces: X = Player 1's queens, O = Player 2's queens, # = blocked squares,
+. = empty. Each turn has three steps: move one of your queens like a chess
+queen (from -> to), then place a barrier on an empty square reachable by
+another queen-move from its new position. Barriers permanently block their
+square: no piece may enter or cross. A player who cannot move on their
+turn loses.
 
 You are playing as {player_name} ({player_glyph}).
-Current sub-action: {phase_upper}
+Current sub-action: {phase_label}
 
 Board:
 {board}
 
-Move history (last {history_max}):
+Move history (last {history_max_turns} completed turns):
 {move_history}
 
 {phase_instruction}
@@ -202,13 +256,31 @@ The move you choose must also be legal in the current state.
 """
 
 
-_HISTORY_MAX = 12
+_HISTORY_MAX_TURNS = 8
 
 
 def _format_history(move_history: list[str]) -> str:
-    if not move_history:
-        return "(no moves yet)"
-    return ", ".join(move_history[-_HISTORY_MAX:])
+    """Group the flat action list into 3-action turns labelled by player.
+
+    The framework stores ``move_history`` as a flat list of algebraic cells,
+    one per sub-action. Without grouping the model sees ``a7, d7, e7, c6,
+    c5, c4`` and has to remember "every three cells is one turn, players
+    alternate, X started" -- which is undocumented and easy to get wrong.
+    Render each completed turn as ``X: a7 -> d7, barrier e7`` instead. Skip
+    any partial trailing turn (its squares are surfaced by the prompt's
+    source-square disclosure instead, so showing it here would duplicate).
+    """
+    if len(move_history) < 3:
+        return "(no completed turns yet)"
+    full_turns = len(move_history) // 3
+    start = max(0, full_turns - _HISTORY_MAX_TURNS)
+    lines = []
+    for t in range(start, full_turns):
+        i = t * 3
+        from_sq, to_sq, barrier_sq = move_history[i:i + 3]
+        player = "X" if t % 2 == 0 else "O"
+        lines.append(f"{player}: {from_sq} -> {to_sq}, barrier {barrier_sq}")
+    return "\n".join(lines)
 
 
 # --- Public functions (called by main.py) -----------------------------------
@@ -242,6 +314,36 @@ def get_legal_moves(observation: Mapping[str, Any]) -> dict[int, str]:
     return {a: _action_to_algebraic(a, num_cols) for a in legal_actions}
 
 
+def _sub_turn_squares(
+    state: Mapping[str, Any],
+    move_history: list[str],
+    phase: str,
+    num_cols: int,
+) -> tuple[str | None, str | None]:
+    """Return ``(from_sq, to_sq)`` algebraic for the in-progress turn.
+
+    Prefers the action ids surfaced by the updated proxy (always accurate);
+    falls back to the trailing entries of ``move_history`` so the harness
+    still works when dropped into a notebook where the proxy module isn't
+    on the path (per ``deserialize_game_and_state`` comment at the top of
+    this file).
+    """
+    from_sq: str | None = None
+    to_sq: str | None = None
+    from_id = state.get("from_action")
+    to_id = state.get("to_action")
+    if isinstance(from_id, int):
+        from_sq = _action_to_algebraic(from_id, num_cols)
+    if isinstance(to_id, int):
+        to_sq = _action_to_algebraic(to_id, num_cols)
+    if from_sq is None and phase == "to" and move_history:
+        from_sq = move_history[-1]
+    elif from_sq is None and phase == "shoot" and len(move_history) >= 2:
+        from_sq = move_history[-2]
+        to_sq = to_sq if to_sq is not None else move_history[-1]
+    return from_sq, to_sq
+
+
 def generate_prompt(
     observation: Mapping[str, Any],
     move_history: list[str],
@@ -254,19 +356,20 @@ def generate_prompt(
     board = state.get("board") or [["." for _ in range(num_cols)] for _ in range(num_rows)]
     phase = state.get("phase") or "from"
     current = state.get("current_player", "x")
-    player_name = "Black" if current == "x" else "White"
+    player_name = "Player 1" if current == "x" else "Player 2"
     player_glyph = "X" if current == "x" else "O"
+    from_sq, to_sq = _sub_turn_squares(state, move_history, phase, num_cols)
 
     prompt = AMAZONS_PROMPT_TEMPLATE.format(
         num_rows=num_rows,
         num_cols=num_cols,
         player_name=player_name,
         player_glyph=player_glyph,
-        phase_upper=phase.upper(),
+        phase_label=_PHASE_LABEL.get(phase, phase.upper()),
         board=_render_board(board),
-        history_max=_HISTORY_MAX,
+        history_max_turns=_HISTORY_MAX_TURNS,
         move_history=_format_history(move_history),
-        phase_instruction=_PHASE_INSTRUCTION.get(phase, _PHASE_INSTRUCTION["from"]),
+        phase_instruction=_phase_instruction(phase, from_sq, to_sq),
     )
 
     prompt += render_rethink_suffix(

--- a/tests/envs/open_spiel_env/games/amazons/harness_test.py
+++ b/tests/envs/open_spiel_env/games/amazons/harness_test.py
@@ -1,12 +1,21 @@
 """Tests for Game of the Amazons LLM harness.
 
-Includes regression tests for two bugs found in the May 2026 review:
+Includes regression tests for the bugs found in the May 2026 review:
 
 1. Fallback coord-scan iterated forward, picking earlier-mentioned (often
    rejected) cells instead of the model's final stated move.
 2. ``_CELL_RE`` used ``\\s*`` between the letter and digit groups, which
    crossed newlines and captured the rendered board's column-header line
    (``"... i j\\n 1"``) as a fake ``j1`` cell.
+
+Plus the June 2026 audit follow-ups:
+
+3. TO and SHOOT prompts hid the in-progress queen's source square -- the
+   model had to infer it from the bare move-history list, often wrongly.
+4. Move history was a flat list of cells with no phase / player markers,
+   making it ambiguous which cell was a "from" vs a "to" vs a barrier.
+5. Prompt vocabulary tripped some model-API safety filters (amazons /
+   shoot / arrow / burned) -- sterilized to queens / barriers / blocked.
 """
 
 from unittest.mock import MagicMock, patch
@@ -187,42 +196,105 @@ class GeneratePromptTest(absltest.TestCase):
     def test_basic_prompt_for_x(self):
         observation = {"observationString": _OBS_10X10_EMPTY, "playerId": 0}
         prompt = generate_prompt(observation, [])
-        self.assertIn("Amazons", prompt)
-        self.assertIn("Black", prompt)  # X = Black per the harness
-        self.assertIn("X", prompt)
+        self.assertIn("Player 1", prompt)  # was "Black" before sterilization
+        self.assertIn("(X)", prompt)
         self.assertIn("10x10", prompt)
-        self.assertIn("FROM", prompt)  # phase label
+        self.assertIn("PICK QUEEN", prompt)  # FROM phase label
+        self.assertIn("queens", prompt.lower())
+        self.assertIn("barrier", prompt.lower())
+        # Sterilization regression: weapon-adjacent vocabulary must NOT
+        # appear -- some model APIs refuse the prompt otherwise.
+        self.assertNotIn("amazon", prompt.lower())
+        self.assertNotIn("shoot", prompt.lower())
+        self.assertNotIn("arrow", prompt.lower())
+        self.assertNotIn("burned", prompt.lower())
 
     def test_prompt_for_o(self):
         obs_str = _OBS_10X10_EMPTY.replace('"current_player": "x"', '"current_player": "o"')
         observation = {"observationString": obs_str, "playerId": 1}
         prompt = generate_prompt(observation, [])
-        self.assertIn("White", prompt)
+        self.assertIn("Player 2", prompt)
+        self.assertIn("(O)", prompt)
 
-    def test_phase_to_instruction(self):
+    def test_from_phase_legality_hint(self):
+        """FROM-phase instruction must warn about trapped queens."""
+        observation = {"observationString": _OBS_10X10_EMPTY, "playerId": 0}
+        prompt = generate_prompt(observation, [])
+        self.assertIn("empty neighbouring square", prompt)
+
+    def test_phase_to_instruction_names_source_square(self):
+        """TO prompt must explicitly name the queen's source square.
+
+        Before the fix it said "you picked up an amazon" without revealing
+        which one; the model had to infer from move_history. Regression
+        for audit finding #1.
+        """
+        obs_str = _OBS_10X10_EMPTY.replace(
+            '"phase": "from"', '"phase": "to", "from_action": 60',
+        )
+        observation = {"observationString": obs_str, "playerId": 0}
+        prompt = generate_prompt(observation, ["a7"])
+        self.assertIn("MOVE QUEEN", prompt)
+        self.assertIn("a7", prompt)  # source square is named in the body
+        self.assertIn("queen-move", prompt.lower())
+
+    def test_phase_shoot_instruction_names_both_squares(self):
+        """SHOOT prompt must name both from and to squares this turn.
+
+        Regression for audit finding #1: a player with 4 queens of the
+        same colour couldn't tell which one had just moved.
+        """
+        obs_str = _OBS_10X10_EMPTY.replace(
+            '"phase": "from"',
+            '"phase": "shoot", "from_action": 60, "to_action": 63',
+        )
+        observation = {"observationString": obs_str, "playerId": 0}
+        prompt = generate_prompt(observation, ["a7", "d7"])
+        self.assertIn("PLACE BARRIER", prompt)
+        self.assertIn("a7", prompt)
+        self.assertIn("d7", prompt)
+        self.assertIn("barrier", prompt.lower())
+
+    def test_to_phase_falls_back_to_move_history(self):
+        """When proxy didn't surface from_action, infer from history."""
+        # Note: no "from_action" key in obs -- harness has to fall back to
+        # move_history[-1].
         obs_str = _OBS_10X10_EMPTY.replace('"phase": "from"', '"phase": "to"')
         observation = {"observationString": obs_str, "playerId": 0}
-        prompt = generate_prompt(observation, [])
-        self.assertIn("TO", prompt)
-        self.assertIn("chess queen", prompt.lower())  # 'to' phase instruction
+        prompt = generate_prompt(observation, ["g10"])
+        self.assertIn("g10", prompt)
 
-    def test_phase_shoot_instruction(self):
-        obs_str = _OBS_10X10_EMPTY.replace('"phase": "from"', '"phase": "shoot"')
-        observation = {"observationString": obs_str, "playerId": 0}
-        prompt = generate_prompt(observation, [])
-        self.assertIn("SHOOT", prompt)
-        self.assertIn("arrow", prompt.lower())
+    def test_move_history_grouped_per_turn(self):
+        """Each completed turn renders as `X: a -> b, barrier c`.
 
-    def test_move_history_rendered(self):
+        Regression for audit finding #2: bare flat list was ambiguous
+        about which cells were from / to / barriers.
+        """
         observation = {"observationString": _OBS_10X10_EMPTY, "playerId": 0}
-        prompt = generate_prompt(observation, ["a7", "a8", "b8"])
-        self.assertIn("a7", prompt)
-        self.assertIn("b8", prompt)
+        prompt = generate_prompt(
+            observation,
+            ["a7", "a8", "b8", "d1", "d2", "e2"],
+        )
+        self.assertIn("X: a7 -> a8, barrier b8", prompt)
+        self.assertIn("O: d1 -> d2, barrier e2", prompt)
+
+    def test_move_history_skips_partial_turn(self):
+        """Partial turn at the tail is omitted (already surfaced via prompt)."""
+        observation = {"observationString": _OBS_10X10_EMPTY, "playerId": 0}
+        prompt = generate_prompt(
+            observation,
+            # X has a complete turn; O has started but not finished.
+            ["a7", "a8", "b8", "d1"],
+        )
+        self.assertIn("X: a7 -> a8, barrier b8", prompt)
+        # The partial "O: d1 (moving...)" line would duplicate info that
+        # the phase instruction already conveys; skip it.
+        self.assertNotIn("O:", prompt)
 
     def test_empty_move_history(self):
         observation = {"observationString": _OBS_10X10_EMPTY, "playerId": 0}
         prompt = generate_prompt(observation, [])
-        self.assertIn("no moves yet", prompt)
+        self.assertIn("no completed turns yet", prompt)
 
     def test_rethink_suffix(self):
         observation = {"observationString": _OBS_10X10_EMPTY, "playerId": 0}

--- a/tests/envs/open_spiel_env/games/amazons/harness_test.py
+++ b/tests/envs/open_spiel_env/games/amazons/harness_test.py
@@ -255,6 +255,39 @@ class GeneratePromptTest(absltest.TestCase):
         self.assertIn("d7", prompt)
         self.assertIn("barrier", prompt.lower())
 
+    def test_phase_shoot_instruction_calls_out_vacated_square(self):
+        """SHOOT prompt must explicitly name the just-vacated square as
+        a legal barrier target. Without the hint, models frequently miss
+        that the queen's previous square is empty again and reachable,
+        and overlook it as a candidate -- often a tactically useful one
+        (e.g. fully sealing the queen into its new square).
+        """
+        obs_str = _OBS_10X10_EMPTY.replace(
+            '"phase": "from"',
+            '"phase": "shoot", "from_action": 60, "to_action": 63',
+        )
+        observation = {"observationString": obs_str, "playerId": 0}
+        prompt = generate_prompt(observation, ["a7", "d7"])
+        # The named-squares branch must point at a7 (the from square)
+        # specifically and call it out as a legal barrier target.
+        flat = " ".join(prompt.split())
+        self.assertIn("INCLUDES a7", flat)
+        self.assertIn("just vacated", flat)
+
+    def test_phase_shoot_fallback_calls_out_vacated_square(self):
+        """Same vacated-square hint must appear on the fallback branch
+        (when neither proxy from_action/to_action nor enough move history
+        is available to name the squares).
+        """
+        # Phase=shoot with NO from_action/to_action and an empty history
+        # forces the fallback branch.
+        obs_str = _OBS_10X10_EMPTY.replace('"phase": "from"', '"phase": "shoot"')
+        observation = {"observationString": obs_str, "playerId": 0}
+        prompt = generate_prompt(observation, [])
+        flat = " ".join(prompt.split())
+        self.assertIn("just vacated", flat)
+        self.assertIn("legal barrier target", flat)
+
     def test_to_phase_falls_back_to_move_history(self):
         """When proxy didn't surface from_action, infer from history."""
         # Note: no "from_action" key in obs -- harness has to fall back to


### PR DESCRIPTION
  - Vocabulary sterilized so safety filters don't bounce the prompt: amazons → queens, shoot/arrow → place barrier, burned → blocked, SHOOT phase label → PLACE BARRIER.
  - Player labels are now Player 1 (X) / Player 2 (O) (fixes the X=Black/O=White inversion).
  - TO and SHOOT phase instructions now explicitly name the source/destination squares ("You picked up the queen previously at a7...", "Your queen moved from a7 to d7 this turn..."), reading from the proxy's new from_action/to_action with a move_history fallback for notebook deploys without the proxy.
  - _format_history groups the flat list into 3-action turns labelled by player (X: a7 -> d7, barrier e7). Cap raised from 12 entries to 8 turns. Partial trailing turns are skipped because the phase nstruction already conveys them.
  - FROM-phase instruction now warns that a queen with no empty neighbour isn't a legal selection.
