### PR TITLE
Add web visualizer for reinforce_tactics

### DIFF
--- a/kaggle_environments/envs/reinforce_tactics/reinforce_tactics.py
+++ b/kaggle_environments/envs/reinforce_tactics/reinforce_tactics.py
@@ -680,7 +680,11 @@ def renderer(state, env):
 # HTML Renderer
 # ---------------------------------------------------------------------------
 def html_renderer():
-    """Return JavaScript for browser-based rendering (placeholder)."""
+    """Return the built visualizer HTML, or an empty string if not built yet."""
+    htmlpath = path.join(_dirpath, "visualizer", "default", "dist", "index.html")
+    if path.exists(htmlpath):
+        with open(htmlpath, encoding="utf-8") as f:
+            return f.read()
     return ""
 
 

--- a/kaggle_environments/envs/reinforce_tactics/visualizer/default/e2e/reinforce_tactics.test.ts
+++ b/kaggle_environments/envs/reinforce_tactics/visualizer/default/e2e/reinforce_tactics.test.ts
@@ -1,0 +1,36 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Reinforce Tactics Visualizer', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+  });
+
+  test('renders the game', async ({ page }) => {
+    await expect(page.locator('.renderer-container')).toBeVisible();
+    await expect(page.locator('.renderer-container canvas')).toBeVisible();
+    await expect(page.locator('.player-card').first()).toBeVisible();
+    await expect(page.locator('.status-container')).toBeVisible();
+  });
+
+  test('displays game state at mid-game', async ({ page }) => {
+    const slider = page.locator('input[type="range"]');
+    await slider.waitFor({ state: 'visible' });
+    const maxValue = await slider.getAttribute('max');
+    const midStep = Math.floor(parseInt(maxValue || '0') / 2);
+    await slider.fill(String(midStep));
+    await page.waitForTimeout(200);
+
+    await expect(page.locator('.renderer-container canvas')).toBeVisible();
+    await expect(page.locator('.status-container')).toContainText(/Turn/);
+  });
+
+  test('displays winner status at final step', async ({ page }) => {
+    const slider = page.locator('input[type="range"]');
+    await slider.waitFor({ state: 'visible' });
+    const maxValue = await slider.getAttribute('max');
+    await slider.fill(maxValue || '0');
+    await page.waitForTimeout(200);
+
+    await expect(page.locator('.status-container')).toContainText(/wins|Draw/);
+  });
+});

--- a/kaggle_environments/envs/reinforce_tactics/visualizer/default/index.html
+++ b/kaggle_environments/envs/reinforce_tactics/visualizer/default/index.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Reinforce Tactics Visualizer</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=Mynerve&display=swap" rel="stylesheet" />
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="/src/main.ts"></script>
+  </body>
+</html>

--- a/kaggle_environments/envs/reinforce_tactics/visualizer/default/package.json
+++ b/kaggle_environments/envs/reinforce_tactics/visualizer/default/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@kaggle-environments/reinforce_tactics-visualizer",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "dev-with-replay": "cross-env VITE_REPLAY_FILE=./replays/test-replay.json vite",
+    "build": "tsc && vite build",
+    "preview": "vite preview"
+  },
+  "devDependencies": {
+    "cross-env": "^10.1.0",
+    "typescript": "^5.0.0",
+    "vite": "^5.0.0"
+  },
+  "dependencies": {
+    "@kaggle-environments/core": "workspace:*"
+  }
+}

--- a/kaggle_environments/envs/reinforce_tactics/visualizer/default/src/main.ts
+++ b/kaggle_environments/envs/reinforce_tactics/visualizer/default/src/main.ts
@@ -1,0 +1,21 @@
+import { createReplayVisualizer, ReplayAdapter } from '@kaggle-environments/core';
+import { renderer } from './renderer';
+import './style.css';
+
+const app = document.getElementById('app');
+if (!app) {
+  throw new Error('Could not find app element');
+}
+
+if (import.meta.env?.DEV && import.meta.hot) {
+  import.meta.hot.accept();
+}
+
+createReplayVisualizer(
+  app,
+  new ReplayAdapter({
+    gameName: 'reinforce_tactics',
+    renderer: renderer as any,
+    ui: 'side-panel',
+  })
+);

--- a/kaggle_environments/envs/reinforce_tactics/visualizer/default/src/renderer.ts
+++ b/kaggle_environments/envs/reinforce_tactics/visualizer/default/src/renderer.ts
@@ -1,0 +1,450 @@
+import type { RendererOptions } from '@kaggle-environments/core';
+
+interface Unit {
+  type: string;
+  owner: number;
+  x: number;
+  y: number;
+  hp: number;
+  maxHp: number;
+  canMove?: boolean;
+  canAttack?: boolean;
+  paralyzedTurns?: number;
+  isHasted?: boolean;
+  distanceMoved?: number;
+  defenceBuffTurns?: number;
+  attackBuffTurns?: number;
+}
+
+interface Structure {
+  x: number;
+  y: number;
+  type: string;
+  owner: number;
+  hp: number;
+  maxHp: number;
+}
+
+interface RTObservation {
+  board: string[][];
+  units: Unit[];
+  structures: Structure[];
+  gold: [number, number];
+  turnNumber: number;
+  mapWidth: number;
+  mapHeight: number;
+}
+
+interface RTAgentStep {
+  observation: Partial<RTObservation> & Record<string, any>;
+  action: any;
+  reward: number | null;
+  status: string;
+}
+
+type RTStep = RTAgentStep[];
+
+const TERRAIN_COLORS: Record<string, string> = {
+  p: '#dfe9c0', // grass
+  f: '#90b779', // forest
+  m: '#c2a987', // mountain
+  w: '#8cc1de', // water
+  r: '#e2d4ad', // road
+  b: '#f0dba1', // building (base)
+  h: '#f5cf72', // HQ (base)
+  t: '#dcd2ad', // tower (base)
+  o: '#6093b4', // ocean
+};
+
+const PLAYER_COLORS: Record<number, string> = {
+  0: '#888888',
+  1: '#2f5fa1', // blue
+  2: '#b03939', // red
+};
+
+const PLAYER_LIGHT: Record<number, string> = {
+  0: '#dcdcdc',
+  1: '#bcd0ec',
+  2: '#ecbcbc',
+};
+
+const STRUCT_NAMES: Record<string, string> = {
+  h: '★',
+  b: '■',
+  t: '▲',
+};
+
+function getObservation(step: RTStep | undefined): RTObservation | null {
+  if (!step || !step[0]) return null;
+  const obs = step[0].observation as RTObservation | undefined;
+  if (!obs || !obs.board) return null;
+  return obs;
+}
+
+function activePlayerIndex(step: RTStep | undefined): number | null {
+  if (!step) return null;
+  for (let i = 0; i < step.length; i++) {
+    if (step[i]?.status === 'ACTIVE') return i;
+  }
+  return null;
+}
+
+function lastActorActions(step: RTStep | undefined): { actorIdx: number | null; actions: any[] } {
+  if (!step) return { actorIdx: null, actions: [] };
+  let actorIdx: number | null = null;
+  let actions: any[] = [];
+  for (let i = 0; i < step.length; i++) {
+    const a = step[i]?.action;
+    if (Array.isArray(a) && a.length > 0) {
+      actorIdx = i;
+      actions = a;
+      break;
+    }
+  }
+  return { actorIdx, actions };
+}
+
+function summariseActions(actions: any[]): string {
+  if (!actions.length) return '';
+  const counts: Record<string, number> = {};
+  for (const a of actions) {
+    if (!a || typeof a !== 'object') continue;
+    const t = String(a.type ?? 'unknown');
+    if (t === 'end_turn') continue;
+    counts[t] = (counts[t] ?? 0) + 1;
+  }
+  const order = [
+    'create_unit',
+    'move',
+    'attack',
+    'seize',
+    'heal',
+    'cure',
+    'paralyze',
+    'haste',
+    'defence_buff',
+    'attack_buff',
+  ];
+  const parts: string[] = [];
+  for (const t of order) {
+    if (counts[t]) parts.push(`${counts[t]} ${t.replace('_', ' ')}`);
+  }
+  for (const t of Object.keys(counts)) {
+    if (!order.includes(t)) parts.push(`${counts[t]} ${t}`);
+  }
+  return parts.join(', ') || 'end turn';
+}
+
+function buildHighlights(prevObs: RTObservation | null, curObs: RTObservation, actions: any[]) {
+  const moved: Array<{ fromX: number; fromY: number; toX: number; toY: number }> = [];
+  const attacked: Array<{ x: number; y: number }> = [];
+  const created: Array<{ x: number; y: number }> = [];
+  const seized: Array<{ x: number; y: number }> = [];
+
+  for (const a of actions) {
+    if (!a || typeof a !== 'object') continue;
+    switch (a.type) {
+      case 'move':
+        moved.push({ fromX: a.from_x, fromY: a.from_y, toX: a.to_x, toY: a.to_y });
+        break;
+      case 'attack':
+      case 'paralyze':
+      case 'heal':
+      case 'cure':
+      case 'haste':
+      case 'defence_buff':
+      case 'attack_buff':
+        attacked.push({ x: a.to_x, y: a.to_y });
+        break;
+      case 'create_unit':
+        created.push({ x: a.x, y: a.y });
+        break;
+      case 'seize':
+        seized.push({ x: a.x, y: a.y });
+        break;
+    }
+  }
+
+  // Fallback: if no actions list (e.g. step 0), diff state
+  if (!actions.length && prevObs) {
+    const prevByPos = new Map<string, Unit>();
+    for (const u of prevObs.units) prevByPos.set(`${u.x},${u.y}`, u);
+    for (const u of curObs.units) {
+      const key = `${u.x},${u.y}`;
+      if (!prevByPos.has(key)) created.push({ x: u.x, y: u.y });
+    }
+  }
+
+  return { moved, attacked, created, seized };
+}
+
+export function renderer(options: RendererOptions) {
+  const { step, replay, parent } = options;
+  const steps = (replay.steps as unknown as RTStep[]) || [];
+  const curStep = steps[step];
+  const prevStep = step > 0 ? steps[step - 1] : null;
+
+  parent.innerHTML = `
+    <div class="renderer-container">
+      <div class="header"></div>
+      <canvas></canvas>
+      <div class="status-container sketched-border"></div>
+    </div>
+  `;
+  const header = parent.querySelector('.header') as HTMLDivElement;
+  const canvas = parent.querySelector('canvas') as HTMLCanvasElement;
+  const statusContainer = parent.querySelector('.status-container') as HTMLDivElement;
+
+  const curObs = getObservation(curStep);
+  if (!canvas || !curObs) return;
+
+  // --- Header ---
+  const activeIdx = activePlayerIndex(curStep);
+  const finalStep = curStep?.some((s) => s.status === 'DONE');
+  const unitCounts: [number, number] = [0, 0];
+  for (const u of curObs.units) {
+    if (u.owner === 1) unitCounts[0]++;
+    if (u.owner === 2) unitCounts[1]++;
+  }
+  const structCounts: [number, number] = [0, 0];
+  for (const s of curObs.structures) {
+    if (s.owner === 1) structCounts[0]++;
+    if (s.owner === 2) structCounts[1]++;
+  }
+  const gold = curObs.gold ?? [0, 0];
+
+  header.innerHTML = '';
+  for (let i = 0; i < 2; i++) {
+    const card = document.createElement('div');
+    card.className = `player-card sketched-border${activeIdx === i && !finalStep ? ' active' : ''}`;
+    const nameColor = PLAYER_COLORS[i + 1];
+    card.innerHTML = `
+      <div class="player-name" style="color: ${nameColor};">Player ${i + 1}</div>
+      <div class="player-stats">
+        <span>${gold[i]}g</span>
+        <span>${unitCounts[i]} units</span>
+        <span>${structCounts[i]} bldgs</span>
+      </div>
+    `;
+    header.appendChild(card);
+    if (i === 0) {
+      const vs = document.createElement('span');
+      vs.className = 'vs-label';
+      vs.textContent = 'vs';
+      header.appendChild(vs);
+    }
+  }
+
+  // --- Canvas board ---
+  canvas.width = 0;
+  canvas.height = 0;
+  const rect = canvas.getBoundingClientRect();
+  const dpr = window.devicePixelRatio || 1;
+  canvas.width = rect.width * dpr;
+  canvas.height = rect.height * dpr;
+  const c = canvas.getContext('2d');
+  if (!c) return;
+  c.scale(dpr, dpr);
+
+  const W = rect.width;
+  const H = rect.height;
+  const mapW = curObs.mapWidth;
+  const mapH = curObs.mapHeight;
+  const cell = Math.floor(Math.min(W / mapW, H / mapH));
+  const boardW = cell * mapW;
+  const boardH = cell * mapH;
+  const xOff = (W - boardW) / 2;
+  const yOff = (H - boardH) / 2;
+
+  c.clearRect(0, 0, W, H);
+
+  // Lookup structure by position to colour terrain by ownership
+  const structByPos = new Map<string, Structure>();
+  for (const s of curObs.structures) structByPos.set(`${s.x},${s.y}`, s);
+
+  // Draw terrain
+  for (let y = 0; y < mapH; y++) {
+    for (let x = 0; x < mapW; x++) {
+      const tile = curObs.board[y]?.[x] ?? 'o';
+      const base = TERRAIN_COLORS[tile] ?? '#cccccc';
+      const px = xOff + x * cell;
+      const py = yOff + y * cell;
+      c.fillStyle = base;
+      c.fillRect(px, py, cell, cell);
+
+      // Ownership tint for capturable structures
+      const struct = structByPos.get(`${x},${y}`);
+      if (struct && struct.owner) {
+        c.fillStyle = PLAYER_LIGHT[struct.owner] ?? '#dddddd';
+        c.globalAlpha = 0.55;
+        c.fillRect(px, py, cell, cell);
+        c.globalAlpha = 1;
+      }
+    }
+  }
+
+  // Grid lines
+  c.strokeStyle = '#3c3b37';
+  c.lineWidth = 1;
+  c.globalAlpha = 0.3;
+  c.beginPath();
+  for (let x = 0; x <= mapW; x++) {
+    const px = xOff + x * cell;
+    c.moveTo(px, yOff);
+    c.lineTo(px, yOff + boardH);
+  }
+  for (let y = 0; y <= mapH; y++) {
+    const py = yOff + y * cell;
+    c.moveTo(xOff, py);
+    c.lineTo(xOff + boardW, py);
+  }
+  c.stroke();
+  c.globalAlpha = 1;
+
+  // Structure labels (HQ flag, tower marker, etc.)
+  c.font = `${Math.max(8, Math.floor(cell * 0.36))}px 'Inter', sans-serif`;
+  c.textAlign = 'center';
+  c.textBaseline = 'middle';
+  for (const s of curObs.structures) {
+    const px = xOff + s.x * cell + cell / 2;
+    const py = yOff + s.y * cell + cell / 2;
+    const label = STRUCT_NAMES[s.type] ?? '';
+    if (label) {
+      const owner = s.owner;
+      c.fillStyle = owner ? PLAYER_COLORS[owner] : '#555';
+      c.fillText(label, px, py);
+    }
+  }
+
+  // Action highlights
+  const prevObs = getObservation(prevStep ?? undefined);
+  const { actorIdx: lastActorIdx, actions: acts } = lastActorActions(curStep);
+  const hl = buildHighlights(prevObs, curObs, acts);
+
+  // Move arrows
+  c.lineWidth = Math.max(2, cell * 0.08);
+  c.strokeStyle = 'rgba(50, 50, 50, 0.7)';
+  for (const m of hl.moved) {
+    const fx = xOff + m.fromX * cell + cell / 2;
+    const fy = yOff + m.fromY * cell + cell / 2;
+    const tx = xOff + m.toX * cell + cell / 2;
+    const ty = yOff + m.toY * cell + cell / 2;
+    c.beginPath();
+    c.moveTo(fx, fy);
+    c.lineTo(tx, ty);
+    c.stroke();
+    // origin marker
+    c.fillStyle = 'rgba(50, 50, 50, 0.4)';
+    c.beginPath();
+    c.arc(fx, fy, cell * 0.12, 0, Math.PI * 2);
+    c.fill();
+  }
+
+  // Attack/cast targets
+  for (const t of hl.attacked) {
+    const tx = xOff + t.x * cell + cell / 2;
+    const ty = yOff + t.y * cell + cell / 2;
+    c.strokeStyle = '#c62828';
+    c.lineWidth = Math.max(2, cell * 0.08);
+    c.beginPath();
+    c.arc(tx, ty, cell * 0.45, 0, Math.PI * 2);
+    c.stroke();
+  }
+
+  // Created units
+  for (const t of hl.created) {
+    const px = xOff + t.x * cell;
+    const py = yOff + t.y * cell;
+    c.strokeStyle = '#2e7d32';
+    c.setLineDash([4, 3]);
+    c.lineWidth = Math.max(1.5, cell * 0.06);
+    c.strokeRect(px + 1, py + 1, cell - 2, cell - 2);
+    c.setLineDash([]);
+  }
+
+  // Seized targets
+  for (const t of hl.seized) {
+    const px = xOff + t.x * cell;
+    const py = yOff + t.y * cell;
+    c.strokeStyle = '#fbc02d';
+    c.lineWidth = Math.max(2, cell * 0.1);
+    c.strokeRect(px + 1, py + 1, cell - 2, cell - 2);
+  }
+
+  // Units
+  const unitRadius = cell * 0.4;
+  const unitFont = Math.max(9, Math.floor(cell * 0.55));
+  for (const u of curObs.units) {
+    const px = xOff + u.x * cell + cell / 2;
+    const py = yOff + u.y * cell + cell / 2;
+    const color = PLAYER_COLORS[u.owner] ?? '#666';
+
+    // body
+    c.fillStyle = color;
+    c.beginPath();
+    c.arc(px, py, unitRadius, 0, Math.PI * 2);
+    c.fill();
+    c.lineWidth = Math.max(1, cell * 0.04);
+    c.strokeStyle = '#050001';
+    c.stroke();
+
+    // letter
+    c.fillStyle = '#ffffff';
+    c.font = `700 ${unitFont}px 'Inter', sans-serif`;
+    c.textAlign = 'center';
+    c.textBaseline = 'middle';
+    c.fillText(u.type, px, py + 1);
+
+    // HP bar
+    const hpFrac = Math.max(0, Math.min(1, u.hp / Math.max(1, u.maxHp)));
+    const barW = cell * 0.7;
+    const barH = Math.max(2, cell * 0.08);
+    const bx = px - barW / 2;
+    const by = py + unitRadius + 1;
+    c.fillStyle = '#3c3b37';
+    c.fillRect(bx, by, barW, barH);
+    c.fillStyle = hpFrac > 0.5 ? '#4caf50' : hpFrac > 0.25 ? '#ff9800' : '#e53935';
+    c.fillRect(bx, by, barW * hpFrac, barH);
+
+    // status badges (paralyzed, hasted, buffs)
+    const badges: string[] = [];
+    if (u.paralyzedTurns && u.paralyzedTurns > 0) badges.push('P');
+    if (u.isHasted) badges.push('H');
+    if (u.attackBuffTurns && u.attackBuffTurns > 0) badges.push('A');
+    if (u.defenceBuffTurns && u.defenceBuffTurns > 0) badges.push('D');
+    if (badges.length) {
+      c.font = `700 ${Math.max(8, Math.floor(cell * 0.25))}px 'Inter', sans-serif`;
+      c.fillStyle = '#050001';
+      c.textAlign = 'left';
+      c.fillText(badges.join(''), px + unitRadius * 0.6, py - unitRadius * 0.7);
+    }
+  }
+
+  // --- Status ---
+  const turnNum = curObs.turnNumber ?? 0;
+  let statusHtml = '';
+  if (finalStep) {
+    const rewards = curStep.map((s) => s.reward ?? 0);
+    let msg = '';
+    let cls = 'status-container sketched-border winner';
+    if (rewards[0] === 1) msg = `Player 1 wins!`;
+    else if (rewards[1] === 1) msg = `Player 2 wins!`;
+    else {
+      msg = 'Draw';
+      cls = 'status-container sketched-border';
+    }
+    statusContainer.className = cls;
+    statusHtml = `<span>${msg}</span><span class="annotation">turn ${turnNum}</span>`;
+  } else {
+    statusContainer.className = 'status-container sketched-border';
+    const summary = summariseActions(acts);
+    const lastLabel =
+      lastActorIdx !== null && summary ? `<span class="annotation">P${lastActorIdx + 1}: ${summary}</span>` : '';
+    const actorLabel =
+      activeIdx !== null
+        ? `<span style="color: ${PLAYER_COLORS[activeIdx + 1]}; font-weight: 700;">P${activeIdx + 1}</span> to act`
+        : '';
+    statusHtml = `<span>Turn ${turnNum}</span>${actorLabel ? ' · ' + actorLabel : ''}${lastLabel ? ' · ' + lastLabel : ''}`;
+  }
+  statusContainer.innerHTML = statusHtml;
+}

--- a/kaggle_environments/envs/reinforce_tactics/visualizer/default/src/style.css
+++ b/kaggle_environments/envs/reinforce_tactics/visualizer/default/src/style.css
@@ -1,0 +1,129 @@
+@import url('https://fonts.googleapis.com/css2?family=Inter:ital,opsz,wght@0,14..32,100..900;1,14..32,100..900&display=swap');
+
+html,
+body,
+#app {
+  width: 100%;
+  height: 100%;
+  margin: 0;
+  padding: 0;
+  overflow: hidden;
+}
+
+.renderer-container {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  width: 100%;
+  height: 100%;
+  min-height: 0;
+  background-color: #f5f1e2;
+  overflow: hidden;
+  font-family: 'Inter', sans-serif;
+  box-sizing: border-box;
+  padding: 12px;
+  color: #050001;
+  container-type: inline-size;
+}
+
+.renderer-container canvas {
+  position: relative;
+  flex-grow: 1;
+  width: 100%;
+  max-width: 640px;
+  max-height: 640px;
+  min-height: 0;
+  aspect-ratio: 1;
+}
+
+.sketched-border {
+  border: 1px dashed #3c3b37;
+}
+
+.header {
+  display: flex;
+  justify-content: center;
+  align-items: stretch;
+  width: 100%;
+  padding: 8px 0;
+  font-size: 1rem;
+  font-weight: 600;
+  flex-shrink: 0;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.player-card {
+  padding: 6px 14px;
+  background-color: white;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  min-width: 140px;
+  transition:
+    scale 300ms,
+    background-color 300ms;
+}
+
+.player-card.active {
+  background-color: #bdeeff;
+  scale: 1.06;
+}
+
+.player-card .player-name {
+  font-weight: 700;
+  font-size: 1rem;
+}
+
+.player-card .player-stats {
+  font-size: 0.8rem;
+  color: #444343;
+  margin-top: 2px;
+  display: flex;
+  gap: 10px;
+}
+
+.vs-label {
+  align-self: center;
+  color: #444343;
+  font-family: 'Mynerve', cursive;
+  font-size: 1.2rem;
+}
+
+.status-container {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 6px 16px;
+  background-color: white;
+  font-size: 0.9rem;
+  font-weight: 600;
+  min-height: 18px;
+  min-width: 220px;
+  margin-top: 8px;
+  flex-shrink: 0;
+  text-align: center;
+  gap: 8px;
+}
+
+.status-container.winner {
+  background-color: #bdeeff;
+}
+
+.status-container .annotation {
+  font-family: 'Mynerve', cursive;
+  font-weight: 400;
+  color: #444343;
+  font-size: 0.95rem;
+}
+
+@container (max-width: 680px) {
+  .header {
+    font-size: 0.9rem;
+    gap: 8px;
+  }
+  .player-card {
+    min-width: 110px;
+    padding: 4px 8px;
+  }
+}

--- a/kaggle_environments/envs/reinforce_tactics/visualizer/default/tsconfig.json
+++ b/kaggle_environments/envs/reinforce_tactics/visualizer/default/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../../../../web/tsconfig.base.json",
+  "compilerOptions": {
+    "allowJs": true
+  },
+  "include": ["src"]
+}

--- a/kaggle_environments/envs/reinforce_tactics/visualizer/default/vite.config.ts
+++ b/kaggle_environments/envs/reinforce_tactics/visualizer/default/vite.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig, mergeConfig } from 'vite';
+import baseConfig from '../../../../../web/vite.config.base';
+
+export default mergeConfig(
+  baseConfig,
+  defineConfig({
+    publicDir: 'replays',
+  })
+);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -874,6 +874,22 @@ importers:
         specifier: ^2.1.4
         version: 2.1.9(@types/node@25.2.1)(happy-dom@20.8.9)(jsdom@25.0.1)
 
+  kaggle_environments/envs/reinforce_tactics/visualizer/default:
+    dependencies:
+      '@kaggle-environments/core':
+        specifier: workspace:*
+        version: link:../../../../../web/core
+    devDependencies:
+      cross-env:
+        specifier: ^10.1.0
+        version: 10.1.0
+      typescript:
+        specifier: ^5.0.0
+        version: 5.9.3
+      vite:
+        specifier: ^5.0.0
+        version: 5.4.21(@types/node@25.2.1)
+
   kaggle_environments/envs/rps/visualizer/default:
     dependencies:
       '@kaggle-environments/core':

--- a/web/scripts/validate-visualizer-conventions.js
+++ b/web/scripts/validate-visualizer-conventions.js
@@ -81,6 +81,7 @@ const KNOWN_STANDALONE_GAME_DIRS = new Set([
   'lux_ai_s3',
   'mab',
   'orbit_wars',
+  'reinforce_tactics',
   'rps',
   'werewolf',
   'word_association',


### PR DESCRIPTION
Adds a Vite + TypeScript visualizer for the reinforce_tactics environment with a canvas board, per-player gold/unit/structure header, move/attack/create highlights, and winner status. Wires html_renderer() to serve the built dist/index.html.