### PR TITLE
Clean up parse_response observation TODO

### DIFF
--- a/kaggle_environments/core_harness.py
+++ b/kaggle_environments/core_harness.py
@@ -735,22 +735,9 @@ def create_agent_fn(
                     "model": model_name,
                     **call_details,
                 })
-                # TODO: drop this fallback once the prod orchestrator
-                # template forwards `observation=` to `parse_response`.
-                # Until then, old adapters whose `parse_response` signature
-                # is `(self, response, legal_action_strings)` would raise
-                # TypeError on the kwarg. Narrow the catch to that specific
-                # signature mismatch so we don't mask real parser bugs.
-                try:
-                    result = game_harness.parse_response(
-                        content, legal_action_strings, observation=observation,
-                    )
-                except TypeError as exc:
-                    if "observation" not in str(exc):
-                        raise
-                    result = game_harness.parse_response(
-                        content, legal_action_strings,
-                    )
+                result = game_harness.parse_response(
+                    content, legal_action_strings, observation=observation,
+                )
                 last_exception = None
             except Exception as exc:
                 last_exception = exc

--- a/tests/envs/open_spiel_env/games/bargaining/harness_test.py
+++ b/tests/envs/open_spiel_env/games/bargaining/harness_test.py
@@ -397,7 +397,7 @@ class _BargainingHarnessForTest:
             previous_action=previous_action,
         )
 
-    def parse_response(self, response, legal_action_strings):
+    def parse_response(self, response, legal_action_strings, *, observation=None):
         return parse_response(response, legal_action_strings)
 
 


### PR DESCRIPTION
The static main script in prod now accepts `observation`  on `parse_response`, so we can remove old code which was backwards compatible.

Per-game harnesses can still choose whether or not to ask for `observation`, and the static main script will check whether to pass it similarly to what was done here.