### PR TITLE
Add detailed error logs in replay file

### DIFF
--- a/kaggle_environments/core.py
+++ b/kaggle_environments/core.py
@@ -35,6 +35,10 @@ environments: dict[str, dict[str, Any]] = {}
 # Registered Interactive Sessions.
 interactives: dict[str, tuple[Any, Any]] = {}
 
+# Agent status values that indicate a failed step. Source of truth is the enum
+# in schemas.json; kept here for cheap reuse without re-reading the schema.
+FAILURE_STATUSES = ("ERROR", "INVALID", "TIMEOUT")
+
 
 def register(name: str, environment: dict[str, Any]) -> None:
     """
@@ -255,18 +259,39 @@ class Environment:
             if isinstance(action, DeadlineExceeded):
                 self.debug_print(f"Timeout: {str(action)}")
                 action_state[index]["status"] = "TIMEOUT"
+                self._record_error(index, "TIMEOUT", str(action))
             elif isinstance(action, BaseException):
-                self.debug_print(f"Error: {traceback.format_exception(None, action, action.__traceback__)}")
+                tb = "".join(traceback.format_exception(None, action, action.__traceback__))
+                self.debug_print(f"Error: {tb}")
                 action_state[index]["status"] = "ERROR"
+                message = f"{type(action).__name__}: {action}" if str(action) else type(action).__name__
+                self._record_error(index, "ERROR", message, traceback_text=tb)
             else:
                 err, data = process_schema(self.__state_schema.properties.action, action)
                 if err:
                     self.debug_print(f"Invalid Action: {str(err)}")
                     action_state[index]["status"] = "INVALID"
+                    self._record_error(index, "INVALID", str(err))
                 else:
                     action_state[index]["action"] = data
 
         self.state = self.__run_interpreter(action_state, logs)
+
+        # Reconcile error entries with the post-interpreter statuses. Interpreters
+        # may have called set_error() with a reason but no type; fill type from
+        # the resulting status. For any failure status with no entry yet, fall
+        # back to a generic placeholder.
+        for index, agent in enumerate(self.state):
+            if agent.status not in FAILURE_STATUSES:
+                continue
+            entry = self.errors[index]
+            if entry is None:
+                self.errors[index] = {
+                    "type": agent.status,
+                    "message": f"Agent marked {agent.status} by interpreter.",
+                }
+            elif entry.get("type") is None:
+                entry["type"] = agent.status
 
         # Max Steps reached. Mark ACTIVE/INACTIVE agents as DONE.
         if self.state[0].observation.step >= self.configuration.episodeSteps - 1:
@@ -514,10 +539,32 @@ class Environment:
                 "steps": self.steps,
                 "rewards": [state.reward for state in self.steps[-1]],
                 "statuses": [state.status for state in self.steps[-1]],
+                "errors": self.errors,
                 "schema_version": 1,
                 "info": self.info,
             }
         )
+
+    def set_error(self, index: int, message: str) -> None:
+        """Record a detailed error reason for an agent. Intended to be called from
+        interpreters when marking an agent ERROR/INVALID/TIMEOUT so the underlying
+        cause is preserved in the replay. The status is filled in automatically
+        from the agent's post-interpreter status. First call per step wins, so
+        callers don't need to coordinate ordering."""
+        if not 0 <= index < len(self.errors):
+            raise InvalidArgument(f"set_error index {index} out of range.")
+        if self.errors[index] is None:
+            self.errors[index] = {"type": None, "message": message}
+
+    def _record_error(
+        self, index: int, error_type: str, message: str, traceback_text: str | None = None
+    ) -> None:
+        if self.errors[index] is not None:
+            return
+        entry: dict[str, Any] = {"type": error_type, "message": message}
+        if traceback_text is not None:
+            entry["traceback"] = traceback_text
+        self.errors[index] = entry
 
     def clone(self) -> "Environment":
         """
@@ -566,6 +613,7 @@ class Environment:
 
         self.state = structify([self.__get_state(index, s) for index, s in enumerate(state)])
         self.steps = [self.state]
+        self.errors = [None] * len(self.state)
         return self.state
 
     def __get_state(self, position: int, state: dict[str, Any]) -> dict[str, Any]:
@@ -609,7 +657,7 @@ class Environment:
             if agent.status not in self.__state_schema.properties.status.enum:
                 self.debug_print(f"Invalid Action: {agent.status}")
                 agent.status = "INVALID"
-            if agent.status in ["ERROR", "INVALID", "TIMEOUT"]:
+            if agent.status in FAILURE_STATUSES:
                 agent.reward = None
         return new_state
 

--- a/kaggle_environments/envs/rps/rps.py
+++ b/kaggle_environments/envs/rps/rps.py
@@ -13,26 +13,34 @@ def interpreter(state, env):
     if env.done:
         return state
 
-    def is_valid_action(player, sign_count):
-        return player.action is not None and isinstance(player.action, int) and 0 <= player.action < sign_count
+    def invalid_reason(player, sign_count):
+        action = player.action
+        if action is None:
+            return "Agent did not produce an action."
+        if not isinstance(action, int) or isinstance(action, bool):
+            return f"Action {action!r} is not an integer."
+        if not 0 <= action < sign_count:
+            return f"Action {action} is out of range [0, {sign_count})."
+        return None
 
-    # Check for validity of actions
-    is_player1_valid = is_valid_action(player1, env.configuration.signs)
-    is_player2_valid = is_valid_action(player2, env.configuration.signs)
-    if not is_player2_valid:
+    reason1 = invalid_reason(player1, env.configuration.signs)
+    reason2 = invalid_reason(player2, env.configuration.signs)
+    if reason2 is not None:
         player2.status = "INVALID"
         player2.reward = 0
+        env.set_error(1, reason2)
 
-        if is_player1_valid:
+        if reason1 is None:
             player1.status = "DONE"
             player1.reward = 1
             return state
 
-    if not is_player1_valid:
+    if reason1 is not None:
         player1.status = "INVALID"
         player1.reward = 0
+        env.set_error(0, reason1)
 
-        if is_player2_valid:
+        if reason2 is None:
             player2.status = "DONE"
             player2.reward = 1
             return state

--- a/tests/envs/rps/test_rps.py
+++ b/tests/envs/rps/test_rps.py
@@ -1,5 +1,6 @@
 from kaggle_environments import make
 from kaggle_environments.envs.rps.agents import agents, paper, rock
+from kaggle_environments.errors import DeadlineExceeded
 
 
 def negative_move_agent(observation, configuration):
@@ -97,6 +98,58 @@ def test_too_big_move():
     json = env.toJSON()
     assert json["rewards"] == [1, None]
     assert json["statuses"] == ["DONE", "INVALID"]
+
+
+def test_replay_records_invalid_action_error():
+    def out_of_range_agent(observation, configuration):
+        return 3
+
+    env = make("rps", configuration={"episodeSteps": 10, "tieRewardThreshold": 1})
+    env.run([out_of_range_agent, rock])
+    json = env.toJSON()
+    assert json["statuses"] == ["INVALID", "DONE"]
+    assert json["errors"][0]["type"] == "INVALID"
+    # The rps interpreter passes a concrete reason through env.set_error rather
+    # than the generic "marked INVALID" fallback.
+    assert "out of range" in json["errors"][0]["message"]
+    assert json["errors"][1] is None
+
+
+def test_replay_records_exception_error():
+    def raising_agent(observation, configuration):
+        raise ValueError("boom from agent")
+
+    env = make("rps", configuration={"episodeSteps": 10, "tieRewardThreshold": 1})
+    env.run([raising_agent, rock])
+    json = env.toJSON()
+    # The granular errors field captures the underlying ValueError even though
+    # the rps interpreter ultimately marks the agent INVALID for not producing
+    # a valid integer action.
+    err = json["errors"][0]
+    assert err["type"] == "ERROR"
+    assert err["message"] == "ValueError: boom from agent"
+    assert "raising_agent" in err["traceback"]
+    assert "ValueError: boom from agent" in err["traceback"]
+    assert json["errors"][1] is None
+
+
+def test_replay_records_timeout_error():
+    def timeout_agent(observation, configuration):
+        return DeadlineExceeded("took too long")
+
+    env = make("rps", configuration={"episodeSteps": 10, "tieRewardThreshold": 1})
+    env.run([timeout_agent, rock])
+    json = env.toJSON()
+    assert json["errors"][0] == {"type": "TIMEOUT", "message": "took too long"}
+    assert json["errors"][1] is None
+
+
+def test_replay_errors_none_for_clean_episode():
+    env = make("rps", configuration={"episodeSteps": 3, "tieRewardThreshold": 1})
+    env.run([rock, paper])
+    json = env.toJSON()
+    assert json["statuses"] == ["DONE", "DONE"]
+    assert json["errors"] == [None, None]
 
 
 def test_agent_reward():

--- a/tests/integration/test_envs.py
+++ b/tests/integration/test_envs.py
@@ -339,9 +339,10 @@ class TestCLI:
 
     def test_cli_evaluate(self):
         """Test CLI evaluate command."""
+        import sys
         result = subprocess.run(
             [
-                "python",
+                sys.executable,
                 "-m",
                 "kaggle_environments.main",
                 "evaluate",


### PR DESCRIPTION
Adds the ability to record detailed error reasons and tracebacks in episode replays. Enahnces the cover-all error reason