### PR TITLE
Reinforce tactics replay fidelity fixes

### DIFF
--- a/kaggle_environments/envs/reinforce_tactics/reinforce_tactics.json
+++ b/kaggle_environments/envs/reinforce_tactics/reinforce_tactics.json
@@ -53,15 +53,21 @@
       "default": []
     },
     "structures": {
-      "description": "Array of structure dicts with keys: x, y, type, owner, hp, maxHp. Only includes capturable tiles (buildings, towers, HQ).",
+      "description": "Array of structure dicts with keys: x, y, type, owner, hp, maxHp, regenerating. Only includes capturable tiles (buildings, towers, HQ). 'regenerating' is true when a structure was recently damaged/vacated and is healing back at end of turn.",
       "type": "array",
       "shared": true,
       "default": []
     },
     "units": {
-      "description": "Array of unit dicts with keys: type, owner, x, y, hp, maxHp, canMove, canAttack, paralyzedTurns, isHasted, distanceMoved, defenceBuffTurns, attackBuffTurns.",
+      "description": "Array of unit dicts with keys: type, owner, x, y, hp, maxHp, canMove, canAttack, paralyzedTurns, isHasted, distanceMoved, defenceBuffTurns, attackBuffTurns, paralyzeCooldown, hasteCooldown, defenceBuffCooldown, attackBuffCooldown. The *Cooldown fields are 'turns until this unit can reuse the named ability' counters (independent of the *Turns duration counters above, which track how long an effect remains active on the target).",
       "type": "array",
       "shared": false,
+      "default": []
+    },
+    "actionLog": {
+      "description": "Engine-side log of the actions executed during the turn just processed. Each entry mirrors a kaggle action plus self-describing outcome fields the agent's raw action doesn't carry: 'attack' entries include damage, counter_damage, attacker_killed, target_killed, *_hp_after, evade (Rogue RNG outcome), and charge_bonus/flank_bonus/attack_buff/defence_buff flags; 'seize' entries include tile_hp_after and tile_owner_after; 'heal' includes amount and target_hp_after. Entries are appended in execution order and the turn ends with an 'end_turn' entry. Coordinate tuples are surfaced as 2-element arrays.",
+      "type": "array",
+      "shared": true,
       "default": []
     },
     "gold": {

--- a/kaggle_environments/envs/reinforce_tactics/reinforce_tactics.py
+++ b/kaggle_environments/envs/reinforce_tactics/reinforce_tactics.py
@@ -161,13 +161,27 @@ def _process_turn(state, env, game, active_idx, key):
 
     game_player = active_idx + 1  # GameState uses 1-indexed players
 
-    # Execute each action in the agent's action list
-    if not _run_actions(state, game, actions, active_idx, game_player):
+    # Snapshot the engine's action_history length so we can slice out the
+    # entries appended during this turn (agent actions + end_turn) and
+    # surface them in the replay.
+    log_start = len(game.action_history)
+
+    executed = _run_actions(state, game, actions, active_idx, game_player)
+    if executed is None:
         return  # Agent lost due to invalid action
 
     # End the turn (income, healing, status effects, etc.)
     if not game.game_over:
         game.end_turn()
+
+    # Replace the agent's submitted action list with the filtered version so
+    # the replay records only the actions the engine actually applied --
+    # otherwise rejected attacks/seizes/moves show up in the replay's
+    # action[] and the visualizer draws highlights for actions that
+    # never happened.
+    agent.action = executed
+
+    action_log = _slice_action_log(game, log_start)
 
     # Check win condition
     if game.game_over:
@@ -182,7 +196,7 @@ def _process_turn(state, env, game, active_idx, key):
             state[winner_idx].status = "DONE"
             state[1 - winner_idx].reward = -1
             state[1 - winner_idx].status = "DONE"
-        _update_observations(state, game)
+        _update_observations(state, game, action_log)
         _games.pop(key, None)
         return
 
@@ -191,12 +205,12 @@ def _process_turn(state, env, game, active_idx, key):
         for i in range(2):
             state[i].reward = 0
             state[i].status = "DONE"
-        _update_observations(state, game)
+        _update_observations(state, game, action_log)
         _games.pop(key, None)
         return
 
     # Normal continuation: update observations and swap active player
-    _update_observations(state, game)
+    _update_observations(state, game, action_log)
     state[active_idx].status = "INACTIVE"
     state[1 - active_idx].status = "ACTIVE"
 
@@ -212,25 +226,31 @@ def _run_actions(state, game, actions, active_idx, game_player):
     and ``get_legal_actions`` already lets agents avoid illegal moves. Only a
     malformed action (not a dict) is treated as a broken agent and forfeits.
 
-    Returns True normally, or False if the agent forfeited (malformed action),
-    in which case it has already been marked as lost.
+    Returns the list of actions the engine actually applied (preserving the
+    submitted ``end_turn`` if reached) so the caller can write the filtered
+    list back to the replay. Returns ``None`` if the agent forfeited (in
+    which case it has already been marked as lost).
     """
+    executed = []
     for action in actions:
         if not isinstance(action, dict):
             _mark_agent_loss(state, active_idx)
-            return False
+            return None
 
         if action.get("type", "") == "end_turn":
+            executed.append(action)
             break
 
         # Illegal-but-well-formed action: skip it (no-op) and keep going.
         if not _execute_action(game, action, game_player):
             continue
 
+        executed.append(action)
+
         if game.game_over:
             break
 
-    return True
+    return executed
 
 
 def _mark_agent_loss(state, losing_idx):
@@ -535,12 +555,20 @@ def _get_source_target(game, action, player, required_type):
 # ---------------------------------------------------------------------------
 # Observation Serialisation
 # ---------------------------------------------------------------------------
-def _update_observations(state, game):
-    """Serialise the current GameState into each agent's observation."""
+def _update_observations(state, game, action_log=None):
+    """Serialise the current GameState into each agent's observation.
+
+    ``action_log`` is the slice of ``game.action_history`` produced during
+    the turn just processed (engine-side records: damage, kills, evade,
+    bonus flags, tile HP/owner after seize, etc.). It's mirrored to both
+    agents' observations so replays carry the engine's self-describing
+    outcomes instead of only the agent's raw submitted actions.
+    """
     board = _serialize_board(game)
     structures = _serialize_structures(game)
     gold = [game.player_gold.get(1, 0), game.player_gold.get(2, 0)]
     units = _serialize_units(game)
+    log = action_log if action_log is not None else []
 
     for i in range(2):
         obs = state[i].observation
@@ -551,6 +579,7 @@ def _update_observations(state, game):
         obs.turnNumber = game.turn_number
         obs.mapWidth = game.grid.width
         obs.mapHeight = game.grid.height
+        obs.actionLog = log
 
 
 def _serialize_board(game):
@@ -566,7 +595,13 @@ def _serialize_board(game):
 
 
 def _serialize_structures(game):
-    """Convert capturable structures to a list of dicts."""
+    """Convert capturable structures to a list of dicts.
+
+    ``regenerating`` is the engine flag flipped on by
+    ``mechanics.regenerate_structures`` (and on attacker/defender tile
+    after a death) -- without it the replay would see structure HP
+    snap upward at end of turn with no in-band explanation.
+    """
     structures = []
     for row in game.grid.tiles:
         for tile in row:
@@ -579,13 +614,21 @@ def _serialize_structures(game):
                         "owner": tile.player if tile.player else 0,
                         "hp": tile.health if tile.health is not None else 0,
                         "maxHp": tile.max_health if tile.max_health is not None else 0,
+                        "regenerating": bool(getattr(tile, "regenerating", False)),
                     }
                 )
     return structures
 
 
 def _serialize_units(game):
-    """Convert units to a list of dicts."""
+    """Convert units to a list of dicts.
+
+    The four ``*Cooldown`` fields are the per-unit "turns until I can
+    reuse this ability" counters tracked on the engine but not visible
+    in the duration counters (``paralyzedTurns`` etc.) above. Surfacing
+    them lets agents avoid submitting ability actions that
+    ``get_legal_actions`` would already mask out as illegal.
+    """
     units = []
     for unit in game.units:
         units.append(
@@ -603,9 +646,35 @@ def _serialize_units(game):
                 "distanceMoved": unit.distance_moved,
                 "defenceBuffTurns": unit.defence_buff_turns,
                 "attackBuffTurns": unit.attack_buff_turns,
+                "paralyzeCooldown": unit.paralyze_cooldown,
+                "hasteCooldown": unit.haste_cooldown,
+                "defenceBuffCooldown": unit.defence_buff_cooldown,
+                "attackBuffCooldown": unit.attack_buff_cooldown,
             }
         )
     return units
+
+
+def _slice_action_log(game, start_idx):
+    """Return engine action_history entries appended this turn.
+
+    Strips the per-entry wall-clock ``timestamp`` (verbose ISO datetime
+    that bloats the replay JSON and isn't needed to reconstruct game
+    state) and converts coordinate tuples (``position``, ``attacker_pos``,
+    etc.) to lists so the result round-trips cleanly through JSON.
+    """
+    entries = []
+    for entry in game.action_history[start_idx:]:
+        record = {}
+        for key, value in entry.items():
+            if key == "timestamp":
+                continue
+            if isinstance(value, tuple):
+                record[key] = list(value)
+            else:
+                record[key] = value
+        entries.append(record)
+    return entries
 
 
 # ---------------------------------------------------------------------------

--- a/kaggle_environments/envs/reinforce_tactics/reinforce_tactics.py
+++ b/kaggle_environments/envs/reinforce_tactics/reinforce_tactics.py
@@ -167,12 +167,6 @@ def _process_turn(state, env, game, active_idx, key):
     log_start = len(game.action_history)
 
     executed = _run_actions(state, game, actions, active_idx, game_player)
-    if executed is None:
-        return  # Agent lost due to invalid action
-
-    # End the turn (income, healing, status effects, etc.)
-    if not game.game_over:
-        game.end_turn()
 
     # Replace the agent's submitted action list with the filtered version so
     # the replay records only the actions the engine actually applied --
@@ -180,6 +174,21 @@ def _process_turn(state, env, game, active_idx, key):
     # action[] and the visualizer draws highlights for actions that
     # never happened.
     agent.action = executed
+
+    # Forfeit short-circuit: ``_run_actions`` already marked both agents
+    # DONE via ``_mark_agent_loss``. Still surface this turn's
+    # action_log slice (which captures any actions executed before the
+    # malformed entry, plus is empty when the malformed action came first)
+    # so the replay's final-step observation isn't a stale carry-over
+    # from the prior turn.
+    if state[active_idx].status == "DONE":
+        _update_observations(state, game, _slice_action_log(game, log_start))
+        _games.pop(key, None)
+        return
+
+    # End the turn (income, healing, status effects, etc.)
+    if not game.game_over:
+        game.end_turn()
 
     action_log = _slice_action_log(game, log_start)
 
@@ -226,16 +235,19 @@ def _run_actions(state, game, actions, active_idx, game_player):
     and ``get_legal_actions`` already lets agents avoid illegal moves. Only a
     malformed action (not a dict) is treated as a broken agent and forfeits.
 
-    Returns the list of actions the engine actually applied (preserving the
-    submitted ``end_turn`` if reached) so the caller can write the filtered
-    list back to the replay. Returns ``None`` if the agent forfeited (in
-    which case it has already been marked as lost).
+    Always returns the list of actions the engine actually applied (up to
+    and including the offending entry's predecessors on forfeit). The
+    forfeit flag is signalled out-of-band via ``state[active_idx].status``,
+    which ``_mark_agent_loss`` sets to ``"DONE"`` before returning -- so
+    the caller can still overwrite ``agent.action`` with the partial
+    executed list and surface this turn's ``action_log`` slice instead of
+    leaving the prior turn's observation stale.
     """
     executed = []
     for action in actions:
         if not isinstance(action, dict):
             _mark_agent_loss(state, active_idx)
-            return None
+            return executed
 
         if action.get("type", "") == "end_turn":
             executed.append(action)
@@ -660,8 +672,11 @@ def _slice_action_log(game, start_idx):
 
     Strips the per-entry wall-clock ``timestamp`` (verbose ISO datetime
     that bloats the replay JSON and isn't needed to reconstruct game
-    state) and converts coordinate tuples (``position``, ``attacker_pos``,
-    etc.) to lists so the result round-trips cleanly through JSON.
+    state) and recursively converts any tuples (today: coordinate pairs
+    like ``position``/``attacker_pos``; future-proof against nested
+    structures like paths or value-lists) to lists so the result
+    round-trips cleanly through JSON without relying on stdlib json's
+    tuple-as-array coercion.
     """
     entries = []
     for entry in game.action_history[start_idx:]:
@@ -669,12 +684,20 @@ def _slice_action_log(game, start_idx):
         for key, value in entry.items():
             if key == "timestamp":
                 continue
-            if isinstance(value, tuple):
-                record[key] = list(value)
-            else:
-                record[key] = value
+            record[key] = _normalize_for_json(value)
         entries.append(record)
     return entries
+
+
+def _normalize_for_json(value):
+    """Recursively convert tuples to lists. Other types pass through."""
+    if isinstance(value, tuple):
+        return [_normalize_for_json(v) for v in value]
+    if isinstance(value, list):
+        return [_normalize_for_json(v) for v in value]
+    if isinstance(value, dict):
+        return {k: _normalize_for_json(v) for k, v in value.items()}
+    return value
 
 
 # ---------------------------------------------------------------------------

--- a/tests/envs/reinforce_tactics/test_reinforce_tactics.py
+++ b/tests/envs/reinforce_tactics/test_reinforce_tactics.py
@@ -1059,6 +1059,114 @@ class TestInterpreterFlow:
         # Only end_turn should survive in the recorded action list.
         assert state[0].action == [{"type": "end_turn"}]
 
+    def test_mixed_success_and_failure_filtered(self):
+        """A turn that mixes successes and failures keeps only the successes.
+
+        Also asserts the actionLog entry count for successes matches what
+        the engine recorded -- catches drift between filtered-action and
+        action_log invariants.
+        """
+        from kaggle_environments.envs.reinforce_tactics.reinforce_tactics import (
+            _games as games_dict,
+            _process_turn,
+        )
+
+        state, env = self._setup_interpreter_game()
+        env.done = False
+        key = id(env)
+        game = games_dict[key]
+
+        attacker = game._spawn_unit("W", 5, 5, player=1)
+        attacker.can_attack = True
+        attacker.can_move = True
+        target = game._spawn_unit("W", 6, 5, player=2)
+        target.health = 10
+
+        actions_submitted = [
+            # Real attack -- succeeds.
+            {"type": "attack", "from_x": 5, "from_y": 5, "to_x": 6, "to_y": 5},
+            # Second attack from the same unit -- engine rejects (can_attack now False).
+            {"type": "attack", "from_x": 5, "from_y": 5, "to_x": 6, "to_y": 5},
+            # Unknown action -- rejected.
+            {"type": "fly_to_moon"},
+            {"type": "end_turn"},
+        ]
+        state[0].action = list(actions_submitted)
+        _process_turn(state, env, game, active_idx=0, key=key)
+
+        # Only the first attack and end_turn survive.
+        assert state[0].action == [actions_submitted[0], actions_submitted[3]]
+        # And the engine action_log should have exactly one attack entry for this turn.
+        attack_entries = [e for e in state[0].observation.actionLog if e["type"] == "attack"]
+        assert len(attack_entries) == 1
+
+    def test_forfeit_path_records_partial_actions_and_log(self):
+        """When the agent forfeits mid-list, the replay must reflect the partial state.
+
+        Pre-fix: a forfeit short-circuited _process_turn before agent.action
+        was overwritten and before _update_observations ran, so the replay
+        carried the agent's full malformed action list and a stale prior-turn
+        actionLog. Post-fix: agent.action is overwritten with the successful
+        prefix and obs.actionLog reflects this turn's engine records.
+        """
+        state, env = self._setup_interpreter_game()
+        env.done = False
+
+        # Drive a second turn so a non-empty prior actionLog exists to compare against.
+        state[0].action = [{"type": "end_turn"}]
+        interpreter(state, env)
+        prior_log = list(state[0].observation.actionLog)
+
+        # P2's turn: submit a well-formed no-op followed by a malformed entry -> forfeit.
+        state[1].action = [{"type": "invalid_nonsense"}, "not_a_dict"]
+        interpreter(state, env)
+
+        # Filtered list excludes both the no-op (it didn't execute) and the
+        # malformed entry. With no successful actions before the forfeit, the
+        # list is empty.
+        assert state[1].action == []
+        # Both agents marked DONE (P2 loses).
+        assert state[0].status == "DONE"
+        assert state[1].status == "DONE"
+        assert state[1].reward == -1
+        assert state[0].reward == 1
+        # actionLog must not be a stale carry-over of the prior turn.
+        new_log = state[1].observation.actionLog
+        assert new_log != prior_log
+
+    def test_mid_turn_game_over_skips_end_turn_record(self):
+        """When an action ends the game mid-list, the action_log slice should not
+        include an 'end_turn' record because GameState.end_turn() is skipped."""
+        from kaggle_environments.envs.reinforce_tactics.reinforce_tactics import (
+            _games as games_dict,
+            _process_turn,
+        )
+
+        state, env = self._setup_interpreter_game()
+        env.done = False
+        key = id(env)
+        game = games_dict[key]
+
+        # Eliminate P2 to set up a kill that wins the game.
+        attacker = game._spawn_unit("W", 5, 5, player=1)
+        attacker.can_attack = True
+        attacker.can_move = True
+        target = game._spawn_unit("W", 6, 5, player=2)
+        target.health = 1  # one-shot
+
+        state[0].action = [
+            {"type": "attack", "from_x": 5, "from_y": 5, "to_x": 6, "to_y": 5},
+            {"type": "end_turn"},  # should not be reached -- game ends on the kill
+        ]
+        _process_turn(state, env, game, active_idx=0, key=key)
+
+        assert game.game_over is True
+        types = [e["type"] for e in state[0].observation.actionLog]
+        # Engine's end_turn record must NOT appear -- game.end_turn() short-circuits.
+        assert "end_turn" not in types
+        # The kill-producing attack is present.
+        assert "attack" in types
+
     def test_observation_carries_action_log(self):
         """The observation should expose the engine's action_history slice for the turn."""
         state, env = self._setup_interpreter_game()

--- a/tests/envs/reinforce_tactics/test_reinforce_tactics.py
+++ b/tests/envs/reinforce_tactics/test_reinforce_tactics.py
@@ -23,6 +23,7 @@ from kaggle_environments.envs.reinforce_tactics.reinforce_tactics import (
     _serialize_board,
     _serialize_structures,
     _serialize_units,
+    _slice_action_log,
     _update_observations,
     html_renderer,
     interpreter,
@@ -183,6 +184,7 @@ class TestSpecification:
             "mapWidth",
             "mapHeight",
             "remainingOverageTime",
+            "actionLog",
         ]
         for field in expected:
             assert field in obs, f"Missing observation field: {field}"
@@ -512,9 +514,52 @@ class TestSerialisation:
                 "distanceMoved",
                 "defenceBuffTurns",
                 "attackBuffTurns",
+                "paralyzeCooldown",
+                "hasteCooldown",
+                "defenceBuffCooldown",
+                "attackBuffCooldown",
             ]
             for key in required_keys:
                 assert key in u, f"Missing key: {key}"
+
+    def test_serialize_units_exposes_ability_cooldowns(self):
+        """The four ability cooldowns must reflect the engine's per-unit state.
+
+        Without these in the observation, an agent can't tell when a Mage's
+        paralyze (or a Sorcerer's haste/buffs) will be reusable -- the
+        legal-action mask would gate it but the raw observation hides it.
+        """
+        game = _create_test_game()
+        mage = game._spawn_unit("M", 5, 5, player=1)
+        sorcerer = game._spawn_unit("S", 6, 6, player=2)
+        mage.paralyze_cooldown = 3
+        sorcerer.haste_cooldown = 2
+        sorcerer.defence_buff_cooldown = 1
+        sorcerer.attack_buff_cooldown = 4
+        units = {(u["type"], u["owner"]): u for u in _serialize_units(game)}
+        assert units[("M", 1)]["paralyzeCooldown"] == 3
+        assert units[("S", 2)]["hasteCooldown"] == 2
+        assert units[("S", 2)]["defenceBuffCooldown"] == 1
+        assert units[("S", 2)]["attackBuffCooldown"] == 4
+
+    def test_serialize_structures_exposes_regenerating(self):
+        """regenerating must be surfaced so replays can explain end-of-turn HP recovery."""
+        game = _create_test_game()
+        # Pick any capturable tile and mark it regenerating.
+        for row in game.grid.tiles:
+            for tile in row:
+                if tile.is_capturable():
+                    tile.regenerating = True
+                    target_pos = (tile.x, tile.y)
+                    break
+            else:
+                continue
+            break
+        structures = {(s["x"], s["y"]): s for s in _serialize_structures(game)}
+        assert structures[target_pos]["regenerating"] is True
+        # Untouched structures default to False (not missing).
+        other = next(s for pos, s in structures.items() if pos != target_pos)
+        assert other["regenerating"] is False
 
     def test_board_serialisation_is_json_serializable(self):
         game = _create_test_game()
@@ -531,6 +576,31 @@ class TestSerialisation:
         game = _create_test_game()
         structures = _serialize_structures(game)
         json.dumps(structures)  # Should not raise
+
+    def test_slice_action_log_converts_tuples_to_lists(self):
+        """action_history stores coord tuples; the replay slice must surface them as JSON-friendly lists."""
+        game = _create_test_game()
+        attacker = game._spawn_unit("W", 5, 5, player=1)
+        attacker.can_attack = True
+        target = game._spawn_unit("W", 6, 5, player=2)
+        target.health = 10
+        start = len(game.action_history)
+        game.attack(attacker, target)
+        log = _slice_action_log(game, start)
+        assert len(log) == 1
+        entry = log[0]
+        # Tuples must be normalised so json.dumps doesn't drop type info.
+        assert isinstance(entry["attacker_pos"], list)
+        assert isinstance(entry["target_pos"], list)
+        assert entry["attacker_pos"] == [5, 5]
+        assert entry["target_pos"] == [6, 5]
+        # And it round-trips through JSON.
+        json.dumps(log)
+
+    def test_slice_action_log_empty_when_no_actions(self):
+        game = _create_test_game()
+        start = len(game.action_history)
+        assert _slice_action_log(game, start) == []
 
 
 # ---------------------------------------------------------------------------
@@ -969,6 +1039,104 @@ class TestInterpreterFlow:
         assert result[1].reward == 0
         assert result[0].status == "INACTIVE"
         assert result[1].status == "ACTIVE"
+
+    def test_failed_actions_filtered_from_replay(self):
+        """Engine-rejected actions must not appear in the replay's action list.
+
+        Without filtering, the visualizer draws highlights for actions that
+        never happened and downstream replay analysis sees phantom moves.
+        """
+        state, env = self._setup_interpreter_game()
+        env.done = False
+
+        state[0].action = [
+            {"type": "invalid_nonsense"},  # unknown -> rejected
+            {"type": "move", "from_x": 99, "from_y": 99, "to_x": 0, "to_y": 0},  # no unit -> rejected
+            {"type": "end_turn"},
+        ]
+        interpreter(state, env)
+
+        # Only end_turn should survive in the recorded action list.
+        assert state[0].action == [{"type": "end_turn"}]
+
+    def test_observation_carries_action_log(self):
+        """The observation should expose the engine's action_history slice for the turn."""
+        state, env = self._setup_interpreter_game()
+        env.done = False
+
+        state[0].action = [{"type": "end_turn"}]
+        interpreter(state, env)
+
+        log = state[0].observation.actionLog
+        assert isinstance(log, list)
+        # end_turn is recorded by GameState.end_turn -- it must show up here.
+        types = [entry["type"] for entry in log]
+        assert "end_turn" in types
+        # Both agents see the same log (shared field).
+        assert state[1].observation.actionLog == log
+
+    def test_action_log_records_combat_outcome(self):
+        """A successful attack must produce an 'attack' entry with outcome fields."""
+        # Hand-build a game we can drive deterministically.
+        from kaggle_environments.envs.reinforce_tactics.reinforce_tactics import (
+            _games as games_dict,
+            _process_turn,
+        )
+
+        state, env = self._setup_interpreter_game()
+        env.done = False
+        key = id(env)
+        game = games_dict[key]
+
+        # Place two adjacent enemies; force-end the prior turn's effects.
+        attacker = game._spawn_unit("W", 5, 5, player=1)
+        attacker.can_attack = True
+        attacker.can_move = True
+        target = game._spawn_unit("W", 6, 5, player=2)
+        target.health = 10
+
+        state[0].action = [
+            {"type": "attack", "from_x": 5, "from_y": 5, "to_x": 6, "to_y": 5},
+            {"type": "end_turn"},
+        ]
+        _process_turn(state, env, game, active_idx=0, key=key)
+
+        log = state[0].observation.actionLog
+        attacks = [e for e in log if e["type"] == "attack"]
+        assert len(attacks) == 1
+        entry = attacks[0]
+        # Self-describing combat outcome that can't be recovered from the raw action.
+        for field in ("damage", "target_killed", "attacker_killed", "counter_damage",
+                      "attacker_hp_after", "target_hp_after", "evade",
+                      "charge_bonus", "flank_bonus"):
+            assert field in entry, f"missing combat outcome field: {field}"
+
+    def test_action_log_does_not_leak_timestamp(self):
+        """Per-entry wall-clock timestamps would bloat the replay -- they must be stripped."""
+        state, env = self._setup_interpreter_game()
+        env.done = False
+        state[0].action = [{"type": "end_turn"}]
+        interpreter(state, env)
+        for entry in state[0].observation.actionLog:
+            assert "timestamp" not in entry
+
+    def test_action_log_only_covers_current_turn(self):
+        """Each step's action_log slice covers only the actions executed during that turn."""
+        state, env = self._setup_interpreter_game()
+        env.done = False
+
+        state[0].action = [{"type": "end_turn"}]
+        interpreter(state, env)
+        first_log = list(state[0].observation.actionLog)
+        assert len(first_log) >= 1  # at least the end_turn record
+
+        state[1].action = [{"type": "end_turn"}]
+        interpreter(state, env)
+        second_log = state[1].observation.actionLog
+        # Second turn's slice must not re-include the first turn's records.
+        assert second_log != first_log
+        # And both turns' records should not appear in the second slice.
+        assert all(entry not in first_log for entry in second_log)
 
     def test_game_state_cleaned_up_on_game_over(self):
         """Module-level _games dict should be cleaned up when the game ends."""


### PR DESCRIPTION
Closes five gaps between what the `reinforce_tactics` engine knows during a turn and what the kaggle replay actually carries. Pre-fix, a replay consumer (visualizer or offline analysis)
  could not reconstruct intra-turn outcomes from `step.action` + the post-turn observation alone — combat sub-events were lost, RNG outcomes weren't reproducible, the visualizer drew
  highlights for engine-rejected actions, and a few engine-side fields agents/visualizers needed weren't serialized.

  ## Changes

  **1. Engine `action_history` slice surfaced into a new shared observation field `actionLog`.**
  The engine records rich self-describing entries on every state mutation (`damage`, `counter_damage`, `attacker_killed`, `target_killed`, `*_hp_after`, `evade` for Rogue RNG, 
  `charge_bonus`/`flank_bonus`/`*_buff` flags, `tile_hp_after`/`tile_owner_after` for seizes, `amount` for heals). None of this was serialized — `step.action` only carried the agent's raw 
  submitted dicts. Now `_process_turn` snapshots `len(game.action_history)` before running actions and slices out this turn's entries afterward. `_slice_action_log` strips per-entry 
  wall-clock timestamps (verbose, no replay value) and recursively normalizes tuples to lists so the result round-trips through JSON. The slice goes to both agents' `obs.actionLog`.

  **2. Combat RNG (Rogue evade) is now reconstructible from the replay** as a side effect of #1 — the `evade` outcome is recorded per attack.

  **3. Engine-rejected actions filtered out of the replay's action list.**
  `_run_actions` now returns the list of actions the engine actually applied; `_process_turn` writes that filtered list back to `agent.action`. Rejected attacks/seizes/moves no longer appear
   in `step.action`, so the visualizer can't draw highlights for actions that never happened.

  **4. `regenerating` flag added to serialized structures** so replays can explain end-of-turn HP recovery on damaged/vacated structures.

  **5. Ability cooldowns added to serialized units** (`paralyzeCooldown`, `hasteCooldown`, `defenceBuffCooldown`, `attackBuffCooldown`) so agents can see ability availability directly in the
   observation instead of needing `get_legal_actions` to find out.