### PR TITLE
reinforce_tactics: inline UI, faster default speed, team names

### DIFF
--- a/kaggle_environments/envs/reinforce_tactics/visualizer/default/src/main.ts
+++ b/kaggle_environments/envs/reinforce_tactics/visualizer/default/src/main.ts
@@ -1,5 +1,6 @@
 import { createReplayVisualizer, ReplayAdapter } from '@kaggle-environments/core';
 import { renderer } from './renderer';
+import { getReinforceTacticsStepRenderTime } from './timing';
 import './style.css';
 
 const app = document.getElementById('app');
@@ -16,6 +17,8 @@ createReplayVisualizer(
   new ReplayAdapter({
     gameName: 'reinforce_tactics',
     renderer: renderer as any,
-    ui: 'side-panel',
+    ui: 'inline',
+    getStepRenderTime: (step, replayMode, speedModifier) =>
+      getReinforceTacticsStepRenderTime(step, replayMode, speedModifier),
   })
 );

--- a/kaggle_environments/envs/reinforce_tactics/visualizer/default/src/renderer.ts
+++ b/kaggle_environments/envs/reinforce_tactics/visualizer/default/src/renderer.ts
@@ -74,6 +74,13 @@ const STRUCT_NAMES: Record<string, string> = {
   t: '▲',
 };
 
+function escapeHtml(s: string): string {
+  return s.replace(
+    /[&<>"']/g,
+    (c) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' })[c] as string
+  );
+}
+
 function getObservation(step: RTStep | undefined): RTObservation | null {
   if (!step || !step[0]) return null;
   const obs = step[0].observation as RTObservation | undefined;
@@ -179,7 +186,7 @@ function buildHighlights(prevObs: RTObservation | null, curObs: RTObservation, a
 }
 
 export function renderer(options: RendererOptions) {
-  const { step, replay, parent } = options;
+  const { step, replay, parent, agents } = options;
   const steps = (replay.steps as unknown as RTStep[]) || [];
   const curStep = steps[step];
   const prevStep = step > 0 ? steps[step - 1] : null;
@@ -218,8 +225,9 @@ export function renderer(options: RendererOptions) {
     const card = document.createElement('div');
     card.className = `player-card sketched-border${activeIdx === i && !finalStep ? ' active' : ''}`;
     const nameColor = PLAYER_COLORS[i + 1];
+    const displayName = agents?.[i]?.name || `Player ${i + 1}`;
     card.innerHTML = `
-      <div class="player-name" style="color: ${nameColor};">Player ${i + 1}</div>
+      <div class="player-name" style="color: ${nameColor};">${escapeHtml(displayName)}</div>
       <div class="player-stats">
         <span>${gold[i]}g</span>
         <span>${unitCounts[i]} units</span>

--- a/kaggle_environments/envs/reinforce_tactics/visualizer/default/src/timing.ts
+++ b/kaggle_environments/envs/reinforce_tactics/visualizer/default/src/timing.ts
@@ -1,0 +1,12 @@
+import { defaultGetStepRenderTime } from '@kaggle-environments/core';
+import type { BaseGameStep, ReplayMode } from '@kaggle-environments/core';
+
+const REINFORCE_TACTICS_STEP_DURATION = 352; // matches kaggriculture — turn-based games can run long, keep playback snappy
+
+export const getReinforceTacticsStepRenderTime = (
+  gameStep: BaseGameStep,
+  replayMode: ReplayMode,
+  speedModifier: number
+): number => {
+  return defaultGetStepRenderTime(gameStep, replayMode, speedModifier, REINFORCE_TACTICS_STEP_DURATION);
+};


### PR DESCRIPTION
Bring the visualizer in line with orbit_wars / kaggriculture:

* main.ts: ui 'side-panel' -> 'inline' for compact bottom-bar controls, and wire getStepRenderTime so the default step duration matches the other turn-based / RTS environments.
* timing.ts: 352 ms per step (mirrors kaggriculture), since rt games can run to 200 turns and the core default of 2200 ms feels glacial.
* renderer.ts: pull agents off RendererOptions and display agents[i].name (sourced from replay info.TeamNames by the core player) instead of hard-coded "Player N". Escape the name for HTML since it's external input.