### PR TITLE
clobber harness: surface configured board size and full move history

### DIFF
--- a/kaggle_environments/envs/open_spiel_env/games/clobber/clobber_proxy.py
+++ b/kaggle_environments/envs/open_spiel_env/games/clobber/clobber_proxy.py
@@ -76,10 +76,14 @@ class ClobberState(proxy.State):
                 # doesn't silently fall through to winner=None.
                 winner = "draw"
 
+        # Clobber has no chance phase; play actions alternate starting with
+        # player 0, so we can derive per-move player_ids by index parity.
         history = self.history()
-        last_move = (
-            self.__wrapped__.action_to_string(0, history[-1]) if history else None
-        )
+        move_history = [
+            self.__wrapped__.action_to_string(idx % 2, action)
+            for idx, action in enumerate(history)
+        ]
+        last_move = move_history[-1] if move_history else None
 
         return {
             "board": board,
@@ -90,6 +94,7 @@ class ClobberState(proxy.State):
             "winner": winner,
             "last_move": last_move,
             "move_number": self.move_number(),
+            "move_history": move_history,
             "params": {
                 "rows": int(params.get("rows", rows)),
                 "columns": int(params.get("columns", columns)),

--- a/kaggle_environments/envs/open_spiel_env/games/clobber/harness.py
+++ b/kaggle_environments/envs/open_spiel_env/games/clobber/harness.py
@@ -45,7 +45,7 @@ Board (top to bottom; '.' = empty):
 {board_ascii}
 
 You are Player {player_label} ('{my_piece}').
-Moves played so far: {move_number}
+Moves played so far (both players, oldest first): {move_history_str}
 Last move played: {last_move}
 
 Choose your move. It must move one of your pieces onto an orthogonally
@@ -116,6 +116,42 @@ def _parse_observation_payload(observation: Mapping[str, Any]) -> dict[str, Any]
     return {}
 
 
+def _board_dims(state: Mapping[str, Any]) -> tuple[int, int]:
+    """Return ``(rows, columns)`` from a parsed state dict.
+
+    Prefers the actual board grid (always accurate for the current state),
+    falls back to the explicit ``rows``/``columns`` fields the proxy emits.
+    Returns ``(0, 0)`` only when nothing is available.
+    """
+    board = state.get("board") or []
+    if board:
+        return len(board), len(board[0])
+    rows = state.get("rows") or 0
+    columns = state.get("columns") or 0
+    return int(rows), int(columns)
+
+
+def _reconstruct_move_history(observation: Mapping[str, Any]) -> list[str]:
+    """Rebuild the full-game move history from the serialized pyspiel state.
+
+    Used only when the proxy state dict didn't surface ``move_history`` (e.g.
+    older replays). Clobber has no chance phase, so play actions alternate
+    starting with player 0.
+    """
+    serialized = observation.get("serializedGameAndState", "")
+    if not serialized:
+        return []
+    _, state = pyspiel.deserialize_game_and_state(serialized)
+    return [
+        state.action_to_string(idx % 2, action)
+        for idx, action in enumerate(state.history())
+    ]
+
+
+def _format_move_history(moves: Sequence[str]) -> str:
+    return ", ".join(moves) if moves else "(none yet)"
+
+
 def _format_board_ascii(board: Sequence[Sequence[str]], rows: int, columns: int) -> str:
     """Render the board with rank labels on the left and file labels on top.
 
@@ -162,15 +198,20 @@ def generate_prompt(
     previous_action: str | None = None,
 ) -> str:
     """Build the LLM prompt for the current clobber state."""
-    del move_history  # The full board state is sufficient context for clobber.
+    # The per-agent `move_history` argument only contains this agent's own
+    # actions. We need both players' moves, so we source the full game
+    # history from the proxy's state_dict (with a serialized-state fallback).
+    del move_history
     state = _parse_observation_payload(observation)
     player_id = observation.get("playerId", 0)
 
-    rows = int(state.get("rows") or 0)
-    columns = int(state.get("columns") or 0)
+    rows, columns = _board_dims(state)
     board = state.get("board") or []
-    move_number = state.get("move_number", 0)
-    last_move = state.get("last_move") or "(none yet)"
+    full_moves = state.get("move_history")
+    if not isinstance(full_moves, list):
+        full_moves = _reconstruct_move_history(observation)
+    last_move = state.get("last_move") or (full_moves[-1] if full_moves else None)
+    last_move_str = last_move or "(none yet)"
     my_piece = "o" if player_id == 0 else "x"
     last_file = chr(ord("a") + max(0, columns - 1))
 
@@ -181,8 +222,8 @@ def generate_prompt(
         board_ascii=_format_board_ascii(board, rows, columns),
         player_label=player_id,
         my_piece=my_piece,
-        move_number=move_number,
-        last_move=last_move,
+        move_history_str=_format_move_history(full_moves),
+        last_move=last_move_str,
     )
 
     prompt += render_rethink_suffix(

--- a/tests/envs/open_spiel_env/games/clobber/harness_test.py
+++ b/tests/envs/open_spiel_env/games/clobber/harness_test.py
@@ -158,6 +158,53 @@ class GeneratePromptTest(absltest.TestCase):
         prompt = generate_prompt(obs1, [])
         self.assertIn(f"Last move played: {first_str}", prompt)
 
+    def test_full_move_history_rendered_for_both_players(self):
+        # Apply one move from each player; prompt must list both.
+        first = self.state.legal_actions(0)[0]
+        first_str = self.state.action_to_string(0, first)
+        self.state.apply_action(first)
+        second = self.state.legal_actions(1)[0]
+        second_str = self.state.action_to_string(1, second)
+        self.state.apply_action(second)
+
+        obs = _make_observation(self.state, self.game, player_id=0)
+        prompt = generate_prompt(obs, [])
+        self.assertIn(
+            f"Moves played so far (both players, oldest first): "
+            f"{first_str}, {second_str}",
+            prompt,
+        )
+
+    def test_empty_move_history_rendered_as_none(self):
+        obs = _make_observation(self.state, self.game, player_id=0)
+        prompt = generate_prompt(obs, [])
+        self.assertIn(
+            "Moves played so far (both players, oldest first): (none yet)",
+            prompt,
+        )
+
+    def test_per_agent_move_history_arg_is_ignored(self):
+        # The framework's per-agent move_history arg only contains this
+        # agent's actions. The prompt must NOT reflect it -- it must source
+        # full-game history from the observation instead.
+        obs = _make_observation(self.state, self.game, player_id=0)
+        prompt = generate_prompt(obs, ["bogus_per_agent_token"])
+        self.assertNotIn("bogus_per_agent_token", prompt)
+
+    def test_non_default_board_size_rendered_in_prompt(self):
+        # Env is configurable: a 5x6 board must surface those dimensions
+        # (and matching coordinate range) rather than any hardcoded default.
+        game = clobber_proxy.ClobberGame({"rows": 5, "columns": 6})
+        state = game.new_initial_state()
+        obs = _make_observation(state, game, player_id=0)
+        prompt = generate_prompt(obs, [])
+        self.assertIn("5x6 checkerboard", prompt)
+        # Files run a..f (6 columns); ranks run 1..5.
+        self.assertIn("a..f", prompt)
+        self.assertIn("1..5", prompt)
+        # Board header lists every file letter.
+        self.assertIn("a b c d e f", prompt)
+
     def test_rethink_suffix(self):
         obs = _make_observation(self.state, self.game, player_id=0)
         prompt = generate_prompt(


### PR DESCRIPTION
The prompt previously showed only the move count (no actual moves) and the per-agent move_history argument was discarded entirely. The proxy now emits a `move_history` list covering both players, and the harness renders it inline (e.g. "a1b1, b3a3, ..."). A `_board_dims` helper sources rows/columns from the live board grid so non-default sizes (rows=5, columns=6, etc.) render the correct dimensions and coordinate range in the prompt.