### PR TITLE
Support new forfiet markers/reasons in open_spiel chess replays

### DIFF
--- a/kaggle_environments/envs/open_spiel_env/games/chess/visualizer/default/src/chess_renderer.ts
+++ b/kaggle_environments/envs/open_spiel_env/games/chess/visualizer/default/src/chess_renderer.ts
@@ -13,6 +13,7 @@ export function renderer(options: RendererOptions<ChessStep[]>) {
   let currentBoardElement: HTMLElement | null = null;
   let currentStatusTextElement: HTMLParagraphElement | null = null;
   let currentWinnerTextElement: HTMLElement | null = null;
+  let currentForfeitReasonElement: HTMLElement | null = null;
   let currentRendererContainer: HTMLElement | null = null;
   let currentBoardContainer: HTMLElement | null = null;
   let currentTitleElement: HTMLElement | null = null;
@@ -189,8 +190,26 @@ export function renderer(options: RendererOptions<ChessStep[]>) {
       fontSize: isMobile ? '0.9rem' : '1.1rem',
       fontWeight: '700',
       margin: '5px 0 0 0',
+      overflowWrap: 'break-word',
+      wordBreak: 'break-word',
     });
     statusContainer.appendChild(currentWinnerTextElement);
+
+    // Forfeit reason lives in its own sibling div so it can render as a
+    // block (a div inside a <p> would auto-close the <p> in browsers, and
+    // it lets us style/wrap it independently of the winner heading).
+    currentForfeitReasonElement = document.createElement('div');
+    Object.assign(currentForfeitReasonElement.style, {
+      fontSize: isMobile ? '0.75rem' : '0.85rem',
+      fontWeight: '400',
+      fontStyle: 'italic',
+      color: '#666',
+      marginTop: '4px',
+      lineHeight: '1.3',
+      overflowWrap: 'break-word',
+      wordBreak: 'break-word',
+    });
+    statusContainer.appendChild(currentForfeitReasonElement);
 
     return true;
   }
@@ -213,8 +232,8 @@ export function renderer(options: RendererOptions<ChessStep[]>) {
     const containerHeight = currentBoardContainer?.clientHeight ?? height;
     let smallestContainerEdge = Math.min(containerWidth, containerHeight);
     // This is greedily trying to take as much space as possible, which can cause some conflict with flex box calculations for other elements
-    // we are going to take 24px off (arbitrary) to give the flex box renderer a bit of space to work with. Without it we will get some clipping.
-    smallestContainerEdge = smallestContainerEdge > 200 ? smallestContainerEdge - 24 : smallestContainerEdge;
+    // We reserve 64px so the status banner below (which grows on the terminal step to show the winner + forfeit reason) always fits without resizing the board.
+    smallestContainerEdge = smallestContainerEdge > 200 ? smallestContainerEdge - 64 : smallestContainerEdge;
     const newSquareSize = Math.floor(smallestContainerEdge / displayCols);
 
     if (newSquareSize !== squareSize) {
@@ -264,18 +283,18 @@ export function renderer(options: RendererOptions<ChessStep[]>) {
     // Render status text
     currentStatusTextElement.innerHTML = '';
     currentWinnerTextElement.innerHTML = '';
+    if (currentForfeitReasonElement) currentForfeitReasonElement.textContent = '';
     if (chessStep.isTerminal) {
-      const escapeHtml = (s: string) =>
-        s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
-      const forfeitHtml = chessStep.forfeitReason
-        ? `<div style="font-size: ${isMobile ? '0.75rem' : '0.85rem'}; font-weight: 400; font-style: italic; color: #666; margin-top: 4px; max-width: 600px;">${escapeHtml(chessStep.forfeitReason)}</div>`
-        : '';
       if (isMobile) {
         currentStatusTextElement.innerHTML = `<div style="font-size: 0.9rem; color: #666;">Winner</div>`;
-        currentWinnerTextElement.innerHTML = `<div style="font-size: 1.1rem; font-weight: bold;">${chessStep.winner}</div>${forfeitHtml}`;
+        currentWinnerTextElement.innerHTML = `<div style="font-size: 1.1rem; font-weight: bold;">${chessStep.winner}</div>`;
       } else {
         currentStatusTextElement.textContent = '';
-        currentWinnerTextElement.innerHTML = `<span style="font-weight: bold; color: black;">${chessStep.winner}</span>${forfeitHtml}`;
+        currentWinnerTextElement.innerHTML = `<span style="font-weight: bold; color: black;">${chessStep.winner}</span>`;
+      }
+      if (currentForfeitReasonElement && chessStep.forfeitReason) {
+        // textContent (not innerHTML) — escapes any markup in the reason.
+        currentForfeitReasonElement.textContent = chessStep.forfeitReason;
       }
     } else {
       const currentPlayer = chessStep.players.find((player) => player.isTurn);

--- a/kaggle_environments/envs/open_spiel_env/games/chess/visualizer/default/src/transformers/chessReplayTypes.ts
+++ b/kaggle_environments/envs/open_spiel_env/games/chess/visualizer/default/src/transformers/chessReplayTypes.ts
@@ -1,7 +1,28 @@
 import { BaseGamePlayer, BaseGameStep } from '@kaggle-environments/core';
 
+/** One LLM call attempt within a single turn (initial + any retries). */
+export interface ChessAttempt {
+  /** Full LLM response text for this attempt. */
+  response: string;
+}
+
 export interface ChessPlayer extends BaseGamePlayer {
   reward: number | null;
+  /**
+   * All LLM attempts on this turn (length 1 = no retries; >1 = retried).
+   * Order is initial → retry 1 → retry 2 → … Only the final attempt was
+   * actually submitted (or, on forfeit, all attempts failed and the
+   * player submitted -1).
+   */
+  attempts?: ChessAttempt[];
+  /** True when this player forfeited on this turn (submission === -1 with a non-null action.status). */
+  forfeited?: boolean;
+  /**
+   * Last attempted move string when the player forfeited. Comes from the
+   * harness's actionString (the raw move the parser rejected). null on
+   * non-forfeit turns.
+   */
+  forfeitLastAttempt?: string | null;
 }
 
 export interface FenState {
@@ -64,6 +85,7 @@ export interface ChessReplay {
 interface ChessReplayStep {
   action?: {
     actionString?: string;
+    call_details?: Array<{ response?: string }>;
     generate_returns?: string[];
     status?: string;
     submission: number;

--- a/kaggle_environments/envs/open_spiel_env/games/chess/visualizer/default/src/transformers/chessTransformer.ts
+++ b/kaggle_environments/envs/open_spiel_env/games/chess/visualizer/default/src/transformers/chessTransformer.ts
@@ -1,4 +1,4 @@
-import { ChessReplay, ChessPlayer, ChessStep, FenState } from './chessReplayTypes';
+import { ChessAttempt, ChessReplay, ChessPlayer, ChessStep, FenState } from './chessReplayTypes';
 
 function parseFen(fen?: string): FenState {
   if (!fen || typeof fen !== 'string') {
@@ -60,7 +60,58 @@ export function getChessStepDescription(step: ChessStep) {
     return step.forfeitReason ? `${winner}\n${step.forfeitReason}` : winner;
   }
 
-  return step.players.find((player) => player.isTurn)?.thoughts ?? '';
+  const player = step.players.find((p) => p.isTurn);
+  if (!player) return '';
+  return renderAttemptsMarkdown(player);
+}
+
+/**
+ * Render a player's per-attempt LLM calls as markdown. When there's only one
+ * attempt this collapses to just the response (the legacy behavior). When
+ * there are retries each attempt gets a header showing its outcome:
+ *   - intermediate attempts → ❌ Attempt N (illegal — retried)
+ *   - final attempt on a successful turn → ✅ Attempt N (submitted)
+ *   - all attempts on a forfeit → ❌ Attempt N (illegal — forfeited on last)
+ *
+ * Falls back to player.thoughts if call_details aren't available (older
+ * replays from before the harness wrote call_details).
+ */
+function renderAttemptsMarkdown(player: ChessPlayer): string {
+  const attempts = player.attempts ?? [];
+  const fallback = player.thoughts ?? '';
+
+  if (attempts.length === 0) return fallback;
+
+  if (attempts.length === 1 && !player.forfeited) {
+    // Single legal attempt — keep the original clean rendering.
+    return attempts[0].response || fallback;
+  }
+
+  const total = attempts.length;
+  const lines: string[] = [];
+
+  if (player.forfeited) {
+    const lastMove = player.forfeitLastAttempt ? ` \`${player.forfeitLastAttempt}\`` : '';
+    lines.push(`> ⚠️ **Forfeited after ${total} attempt${total === 1 ? '' : 's'}.** Last attempt:${lastMove}`);
+    lines.push('');
+  } else {
+    lines.push(`> 🔁 **Took ${total} attempts** to find a legal move.`);
+    lines.push('');
+  }
+
+  attempts.forEach((attempt, i) => {
+    const isLast = i === attempts.length - 1;
+    const ok = isLast && !player.forfeited;
+    const tag = ok
+      ? `✅ **Attempt ${i + 1} of ${total}** (submitted)`
+      : `❌ **Attempt ${i + 1} of ${total}** (illegal — ${isLast ? 'forfeited' : 'retried'})`;
+    lines.push(`### ${tag}`);
+    lines.push('');
+    lines.push(attempt.response || '_(empty response)_');
+    lines.push('');
+  });
+
+  return lines.join('\n').trim();
 }
 
 export function deriveWinnerFromRewards(players: ChessPlayer[]) {
@@ -85,6 +136,11 @@ export function deriveWinnerFromRewards(players: ChessPlayer[]) {
  *   ERROR   — agent crashed or response was unparsable / cut off
  *   INVALID — submitted an illegal move
  * In all three cases the opponent wins by default.
+ *
+ * Note: when illegalMoveForfeit:true and the env's INVALID branch runs, both
+ * players' top-level status gets overwritten to DONE — the per-player forfeit
+ * is only visible via action.submission === -1 + a non-null action.status on
+ * the offender. detectForfeitLoser() below handles that case.
  */
 const FORFEIT_STATUSES = new Set(['TIMEOUT', 'ERROR', 'INVALID']);
 
@@ -100,6 +156,48 @@ function describeForfeit(status: string): string {
   }
 }
 
+/**
+ * Find the index of the player who forfeited, or -1 if there's no
+ * unambiguous single forfeiter. Returns ``{loserIndex, reason}``.
+ *
+ * Two signals:
+ *   1. Top-level player.status in FORFEIT_STATUSES — used in strict mode
+ *      and for ERROR/TIMEOUT cases where the env doesn't overwrite status.
+ *   2. action.submission === -1 with a non-null action.status — used for
+ *      the illegalMoveForfeit:true path, where the env normalizes both
+ *      top-level statuses to DONE but leaves the offender's self-reported
+ *      forfeit message on action.status.
+ *
+ * Returns -1 / null when no detector fires OR when both players match
+ * (genuinely undetermined — episode voided).
+ */
+function detectForfeitLoser(rawLastStep: any[]): { loserIndex: number; reason: string | null } {
+  if (rawLastStep.length < 2) return { loserIndex: -1, reason: null };
+
+  const statusForfeits = rawLastStep
+    .map((player, index) => (FORFEIT_STATUSES.has(player.status) ? index : -1))
+    .filter((index) => index !== -1);
+  if (statusForfeits.length === 1) {
+    const i = statusForfeits[0];
+    return { loserIndex: i, reason: describeForfeit(rawLastStep[i].status) };
+  }
+  if (statusForfeits.length > 1) {
+    return { loserIndex: -1, reason: null };
+  }
+
+  const actionForfeits = rawLastStep
+    .map((player, index) => (player.action?.submission === -1 && player.action?.status ? index : -1))
+    .filter((index) => index !== -1);
+  if (actionForfeits.length === 1) {
+    // Reuse INVALID phrasing — submission=-1 is the same forfeit-by-illegal-
+    // move mechanism, just routed through the env's invalid_action branch
+    // (which normalizes top-level status to DONE).
+    return { loserIndex: actionForfeits[0], reason: describeForfeit('INVALID') };
+  }
+
+  return { loserIndex: -1, reason: null };
+}
+
 export const chessTransformer = (environment: any) => {
   const chessReplay = environment as ChessReplay;
   const agents = environment.info.TeamNames;
@@ -108,15 +206,27 @@ export const chessTransformer = (environment: any) => {
 
   chessReplay.steps.forEach((step, index) => {
     // Each step contains a tuple of players, one who acted and one who's waiting
-    const stepPlayers: ChessPlayer[] = step.map((player, index): ChessPlayer => {
+    const stepPlayers: ChessPlayer[] = step.map((player, playerIndex): ChessPlayer => {
+      const attempts: ChessAttempt[] = player.action?.call_details?.map((c) => ({ response: c.response ?? '' })) ?? [];
+      // A forfeit step is one where the player submitted -1 *and* the harness
+      // wrote a self-reported status (action.status). Inactive turns also
+      // have submission === -1 but with null action.status.
+      const forfeited = player.action?.submission === -1 && !!player.action?.status;
       return {
-        id: index,
-        name: agents[index],
+        id: playerIndex,
+        name: agents[playerIndex],
         thumbnail: '',
-        isTurn: player.action?.submission !== -1,
-        actionDisplayText: player.action?.actionString ?? '',
+        // Treat forfeits as a "turn" too so the reasoning panel surfaces the
+        // attempts — the player did act, they just failed every attempt.
+        isTurn: player.action?.submission !== -1 || forfeited,
+        actionDisplayText: forfeited
+          ? `(forfeited: ${player.action?.actionString ?? 'no move'})`
+          : (player.action?.actionString ?? ''),
         thoughts: player.action?.thoughts ?? '',
         reward: player.reward,
+        attempts,
+        forfeited,
+        forfeitLastAttempt: forfeited ? (player.action?.actionString ?? null) : null,
       };
     });
 
@@ -134,21 +244,40 @@ export const chessTransformer = (environment: any) => {
   });
 
   const lastStep = chessSteps[chessSteps.length - 1];
-  const winDescription = deriveWinnerFromRewards(lastStep.players);
+
+  // The raw terminal step is the only place rewards are populated — earlier
+  // steps have reward: null. The chessSteps filter above drops any step
+  // where neither player has isTurn (submission !== -1), which means the
+  // terminal step (both submitted -1) gets dropped when the game ended by
+  // forfeit. Always pull rewards and statuses from the raw last step.
+  const rawLastStep = chessReplay.steps[chessReplay.steps.length - 1] ?? [];
+  const terminalPlayers: ChessPlayer[] =
+    rawLastStep.length >= 2
+      ? lastStep.players.map((p, i) => ({ ...p, reward: rawLastStep[i]?.reward ?? null }))
+      : lastStep.players;
 
   // If the loser exceeded their time budget / errored / submitted an illegal
-  // move, open_spiel_env marks their final status as TIMEOUT/ERROR/INVALID
-  // and gives the opponent the win. Surface this so the UI doesn't imply a
-  // normal checkmate/draw outcome.
+  // move, declare the opponent the winner. Otherwise fall back to the
+  // rewards-based detection (normal checkmate/stalemate paths).
+  let winDescription: string;
   let forfeitReason: string | null = null;
-  const rawLastStep = chessReplay.steps[chessReplay.steps.length - 1] ?? [];
-  const loserIndex = rawLastStep.findIndex((player) => FORFEIT_STATUSES.has(player.status));
-  if (loserIndex !== -1 && rawLastStep.length >= 2) {
+  const { loserIndex, reason } = detectForfeitLoser(rawLastStep);
+
+  if (loserIndex !== -1) {
     const winnerIndex = 1 - loserIndex;
     const loserName = agents[loserIndex] || `Player ${loserIndex + 1}`;
     const winnerName = agents[winnerIndex] || `Player ${winnerIndex + 1}`;
-    const reason = describeForfeit(rawLastStep[loserIndex].status);
+    const winnerColor = winnerIndex === 0 ? 'Black' : 'White';
     forfeitReason = `${loserName} ${reason}. ${winnerName} wins by default.`;
+    winDescription = `🎉 ${winnerColor} (${winnerName}) Wins!`;
+  } else {
+    winDescription = deriveWinnerFromRewards(terminalPlayers);
+    const multiStatusForfeit = rawLastStep.filter((p) => FORFEIT_STATUSES.has(p.status)).length > 1;
+    if (multiStatusForfeit) {
+      // Both players forfeited (e.g. non-strict mode where any agent error
+      // marks everyone ERROR). The episode is voided rather than a draw.
+      forfeitReason = 'Both players failed to produce valid input; episode voided.';
+    }
   }
 
   // Artificially insert a step at the end to emphasize the win state


### PR DESCRIPTION
Before:

<img width="2560" height="1247" alt="image" src="https://github.com/user-attachments/assets/c5d3801d-b611-446d-9b8e-bc02bdb4442e" />


After:

<img width="2309" height="1314" alt="image" src="https://github.com/user-attachments/assets/1d8dac45-c46d-4ba8-b663-7c794ba6b8f0" />

I think at some point open_spiel added better support in the replay files for forfiet, but we didn't update the visualizer to pick it up correctly. Wonder if we should have some reviewer check for open_spiel updates to make sure we pickup replay format changes in our visualizer... but problem for a different day.