### PR TITLE
Delete unused harness adapter classes

### DIFF
--- a/.agents/skills/create-harness/SKILL.md
+++ b/.agents/skills/create-harness/SKILL.md
@@ -17,7 +17,7 @@ A harness module that implements three functions (the `GameHarness` protocol):
 | `make_prompt(observation, move_history, ...)` | Build the LLM prompt |
 | `parse_response(response, legal_action_strings)` | Extract the chosen action from the LLM's text |
 
-Plus an adapter class that wraps these into the protocol, and a call to `create_agent_fn()` to produce the final Kaggle agent.
+Production wires these three module-level functions into an agent via an external wrapper template — **do not write an adapter class or a `create_agent_fn(...)` line in `harness.py`**. Tests construct their own local adapter when they want end-to-end coverage; see Step 6 for the pattern.
 
 ## Step 1: Understand the game
 
@@ -367,35 +367,6 @@ empirical impact.
 - **Adapt the JSON key** to your game by passing `json_key=`: `"move"` for board games (default), `"bid"` for auction games, `"action"` for generic games — whatever matches your prompt.
 - **For numeric actions** (like bids), validate in the matcher: convert raw → int, check membership in the legal-action-encoded integers, and return the canonical legal string.
 
-## Step 5: Create the adapter class and agent function
-
-Wrap your module-level functions into a class that satisfies the `GameHarness` protocol, then call `create_agent_fn`:
-
-```python
-from kaggle_environments.core_harness import create_agent_fn
-
-class _MyGameHarness:
-    """Adapts module-level harness functions to the GameHarness protocol."""
-
-    def get_legal_moves(self, observation):
-        return get_legal_moves(observation)
-
-    def make_prompt(self, observation, move_history,
-                    previous_response=None, previous_action=None):
-        return generate_prompt(
-            observation, move_history, previous_response, previous_action
-        )
-
-    def parse_response(self, response, legal_action_strings):
-        return parse_response(response, legal_action_strings)
-
-agent_fn = create_agent_fn(_MyGameHarness())
-```
-
-The adapter is thin by design — it just bridges the naming convention. `create_agent_fn` handles everything else: model setup, the retry loop, inactive-call guards, move history tracking, and telemetry.
-
-`create_agent_fn` accepts an optional `max_retries` parameter (default 2) — the total number of LLM calls before giving up.
-
 ## Step 6: Write tests
 
 Harness tests follow a consistent 4-class structure. Create your test file at the same relative path as the harness, under `tests/`.
@@ -414,7 +385,26 @@ classes that together cover the surface area.
 | `ParseResponseTest` | Parser in isolation. Cover at minimum: fenced JSON, bare JSON, case-insensitive match, illegal-move-returns-raw, prose-only-returns-None (no ghost fallback), multiple-JSON-last-wins. Add a `test_illegal_json_does_not_ghost_substitute_from_prose` regression — the model writes a legal token in prose, then commits to an illegal one in JSON; the parser must NOT silently substitute the prose token. |
 | `GeneratePromptTest` | Prompt contents from a real proxy state. Cover: rules keywords present, board orientation, player-asymmetric text differs between `player_id=0` and `player_id=1`, captures/phase flags render correctly, rethink suffixes appear under the right conditions, the JSON example format is unambiguous. If the harness has multi-branch prompts (roles/phases), assert each branch contains its required rules. |
 | `GetLegalMovesTest` | Round-trip from `legalActions` + `legalActionStrings`, fallback from `serializedGameAndState`, empty-obs returns `{}`. |
-| `AgentIntegrationTest` | Full harness through `create_agent_fn` with `litellm.completion` patched. Cover: successful move, retry-on-bad-parse, raise-after-two-failures, terminal-step-returns-inactive, and a short scripted game (first-legal-each-turn) that round-trips through pyspiel without raising. |
+| `AgentIntegrationTest` | Full harness through `create_agent_fn` with `litellm.completion` patched. Cover: successful move, retry-on-bad-parse, raise-after-two-failures, terminal-step-returns-inactive, and a short scripted game (first-legal-each-turn) that round-trips through pyspiel without raising. Define a small test-local `_MyGameHarness` adapter (see the snippet below) at the top of the test file and pass it to `create_agent_fn`; do NOT import an adapter from `harness.py` (there isn't one). |
+
+Test-local adapter pattern (the only place an adapter class should live):
+
+```python
+class _MyGameHarness:
+    """Test-local GameHarness adapter; mirrors the prod wrapper shape."""
+
+    def get_legal_moves(self, observation):
+        return get_legal_moves(observation)
+
+    def make_prompt(self, observation, move_history,
+                    previous_response=None, previous_action=None):
+        return generate_prompt(
+            observation, move_history, previous_response, previous_action,
+        )
+
+    def parse_response(self, response, legal_action_strings):
+        return parse_response(response, legal_action_strings)
+```
 
 Mock helpers (`_StreamDelta`, `_StreamChoice`, `_StreamChunk`,
 `_make_mock_response`, `_ENV`) live at the top of checkers'
@@ -501,9 +491,7 @@ uv sync && uv run pytest tests/envs/open_spiel_env/games/<name>/harness_test.py 
 - [ ] `parse_response` delegates to `parse_json_action` (uses last-mention-wins JSON extraction; no prose-scan fallback — that's the ghost-fallback anti-pattern)
 - [ ] `parse_response` does case-insensitive matching (default matcher) or passes a custom `matcher=` for notation tolerance (check `state.action_to_string` outputs for `*`, `x`, trailing `Pass`, `-`, etc. that models drop or add)
 - [ ] `ParseResult` fields are set correctly (enumerable: `legal_action`; free-form: `submission`)
-- [ ] Adapter class wraps functions into `GameHarness` protocol
-- [ ] `agent_fn = create_agent_fn(adapter)` is defined at module level
-- [ ] Tests cover: parsing, prompt generation, legal moves, and integration with mocked LLM
+- [ ] Tests cover: parsing, prompt generation, legal moves, and integration with mocked LLM (using a test-local adapter at the top of the test file)
 - [ ] `test_llm_game.py` script runs a full game with real LLM agents
 - [ ] Linting passes: `uv run ruff check --fix . && uv run ruff format .`
 

--- a/.agents/skills/review-harness/SKILL.md
+++ b/.agents/skills/review-harness/SKILL.md
@@ -477,7 +477,6 @@ Bugs that have been found in real reviews. Treat this as a starting point — fi
 
 | Pattern | Symptom | Detection | Fix |
 |---|---|---|---|
-| **Missing `agent_fn`** | `env.run([harness.py, ...])` doesn't load an LLM agent | `grep create_agent_fn` in the harness | Add adapter class + `agent_fn = create_agent_fn(adapter())` |
 | **Relative imports in harness** | Production loader (single-file) fails to import | `grep 'from \.' harness.py` | Use absolute `kaggle_environments...` imports |
 | **No `test_llm_game.py`** | No in-repo end-to-end LLM sanity test | `ls` for `test_llm_game.py` | Create from `create-harness` template |
 | **No `harness_test.py`** | No unit tests for prompt/parser/legal-moves | `ls` for the test file | Create from `create-harness` template |

--- a/kaggle_environments/envs/open_spiel_env/games/chess/harness.py
+++ b/kaggle_environments/envs/open_spiel_env/games/chess/harness.py
@@ -19,7 +19,6 @@ from kaggle_environments.core_harness import (
     BASIC_RETHINK_ILLEGAL,
     BASIC_RETHINK_UNPARSABLE,
     ParseResult,
-    create_agent_fn,
 )
 
 # ---------------------------------------------------------------------------
@@ -291,24 +290,3 @@ def parse_response(
         return ParseResult(legal_action=matched, raw_action=raw)
 
     return ParseResult(legal_action=None, raw_action=raw)
-
-
-# ---------------------------------------------------------------------------
-# Adapter + agent factory
-# ---------------------------------------------------------------------------
-
-
-class _ChessHarness:
-    """Adapts module-level harness functions to the ``GameHarness`` protocol."""
-
-    def get_legal_moves(self, observation):
-        return get_legal_moves(observation)
-
-    def make_prompt(self, observation, move_history, previous_response=None, previous_action=None):
-        return generate_prompt(observation, move_history, previous_response, previous_action)
-
-    def parse_response(self, response, legal_action_strings):
-        return parse_response(response, legal_action_strings)
-
-
-agent_fn = create_agent_fn(_ChessHarness())

--- a/kaggle_environments/envs/open_spiel_env/games/connect_four/harness.py
+++ b/kaggle_environments/envs/open_spiel_env/games/connect_four/harness.py
@@ -11,7 +11,7 @@ from typing import Any, Mapping, Sequence
 
 import pyspiel
 
-from kaggle_environments.core_harness import ParseResult, create_agent_fn
+from kaggle_environments.core_harness import ParseResult
 
 # ---------------------------------------------------------------------------
 # Prompt templates — exact copies from GameArena
@@ -175,27 +175,3 @@ def _match_column_to_legal(
     return None
 
 
-# ---------------------------------------------------------------------------
-# Adapter and agent
-# ---------------------------------------------------------------------------
-
-
-class _ConnectFourHarness:
-    """Adapts module-level functions to the GameHarness protocol."""
-
-    def get_legal_moves(self, observation):
-        return get_legal_moves(observation)
-
-    def make_prompt(self, observation, move_history, previous_response=None, previous_action=None):
-        return generate_prompt(
-            observation,
-            move_history,
-            previous_response,
-            previous_action,
-        )
-
-    def parse_response(self, response, legal_action_strings):
-        return parse_response(response, legal_action_strings)
-
-
-agent_fn = create_agent_fn(_ConnectFourHarness())

--- a/kaggle_environments/envs/open_spiel_env/games/mancala/harness.py
+++ b/kaggle_environments/envs/open_spiel_env/games/mancala/harness.py
@@ -26,7 +26,7 @@ from typing import Any, Mapping, Sequence
 
 import pyspiel
 
-from kaggle_environments.core_harness import ParseResult, create_agent_fn, parse_json_action, render_rethink_suffix
+from kaggle_environments.core_harness import ParseResult, parse_json_action, render_rethink_suffix
 
 
 # --- Prompt -----------------------------------------------------------------
@@ -238,31 +238,3 @@ def parse_response(
     return parse_json_action(response, legal_action_strings)
 
 
-# --- Adapter & agent function -----------------------------------------------
-
-
-class _MancalaHarness:
-    """Adapter wrapping module-level functions into the GameHarness protocol."""
-
-    def get_legal_moves(self, observation):
-        return get_legal_moves(observation)
-
-    def make_prompt(
-        self,
-        observation,
-        move_history,
-        previous_response=None,
-        previous_action=None,
-    ):
-        return generate_prompt(
-            observation,
-            move_history,
-            previous_response=previous_response,
-            previous_action=previous_action,
-        )
-
-    def parse_response(self, response, legal_action_strings):
-        return parse_response(response, legal_action_strings)
-
-
-agent_fn = create_agent_fn(_MancalaHarness())

--- a/kaggle_environments/envs/open_spiel_env/games/negotiation/harness.py
+++ b/kaggle_environments/envs/open_spiel_env/games/negotiation/harness.py
@@ -443,31 +443,3 @@ def parse_response(
     return ParseResult(legal_action=None, raw_action=raw_repr)
 
 
-# --- GameHarness adapter ----------------------------------------------------
-
-
-class _NegotiationHarness:
-    def get_legal_moves(self, observation: Mapping[str, Any]) -> dict[int, str]:
-        return get_legal_moves(observation)
-
-    def make_prompt(
-        self,
-        observation: Mapping[str, Any],
-        move_history: list[str],
-        previous_response: str | None = None,
-        previous_action: str | None = None,
-    ) -> str:
-        return generate_prompt(observation, move_history, previous_response, previous_action)
-
-    def parse_response(self, response: str, legal_action_strings: Sequence[str] | None) -> ParseResult:
-        return parse_response(response, legal_action_strings)
-
-
-# Lazy import so the module can be imported without litellm available
-# (the framework requires it when actually running an agent).
-try:
-    from kaggle_environments.core_harness import create_agent_fn
-
-    agent_fn = create_agent_fn(_NegotiationHarness())
-except ImportError:  # pragma: no cover - import-time fallback
-    agent_fn = None

--- a/kaggle_environments/envs/open_spiel_env/games/repeated_poker/harness.py
+++ b/kaggle_environments/envs/open_spiel_env/games/repeated_poker/harness.py
@@ -14,7 +14,7 @@ from typing import Any, Mapping, Sequence
 
 import pyspiel
 
-from kaggle_environments.core_harness import ParseResult, create_agent_fn
+from kaggle_environments.core_harness import ParseResult
 from kaggle_environments.envs.open_spiel_env.games.repeated_poker import (
     hand_history_utils as hh_utils,
 )
@@ -441,41 +441,3 @@ def parse_response(
     return parse_response_with_state(response, legal_action_strings, state)
 
 
-# ---------------------------------------------------------------------------
-# Adapter + agent factory
-# ---------------------------------------------------------------------------
-
-
-class _PokerHarness:
-    """Adapts module-level harness functions to the GameHarness protocol.
-
-    Stores the most recent observation so ``parse_response`` can reach the
-    pyspiel state it needs to compute bet-size offsets.
-    """
-
-    def __init__(self) -> None:
-        self._observation: Mapping[str, Any] | None = None
-
-    def get_legal_moves(self, observation):
-        self._observation = observation
-        return get_legal_moves(observation)
-
-    def make_prompt(
-        self,
-        observation,
-        move_history,
-        previous_response=None,
-        previous_action=None,
-    ):
-        self._observation = observation
-        return generate_prompt(observation, move_history, previous_response, previous_action)
-
-    def parse_response(self, response, legal_action_strings):
-        return parse_response(
-            response,
-            legal_action_strings,
-            observation=self._observation,
-        )
-
-
-agent_fn = create_agent_fn(_PokerHarness())

--- a/kaggle_environments/envs/open_spiel_env/games/repeated_poker/test_llm_game.py
+++ b/kaggle_environments/envs/open_spiel_env/games/repeated_poker/test_llm_game.py
@@ -18,6 +18,31 @@ from kaggle_environments.envs.open_spiel_env import open_spiel_env
 from kaggle_environments.envs.open_spiel_env.games.repeated_poker import harness
 
 
+class _PokerHarness:
+    """Local GameHarness adapter for the debug runner."""
+
+    def __init__(self) -> None:
+        self._observation = None
+
+    def get_legal_moves(self, observation):
+        self._observation = observation
+        return harness.get_legal_moves(observation)
+
+    def make_prompt(
+        self, observation, move_history,
+        previous_response=None, previous_action=None,
+    ):
+        self._observation = observation
+        return harness.generate_prompt(
+            observation, move_history, previous_response, previous_action,
+        )
+
+    def parse_response(self, response, legal_action_strings):
+        return harness.parse_response(
+            response, legal_action_strings, observation=self._observation,
+        )
+
+
 def _wrap_litellm_with_logging() -> None:
     """Replace litellm.completion with a version that prints I/O."""
     original = litellm.completion
@@ -69,7 +94,7 @@ def main() -> None:
     env.reset()
     _wrap_litellm_with_logging()
 
-    agent_fn = create_agent_fn(harness._PokerHarness())
+    agent_fn = create_agent_fn(_PokerHarness())
 
     move_count = 0
     while not env.done:

--- a/kaggle_environments/envs/word_association/harness/main.py
+++ b/kaggle_environments/envs/word_association/harness/main.py
@@ -20,7 +20,6 @@ from typing import Any, Mapping, Sequence
 
 from kaggle_environments.core_harness import (
     ParseResult,
-    create_agent_fn,
     extract_last_json_object,
 )
 
@@ -453,24 +452,3 @@ def parse_response(
     return ParseResult(legal_action=None, raw_action=raw, thoughts=thinking)
 
 
-# --- Agent wiring -----------------------------------------------------------
-
-
-class _WordAssociationHarness:
-    """Adapter bridging module-level functions to the GameHarness protocol."""
-
-    def get_legal_moves(self, observation):
-        return get_legal_moves(observation)
-
-    def make_prompt(
-        self, observation, move_history, previous_response=None, previous_action=None,
-    ):
-        return generate_prompt(
-            observation, move_history, previous_response, previous_action,
-        )
-
-    def parse_response(self, response, legal_action_strings):
-        return parse_response(response, legal_action_strings)
-
-
-agent_fn = create_agent_fn(_WordAssociationHarness())

--- a/tests/envs/open_spiel_env/games/repeated_poker/harness_test.py
+++ b/tests/envs/open_spiel_env/games/repeated_poker/harness_test.py
@@ -8,11 +8,40 @@ from absl.testing import absltest
 from kaggle_environments.core_harness import ParseResult, create_agent_fn
 from kaggle_environments.envs.open_spiel_env.games.repeated_poker.harness import (
     _extract_move_from_response,
-    _PokerHarness,
     generate_prompt,
     get_legal_moves,
     parse_response,
 )
+
+
+class _PokerHarness:
+    """Test-local GameHarness adapter for repeated_poker.
+
+    Stashes the latest observation so ``parse_response`` can reach the
+    pyspiel state the soft parser needs for bet-size offsets. Mirrors the
+    shape the production wrapper template needs to take for this harness.
+    """
+
+    def __init__(self) -> None:
+        self._observation = None
+
+    def get_legal_moves(self, observation):
+        self._observation = observation
+        return get_legal_moves(observation)
+
+    def make_prompt(
+        self, observation, move_history,
+        previous_response=None, previous_action=None,
+    ):
+        self._observation = observation
+        return generate_prompt(
+            observation, move_history, previous_response, previous_action,
+        )
+
+    def parse_response(self, response, legal_action_strings):
+        return parse_response(
+            response, legal_action_strings, observation=self._observation,
+        )
 
 _GAME_STRING = (
     "repeated_poker(max_num_hands=100,reset_stacks=True,rotate_dealer=True,"

--- a/tests/envs/word_association/test_harness.py
+++ b/tests/envs/word_association/test_harness.py
@@ -8,11 +8,28 @@ from absl.testing import absltest
 from kaggle_environments import core_harness
 from kaggle_environments.core_harness import ParseResult, create_agent_fn, set_telemetry_exporter
 from kaggle_environments.envs.word_association.harness.main import (
-    _WordAssociationHarness,
     generate_prompt,
     get_legal_moves,
     parse_response,
 )
+
+
+class _WordAssociationHarness:
+    """Test-local GameHarness adapter for word_association."""
+
+    def get_legal_moves(self, observation):
+        return get_legal_moves(observation)
+
+    def make_prompt(
+        self, observation, move_history,
+        previous_response=None, previous_action=None,
+    ):
+        return generate_prompt(
+            observation, move_history, previous_response, previous_action,
+        )
+
+    def parse_response(self, response, legal_action_strings):
+        return parse_response(response, legal_action_strings)
 
 
 # --- Helpers ----------------------------------------------------------------


### PR DESCRIPTION
These classes appear as if they are to be imported and run in prod, however they are actually dead code and introduce confusion. Delete them and update skills to stop writing them.