### PR TITLE
Log end of response on illegal move failure

### DIFF
--- a/kaggle_environments/core_harness.py
+++ b/kaggle_environments/core_harness.py
@@ -847,7 +847,7 @@ def create_agent_fn(
 
         raise ValueError(
             f"Failed to parse a legal move after {max_retries} attempts. "
-            f"Last response: {last_content[:200]}"
+            f"End of last response: {last_content[-200:]}"
         )
 
     return agent_fn


### PR DESCRIPTION
We tend to parse a move from the end of a response, not the start, so logging the start is not helpful.