### PR TITLE
Pass 'observation' to parse_response

### DIFF
--- a/.agents/skills/create-harness/SKILL.md
+++ b/.agents/skills/create-harness/SKILL.md
@@ -402,9 +402,14 @@ class _MyGameHarness:
             observation, move_history, previous_response, previous_action,
         )
 
-    def parse_response(self, response, legal_action_strings):
+    def parse_response(self, response, legal_action_strings, *, observation=None):
+        # Most parsers ignore `observation`. If yours forwards it to a
+        # module-level parse_response that needs the env state, pass it
+        # through here.
         return parse_response(response, legal_action_strings)
 ```
+
+The `*, observation` keyword on `parse_response` is required by the `GameHarness` protocol — `core_harness` always passes the current turn's observation. Most parsers can match the model's output against `legal_action_strings` alone and can ignore it; for parsers that genuinely need the env state at parse time (e.g. repeated_poker's bet-size soft-matching), declare an opt-in `*, observation: Mapping[str, Any] | None = None` kwarg on the *module-level* `parse_response` too and forward it through. See `kaggle_environments/envs/open_spiel_env/games/repeated_poker/harness.py` for that pattern.
 
 Mock helpers (`_StreamDelta`, `_StreamChoice`, `_StreamChunk`,
 `_make_mock_response`, `_ENV`) live at the top of checkers'

--- a/kaggle_environments/core_harness.py
+++ b/kaggle_environments/core_harness.py
@@ -391,6 +391,8 @@ class GameHarness(Protocol):
         self,
         response: str,
         legal_action_strings: Sequence[str] | None,
+        *,
+        observation: Mapping[str, Any],
     ) -> ParseResult:
         """Extract a move from the LLM response.
 
@@ -399,6 +401,13 @@ class GameHarness(Protocol):
         ``legal_action_strings``.  For free-form actions
         (``legal_action_strings is None``), set ``submission`` on the
         result instead.
+
+        ``observation`` is the current turn's observation dict — always
+        passed by ``core_harness``. Most parsers can match the model's
+        output against ``legal_action_strings`` alone and may ignore it;
+        parsers that genuinely need the env state at parse time (e.g.
+        repeated_poker's bet-size soft-matching) forward it to the
+        module-level helper that does the work.
         """
         ...
 
@@ -726,7 +735,22 @@ def create_agent_fn(
                     "model": model_name,
                     **call_details,
                 })
-                result = game_harness.parse_response(content, legal_action_strings)
+                # TODO: drop this fallback once the prod orchestrator
+                # template forwards `observation=` to `parse_response`.
+                # Until then, old adapters whose `parse_response` signature
+                # is `(self, response, legal_action_strings)` would raise
+                # TypeError on the kwarg. Narrow the catch to that specific
+                # signature mismatch so we don't mask real parser bugs.
+                try:
+                    result = game_harness.parse_response(
+                        content, legal_action_strings, observation=observation,
+                    )
+                except TypeError as exc:
+                    if "observation" not in str(exc):
+                        raise
+                    result = game_harness.parse_response(
+                        content, legal_action_strings,
+                    )
                 last_exception = None
             except Exception as exc:
                 last_exception = exc

--- a/kaggle_environments/envs/open_spiel_env/games/connect_four/debug_match_runner.py
+++ b/kaggle_environments/envs/open_spiel_env/games/connect_four/debug_match_runner.py
@@ -37,7 +37,7 @@ class _C4Harness:
             previous_action,
         )
 
-    def parse_response(self, response, legal_action_strings):
+    def parse_response(self, response, legal_action_strings, *, observation=None):
         return harness.parse_response(response, legal_action_strings)
 
 

--- a/kaggle_environments/envs/open_spiel_env/games/go/debug_match_runner.py
+++ b/kaggle_environments/envs/open_spiel_env/games/go/debug_match_runner.py
@@ -31,7 +31,7 @@ class _GoHarness:
     def make_prompt(self, observation, move_history, previous_response=None, previous_action=None):
         return harness.generate_prompt(observation, move_history, previous_response, previous_action)
 
-    def parse_response(self, response, legal_action_strings):
+    def parse_response(self, response, legal_action_strings, *, observation=None):
         return harness.parse_response(response, legal_action_strings)
 
 

--- a/kaggle_environments/envs/open_spiel_env/games/repeated_poker/test_llm_game.py
+++ b/kaggle_environments/envs/open_spiel_env/games/repeated_poker/test_llm_game.py
@@ -21,25 +21,20 @@ from kaggle_environments.envs.open_spiel_env.games.repeated_poker import harness
 class _PokerHarness:
     """Local GameHarness adapter for the debug runner."""
 
-    def __init__(self) -> None:
-        self._observation = None
-
     def get_legal_moves(self, observation):
-        self._observation = observation
         return harness.get_legal_moves(observation)
 
     def make_prompt(
         self, observation, move_history,
         previous_response=None, previous_action=None,
     ):
-        self._observation = observation
         return harness.generate_prompt(
             observation, move_history, previous_response, previous_action,
         )
 
-    def parse_response(self, response, legal_action_strings):
+    def parse_response(self, response, legal_action_strings, *, observation=None):
         return harness.parse_response(
-            response, legal_action_strings, observation=self._observation,
+            response, legal_action_strings, observation=observation,
         )
 
 

--- a/tests/core_harness_test.py
+++ b/tests/core_harness_test.py
@@ -36,7 +36,7 @@ class _SimpleHarness:
         self.prompts.append(prompt)
         return prompt
 
-    def parse_response(self, response, legal_action_strings):
+    def parse_response(self, response, legal_action_strings, *, observation=None):
         response = response.strip()
         if response in legal_action_strings:
             return ParseResult(legal_action=response, raw_action=response)
@@ -178,7 +178,7 @@ class CoreHarnessTest(absltest.TestCase):
         # Stub parse_response to return raw_action=None for non-empty
         # content -- mimics a parser that couldn't extract anything.
         harness = _SimpleHarness()
-        harness.parse_response = lambda r, l: ParseResult(legal_action=None, raw_action=None)
+        harness.parse_response = lambda r, l, *, observation=None: ParseResult(legal_action=None, raw_action=None)
         agent = create_agent_fn(harness, max_retries=1)
         with patch.dict("os.environ", _ENV, clear=False), patch.object(
             core_harness.litellm, "completion",
@@ -542,7 +542,7 @@ class CoreHarnessTest(absltest.TestCase):
                 super().__init__()
                 self.parse_calls = 0
 
-            def parse_response(self, response, legal_action_strings):
+            def parse_response(self, response, legal_action_strings, *, observation=None):
                 self.parse_calls += 1
                 if self.parse_calls == 1:
                     raise RuntimeError("parser blew up")
@@ -682,7 +682,7 @@ class _FreeFormHarness:
         self.prompts.append(prompt)
         return prompt
 
-    def parse_response(self, response, legal_action_strings):
+    def parse_response(self, response, legal_action_strings, *, observation=None):
         assert legal_action_strings is None
         try:
             import json
@@ -715,7 +715,7 @@ class _MixedHarness:
         self.prompts.append(prompt)
         return prompt
 
-    def parse_response(self, response, legal_action_strings):
+    def parse_response(self, response, legal_action_strings, *, observation=None):
         if legal_action_strings is None:
             try:
                 import json

--- a/tests/envs/open_spiel_env/games/amazons/harness_test.py
+++ b/tests/envs/open_spiel_env/games/amazons/harness_test.py
@@ -419,7 +419,7 @@ class _AmazonsHarness:
     def make_prompt(self, observation, move_history, previous_response=None, previous_action=None):
         return generate_prompt(observation, move_history, previous_response, previous_action)
 
-    def parse_response(self, response, legal_action_strings):
+    def parse_response(self, response, legal_action_strings, *, observation=None):
         return parse_response(response, legal_action_strings)
 
 

--- a/tests/envs/open_spiel_env/games/backgammon/harness_test.py
+++ b/tests/envs/open_spiel_env/games/backgammon/harness_test.py
@@ -316,7 +316,7 @@ class _BackgammonHarness:
             previous_action=previous_action,
         )
 
-    def parse_response(self, response, legal_action_strings):
+    def parse_response(self, response, legal_action_strings, *, observation=None):
         return parse_response(response, legal_action_strings)
 
 

--- a/tests/envs/open_spiel_env/games/checkers/harness_test.py
+++ b/tests/envs/open_spiel_env/games/checkers/harness_test.py
@@ -310,7 +310,7 @@ class _CheckersHarness:
             previous_action=previous_action,
         )
 
-    def parse_response(self, response, legal_action_strings):
+    def parse_response(self, response, legal_action_strings, *, observation=None):
         return parse_response(response, legal_action_strings)
 
 

--- a/tests/envs/open_spiel_env/games/chess/harness_test.py
+++ b/tests/envs/open_spiel_env/games/chess/harness_test.py
@@ -361,7 +361,7 @@ class _ChessHarness:
     def make_prompt(self, observation, move_history, previous_response=None, previous_action=None):
         return generate_prompt(observation, move_history, previous_response, previous_action)
 
-    def parse_response(self, response, legal_action_strings):
+    def parse_response(self, response, legal_action_strings, *, observation=None):
         return parse_response(response, legal_action_strings)
 
 

--- a/tests/envs/open_spiel_env/games/clobber/harness_test.py
+++ b/tests/envs/open_spiel_env/games/clobber/harness_test.py
@@ -272,7 +272,7 @@ class _ClobberHarness:
             previous_action=previous_action,
         )
 
-    def parse_response(self, response, legal_action_strings):
+    def parse_response(self, response, legal_action_strings, *, observation=None):
         return parse_response(response, legal_action_strings)
 
 

--- a/tests/envs/open_spiel_env/games/coin_game/harness_test.py
+++ b/tests/envs/open_spiel_env/games/coin_game/harness_test.py
@@ -326,7 +326,7 @@ class _CoinHarness:
             previous_action=previous_action,
         )
 
-    def parse_response(self, response, legal_action_strings):
+    def parse_response(self, response, legal_action_strings, *, observation=None):
         return parse_response(response, legal_action_strings)
 
 

--- a/tests/envs/open_spiel_env/games/coin_game_arena/harness_test.py
+++ b/tests/envs/open_spiel_env/games/coin_game_arena/harness_test.py
@@ -338,7 +338,7 @@ class _ArenaHarness:
             previous_action=previous_action,
         )
 
-    def parse_response(self, response, legal_action_strings):
+    def parse_response(self, response, legal_action_strings, *, observation=None):
         return parse_response(response, legal_action_strings)
 
 

--- a/tests/envs/open_spiel_env/games/connect_four/harness_test.py
+++ b/tests/envs/open_spiel_env/games/connect_four/harness_test.py
@@ -253,7 +253,7 @@ class _C4Harness:
             previous_action,
         )
 
-    def parse_response(self, response, legal_action_strings):
+    def parse_response(self, response, legal_action_strings, *, observation=None):
         return parse_response(response, legal_action_strings)
 
 

--- a/tests/envs/open_spiel_env/games/dark_hex/harness_test.py
+++ b/tests/envs/open_spiel_env/games/dark_hex/harness_test.py
@@ -304,7 +304,7 @@ class _DarkHexHarness:
     def make_prompt(self, observation, move_history, previous_response=None, previous_action=None):
         return generate_prompt(observation, move_history, previous_response, previous_action)
 
-    def parse_response(self, response, legal_action_strings):
+    def parse_response(self, response, legal_action_strings, *, observation=None):
         return parse_response(response, legal_action_strings)
 
 

--- a/tests/envs/open_spiel_env/games/dots_and_boxes/harness_test.py
+++ b/tests/envs/open_spiel_env/games/dots_and_boxes/harness_test.py
@@ -253,7 +253,7 @@ class _DotsAndBoxesHarness:
             previous_action=previous_action,
         )
 
-    def parse_response(self, response, legal_action_strings):
+    def parse_response(self, response, legal_action_strings, *, observation=None):
         return parse_response(response, legal_action_strings)
 
 

--- a/tests/envs/open_spiel_env/games/go/harness_test.py
+++ b/tests/envs/open_spiel_env/games/go/harness_test.py
@@ -246,7 +246,7 @@ class _GoHarness:
     def make_prompt(self, observation, move_history, previous_response=None, previous_action=None):
         return generate_prompt(observation, move_history, previous_response, previous_action)
 
-    def parse_response(self, response, legal_action_strings):
+    def parse_response(self, response, legal_action_strings, *, observation=None):
         return parse_response(response, legal_action_strings)
 
 

--- a/tests/envs/open_spiel_env/games/havannah/harness_test.py
+++ b/tests/envs/open_spiel_env/games/havannah/harness_test.py
@@ -284,7 +284,7 @@ class _HavannahHarness:
     def make_prompt(self, observation, move_history, previous_response=None, previous_action=None):
         return generate_prompt(observation, move_history, previous_response, previous_action)
 
-    def parse_response(self, response, legal_action_strings):
+    def parse_response(self, response, legal_action_strings, *, observation=None):
         return parse_response(response, legal_action_strings)
 
 

--- a/tests/envs/open_spiel_env/games/lines_of_action/harness_test.py
+++ b/tests/envs/open_spiel_env/games/lines_of_action/harness_test.py
@@ -311,7 +311,7 @@ class _LoAHarness:
             previous_action=previous_action,
         )
 
-    def parse_response(self, response, legal_action_strings):
+    def parse_response(self, response, legal_action_strings, *, observation=None):
         return parse_response(response, legal_action_strings)
 
 

--- a/tests/envs/open_spiel_env/games/mancala/harness_test.py
+++ b/tests/envs/open_spiel_env/games/mancala/harness_test.py
@@ -258,7 +258,7 @@ class _MancalaHarness:
             previous_action=previous_action,
         )
 
-    def parse_response(self, response, legal_action_strings):
+    def parse_response(self, response, legal_action_strings, *, observation=None):
         return parse_response(response, legal_action_strings)
 
 

--- a/tests/envs/open_spiel_env/games/negotiation/harness_test.py
+++ b/tests/envs/open_spiel_env/games/negotiation/harness_test.py
@@ -291,7 +291,7 @@ class _Harness:
     def make_prompt(self, observation, move_history, previous_response=None, previous_action=None):
         return generate_prompt(observation, move_history, previous_response, previous_action)
 
-    def parse_response(self, response, legal_action_strings):
+    def parse_response(self, response, legal_action_strings, *, observation=None):
         return parse_response(response, legal_action_strings)
 
 

--- a/tests/envs/open_spiel_env/games/oshi_zumo/harness_test.py
+++ b/tests/envs/open_spiel_env/games/oshi_zumo/harness_test.py
@@ -274,7 +274,7 @@ class _OshiZumoHarness:
             previous_action=previous_action,
         )
 
-    def parse_response(self, response, legal_action_strings):
+    def parse_response(self, response, legal_action_strings, *, observation=None):
         return parse_response(response, legal_action_strings)
 
 

--- a/tests/envs/open_spiel_env/games/python_ant_foraging/harness_test.py
+++ b/tests/envs/open_spiel_env/games/python_ant_foraging/harness_test.py
@@ -367,7 +367,7 @@ class _AntHarness:
             previous_action=previous_action,
         )
 
-    def parse_response(self, response, legal_action_strings):
+    def parse_response(self, response, legal_action_strings, *, observation=None):
         return parse_response(response, legal_action_strings)
 
 

--- a/tests/envs/open_spiel_env/games/repeated_poker/harness_test.py
+++ b/tests/envs/open_spiel_env/games/repeated_poker/harness_test.py
@@ -15,32 +15,22 @@ from kaggle_environments.envs.open_spiel_env.games.repeated_poker.harness import
 
 
 class _PokerHarness:
-    """Test-local GameHarness adapter for repeated_poker.
-
-    Stashes the latest observation so ``parse_response`` can reach the
-    pyspiel state the soft parser needs for bet-size offsets. Mirrors the
-    shape the production wrapper template needs to take for this harness.
-    """
-
-    def __init__(self) -> None:
-        self._observation = None
+    """Test-local GameHarness adapter for repeated_poker."""
 
     def get_legal_moves(self, observation):
-        self._observation = observation
         return get_legal_moves(observation)
 
     def make_prompt(
         self, observation, move_history,
         previous_response=None, previous_action=None,
     ):
-        self._observation = observation
         return generate_prompt(
             observation, move_history, previous_response, previous_action,
         )
 
-    def parse_response(self, response, legal_action_strings):
+    def parse_response(self, response, legal_action_strings, *, observation=None):
         return parse_response(
-            response, legal_action_strings, observation=self._observation,
+            response, legal_action_strings, observation=observation,
         )
 
 _GAME_STRING = (

--- a/tests/envs/open_spiel_env/games/snake/harness_test.py
+++ b/tests/envs/open_spiel_env/games/snake/harness_test.py
@@ -323,7 +323,7 @@ class _SnakeHarness:
             previous_action=previous_action,
         )
 
-    def parse_response(self, response, legal_action_strings):
+    def parse_response(self, response, legal_action_strings, *, observation=None):
         return parse_response(response, legal_action_strings)
 
 

--- a/tests/envs/word_association/test_harness.py
+++ b/tests/envs/word_association/test_harness.py
@@ -28,7 +28,7 @@ class _WordAssociationHarness:
             observation, move_history, previous_response, previous_action,
         )
 
-    def parse_response(self, response, legal_action_strings):
+    def parse_response(self, response, legal_action_strings, *, observation=None):
         return parse_response(response, legal_action_strings)
 
 


### PR DESCRIPTION
The Poker harness `parse_response` needs the `observation` to be passed, which we do not do currently.

In order to pass it, we would have to update and re-deploy *every single harness* along with the static main script that imports the harness.

Instead, we will update the static main script to support either scenario-- `observation` being defined in the signature, or not. We will ALWAYS pass `observation` in `core_harness.py` and leave it up to the main script to decide on passing it further or not.

Implement this change in a backwards compatible fashion while we wait for a deployment of the static main script.