### PR TITLE
Prefer host-provided agent names in visualizers over static names

### DIFF
--- a/web/core/src/player/player.test.ts
+++ b/web/core/src/player/player.test.ts
@@ -202,6 +202,48 @@ describe('ReplayVisualizer', () => {
     });
   });
 
+  describe('host-supplied agent names override info.TeamNames', () => {
+    it('overrides TeamNames when agents arrive after replay', () => {
+      new ReplayVisualizer(container, adapter);
+      const replay = makeReplay({ info: { TeamNames: ['Stale A', 'Stale B'] } });
+      window.dispatchEvent(new MessageEvent('message', { data: { replay } }));
+
+      const agents = [{ name: 'Host A' }, { name: 'Host B' }];
+      window.dispatchEvent(new MessageEvent('message', { data: { agents } }));
+
+      expect(adapter.render).toHaveBeenLastCalledWith(
+        0,
+        expect.objectContaining({ info: expect.objectContaining({ TeamNames: ['Host A', 'Host B'] }) }),
+        agents
+      );
+    });
+
+    it('overrides TeamNames when agents arrive before replay', () => {
+      new ReplayVisualizer(container, adapter);
+      const agents = [{ name: 'Host A' }, { name: 'Host B' }];
+      window.dispatchEvent(new MessageEvent('message', { data: { agents } }));
+
+      const replay = makeReplay({ info: { TeamNames: ['Stale A', 'Stale B'] } });
+      window.dispatchEvent(new MessageEvent('message', { data: { replay } }));
+
+      expect(adapter.mount).toHaveBeenCalledWith(
+        expect.any(HTMLElement),
+        expect.objectContaining({ info: expect.objectContaining({ TeamNames: ['Host A', 'Host B'] }) })
+      );
+    });
+
+    it('leaves TeamNames intact when no agents are supplied', () => {
+      new ReplayVisualizer(container, adapter);
+      const replay = makeReplay({ info: { TeamNames: ['A', 'B'] } });
+      window.dispatchEvent(new MessageEvent('message', { data: { replay } }));
+
+      expect(adapter.mount).toHaveBeenCalledWith(
+        expect.any(HTMLElement),
+        expect.objectContaining({ info: expect.objectContaining({ TeamNames: ['A', 'B'] }) })
+      );
+    });
+  });
+
   describe('setAgents', () => {
     it('updates the agents list', () => {
       const rv = new ReplayVisualizer(container, adapter);

--- a/web/core/src/player/player.ts
+++ b/web/core/src/player/player.ts
@@ -1,5 +1,6 @@
 import { GameAdapter } from '../adapter';
 import { BaseGameStep, ReplayData } from '../types';
+import { applyAgentNamesToReplay } from '../utils/utils';
 import './style.css';
 
 /**
@@ -169,8 +170,12 @@ export class ReplayVisualizer<TSteps extends BaseGameStep[] = BaseGameStep[]> {
   };
 
   private setData(replay: ReplayData<TSteps>, agents: any[] = []) {
+    // Override info.TeamNames with host-supplied agents[].name before transforming so
+    // any downstream consumer that reads info.TeamNames picks up the canonical label.
+    const reconciled = applyAgentNamesToReplay(replay, agents);
+
     // Apply the transformer if one is provided
-    const transformedReplay = this.transformer ? this.transformer(replay) : replay;
+    const transformedReplay = this.transformer ? this.transformer(reconciled) : reconciled;
 
     this.replay = transformedReplay as ReplayData<TSteps>;
     this.agents = agents;

--- a/web/core/src/replay-adapter/replay-adapter.test.ts
+++ b/web/core/src/replay-adapter/replay-adapter.test.ts
@@ -167,7 +167,15 @@ describe('ReplayAdapter', () => {
       const replay = makeReplay({ name: 'new-data' });
       adapter.render(0, replay, [{ name: 'Agent1' }]);
 
-      expect(processEpisodeData).toHaveBeenCalledWith(replay, 'test');
+      // ReplayAdapter now overrides info.TeamNames from host-supplied agents
+      // before calling the transformer, so the transformer sees a reconciled replay.
+      expect(processEpisodeData).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: 'new-data',
+          info: expect.objectContaining({ TeamNames: ['Agent1'] }),
+        }),
+        'test'
+      );
       expect(renderFn).toHaveBeenCalled();
     });
 

--- a/web/core/src/replay-adapter/replay-adapter.ts
+++ b/web/core/src/replay-adapter/replay-adapter.ts
@@ -8,6 +8,7 @@ import { BaseGameStep, InterestingEvent, ReplayData, ReplayMode } from '../types
 import { EpisodePlayer, GameRendererProps, UiMode } from '../components/EpisodePlayer';
 import { theme, lightTheme } from '../theme';
 import { processEpisodeData } from '../transformers/transformers';
+import { applyAgentNamesToReplay } from '../utils/utils';
 
 /** Transformer function type for processing replay data */
 export type ReplayTransformer<TSteps = BaseGameStep[]> = (replay: ReplayData, gameName: string) => ReplayData<TSteps>;
@@ -452,10 +453,14 @@ export class ReplayAdapter<TSteps extends BaseGameStep[] = BaseGameStep[]> imple
   render(_step: number, replay: ReplayData<TSteps>, agents: any[]): void {
     this.currentAgents = agents;
 
+    // Override info.TeamNames with host-supplied agents[].name before transforming so
+    // any transformer / renderer that reads info.TeamNames picks up the canonical label.
+    const reconciled = applyAgentNamesToReplay(replay, agents);
+
     // Only re-transform if replay changed
-    if (replay !== this.rawReplay) {
-      this.rawReplay = replay;
-      this.transformedReplay = this.transformReplay(replay);
+    if (reconciled !== this.rawReplay) {
+      this.rawReplay = reconciled;
+      this.transformedReplay = this.transformReplay(reconciled);
     }
 
     // EpisodePlayer manages step internally via usePlaybackState,

--- a/web/core/src/utils/utils.test.ts
+++ b/web/core/src/utils/utils.test.ts
@@ -94,7 +94,10 @@ describe('applyAgentNamesToReplay', () => {
 
   it('respects agent.index for sparse / out-of-order agents', () => {
     const replay = makeReplay({ info: { TeamNames: ['x', 'y', 'z'] } });
-    const result = applyAgentNamesToReplay(replay, [{ name: 'Z', index: 2 }, { name: 'X', index: 0 }]);
+    const result = applyAgentNamesToReplay(replay, [
+      { name: 'Z', index: 2 },
+      { name: 'X', index: 0 },
+    ]);
     expect(result.info?.TeamNames).toEqual(['X', 'y', 'Z']);
   });
 

--- a/web/core/src/utils/utils.test.ts
+++ b/web/core/src/utils/utils.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
-import { getPlayer } from './utils';
-import { makeStep } from '../test-utils';
+import { getPlayer, applyAgentNamesToReplay } from './utils';
+import { makeStep, makeReplay } from '../test-utils';
 
 const alice = { id: 0, name: 'Alice', thumbnail: '', isTurn: true };
 const bob = { id: 1, name: 'Bob', thumbnail: '', isTurn: false };
@@ -49,5 +49,59 @@ describe('getPlayer', () => {
       ],
     });
     expect(getPlayer(step)).toEqual(alice);
+  });
+});
+
+describe('applyAgentNamesToReplay', () => {
+  it('overrides info.TeamNames with agents[].name', () => {
+    const replay = makeReplay({ info: { TeamNames: ['Old A', 'Old B'] } });
+    const result = applyAgentNamesToReplay(replay, [{ name: 'New A' }, { name: 'New B' }]);
+    expect(result.info?.TeamNames).toEqual(['New A', 'New B']);
+  });
+
+  it('returns the same reference when no override is needed', () => {
+    const replay = makeReplay({ info: { TeamNames: ['A', 'B'] } });
+    const result = applyAgentNamesToReplay(replay, [{ name: 'A' }, { name: 'B' }]);
+    expect(result).toBe(replay);
+  });
+
+  it('returns the same reference when agents is empty', () => {
+    const replay = makeReplay({ info: { TeamNames: ['A', 'B'] } });
+    expect(applyAgentNamesToReplay(replay, [])).toBe(replay);
+    expect(applyAgentNamesToReplay(replay, undefined)).toBe(replay);
+    expect(applyAgentNamesToReplay(replay, null)).toBe(replay);
+  });
+
+  it('keeps existing TeamName when agent.name is missing or empty', () => {
+    const replay = makeReplay({ info: { TeamNames: ['Keep A', 'Keep B'] } });
+    const result = applyAgentNamesToReplay(replay, [{ name: '' }, {}]);
+    expect(result.info?.TeamNames).toEqual(['Keep A', 'Keep B']);
+    expect(result).toBe(replay);
+  });
+
+  it('seeds TeamNames when replay has no info.TeamNames', () => {
+    const replay = makeReplay({ info: {} });
+    const result = applyAgentNamesToReplay(replay, [{ name: 'A' }, { name: 'B' }]);
+    expect(result.info?.TeamNames).toEqual(['A', 'B']);
+  });
+
+  it('seeds TeamNames when replay has no info at all', () => {
+    const replay = makeReplay();
+    delete (replay as any).info;
+    const result = applyAgentNamesToReplay(replay, [{ name: 'A' }, { name: 'B' }]);
+    expect(result.info?.TeamNames).toEqual(['A', 'B']);
+  });
+
+  it('respects agent.index for sparse / out-of-order agents', () => {
+    const replay = makeReplay({ info: { TeamNames: ['x', 'y', 'z'] } });
+    const result = applyAgentNamesToReplay(replay, [{ name: 'Z', index: 2 }, { name: 'X', index: 0 }]);
+    expect(result.info?.TeamNames).toEqual(['X', 'y', 'Z']);
+  });
+
+  it('preserves other info fields', () => {
+    const replay = makeReplay({ info: { TeamNames: ['A'], LiveStats: { wins: 5 } } });
+    const result = applyAgentNamesToReplay(replay, [{ name: 'A2' }]);
+    expect(result.info?.LiveStats).toEqual({ wins: 5 });
+    expect(result.info?.TeamNames).toEqual(['A2']);
   });
 });

--- a/web/core/src/utils/utils.ts
+++ b/web/core/src/utils/utils.ts
@@ -1,4 +1,4 @@
-import { BaseGameStep, BaseGamePlayer } from '../types';
+import { BaseGameStep, BaseGamePlayer, ReplayData } from '../types';
 
 /**
  * Returns the player whose turn it is for the given step.
@@ -11,4 +11,46 @@ export function getPlayer(step: BaseGameStep): BaseGamePlayer | undefined {
   }
 
   return players.find((p) => p.isTurn);
+}
+
+interface AgentLike {
+  name?: string;
+  index?: number;
+}
+
+/**
+ * Overrides replay.info.TeamNames[i] with agents[i].name when the host supplies a name.
+ *
+ * The host (Kaggle.com EpisodesPanel) posts a fresh `agents` list whose name reflects
+ * current DB state (BenchmarkModelVersion.DisplayName, falling back to team_name). The
+ * replay's baked-in info.TeamNames is frozen at game-creation time and goes stale when
+ * a team is later linked to a benchmark model or renamed — the host-supplied label is
+ * the source of truth. Returns the original replay reference when no override applies
+ * so downstream reference-equality checks keep working.
+ */
+export function applyAgentNamesToReplay<T extends ReplayData<any>>(
+  replay: T,
+  agents: (AgentLike | undefined | null)[] | undefined | null
+): T {
+  if (!replay || !agents || agents.length === 0) return replay;
+
+  const existing: string[] = Array.isArray(replay.info?.TeamNames) ? (replay.info!.TeamNames as string[]) : [];
+  const merged: string[] = [...existing];
+  let changed = false;
+
+  agents.forEach((agent, i) => {
+    const idx = typeof agent?.index === 'number' ? agent.index : i;
+    const name = agent?.name;
+    if (typeof name === 'string' && name.length > 0 && merged[idx] !== name) {
+      merged[idx] = name;
+      changed = true;
+    }
+  });
+
+  if (!changed) return replay;
+
+  return {
+    ...replay,
+    info: { ...(replay.info ?? {}), TeamNames: merged },
+  };
 }


### PR DESCRIPTION
Currently, most visualizers use static agent names from the replay file. The host (kaggle.com replay panel) already provides agent information dynamically in a post message, and a few visualizers use the display name from there, which is preferred since it can be updated over time.

Prefer the up-to-date agent display names at the framework level, if available.