### PR TITLE
reinforce_tactics: gate recruitment on owned Building/HQ

### DIFF
--- a/kaggle_environments/envs/reinforce_tactics/README.md
+++ b/kaggle_environments/envs/reinforce_tactics/README.md
@@ -210,14 +210,14 @@ def my_agent(observation, configuration):
     my_buildings = [s for s in structures if s["owner"] == player and s["type"] == "b"]
     occupied = {(u["x"], u["y"]) for u in units}
     for bldg in my_buildings:
-        if gold >= 200 and (bldg["x"], bldg["y"]) not in occupied:
+        if gold >= 300 and (bldg["x"], bldg["y"]) not in occupied:
             actions.append({
                 "type": "create_unit",
                 "unit_type": "W",
                 "x": bldg["x"],
                 "y": bldg["y"],
             })
-            gold -= 200
+            gold -= 300
 
     # Move, attack, seize, etc.
     # ...

--- a/kaggle_environments/envs/reinforce_tactics/reinforce_tactics_engine/core/game_state.py
+++ b/kaggle_environments/envs/reinforce_tactics/reinforce_tactics_engine/core/game_state.py
@@ -549,6 +549,19 @@ class GameState:
         if self.get_unit_at_position(x, y):
             return None
 
+        # Recruitment is only legal on an owned Building or HQ. Without this
+        # guard, create_unit would spawn units on any unoccupied tile
+        # (grass, mountain, even enemy structures), which contradicts the
+        # README's "Recruit at owned buildings/HQ" rule and the action mask
+        # in get_legal_actions.
+        tile = self.grid.get_tile(x, y)
+        if tile is None:
+            return None
+        if tile.type not in (TileType.BUILDING.value, TileType.HEADQUARTERS.value):
+            return None
+        if tile.player != player:
+            return None
+
         # Check if player can afford
         if unit_type not in self.unit_data:
             logger.warning(f"Unknown unit type: {unit_type}")
@@ -559,6 +572,16 @@ class GameState:
             return None
 
         self.player_gold[player] -= cost
+        return self._spawn_unit(unit_type, x, y, player)
+
+    def _spawn_unit(self, unit_type: str, x: int, y: int, player: int) -> Unit:
+        """Insert a unit at (x, y) without recruitment validation.
+
+        Skips the unit cap, occupancy, tile-type, ownership, and cost
+        checks that ``create_unit`` enforces. Intended for tests that
+        need arbitrary board setups (combat, movement, abilities) and
+        for internal callers that have already validated placement.
+        """
         unit = Unit(unit_type, x, y, player, stats=self.unit_data[unit_type])
         unit.unit_id = self._next_unit_id
         self._next_unit_id += 1
@@ -1126,13 +1149,14 @@ class GameState:
             "end_turn": True,
         }
 
-        # Building units (only at Buildings, not HQ)
+        # Recruit at owned Buildings or HQ (matches create_unit's tile-type
+        # guard and the README's "Recruit at owned buildings/HQ" rule).
         # Only include enabled unit types. Suppressed entirely once the player
         # is at the unit cap so the action mask matches create_unit's own
         # enforcement (no offered-then-rejected create actions).
         if sum(1 for u in self.units if u.player == player) < self.max_units_per_player:
             for tile in self.grid.get_capturable_tiles(player):
-                if tile.type == TileType.BUILDING.value and not self.get_unit_at_position(tile.x, tile.y):
+                if tile.type in (TileType.BUILDING.value, TileType.HEADQUARTERS.value) and not self.get_unit_at_position(tile.x, tile.y):
                     for unit_type in self.enabled_units:
                         if self.player_gold[player] >= self.unit_data[unit_type]["cost"]:
                             legal_actions["create_unit"].append({"unit_type": unit_type, "x": tile.x, "y": tile.y})

--- a/tests/envs/reinforce_tactics/test_reinforce_tactics.py
+++ b/tests/envs/reinforce_tactics/test_reinforce_tactics.py
@@ -505,8 +505,8 @@ class TestSerialisation:
         game = _create_test_game()
         game.player_gold[1] = 500
         game.player_gold[2] = 500
-        game.create_unit("W", 5, 5, player=1)
-        game.create_unit("M", 7, 7, player=2)
+        game._spawn_unit("W", 5, 5, player=1)
+        game._spawn_unit("M", 7, 7, player=2)
         units = _serialize_units(game)
         assert len(units) == 2
         # Check keys
@@ -537,8 +537,8 @@ class TestSerialisation:
         game.player_gold[1] = 500
         game.player_gold[2] = 500
         # Create a friendly unit at (1,1) and enemy far away at (8,8)
-        game.create_unit("W", 1, 1, player=1)
-        game.create_unit("W", 8, 8, player=2)
+        game._spawn_unit("W", 1, 1, player=1)
+        game._spawn_unit("W", 8, 8, player=2)
         # Initialize visibility maps
         from kaggle_environments.envs.reinforce_tactics.reinforce_tactics_engine.core.visibility import VisibilityMap
 
@@ -559,7 +559,7 @@ class TestSerialisation:
 
     def test_units_serialisation_is_json_serializable(self):
         game = _create_test_game()
-        game.create_unit("W", 5, 5, player=1)
+        game._spawn_unit("W", 5, 5, player=1)
         units = _serialize_units(game)
         json.dumps(units)  # Should not raise
 
@@ -627,7 +627,7 @@ class TestActionExecution:
 
     def test_move_unit(self):
         game = _create_test_game()
-        unit = game.create_unit("W", 5, 5, player=1)
+        unit = game._spawn_unit("W", 5, 5, player=1)
         unit.can_move = True
         result = _execute_action(
             game,
@@ -646,7 +646,7 @@ class TestActionExecution:
 
     def test_move_unit_wrong_player(self):
         game = _create_test_game()
-        unit = game.create_unit("W", 5, 5, player=2)
+        unit = game._spawn_unit("W", 5, 5, player=2)
         unit.can_move = True
         result = _execute_action(
             game,
@@ -663,9 +663,9 @@ class TestActionExecution:
 
     def test_attack_unit(self):
         game = _create_test_game()
-        attacker = game.create_unit("W", 5, 5, player=1)
+        attacker = game._spawn_unit("W", 5, 5, player=1)
         attacker.can_attack = True
-        assert game.create_unit("C", 6, 5, player=2) is not None
+        assert game._spawn_unit("C", 6, 5, player=2) is not None
         result = _execute_action(
             game,
             {
@@ -682,9 +682,9 @@ class TestActionExecution:
     def test_attack_own_unit_fails(self):
         game = _create_test_game()
         game.player_gold[1] = 1000
-        attacker = game.create_unit("W", 5, 5, player=1)
+        attacker = game._spawn_unit("W", 5, 5, player=1)
         attacker.can_attack = True
-        assert game.create_unit("W", 6, 5, player=1) is not None
+        assert game._spawn_unit("W", 6, 5, player=1) is not None
         result = _execute_action(
             game,
             {
@@ -701,7 +701,7 @@ class TestActionExecution:
     def test_seize_structure(self):
         game = _create_test_game()
         # Place P1 unit on P2 HQ at (9,9)
-        unit = game.create_unit("W", 9, 9, player=1)
+        unit = game._spawn_unit("W", 9, 9, player=1)
         unit.can_attack = True
         result = _execute_action(
             game,
@@ -717,7 +717,7 @@ class TestActionExecution:
     def test_seize_own_structure_fails(self):
         game = _create_test_game()
         # Place P1 unit on P1 HQ at (0,0)
-        assert game.create_unit("W", 0, 0, player=1) is not None
+        assert game._spawn_unit("W", 0, 0, player=1) is not None
         result = _execute_action(
             game,
             {
@@ -733,7 +733,7 @@ class TestActionExecution:
         # A unit gets one can_attack-action per turn: the second seize is a
         # no-op, so a structure can't be captured to completion in one turn.
         game = _create_test_game()
-        unit = game.create_unit("W", 9, 9, player=1)  # P1 unit on the P2 HQ
+        unit = game._spawn_unit("W", 9, 9, player=1)  # P1 unit on the P2 HQ
         unit.can_attack = True
         first = _execute_action(game, {"type": "seize", "x": 9, "y": 9}, player=1)
         second = _execute_action(game, {"type": "seize", "x": 9, "y": 9}, player=1)
@@ -744,9 +744,9 @@ class TestActionExecution:
 
     def test_unit_cannot_attack_twice_in_one_turn(self):
         game = _create_test_game()
-        attacker = game.create_unit("W", 5, 5, player=1)
+        attacker = game._spawn_unit("W", 5, 5, player=1)
         attacker.can_attack = True
-        game.create_unit("W", 6, 5, player=2)  # adjacent enemy
+        game._spawn_unit("W", 6, 5, player=2)  # adjacent enemy
         first = _execute_action(game, {"type": "attack", "from_x": 5, "from_y": 5, "to_x": 6, "to_y": 5}, player=1)
         target = game.get_unit_at_position(6, 5)
         hp_after_first = target.health
@@ -761,9 +761,9 @@ class TestActionExecution:
         # can't heal more than once per turn.
         game = _create_test_game()
         game.player_gold[1] = 1000
-        cleric = game.create_unit("C", 5, 5, player=1)
+        cleric = game._spawn_unit("C", 5, 5, player=1)
         cleric.can_attack = True
-        target = game.create_unit("W", 6, 5, player=1)
+        target = game._spawn_unit("W", 6, 5, player=1)
         target.health = 1  # damaged enough that a second heal would also help
         first = _execute_action(game, {"type": "heal", "from_x": 5, "from_y": 5, "to_x": 6, "to_y": 5}, player=1)
         hp_after_first = target.health
@@ -775,9 +775,9 @@ class TestActionExecution:
     def test_heal_action(self):
         game = _create_test_game()
         game.player_gold[1] = 1000
-        cleric = game.create_unit("C", 5, 5, player=1)
+        cleric = game._spawn_unit("C", 5, 5, player=1)
         cleric.can_attack = True
-        target = game.create_unit("W", 6, 5, player=1)
+        target = game._spawn_unit("W", 6, 5, player=1)
         target.health = 5  # Damage the target
         result = _execute_action(
             game,
@@ -797,9 +797,9 @@ class TestActionExecution:
         game = _create_test_game()
         game.player_gold[1] = 1000
         game.player_gold[2] = 1000
-        mage = game.create_unit("M", 5, 5, player=1)
+        mage = game._spawn_unit("M", 5, 5, player=1)
         mage.can_attack = True
-        enemy = game.create_unit("W", 6, 5, player=2)
+        enemy = game._spawn_unit("W", 6, 5, player=2)
         result = _execute_action(
             game,
             {
@@ -832,9 +832,9 @@ class TestActionExecution:
     def test_haste_action(self):
         game = _create_test_game()
         game.player_gold[1] = 1000
-        sorcerer = game.create_unit("S", 5, 5, player=1)
+        sorcerer = game._spawn_unit("S", 5, 5, player=1)
         sorcerer.can_attack = True
-        ally = game.create_unit("W", 6, 5, player=1)
+        ally = game._spawn_unit("W", 6, 5, player=1)
         result = _execute_action(
             game,
             {
@@ -852,9 +852,9 @@ class TestActionExecution:
     def test_defence_buff_action(self):
         game = _create_test_game()
         game.player_gold[1] = 1000
-        sorcerer = game.create_unit("S", 5, 5, player=1)
+        sorcerer = game._spawn_unit("S", 5, 5, player=1)
         sorcerer.can_attack = True
-        ally = game.create_unit("W", 6, 5, player=1)
+        ally = game._spawn_unit("W", 6, 5, player=1)
         result = _execute_action(
             game,
             {
@@ -872,9 +872,9 @@ class TestActionExecution:
     def test_attack_buff_action(self):
         game = _create_test_game()
         game.player_gold[1] = 1000
-        sorcerer = game.create_unit("S", 5, 5, player=1)
+        sorcerer = game._spawn_unit("S", 5, 5, player=1)
         sorcerer.can_attack = True
-        ally = game.create_unit("W", 6, 5, player=1)
+        ally = game._spawn_unit("W", 6, 5, player=1)
         result = _execute_action(
             game,
             {
@@ -892,9 +892,9 @@ class TestActionExecution:
     def test_cure_action(self):
         game = _create_test_game()
         game.player_gold[1] = 1000
-        cleric = game.create_unit("C", 5, 5, player=1)
+        cleric = game._spawn_unit("C", 5, 5, player=1)
         cleric.can_attack = True
-        ally = game.create_unit("W", 6, 5, player=1)
+        ally = game._spawn_unit("W", 6, 5, player=1)
         ally.paralyzed_turns = 3
         result = _execute_action(
             game,
@@ -1058,7 +1058,7 @@ class TestWinConditions:
         game.player_gold[1] = 500
 
         # Place a warrior on enemy HQ
-        warrior = game.create_unit("W", 9, 9, player=1)
+        warrior = game._spawn_unit("W", 9, 9, player=1)
         warrior.can_attack = True
 
         # Reduce HQ HP so warrior can capture in one seize
@@ -1076,9 +1076,9 @@ class TestWinConditions:
     def test_eliminate_all_units_wins(self):
         """Eliminating all enemy units should end the game."""
         game = _create_test_game()
-        attacker = game.create_unit("W", 5, 5, player=1)
+        attacker = game._spawn_unit("W", 5, 5, player=1)
         attacker.can_attack = True
-        target = game.create_unit("C", 6, 5, player=2)
+        target = game._spawn_unit("C", 6, 5, player=2)
 
         # Drop player 2's only unit to lethal HP so the Warrior's attack is
         # guaranteed to kill it regardless of unit balance tuning.
@@ -1386,7 +1386,7 @@ class TestHelpers:
     def test_update_observations(self):
         game = _create_test_game()
         game.player_gold[1] = 500
-        game.create_unit("W", 5, 5, player=1)
+        game._spawn_unit("W", 5, 5, player=1)
         config = _make_config()
         obs0 = _make_observation(player=0)
         obs1 = _make_observation(player=1)

--- a/tests/envs/reinforce_tactics/test_reinforce_tactics_engine.py
+++ b/tests/envs/reinforce_tactics/test_reinforce_tactics_engine.py
@@ -83,8 +83,8 @@ class TestLegalActions:
     def test_move_destinations_exclude_own_unit(self):
         """A unit's reachable set must not include tiles occupied by allies."""
         game = _new_game()
-        ally_a = game.create_unit("W", 4, 4, player=1)
-        game.create_unit("W", 5, 4, player=1)  # ally blocks (5, 4)
+        ally_a = game._spawn_unit("W", 4, 4, player=1)
+        game._spawn_unit("W", 5, 4, player=1)  # ally blocks (5, 4)
         ally_a.can_move = True
 
         actions = game.get_legal_actions(player=1)
@@ -119,8 +119,8 @@ class TestMaxTurnsDraw:
 class TestSaveLoadRoundTrip:
     def _ready_game(self):
         game = _new_game(max_turns=42)
-        game.create_unit("W", 3, 3, player=1)
-        game.create_unit("M", 6, 6, player=2)
+        game._spawn_unit("W", 3, 3, player=1)
+        game._spawn_unit("M", 6, 6, player=2)
         # Move once so the unit's original_x / original_y diverges from x / y.
         warrior = next(u for u in game.units if u.type == "W")
         warrior.x, warrior.y = 4, 3
@@ -209,8 +209,8 @@ class TestToNumpyHealthGuard:
 class TestResign:
     def test_resign_strips_units_and_sets_winner(self):
         game = _new_game()
-        game.create_unit("W", 3, 3, player=1)
-        game.create_unit("M", 6, 6, player=2)
+        game._spawn_unit("W", 3, 3, player=1)
+        game._spawn_unit("M", 6, 6, player=2)
         assert len(game.units) == 2
 
         game.resign(player=1)
@@ -233,7 +233,7 @@ class TestSeizeGating:
         game = _new_game()
         enemy_hq = game.grid.get_tile(9, 9)
         assert enemy_hq.type == "h" and enemy_hq.player == 2
-        unit = game.create_unit("W", 9, 9, player=1)
+        unit = game._spawn_unit("W", 9, 9, player=1)
         unit.can_move = True
         unit.can_attack = True
         return game, unit, enemy_hq
@@ -261,7 +261,7 @@ class TestSeizeGating:
         game = _new_game()
         hq = game.grid.get_tile(9, 9)
         starting_hp = hq.health
-        unit = game.create_unit("W", 9, 9, player=1)
+        unit = game._spawn_unit("W", 9, 9, player=1)
         assert unit.can_attack is False
 
         result = game.seize(unit)


### PR DESCRIPTION
create_unit silently spawned units on any unoccupied tile (grass, mountain, enemy structures), contradicting the README's "Recruit at owned buildings/HQ" rule and the get_legal_actions mask. Add a tile-type + ownership guard, extend the action mask to include HQ tiles, and extract the unchecked insertion into _spawn_unit for tests that need arbitrary board setups.

Also fix the README "Writing an Agent" snippet: it used the engine default Warrior cost of 200, but the env's v52a overrides raise it to 300.