### PR TITLE
Add resolve_episode_seed helper and adopt in crawl/kaggriculture/orbit_wars

### DIFF
--- a/kaggle_environments/envs/crawl/crawl.py
+++ b/kaggle_environments/envs/crawl/crawl.py
@@ -1,7 +1,10 @@
 import json
+import time
 from collections import defaultdict
 from os import path
 from random import Random
+
+from kaggle_environments.utils import resolve_episode_seed
 
 from .agents import agents  # noqa: F401
 
@@ -352,27 +355,14 @@ def initialize_game(state, env):
     width = config.width
     height = config.height
 
-    # Resolve the episode seed and stash it on env.info so it persists into
-    # the replay (via toJSON) but stays out of `configuration`, which agents
-    # can read. The seed determines maze layout and scroll-time row
-    # generation — both hidden info that agents must not be able to predict.
-    if not hasattr(env, "info") or env.info is None:
-        env.info = {}
-    seed = env.info.get("seed")
-    if seed is None:
-        seed = getattr(config, "randomSeed", None)
-        if seed is None and isinstance(config, dict):
-            seed = config.get("randomSeed")
-    if seed is None:
-        import time
-
-        seed = int(time.time() * 1000) % (2**31)
-    # Scrub the seed from configuration so agents can't read it.
-    try:
-        config.randomSeed = None
-    except (AttributeError, TypeError):
-        config["randomSeed"] = None
-    env.info["seed"] = seed
+    # The seed determines maze layout and scroll-time row generation -- both
+    # hidden info that agents must not be able to predict. resolve_episode_seed
+    # scrubs it from configuration and stashes it on env.info for the replay.
+    seed = resolve_episode_seed(
+        env,
+        config_key="randomSeed",
+        fallback=lambda: int(time.time() * 1000) % (2**31),
+    )
     rng = Random(seed)
 
     # Initialize hidden state

--- a/kaggle_environments/envs/kaggriculture/kaggriculture.py
+++ b/kaggle_environments/envs/kaggriculture/kaggriculture.py
@@ -3,6 +3,8 @@ import math
 import random
 from os import path
 
+from kaggle_environments.utils import resolve_episode_seed
+
 dirpath = path.dirname(__file__)
 
 
@@ -229,19 +231,7 @@ def _initialize(state, env):
     num_agents = len(state)
     obs0 = state[0].observation
 
-    if not hasattr(env, "info") or env.info is None:
-        env.info = {}
-
-    seed = env.info.get("seed")
-    if seed is None:
-        seed = get(configuration, "seed", None)
-    if seed is None:
-        seed = random.randrange(2**31)
-    try:
-        configuration.seed = None
-    except (AttributeError, TypeError):
-        configuration["seed"] = None
-    env.info["seed"] = seed
+    seed = resolve_episode_seed(env)
 
     board_size = int(get(configuration, "boardSize", 10))
     starting_money = int(get(configuration, "startingMoney", 3000))

--- a/kaggle_environments/envs/orbit_wars/orbit_wars.py
+++ b/kaggle_environments/envs/orbit_wars/orbit_wars.py
@@ -4,6 +4,8 @@ from collections import namedtuple
 from os import path
 import random
 
+from kaggle_environments.utils import resolve_episode_seed
+
 # Named tuples for agent convenience.
 # Planets and fleets share a common [id, owner, x, y, ...] prefix.
 Planet = namedtuple(
@@ -342,25 +344,10 @@ def interpreter(state, env):
     # the seed is scrubbed from configuration before the first agent.act()
     # call — otherwise agents would see the seed on turn 0.
     if not hasattr(obs0, "planets") or not obs0.planets:
-        # Resolve episode seed and stash it on env.info so it persists into
-        # the replay but stays out of `configuration`, which is visible to
-        # agents. Agents must not be able to reconstruct the comet schedule.
-        if not hasattr(env, "info") or env.info is None:
-            env.info = {}
-        # Reuse the previously-resolved seed if env.reset() runs twice
-        # (e.g. make() + run() both trigger reset). Otherwise read from
-        # configuration, then fall back to a random one.
-        seed = env.info.get("seed")
-        if seed is None:
-            seed = get(configuration, "seed", None)
-        if seed is None:
-            seed = random.randrange(2**31)
-        # Scrub seed from configuration so agents can't read it.
-        try:
-            configuration.seed = None
-        except (AttributeError, TypeError):
-            configuration["seed"] = None
-        env.info["seed"] = seed
+        # Agents must not be able to reconstruct the comet schedule, so
+        # resolve_episode_seed scrubs the seed from configuration before the
+        # first agent.act() call and stashes it on env.info for the replay.
+        seed = resolve_episode_seed(env)
         init_rng = random.Random(seed)
 
         angular_velocity = init_rng.uniform(0.025, 0.05)

--- a/kaggle_environments/utils.py
+++ b/kaggle_environments/utils.py
@@ -13,9 +13,10 @@
 # limitations under the License.
 
 import json
+import random
 from copy import deepcopy
 from pathlib import Path
-from typing import Any, Type
+from typing import Any, Callable, Type
 
 import jsonschema
 
@@ -192,6 +193,42 @@ def process_schema(schema: Any, data: Any, use_default: bool = True) -> tuple[st
     except Exception as err:
         error = str(err)
     return error, data
+
+
+# Seed utilities
+def resolve_episode_seed(
+    env: Any,
+    *,
+    config_key: str = "seed",
+    fallback: Callable[[], int] | None = None,
+) -> int:
+    """Resolve, scrub, and persist an episode seed for envs with hidden state.
+
+    Used by interpreters whose initial state depends on a seed that agents
+    must not be able to read (e.g. random maze layout, comet schedules,
+    weather rolls). The seed is taken from the first available source:
+    ``env.info["seed"]`` (preserved across re-initialization), then
+    ``configuration[config_key]``, then ``fallback()`` (defaulting to a random
+    31-bit int). The value is then cleared from ``configuration`` so agents
+    can't read it via the observation, and stored on ``env.info["seed"]`` so
+    it persists into the replay.
+    """
+    if not hasattr(env, "info") or env.info is None:
+        env.info = {}
+    seed = env.info.get("seed")
+    config = env.configuration
+    if seed is None:
+        seed = getattr(config, config_key, None)
+        if seed is None and isinstance(config, dict):
+            seed = config.get(config_key)
+    if seed is None:
+        seed = fallback() if fallback is not None else random.randrange(2**31)
+    try:
+        setattr(config, config_key, None)
+    except (AttributeError, TypeError):
+        config[config_key] = None
+    env.info["seed"] = seed
+    return seed
 
 
 # Player utilities

--- a/tests/utils_test.py
+++ b/tests/utils_test.py
@@ -1,0 +1,105 @@
+"""Tests for kaggle_environments.utils."""
+
+from types import SimpleNamespace
+
+from absl.testing import absltest
+
+from kaggle_environments.utils import resolve_episode_seed
+
+
+def _make_env(*, info=None, configuration=None):
+    env = SimpleNamespace()
+    if info is not None:
+        env.info = info
+    env.configuration = configuration if configuration is not None else SimpleNamespace()
+    return env
+
+
+class ResolveEpisodeSeedTest(absltest.TestCase):
+
+    def test_initializes_info_when_missing(self):
+        env = SimpleNamespace(configuration=SimpleNamespace(seed=7))
+        seed = resolve_episode_seed(env)
+        self.assertEqual(seed, 7)
+        self.assertEqual(env.info, {"seed": 7})
+
+    def test_initializes_info_when_none(self):
+        env = SimpleNamespace(info=None, configuration=SimpleNamespace(seed=11))
+        seed = resolve_episode_seed(env)
+        self.assertEqual(seed, 11)
+        self.assertEqual(env.info, {"seed": 11})
+
+    def test_env_info_takes_precedence_over_configuration(self):
+        env = _make_env(info={"seed": 42}, configuration=SimpleNamespace(seed=99))
+        seed = resolve_episode_seed(env)
+        self.assertEqual(seed, 42)
+        # configuration is still scrubbed even when info won.
+        self.assertIsNone(env.configuration.seed)
+
+    def test_configuration_used_when_info_empty(self):
+        env = _make_env(info={}, configuration=SimpleNamespace(seed=123))
+        seed = resolve_episode_seed(env)
+        self.assertEqual(seed, 123)
+        self.assertIsNone(env.configuration.seed)
+        self.assertEqual(env.info["seed"], 123)
+
+    def test_fallback_used_when_no_seed_anywhere(self):
+        env = _make_env(info={}, configuration=SimpleNamespace())
+        seed = resolve_episode_seed(env, fallback=lambda: 555)
+        self.assertEqual(seed, 555)
+        self.assertEqual(env.info["seed"], 555)
+
+    def test_default_fallback_is_random_31bit_int(self):
+        env = _make_env(info={}, configuration=SimpleNamespace())
+        seed = resolve_episode_seed(env)
+        self.assertIsInstance(seed, int)
+        self.assertGreaterEqual(seed, 0)
+        self.assertLess(seed, 2**31)
+
+    def test_custom_config_key(self):
+        env = _make_env(info={}, configuration=SimpleNamespace(randomSeed=314))
+        seed = resolve_episode_seed(env, config_key="randomSeed")
+        self.assertEqual(seed, 314)
+        self.assertIsNone(env.configuration.randomSeed)
+
+    def test_dict_configuration(self):
+        env = _make_env(info={}, configuration={"seed": 17})
+        seed = resolve_episode_seed(env)
+        self.assertEqual(seed, 17)
+        self.assertIsNone(env.configuration["seed"])
+        self.assertEqual(env.info["seed"], 17)
+
+    def test_dict_configuration_with_custom_key(self):
+        env = _make_env(info={}, configuration={"randomSeed": 9})
+        seed = resolve_episode_seed(env, config_key="randomSeed")
+        self.assertEqual(seed, 9)
+        self.assertIsNone(env.configuration["randomSeed"])
+
+    def test_dict_configuration_falls_back_when_key_missing(self):
+        env = _make_env(info={}, configuration={})
+        seed = resolve_episode_seed(env, fallback=lambda: 1234)
+        self.assertEqual(seed, 1234)
+        self.assertIsNone(env.configuration["seed"])
+        self.assertEqual(env.info["seed"], 1234)
+
+    def test_seed_value_of_zero_is_respected(self):
+        # zero is a valid seed; the resolver must not treat it as missing.
+        env = _make_env(info={}, configuration=SimpleNamespace(seed=0))
+        seed = resolve_episode_seed(env, fallback=lambda: 999)
+        self.assertEqual(seed, 0)
+        self.assertEqual(env.info["seed"], 0)
+
+    def test_idempotent_across_calls(self):
+        # Second call (e.g. after env.reset() runs twice) reuses env.info.
+        env = _make_env(info={}, configuration=SimpleNamespace(seed=8))
+        first = resolve_episode_seed(env)
+        # Pretend something repopulated the config; the helper should still
+        # return the original resolved seed.
+        env.configuration.seed = 99
+        second = resolve_episode_seed(env)
+        self.assertEqual(first, 8)
+        self.assertEqual(second, 8)
+
+
+if __name__ == "__main__":
+    absltest.main()


### PR DESCRIPTION
Hidden-state envs all duplicated the same extract+scrub+stash dance to keep the episode seed out of agent observations while preserving it in the replay. Pull the common code into kaggle_environments.utils so new envs can opt in with one call. crawl keeps its time-based fallback via the fallback kwarg; kaggriculture and orbit_wars use the default random 31-bit int. reinforce_tactics will adopt it once its seed PR lands.