### PR TITLE
Remove misleading strategy hint from coin_game_arena prompt

### DIFF
--- a/kaggle_environments/envs/open_spiel_env/games/coin_game_arena/harness.py
+++ b/kaggle_environments/envs/open_spiel_env/games/coin_game_arena/harness.py
@@ -71,8 +71,9 @@ Current state of your team's board (JSON):
 Move history on your team's board so far (most recent last):
 {move_history_str}
 
-{moves_remaining_this_board} of {episode_length} moves remain on
-your team's board.
+This is your move {your_move_number} of {seat_total} on your team's
+board. Your teammate has {teammate_remaining} moves remaining.
+(Your team's board has {episode_length} moves total; seats alternate.)
 
 It is now your turn. Choose your move.
 The move MUST be one of: up, down, left, right, stand.
@@ -183,13 +184,26 @@ def generate_prompt(
 
     board = obs.get("board", {})
     history = board.get("move_history") or []
-    # Per-board moves remaining (engine's obs.moves_remaining counts BOTH
-    # boards' steps, which mixes units with episode_length above). One
-    # entry in history per move taken on this board, so subtract.
-    moves_remaining_this_board = max(0, episode_length - len(history))
+    # Per-seat counts: the model is a single seat, so framing remaining
+    # moves as a per-board total (which the seats split) invites a 2x
+    # planning-horizon error. Surface this seat's and the teammate's
+    # personal horizons instead.
+    seat_played = sum(1 for entry in history if entry.get("seat") == seat)
+    teammate_played = sum(
+        1 for entry in history if entry.get("seat") == teammate_seat
+    )
+    seat_total = max(
+        0, (episode_length - seat + players_per_team - 1) // players_per_team
+    )
+    teammate_total = max(
+        0,
+        (episode_length - teammate_seat + players_per_team - 1) // players_per_team,
+    )
+    your_move_number = seat_played + 1
+    teammate_remaining = max(0, teammate_total - teammate_played)
     # Emit a compact subset of the board view to the model. No
-    # moves_remaining here — it's surfaced as a separate sentence below
-    # to avoid a unit mismatch with episode_length.
+    # moves_remaining here — it's surfaced as separate per-seat
+    # sentences below to avoid a unit mismatch with episode_length.
     board_view = {
         "board": board.get("board"),
         "player_positions": board.get("player_positions"),
@@ -218,7 +232,9 @@ def generate_prompt(
         your_pref=your_pref,
         board_str=board_str,
         move_history_str=move_history_str,
-        moves_remaining_this_board=moves_remaining_this_board,
+        your_move_number=your_move_number,
+        seat_total=seat_total,
+        teammate_remaining=teammate_remaining,
     )
 
     prompt += render_rethink_suffix(

--- a/kaggle_environments/envs/open_spiel_env/games/coin_game_arena/harness.py
+++ b/kaggle_environments/envs/open_spiel_env/games/coin_game_arena/harness.py
@@ -57,11 +57,6 @@ collected by anyone on your board; bad_coins = coins of unowned colours
 (not preferred by either teammate) collected by anyone on your board.
 The team with the higher total reward wins. Ties are draws.
 
-Strategy: collect your preferred colour, leave your teammate's
-preference for them, and AVOID coins of unowned colours (each one
-collected hurts both of you quadratically). You don't know your
-teammate's preference up front — infer it from what they pick up.
-
 Cells are ``"."`` for empty, digits for players (the player ids shown
 below, not the seat indices), lowercase letters for coin colours.
 Coordinates are ``[row, column]`` with ``row=0`` at the top.

--- a/tests/envs/open_spiel_env/games/coin_game_arena/harness_test.py
+++ b/tests/envs/open_spiel_env/games/coin_game_arena/harness_test.py
@@ -229,21 +229,32 @@ class GeneratePromptTest(absltest.TestCase):
         self.assertIn("You suggested", prompt)  # ILLEGAL leads with action
         self.assertIn("diagonal", prompt)
 
-    def test_per_board_moves_remaining(self):
-        # Per-board countdown is computed from the team's own move
-        # history length, NOT the engine's global moves_remaining (which
-        # counts both boards in the same units as episode_length=per-board
-        # and would mislead the model into thinking it has twice the
-        # runway it does).
+    def test_per_seat_move_horizon(self):
+        # The model is a single seat, so the prompt must surface its
+        # personal move horizon -- not the per-board total, which the
+        # two seats split. Misframing as per-board invites a 2x
+        # planning-horizon error ("I have 20 moves" when really 10).
         s = _state(seed=7, episode_length=20)
-        # 2 of player 0's team's seats move on this board (1 per global
-        # tick alternating teams: actions 0 and 2 land on team A's board).
-        s.apply_action(3)  # player 0
-        s.apply_action(2)  # player 2
-        s.apply_action(1)  # player 1
-        s.apply_action(0)  # player 3
+        # Drive one full round: each seat on each board moves once.
+        s.apply_action(3)  # player 0 (team A seat 0)
+        s.apply_action(2)  # player 2 (team B seat 0)
+        s.apply_action(1)  # player 1 (team A seat 1)
+        s.apply_action(0)  # player 3 (team B seat 1)
+        # Now player 0 is up again -- their second personal move; their
+        # teammate has 9 personal moves remaining.
         prompt = generate_prompt(_make_observation(s, 0), [])
-        self.assertIn("18 of 20 moves remain", prompt)
+        flat = " ".join(prompt.split())
+        self.assertIn("your move 2 of 10", flat)
+        self.assertIn("teammate has 9 moves remaining", flat)
+        self.assertIn("20 moves total", flat)
+
+    def test_first_move_shows_full_personal_horizon(self):
+        # Sanity: at the very start, the first mover sees "move 1 of 10".
+        s = _state(seed=7, episode_length=20)
+        prompt = generate_prompt(_make_observation(s, 0), [])
+        flat = " ".join(prompt.split())
+        self.assertIn("your move 1 of 10", flat)
+        self.assertIn("teammate has 10 moves remaining", flat)
 
     def test_no_op_rule_in_prompt(self):
         prompt = generate_prompt(_make_observation(_state(seed=7), 0), [])


### PR DESCRIPTION
The per-board reward formula is symmetric across the two teammates (both score self_pref^2 + other_pref^2 - bad_coins^2 over the same team-wide coin counts), so 'leave your teammate's preference for them' had no scoring basis and could push the model to skip coins it should collect. Drop the paragraph and let the rules speak for themselves.