### PR TITLE
Add more detailed errors to replay files

### DIFF
--- a/kaggle_environments/agent.py
+++ b/kaggle_environments/agent.py
@@ -211,6 +211,13 @@ class Agent:
             "stderr": err,
         }
 
+        if isinstance(action, BaseException):
+            log["error"] = {
+                "type": type(action).__name__,
+                "message": str(action),
+                "traceback": traceback.format_exception(None, action, action.__traceback__),
+            }
+
         if self.debug:
             if not log["stdout"].isspace():
                 print(log["stdout"], end="")

--- a/kaggle_environments/agent.py
+++ b/kaggle_environments/agent.py
@@ -26,7 +26,7 @@ import requests
 from requests.exceptions import Timeout
 
 from .errors import DeadlineExceeded, InvalidArgument
-from .utils import read_file, structify
+from .utils import format_traceback, read_file, structify
 
 
 def is_url(url: str) -> bool:
@@ -215,7 +215,7 @@ class Agent:
             log["error"] = {
                 "type": type(action).__name__,
                 "message": str(action),
-                "traceback": traceback.format_exception(None, action, action.__traceback__),
+                "traceback": format_traceback(action),
             }
 
         if self.debug:

--- a/kaggle_environments/core.py
+++ b/kaggle_environments/core.py
@@ -27,7 +27,7 @@ from typing import Any, Callable
 from . import __version__
 from .agent import Agent
 from .errors import DeadlineExceeded, FailedPrecondition, InvalidArgument
-from .utils import get, get_player, has, process_schema, schemas, structify
+from .utils import format_traceback, get, get_player, has, process_schema, schemas, structify
 
 # Registered Environments.
 environments: dict[str, dict[str, Any]] = {}
@@ -281,10 +281,10 @@ class Environment:
                 action_state[index]["status"] = "TIMEOUT"
                 action_state[index]["error"] = {
                     "type": "TIMEOUT",
-                    "message": str(action),
+                    "message": str(action) or f"Exceeded actTimeout ({self.configuration.actTimeout}s)",
                 }
             elif isinstance(action, BaseException):
-                tb = "".join(traceback.format_exception(None, action, action.__traceback__))
+                tb = format_traceback(action)
                 self.debug_print(f"Error: {tb}")
                 action_state[index]["status"] = "ERROR"
                 action_state[index]["error"] = {
@@ -647,6 +647,11 @@ class Environment:
                 agent.observation.remainingOverageTime -= overage_time_consumed
             if agent.status not in self.__state_schema.properties.status.enum:
                 self.debug_print(f"Invalid Action: {agent.status}")
+                if "error" not in agent:
+                    agent.error = {
+                        "type": "INVALID",
+                        "message": str(agent.status),
+                    }
                 agent.status = "INVALID"
             if agent.status in ["ERROR", "INVALID", "TIMEOUT"]:
                 agent.reward = None

--- a/kaggle_environments/core.py
+++ b/kaggle_environments/core.py
@@ -279,14 +279,29 @@ class Environment:
             if isinstance(action, DeadlineExceeded):
                 self.debug_print(f"Timeout: {str(action)}")
                 action_state[index]["status"] = "TIMEOUT"
+                action_state[index]["error"] = {
+                    "type": "TIMEOUT",
+                    "message": str(action),
+                }
             elif isinstance(action, BaseException):
-                self.debug_print(f"Error: {traceback.format_exception(None, action, action.__traceback__)}")
+                tb = "".join(traceback.format_exception(None, action, action.__traceback__))
+                self.debug_print(f"Error: {tb}")
                 action_state[index]["status"] = "ERROR"
+                action_state[index]["error"] = {
+                    "type": "ERROR",
+                    "message": str(action),
+                    "traceback": tb,
+                }
             else:
                 err, data = process_schema(self.__state_schema.properties.action, action)
                 if err:
                     self.debug_print(f"Invalid Action: {str(err)}")
                     action_state[index]["status"] = "INVALID"
+                    action_state[index]["error"] = {
+                        "type": "INVALID",
+                        "message": str(err),
+                        "raw_action": repr(action),
+                    }
                 else:
                     action_state[index]["action"] = data
 

--- a/kaggle_environments/utils.py
+++ b/kaggle_environments/utils.py
@@ -14,6 +14,7 @@
 
 import json
 import random
+import traceback
 from copy import deepcopy
 from pathlib import Path
 from typing import Any, Callable, Type
@@ -111,6 +112,10 @@ class Struct(dict):
     def __setattr__(self, attr: str, value: Any) -> None:
         self.__dict__[attr] = value
         self[attr] = value
+
+
+def format_traceback(exc: BaseException) -> str:
+    return "".join(traceback.format_exception(None, exc, exc.__traceback__))
 
 
 # Added benefit of cloning lists and dicts.

--- a/tests/envs/connectx/test_connectx.py
+++ b/tests/envs/connectx/test_connectx.py
@@ -114,6 +114,7 @@ def test_can_mark_out_of_bounds():
                 "step": 1,
             },
             "reward": None,
+            "error": {"type": "INVALID", "message": "Invalid column: 10"},
         },
         {
             "action": 0,
@@ -138,6 +139,7 @@ def test_can_mark_a_full_column():
             "info": {},
             "observation": {"remainingOverageTime": 60, "board": board, "mark": 1, "step": 1},
             "reward": None,
+            "error": {"type": "INVALID", "message": "Invalid column: 1"},
         },
         {
             "action": 0,

--- a/tests/replay_error_test.py
+++ b/tests/replay_error_test.py
@@ -1,0 +1,64 @@
+"""Tests for the per-step `error` field attached to failing agents.
+
+Covers all three failure modes: ERROR (agent raises), TIMEOUT (agent exceeds
+actTimeout), and INVALID (action rejected by the interpreter).
+"""
+
+from absl.testing import absltest
+
+from kaggle_environments import make
+
+
+def raising_agent(obs, cfg):
+    raise ValueError("intentional boom")
+
+
+def slow_agent(obs, cfg):
+    import time
+    time.sleep(30)
+    return 0
+
+
+def invalid_agent(obs, cfg):
+    return 999  # out-of-range column for connectx
+
+
+class ReplayErrorTest(absltest.TestCase):
+
+    def test_error_status_attaches_traceback(self):
+        env = make("connectx")
+        env.run([raising_agent, "random"])
+
+        self.assertEqual(env.toJSON()["statuses"], ["ERROR", "DONE"])
+        agent_state = env.steps[-1][0]
+        self.assertEqual(agent_state["status"], "ERROR")
+        error = agent_state["error"]
+        self.assertEqual(error["type"], "ERROR")
+        self.assertEqual(error["message"], "intentional boom")
+        self.assertIn("ValueError: intentional boom", error["traceback"])
+
+        log_error = env.logs[-1][0]["error"]
+        self.assertEqual(log_error["type"], "ValueError")
+        self.assertIn("ValueError: intentional boom", log_error["traceback"])
+
+    def test_timeout_status_attaches_error(self):
+        env = make("connectx", configuration={"actTimeout": 1})
+        env.run([slow_agent, "random"])
+
+        self.assertEqual(env.toJSON()["statuses"], ["TIMEOUT", "DONE"])
+        error = env.steps[-1][0]["error"]
+        self.assertEqual(error["type"], "TIMEOUT")
+        self.assertTrue(error["message"], "TIMEOUT message should be non-empty")
+
+    def test_invalid_status_preserves_interpreter_reason(self):
+        env = make("connectx")
+        env.run([invalid_agent, "random"])
+
+        self.assertEqual(env.toJSON()["statuses"], ["INVALID", "DONE"])
+        error = env.steps[-1][0]["error"]
+        self.assertEqual(error["type"], "INVALID")
+        self.assertIn("999", error["message"])
+
+
+if __name__ == "__main__":
+    absltest.main()

--- a/tests/replay_error_test.py
+++ b/tests/replay_error_test.py
@@ -1,22 +1,18 @@
 """Tests for the per-step `error` field attached to failing agents.
 
 Covers all three failure modes: ERROR (agent raises), TIMEOUT (agent exceeds
-actTimeout), and INVALID (action rejected by the interpreter).
+actTimeout, injected as a DeadlineExceeded action), and INVALID (action
+rejected by the interpreter).
 """
 
 from absl.testing import absltest
 
 from kaggle_environments import make
+from kaggle_environments.errors import DeadlineExceeded
 
 
 def raising_agent(obs, cfg):
     raise ValueError("intentional boom")
-
-
-def slow_agent(obs, cfg):
-    import time
-    time.sleep(30)
-    return 0
 
 
 def invalid_agent(obs, cfg):
@@ -41,14 +37,29 @@ class ReplayErrorTest(absltest.TestCase):
         self.assertEqual(log_error["type"], "ValueError")
         self.assertIn("ValueError: intentional boom", log_error["traceback"])
 
-    def test_timeout_status_attaches_error(self):
+    def test_timeout_status_falls_back_to_generated_message(self):
+        # Inject the DeadlineExceeded the runner would have produced, so the
+        # timeout path is exercised deterministically instead of sleeping past
+        # the banked overage. An empty message should fall back to a generated
+        # "Exceeded actTimeout" string.
         env = make("connectx", configuration={"actTimeout": 1})
-        env.run([slow_agent, "random"])
+        env.reset(2)
+        state = env.step([DeadlineExceeded(), 0])
 
-        self.assertEqual(env.toJSON()["statuses"], ["TIMEOUT", "DONE"])
-        error = env.steps[-1][0]["error"]
+        self.assertEqual(state[0]["status"], "TIMEOUT")
+        error = state[0]["error"]
         self.assertEqual(error["type"], "TIMEOUT")
-        self.assertTrue(error["message"], "TIMEOUT message should be non-empty")
+        self.assertEqual(error["message"], "Exceeded actTimeout (1s)")
+
+    def test_timeout_status_preserves_custom_message(self):
+        env = make("connectx", configuration={"actTimeout": 1})
+        env.reset(2)
+        state = env.step([DeadlineExceeded("agent ran too long"), 0])
+
+        self.assertEqual(state[0]["status"], "TIMEOUT")
+        error = state[0]["error"]
+        self.assertEqual(error["type"], "TIMEOUT")
+        self.assertEqual(error["message"], "agent ran too long")
 
     def test_invalid_status_preserves_interpreter_reason(self):
         env = make("connectx")


### PR DESCRIPTION
Adds an `error` dict to the per-agent step state in `core.py`
for TIMEOUT, ERROR, and INVALID cases, and captures exception details
in the agent log dict in `agent.py`.

## Changes
  - `core.py` — `Environment.step()` attaches `error` on TIMEOUT / ERROR / schema-rejected INVALID.
  - `core.py` — `__loop_through_interpreter` attaches `error` when the interpreter
    returns an off-enum status (e.g. connectx's `"Invalid column: 999"`), preserving
    the interpreter's message before coercing the status to `"INVALID"`.
  - `agent.py` — `Agent.act()` attaches `error` to the per-turn log when the agent raises.
  - `utils.py` — new `format_traceback(exc)` helper used by both sites.
  - `tests/replay_error_test.py` — 3 tests covering all failure modes; asserts
        the `error` block is present with the expected `type` and message on both
        `env.steps` and `env.logs`.
