### PR TITLE
Fix reinforce_tactics simple_bot agent submission load error

### DIFF
--- a/kaggle_environments/envs/reinforce_tactics/agents/simple_bot_agent.py
+++ b/kaggle_environments/envs/reinforce_tactics/agents/simple_bot_agent.py
@@ -41,6 +41,53 @@ UNIT_MOVEMENT = {
 UNIT_PRIORITY = ["W", "A", "K", "B", "R", "M", "C", "S"]
 
 
+def _find_nearest_enemy(ux, uy, enemy_units):
+    """Find the nearest enemy unit by Manhattan distance."""
+    return min(enemy_units, key=lambda e: abs(ux - e["x"]) + abs(uy - e["y"]))
+
+
+def _get_attack_range(unit_type):
+    """Return (min_range, max_range) for a unit type."""
+    if unit_type in ("M", "S"):
+        return (1, 2)
+    if unit_type == "A":
+        return (2, 3)
+    return (1, 1)
+
+
+def _get_structure_at(structures, x, y):
+    """Find a structure at the given position."""
+    for s in structures:
+        if s["x"] == x and s["y"] == y:
+            return s
+    return None
+
+
+def _step_toward(from_x, from_y, to_x, to_y, board, occupied, map_w, map_h):
+    """
+    Return the best adjacent position that moves toward the target.
+    Uses simple greedy Manhattan distance minimisation.
+    """
+    best_pos = None
+    best_dist = abs(from_x - to_x) + abs(from_y - to_y)
+
+    non_walkable = {"w", "o"}
+
+    for dx, dy in [(0, -1), (0, 1), (-1, 0), (1, 0)]:
+        nx, ny = from_x + dx, from_y + dy
+        if 0 <= nx < map_w and 0 <= ny < map_h:
+            if (nx, ny) not in occupied:
+                tile = board[ny][nx] if ny < len(board) and nx < len(board[ny]) else "o"
+                if tile not in non_walkable:
+                    dist = abs(nx - to_x) + abs(ny - to_y)
+                    if dist < best_dist:
+                        best_dist = dist
+                        best_pos = (nx, ny)
+
+    return best_pos
+
+
+# NOTE: ``agent`` must remain the LAST callable defined; the Kaggle loader picks the last callable in the module.
 def agent(observation, configuration):
     """
     Simple strategic bot that creates units, attacks, and captures.
@@ -165,49 +212,3 @@ def agent(observation, configuration):
 
     actions.append({"type": "end_turn"})
     return actions
-
-
-def _find_nearest_enemy(ux, uy, enemy_units):
-    """Find the nearest enemy unit by Manhattan distance."""
-    return min(enemy_units, key=lambda e: abs(ux - e["x"]) + abs(uy - e["y"]))
-
-
-def _get_attack_range(unit_type):
-    """Return (min_range, max_range) for a unit type."""
-    if unit_type in ("M", "S"):
-        return (1, 2)
-    if unit_type == "A":
-        return (2, 3)
-    return (1, 1)
-
-
-def _get_structure_at(structures, x, y):
-    """Find a structure at the given position."""
-    for s in structures:
-        if s["x"] == x and s["y"] == y:
-            return s
-    return None
-
-
-def _step_toward(from_x, from_y, to_x, to_y, board, occupied, map_w, map_h):
-    """
-    Return the best adjacent position that moves toward the target.
-    Uses simple greedy Manhattan distance minimisation.
-    """
-    best_pos = None
-    best_dist = abs(from_x - to_x) + abs(from_y - to_y)
-
-    non_walkable = {"w", "o"}
-
-    for dx, dy in [(0, -1), (0, 1), (-1, 0), (1, 0)]:
-        nx, ny = from_x + dx, from_y + dy
-        if 0 <= nx < map_w and 0 <= ny < map_h:
-            if (nx, ny) not in occupied:
-                tile = board[ny][nx] if ny < len(board) and nx < len(board[ny]) else "o"
-                if tile not in non_walkable:
-                    dist = abs(nx - to_x) + abs(ny - to_y)
-                    if dist < best_dist:
-                        best_dist = dist
-                        best_pos = (nx, ny)
-
-    return best_pos

--- a/tests/envs/reinforce_tactics/test_reinforce_tactics.py
+++ b/tests/envs/reinforce_tactics/test_reinforce_tactics.py
@@ -134,6 +134,25 @@ def test_can_run_simple_bot_agents(make_env):
     assert final[1].status == "DONE"
 
 
+@pytest.mark.parametrize("agent_filename", ["random_agent.py", "simple_bot_agent.py"])
+def test_builtin_agent_files_loadable_as_submission(make_env, agent_filename):
+    """Regression: Kaggle loads submitted agent files via get_last_callable,
+    which picks the LAST callable defined in the module. If helper functions
+    are defined after ``agent``, the wrong callable is selected and the
+    submission fails with a TypeError at runtime. Load each shipped agent
+    file the same way Kaggle does and ensure it can actually play a turn."""
+    agents_dir = Path(rt_module.__file__).parent / "agents"
+    agent_path = agents_dir / agent_filename
+    assert agent_path.exists(), f"missing agent file: {agent_path}"
+
+    env = make_env(configuration={"mapSeed": 42, "episodeSteps": 10})
+    # Passing the path string mirrors how a Kaggle submission file is loaded.
+    result = env.run([str(agent_path), "random"])
+    final = result[-1]
+    assert final[0].status == "DONE", f"agent file {agent_filename} errored: {final[0].status}"
+    assert final[1].status == "DONE"
+
+
 def test_draw_on_max_steps(make_env):
     env = make_env(configuration={"mapSeed": 42, "episodeSteps": 5})
     result = env.run(["random", "random"])


### PR DESCRIPTION
The Kaggle agent loader picks the last callable defined in a submitted module. simple_bot_agent.py defined helper functions after `agent`, so `_step_toward` was selected as the entry point and crashed with a TypeError on the first turn. Reorder so `agent` is defined last, and add a regression test that loads each shipped agent file via the submission path (not the built-in registry).