### PR TITLE
Modify timeouts in cabt.json configuration

### DIFF
--- a/kaggle_environments/envs/cabt/cabt.json
+++ b/kaggle_environments/envs/cabt/cabt.json
@@ -6,8 +6,7 @@
   "agents": [2],
   "configuration": {
     "episodeSteps": 10000,
-    "actTimeout": 0,
-    "runTimeout": 3000
+    "actTimeout": 1
   },
   "reward": {
     "description": "Lost:-1, Won:1, Draw:0",
@@ -15,7 +14,7 @@
     "default": 0
   },
   "observation": {
-    "remainingOverageTime": 600
+    "remainingOverageTime": 60
   },
   "action": {
     "description": "List of option index.",


### PR DESCRIPTION
Updated actTimeout to 1 and reduced remainingOverageTime to 60.