### PR TITLE
feat(chess): include forfeit attempt reasoning in logs

### DIFF
--- a/kaggle_environments/envs/open_spiel_env/games/chess/visualizer/v2/replays/test-replay-forfeit.json
+++ b/kaggle_environments/envs/open_spiel_env/games/chess/visualizer/v2/replays/test-replay-forfeit.json
@@ -24,12 +24,12 @@
   "id": "e827b9b8-64cb-11f1-80a5-0242ac130204",
   "info": {
     "Agents": [
-      { "Name": "Will Cukierski", "ThumbnailUrl": null },
-      { "Name": "Bovard Doerschuk-Tiberi", "ThumbnailUrl": null }
+      { "Name": "Gemini 3.1 Pro Preview-1", "ThumbnailUrl": null },
+      { "Name": "Claude Opus 4.8", "ThumbnailUrl": null }
     ],
     "EpisodeId": 79409112,
     "LiveVideoPath": null,
-    "TeamNames": ["Will Cukierski", "Bovard Doerschuk-Tiberi"],
+    "TeamNames": ["Gemini 3.1 Pro Preview-1", "Claude Opus 4.8"],
     "actionHistory": [
       "2426",
       "2426",

--- a/kaggle_environments/envs/open_spiel_env/games/chess/visualizer/v2/replays/test-replay-forfeit.json
+++ b/kaggle_environments/envs/open_spiel_env/games/chess/visualizer/v2/replays/test-replay-forfeit.json
@@ -2,200 +2,241 @@
   "configuration": {
     "actTimeout": 3600,
     "episodeSteps": 17795,
+    "freeForm": false,
+    "illegalMoveForfeit": true,
+    "includeGenerateReturns": false,
+    "includeLegalActions": false,
+    "loadPresetHands": false,
     "metadata": {},
+    "observationType": "observation",
     "openSpielGameName": "chess",
-    "openSpielGameParameters": {
-      "chess960": false
-    },
+    "openSpielGameParameters": { "chess960": false },
     "openSpielGameString": "chess()",
-    "runTimeout": 172800,
-    "seed": 1398552928
+    "runTimeout": 108000,
+    "savePrompt": true,
+    "saveResponse": true,
+    "seed": 1303609515,
+    "strictMode": false,
+    "useImage": false,
+    "useOpenings": false
   },
   "description": "Kaggle environment wrapper for OpenSpiel games.\nFor game implementation details see:\nhttps://github.com/google-deepmind/open_spiel/tree/master/open_spiel/games",
-  "id": "fd1f9084-793a-11f0-aca2-0242ac130202",
+  "id": "e827b9b8-64cb-11f1-80a5-0242ac130204",
   "info": {
-    "EpisodeId": 73000130,
+    "Agents": [
+      { "Name": "Will Cukierski", "ThumbnailUrl": null },
+      { "Name": "Bovard Doerschuk-Tiberi", "ThumbnailUrl": null }
+    ],
+    "EpisodeId": 79409112,
     "LiveVideoPath": null,
-    "TeamNames": ["GPT 4.1", "o3"],
+    "TeamNames": ["Will Cukierski", "Bovard Doerschuk-Tiberi"],
     "actionHistory": [
       "2426",
-      "1258",
-      "3572",
-      "656",
-      "1842",
-      "1431",
-      "3132",
-      "3572",
-      "656",
       "2426",
-      "2037",
-      "89",
-      "943",
+      "3572",
+      "656",
       "2974",
-      "216",
+      "89",
+      "919",
+      "3572",
+      "4673",
+      "2977",
+      "2949",
       "674",
-      "1456",
-      "3134",
-      "1798",
-      "3593",
-      "3751",
-      "1842",
-      "2612",
-      "1213",
-      "2101",
-      "2366",
-      "1550",
-      "31",
-      "1212",
-      "920",
-      "701",
-      "1769",
-      "4672",
-      "1917",
-      "1768",
-      "1188",
-      "1846",
-      "2964",
-      "2277",
-      "4113",
-      "2144",
-      "2536",
-      "377",
-      "819",
-      "2550",
-      "892",
-      "2111",
-      "1006",
-      "1379",
-      "1189",
-      "1184",
-      "3666",
-      "143",
-      "3739",
-      "4177",
-      "2571",
-      "1384",
-      "4178",
-      "4250",
-      "3812",
-      "2624",
-      "3634",
-      "3722",
-      "3109",
-      "2976",
-      "2466",
-      "4115",
-      "1955",
-      "2355",
-      "1444",
-      "2655",
-      "905",
+      "277",
+      "1841",
       "1257",
+      "4673",
+      "4177",
+      "1380",
+      "788",
+      "1258",
+      "1842",
+      "1809",
+      "1987",
+      "289",
+      "673",
+      "1527",
+      "654",
+      "3133",
+      "1894",
       "3010",
-      "909",
-      "308",
-      "3237"
+      "2599",
+      "1214",
+      "1287",
+      "2938",
+      "2992",
+      "3154",
+      "3138",
+      "3096",
+      "3862",
+      "1270",
+      "3718",
+      "800",
+      "1771",
+      "702",
+      "3280",
+      "3561",
+      "2841",
+      "3050",
+      "1330",
+      "2408",
+      "2112",
+      "2525",
+      "1672",
+      "1882",
+      "1212",
+      "847",
+      "774",
+      "3131",
+      "30",
+      "1891",
+      "582",
+      "3678",
+      "1018",
+      "1372",
+      "605",
+      "1883",
+      "2112",
+      "2393",
+      "1675",
+      "1869",
+      "1056",
+      "1914",
+      "1431",
+      "2539",
+      "3972",
+      "2028",
+      "2354",
+      "1504",
+      "2570",
+      "2174",
+      "4552",
+      "1403",
+      "2510",
+      "1663",
+      "1330",
+      "1138",
+      "1415",
+      "496",
+      "249",
+      "993",
+      "2204"
     ],
     "moveDurations": [
-      9.701, 8.783, 16.793, 7.933, 12.022, 9.231, 15.645, 11.233, 133.187,
-      14.42, 37.564, 21.113, 72.547, 15.581, 175.324, 17.605, 187.625, 25.964,
-      285.149, 17.086, 175.493, 18.577, 166.499, 25.355, 122.101, 14.178,
-      89.772, 10.111, 255.745, 9.302, 396.231, 16.902, 338.167, 17.504, 103.405,
-      9.602, 357.176, 32.032, 402.203, 11.831, 229.274, 14.759, 190.808, 18.089,
-      459.089, 24.123, 334.334, 19.275, 111.796, 11.921, 31.435, 23.902,
-      223.511, 14.651, 175.514, 12.758, 65.267, 29.628, 222.015, 14.309, 30.706,
-      20.816, 85.731, 16.321, 304.163, 26.945, 442.873, 16.672, 168.228, 12.959,
-      569.712, 30.798, 212.031, 20.714, 134.647, 22.429, 58.774
+      4.242, 4.289, 2.971, 7.475, 2.925, 2.98, 3.105, 3.19, 3.429, 3.051, 2.995,
+      3.147, 3.105, 3.192, 2.745, 3.604, 3.13, 3.571, 5.374, 3.442, 3.294,
+      3.388, 9.061, 3.466, 3.082, 3.327, 3.275, 4.009, 3.709, 4.059, 3.89,
+      3.481, 3.264, 3.547, 3.561, 3.831, 3.901, 3.802, 3.84, 4.295, 3.379,
+      3.618, 4.076, 5.3, 4.655, 3.164, 3.706, 5.456, 3.889, 3.408, 3.687, 3.416,
+      3.249, 3.209, 4.001, 3.727, 3.786, 3.371, 3.376, 3.733, 4.08, 3.838,
+      3.143, 3.924, 3.314, 4.015, 3.761, 4.358, 3.429, 2.458, 2.917, 3.631,
+      3.338, 3.14, 3.647, 3.628, 3.994, 3.786, 4.006, 5.302, 3.748, 3.516,
+      3.782, 5.383, 3.575, 3.27, 3.111, 2.964, 4.78, 3.502, 3.84, 8.27
     ],
+    "openSpielGameStringResolved": "chess(chess960=False)",
     "stateHistory": [
       "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1",
       "rnbqkbnr/pppppppp/8/8/4P3/8/PPPP1PPP/RNBQKBNR b KQkq - 0 1",
-      "rnbqkbnr/pp1ppppp/8/2p5/4P3/8/PPPP1PPP/RNBQKBNR w KQkq - 0 2",
-      "rnbqkbnr/pp1ppppp/8/2p5/4P3/5N2/PPPP1PPP/RNBQKB1R b KQkq - 1 2",
-      "r1bqkbnr/pp1ppppp/2n5/2p5/4P3/5N2/PPPP1PPP/RNBQKB1R w KQkq - 2 3",
-      "r1bqkbnr/pp1ppppp/2n5/2p5/3PP3/5N2/PPP2PPP/RNBQKB1R b KQkq - 0 3",
-      "r1bqkbnr/pp1ppppp/2n5/8/3pP3/5N2/PPP2PPP/RNBQKB1R w KQkq - 0 4",
-      "r1bqkbnr/pp1ppppp/2n5/8/3NP3/8/PPP2PPP/RNBQKB1R b KQkq - 0 4",
-      "r1bqkb1r/pp1ppppp/2n2n2/8/3NP3/8/PPP2PPP/RNBQKB1R w KQkq - 1 5",
-      "r1bqkb1r/pp1ppppp/2n2n2/8/3NP3/2N5/PPP2PPP/R1BQKB1R b KQkq - 2 5",
-      "r1bqkb1r/pp1p1ppp/2n2n2/4p3/3NP3/2N5/PPP2PPP/R1BQKB1R w KQkq - 0 6",
-      "r1bqkb1r/pp1p1ppp/2n2n2/1N2p3/4P3/2N5/PPP2PPP/R1BQKB1R b KQkq - 1 6",
-      "r1bqkb1r/1p1p1ppp/p1n2n2/1N2p3/4P3/2N5/PPP2PPP/R1BQKB1R w KQkq - 0 7",
-      "r1bqkb1r/1p1p1ppp/p1n2n2/4p3/4P3/N1N5/PPP2PPP/R1BQKB1R b KQkq - 1 7",
-      "r1bqk2r/1p1p1ppp/p1n2n2/4p3/1b2P3/N1N5/PPP2PPP/R1BQKB1R w KQkq - 2 8",
-      "r1bqk2r/1p1p1ppp/p1n2n2/4p3/1bN1P3/2N5/PPP2PPP/R1BQKB1R b KQkq - 3 8",
-      "r1bqk2r/3p1ppp/p1n2n2/1p2p3/1bN1P3/2N5/PPP2PPP/R1BQKB1R w KQkq - 0 9",
-      "r1bqk2r/3p1ppp/p1n2n2/1p2p3/1b2P3/2N1N3/PPP2PPP/R1BQKB1R b KQkq - 1 9",
-      "r1bqk2r/3p1ppp/p1n5/1p2p3/1b2n3/2N1N3/PPP2PPP/R1BQKB1R w KQkq - 0 10",
-      "r1bqk2r/3p1ppp/p1n5/1p2p3/1b2n1Q1/2N1N3/PPP2PPP/R1B1KB1R b KQkq - 1 10",
-      "r1bqk2r/3p1p1p/p1n3p1/1p2p3/1b2n1Q1/2N1N3/PPP2PPP/R1B1KB1R w KQkq - 0 11",
-      "r1bqk2r/3p1p1p/p1n3p1/1p2p3/1b2Q3/2N1N3/PPP2PPP/R1B1KB1R b KQkq - 0 11",
-      "r1bqk2r/5p1p/p1n3p1/1p1pp3/1b2Q3/2N1N3/PPP2PPP/R1B1KB1R w KQkq - 0 12",
-      "r1bqk2r/5p1p/p1n3p1/1p1Qp3/1b6/2N1N3/PPP2PPP/R1B1KB1R b KQkq - 0 12",
-      "r2qk2r/5p1p/p1n1b1p1/1p1Qp3/1b6/2N1N3/PPP2PPP/R1B1KB1R w KQkq - 1 13",
-      "r2qk2r/5p1p/p1Q1b1p1/1p2p3/1b6/2N1N3/PPP2PPP/R1B1KB1R b KQkq - 0 13",
-      "r2q1k1r/5p1p/p1Q1b1p1/1p2p3/1b6/2N1N3/PPP2PPP/R1B1KB1R w KQ - 1 14",
-      "r1Qq1k1r/5p1p/p3b1p1/1p2p3/1b6/2N1N3/PPP2PPP/R1B1KB1R b KQ - 2 14",
-      "2rq1k1r/5p1p/p3b1p1/1p2p3/1b6/2N1N3/PPP2PPP/R1B1KB1R w KQ - 0 15",
-      "2rq1k1r/5p1p/p3b1p1/1p2p3/1b6/2N1N3/PPPB1PPP/R3KB1R b KQ - 1 15",
-      "2rq1k1r/5p1p/p3b1p1/1p2p3/8/2b1N3/PPPB1PPP/R3KB1R w KQ - 0 16",
-      "2rq1k1r/5p1p/p3b1p1/1p2p3/8/2P1N3/P1PB1PPP/R3KB1R b KQ - 0 16",
-      "2r2k1r/5p1p/p2qb1p1/1p2p3/8/2P1N3/P1PB1PPP/R3KB1R w KQ - 1 17",
-      "2r2k1r/5p1p/p2qb1p1/1p2p3/8/2P1N3/P1PB1PPP/2KR1B1R b - - 2 17",
-      "2r2k1r/5p1p/p3b1p1/1p2p3/8/2P1N3/P1Pq1PPP/2KR1B1R w - - 0 18",
-      "2r2k1r/5p1p/p3b1p1/1p2p3/8/2P1N3/P1PR1PPP/2K2B1R b - - 0 18",
-      "5k1r/5p1p/p3b1p1/1p2p3/8/2r1N3/P1PR1PPP/2K2B1R w - - 0 19",
-      "3R1k1r/5p1p/p3b1p1/1p2p3/8/2r1N3/P1P2PPP/2K2B1R b - - 1 19",
-      "3R3r/5pkp/p3b1p1/1p2p3/8/2r1N3/P1P2PPP/2K2B1R w - - 2 20",
-      "7r/5pkp/p2Rb1p1/1p2p3/8/2r1N3/P1P2PPP/2K2B1R b - - 3 20",
-      "2r5/5pkp/p2Rb1p1/1p2p3/8/2r1N3/P1P2PPP/2K2B1R w - - 4 21",
-      "2r5/5pkp/R3b1p1/1p2p3/8/2r1N3/P1P2PPP/2K2B1R b - - 0 21",
-      "2r5/5pkp/R5p1/1p2p3/8/2r1N3/b1P2PPP/2K2B1R w - - 0 22",
-      "2r5/5pkp/6p1/1p2p3/8/2r1N3/R1P2PPP/2K2B1R b - - 0 22",
-      "2r5/5pkp/6p1/4p3/1p6/2r1N3/R1P2PPP/2K2B1R w - - 0 23",
-      "2r5/5pkp/6p1/3Np3/1p6/2r5/R1P2PPP/2K2B1R b - - 1 23",
-      "2r5/5pkp/6p1/3Np3/8/1pr5/R1P2PPP/2K2B1R w - - 0 24",
-      "2r5/5pkp/6p1/4p3/8/1pN5/R1P2PPP/2K2B1R b - - 0 24",
-      "2r5/5pkp/6p1/4p3/8/2N5/p1P2PPP/2K2B1R w - - 0 25",
-      "2r5/5pkp/6p1/4p3/8/8/N1P2PPP/2K2B1R b - - 0 25",
-      "8/5pkp/6p1/4p3/8/8/N1r2PPP/2K2B1R w - - 0 26",
-      "8/5pkp/6p1/4p3/8/8/N1K2PPP/5B1R b - - 0 26",
-      "8/5pkp/8/4p1p1/8/8/N1K2PPP/5B1R w - - 0 27",
-      "8/5pkp/8/4p1p1/8/2N5/2K2PPP/5B1R b - - 1 27",
-      "8/5pkp/8/4p3/6p1/2N5/2K2PPP/5B1R w - - 0 28",
-      "8/5pkp/8/4p3/6p1/2N4P/2K2PP1/5B1R b - - 0 28",
-      "8/5pkp/8/8/4p1p1/2N4P/2K2PP1/5B1R w - - 0 29",
-      "8/5pkp/8/8/4N1p1/7P/2K2PP1/5B1R b - - 0 29",
-      "8/5pk1/8/7p/4N1p1/7P/2K2PP1/5B1R w - - 0 30",
-      "8/5pk1/8/7p/4N1pP/8/2K2PP1/5B1R b - - 0 30",
-      "8/5pk1/8/7p/4N2P/6p1/2K2PP1/5B1R w - - 0 31",
-      "8/5pk1/8/7p/7P/6N1/2K2PP1/5B1R b - - 0 31",
-      "8/5p2/5k2/7p/7P/6N1/2K2PP1/5B1R w - - 1 32",
-      "8/5p2/5k2/7N/7P/8/2K2PP1/5B1R b - - 0 32",
-      "8/4kp2/8/7N/7P/8/2K2PP1/5B1R w - - 1 33",
-      "8/4kp2/8/7N/7P/3B4/2K2PP1/7R b - - 2 33",
-      "8/5p2/3k4/7N/7P/3B4/2K2PP1/7R w - - 3 34",
-      "8/5p2/3k4/7N/7P/3B4/2K2PP1/4R3 b - - 4 34",
-      "8/5p2/8/2k4N/7P/3B4/2K2PP1/4R3 w - - 5 35",
-      "8/5p2/8/2k1R2N/7P/3B4/2K2PP1/8 b - - 6 35",
-      "8/5p2/8/4R2N/1k5P/3B4/2K2PP1/8 w - - 7 36",
-      "8/5p2/8/1R5N/1k5P/3B4/2K2PP1/8 b - - 8 36",
-      "8/5p2/8/1R5N/k6P/3B4/2K2PP1/8 w - - 9 37",
-      "8/5p2/8/1R5N/k6P/2KB4/5PP1/8 b - - 10 37",
-      "8/8/8/1R3p1N/k6P/2KB4/5PP1/8 w - - 0 38",
-      "8/8/8/5R1N/k6P/2KB4/5PP1/8 b - - 0 38",
-      "8/8/8/5R1N/7P/k1KB4/5PP1/8 w - - 1 39",
-      "8/8/8/R6N/7P/k1KB4/5PP1/8 b - - 2 39"
+      "rnbqkbnr/pppp1ppp/8/4p3/4P3/8/PPPP1PPP/RNBQKBNR w KQkq - 0 2",
+      "rnbqkbnr/pppp1ppp/8/4p3/4P3/5N2/PPPP1PPP/RNBQKB1R b KQkq - 1 2",
+      "r1bqkbnr/pppp1ppp/2n5/4p3/4P3/5N2/PPPP1PPP/RNBQKB1R w KQkq - 2 3",
+      "r1bqkbnr/pppp1ppp/2n5/1B2p3/4P3/5N2/PPPP1PPP/RNBQK2R b KQkq - 3 3",
+      "r1bqkbnr/1ppp1ppp/p1n5/1B2p3/4P3/5N2/PPPP1PPP/RNBQK2R w KQkq - 0 4",
+      "r1bqkbnr/1ppp1ppp/p1n5/4p3/B3P3/5N2/PPPP1PPP/RNBQK2R b KQkq - 1 4",
+      "r1bqkb1r/1ppp1ppp/p1n2n2/4p3/B3P3/5N2/PPPP1PPP/RNBQK2R w KQkq - 2 5",
+      "r1bqkb1r/1ppp1ppp/p1n2n2/4p3/B3P3/5N2/PPPP1PPP/RNBQ1RK1 b kq - 3 5",
+      "r1bqk2r/1pppbppp/p1n2n2/4p3/B3P3/5N2/PPPP1PPP/RNBQ1RK1 w kq - 4 6",
+      "r1bqk2r/1pppbppp/p1n2n2/4p3/B3P3/5N2/PPPP1PPP/RNBQR1K1 b kq - 5 6",
+      "r1bqk2r/2ppbppp/p1n2n2/1p2p3/B3P3/5N2/PPPP1PPP/RNBQR1K1 w kq - 0 7",
+      "r1bqk2r/2ppbppp/p1n2n2/1p2p3/4P3/1B3N2/PPPP1PPP/RNBQR1K1 b kq - 1 7",
+      "r1bqk2r/2p1bppp/p1np1n2/1p2p3/4P3/1B3N2/PPPP1PPP/RNBQR1K1 w kq - 0 8",
+      "r1bqk2r/2p1bppp/p1np1n2/1p2p3/4P3/1BP2N2/PP1P1PPP/RNBQR1K1 b kq - 0 8",
+      "r1bq1rk1/2p1bppp/p1np1n2/1p2p3/4P3/1BP2N2/PP1P1PPP/RNBQR1K1 w - - 1 9",
+      "r1bq1rk1/2p1bppp/p1np1n2/1p2p3/4P3/1BP2N1P/PP1P1PP1/RNBQR1K1 b - - 0 9",
+      "r1bq1rk1/2p1bppp/p2p1n2/np2p3/4P3/1BP2N1P/PP1P1PP1/RNBQR1K1 w - - 1 10",
+      "r1bq1rk1/2p1bppp/p2p1n2/np2p3/4P3/2P2N1P/PPBP1PP1/RNBQR1K1 b - - 2 10",
+      "r1bq1rk1/4bppp/p2p1n2/npp1p3/4P3/2P2N1P/PPBP1PP1/RNBQR1K1 w - - 0 11",
+      "r1bq1rk1/4bppp/p2p1n2/npp1p3/3PP3/2P2N1P/PPB2PP1/RNBQR1K1 b - - 0 11",
+      "r1b2rk1/2q1bppp/p2p1n2/npp1p3/3PP3/2P2N1P/PPB2PP1/RNBQR1K1 w - - 1 12",
+      "r1b2rk1/2q1bppp/p2p1n2/nppPp3/4P3/2P2N1P/PPB2PP1/RNBQR1K1 b - - 0 12",
+      "r1b2rk1/2q1bppp/p2p1n2/1ppPp3/2n1P3/2P2N1P/PPB2PP1/RNBQR1K1 w - - 1 13",
+      "r1b2rk1/2q1bppp/p2p1n2/1ppPp3/2n1P3/1PP2N1P/P1B2PP1/RNBQR1K1 b - - 0 13",
+      "r1b2rk1/2q1bppp/pn1p1n2/1ppPp3/4P3/1PP2N1P/P1B2PP1/RNBQR1K1 w - - 1 14",
+      "r1b2rk1/2q1bppp/pn1p1n2/1ppPp3/4P3/1PP2N1P/P1BN1PP1/R1BQR1K1 b - - 2 14",
+      "r1b1nrk1/2q1bppp/pn1p4/1ppPp3/4P3/1PP2N1P/P1BN1PP1/R1BQR1K1 w - - 3 15",
+      "r1b1nrk1/2q1bppp/pn1p4/1ppPp3/4P3/1PP2N1P/P1B2PP1/R1BQRNK1 b - - 4 15",
+      "r1b1nrk1/2q1b1pp/pn1p4/1ppPpp2/4P3/1PP2N1P/P1B2PP1/R1BQRNK1 w - - 0 16",
+      "r1b1nrk1/2q1b1pp/pn1p4/1ppPpP2/8/1PP2N1P/P1B2PP1/R1BQRNK1 b - - 0 16",
+      "r3nrk1/2q1b1pp/pn1p4/1ppPpb2/8/1PP2N1P/P1B2PP1/R1BQRNK1 w - - 0 17",
+      "r3nrk1/2q1b1pp/pn1p4/1ppPpB2/8/1PP2N1P/P4PP1/R1BQRNK1 b - - 0 17",
+      "r3n1k1/2q1b1pp/pn1p4/1ppPpr2/8/1PP2N1P/P4PP1/R1BQRNK1 w - - 0 18",
+      "r3n1k1/2q1b1pp/pn1p4/1ppPpr2/8/1PP2NNP/P4PP1/R1BQR1K1 b - - 1 18",
+      "r3n1k1/2q1b1pp/pn1p1r2/1ppPp3/8/1PP2NNP/P4PP1/R1BQR1K1 w - - 2 19",
+      "r3n1k1/2q1b1pp/pn1p1r2/1ppPp1N1/8/1PP3NP/P4PP1/R1BQR1K1 b - - 3 19",
+      "r3n1k1/2q1b1pp/pn1p2r1/1ppPp1N1/8/1PP3NP/P4PP1/R1BQR1K1 w - - 4 20",
+      "r3n1k1/2q1b1pp/pn1pN1r1/1ppPp3/8/1PP3NP/P4PP1/R1BQR1K1 b - - 5 20",
+      "r3n1k1/1q2b1pp/pn1pN1r1/1ppPp3/8/1PP3NP/P4PP1/R1BQR1K1 w - - 6 21",
+      "r3n1k1/1q2b1pp/pn1pN1r1/1ppPpN2/8/1PP4P/P4PP1/R1BQR1K1 b - - 7 21",
+      "r3n1k1/1q2b1pp/p2pN1r1/1ppnpN2/8/1PP4P/P4PP1/R1BQR1K1 w - - 0 22",
+      "r3n1k1/1q2b1pp/p2pN1r1/1ppQpN2/8/1PP4P/P4PP1/R1B1R1K1 b - - 0 22",
+      "r3n1k1/4b1pp/p2pN1r1/1ppqpN2/8/1PP4P/P4PP1/R1B1R1K1 w - - 0 23",
+      "r3n1k1/4N1pp/p2pN1r1/1ppqp3/8/1PP4P/P4PP1/R1B1R1K1 b - - 0 23",
+      "r3n3/4Nkpp/p2pN1r1/1ppqp3/8/1PP4P/P4PP1/R1B1R1K1 w - - 1 24",
+      "r3n3/5kpp/p2pN1r1/1ppNp3/8/1PP4P/P4PP1/R1B1R1K1 b - - 0 24",
+      "r3n3/6pp/p2pk1r1/1ppNp3/8/1PP4P/P4PP1/R1B1R1K1 w - - 0 25",
+      "r3n3/6pp/p2pk1r1/1ppNp3/2P5/1P5P/P4PP1/R1B1R1K1 b - - 0 25",
+      "r7/6pp/p2pknr1/1ppNp3/2P5/1P5P/P4PP1/R1B1R1K1 w - - 1 26",
+      "r7/2N3pp/p2pknr1/1pp1p3/2P5/1P5P/P4PP1/R1B1R1K1 b - - 2 26",
+      "r7/2Nk2pp/p2p1nr1/1pp1p3/2P5/1P5P/P4PP1/R1B1R1K1 w - - 3 27",
+      "N7/3k2pp/p2p1nr1/1pp1p3/2P5/1P5P/P4PP1/R1B1R1K1 b - - 0 27",
+      "N7/6pp/p1kp1nr1/1pp1p3/2P5/1P5P/P4PP1/R1B1R1K1 w - - 1 28",
+      "N7/6pp/p1kp1nr1/1pp1p3/2P5/1P5P/P2B1PP1/R3R1K1 b - - 2 28",
+      "N7/6pp/p1kp1nr1/2p1p3/2p5/1P5P/P2B1PP1/R3R1K1 w - - 0 29",
+      "N7/6pp/p1kp1nr1/2p1p3/2P5/7P/P2B1PP1/R3R1K1 b - - 0 29",
+      "N7/3n2pp/p1kp2r1/2p1p3/2P5/7P/P2B1PP1/R3R1K1 w - - 1 30",
+      "N7/3n2pp/p1kp2r1/2p1p3/2P5/7P/P2B1PP1/1R2R1K1 b - - 2 30",
+      "N7/6pp/pnkp2r1/2p1p3/2P5/7P/P2B1PP1/1R2R1K1 w - - 3 31",
+      "8/6pp/pNkp2r1/2p1p3/2P5/7P/P2B1PP1/1R2R1K1 b - - 0 31",
+      "8/6pp/pNkpr3/2p1p3/2P5/7P/P2B1PP1/1R2R1K1 w - - 1 32",
+      "8/6pp/p1kpr3/2pNp3/2P5/7P/P2B1PP1/1R2R1K1 b - - 2 32",
+      "8/3k2pp/p2pr3/2pNp3/2P5/7P/P2B1PP1/1R2R1K1 w - - 3 33",
+      "8/1R1k2pp/p2pr3/2pNp3/2P5/7P/P2B1PP1/4R1K1 b - - 4 33",
+      "4k3/1R4pp/p2pr3/2pNp3/2P5/7P/P2B1PP1/4R1K1 w - - 5 34",
+      "4k3/1RN3pp/p2pr3/2p1p3/2P5/7P/P2B1PP1/4R1K1 b - - 6 34",
+      "8/1RNk2pp/p2pr3/2p1p3/2P5/7P/P2B1PP1/4R1K1 w - - 7 35",
+      "8/1R1k2pp/p2pN3/2p1p3/2P5/7P/P2B1PP1/4R1K1 b - - 0 35",
+      "8/1R4pp/p2pk3/2p1p3/2P5/7P/P2B1PP1/4R1K1 w - - 0 36",
+      "8/6Rp/p2pk3/2p1p3/2P5/7P/P2B1PP1/4R1K1 b - - 0 36",
+      "8/6Rp/p3k3/2ppp3/2P5/7P/P2B1PP1/4R1K1 w - - 0 37",
+      "8/6Rp/p3k3/2pPp3/8/7P/P2B1PP1/4R1K1 b - - 0 37",
+      "8/6Rp/p7/2pkp3/8/7P/P2B1PP1/4R1K1 w - - 0 38",
+      "8/7R/p7/2pkp3/8/7P/P2B1PP1/4R1K1 b - - 0 38",
+      "8/7R/p7/2p1p3/2k5/7P/P2B1PP1/4R1K1 w - - 1 39",
+      "8/7R/p7/2p1p3/2k1R3/7P/P2B1PP1/6K1 b - - 2 39",
+      "8/7R/p7/2p1p3/4R3/3k3P/P2B1PP1/6K1 w - - 3 40",
+      "8/7R/p7/2p1p3/8/3kR2P/P2B1PP1/6K1 b - - 4 40",
+      "8/7R/p7/2p1p3/8/4R2P/P1kB1PP1/6K1 w - - 5 41",
+      "8/3R4/p7/2p1p3/8/4R2P/P1kB1PP1/6K1 b - - 6 41",
+      "8/3R4/p7/4p3/2p5/4R2P/P1kB1PP1/6K1 w - - 0 42",
+      "8/3R4/p7/4p3/2p5/2R4P/P1kB1PP1/6K1 b - - 1 42",
+      "8/3R4/p7/4p3/2p5/2R4P/P2B1PP1/1k4K1 w - - 2 43",
+      "8/3R4/p7/4p3/2R5/7P/P2B1PP1/1k4K1 b - - 0 43",
+      "8/3R4/p7/4p3/2R5/7P/k2B1PP1/6K1 w - - 0 44",
+      "8/3R4/p7/4p3/R7/7P/k2B1PP1/6K1 b - - 1 44",
+      "8/3R4/p7/4p3/R7/1k5P/3B1PP1/6K1 w - - 2 45",
+      "8/3R4/p7/4p3/1R6/1k5P/3B1PP1/6K1 b - - 3 45",
+      "8/3R4/p7/4p3/1R6/7P/2kB1PP1/6K1 w - - 4 46",
+      "8/8/p7/3Rp3/1R6/7P/2kB1PP1/6K1 b - - 5 46"
     ]
   },
+  "module_version": "1.30.1",
   "name": "open_spiel_chess",
-  "rewards": [1.0, -1.0],
+  "rewards": [-1, 1],
   "schema_version": 1,
   "specification": {
     "action": {
-      "default": {
-        "submission": -1
-      },
+      "default": { "submission": -1 },
       "description": "Action object MUST contain a field `submission`, and MAY contain arbitrary additional information.",
       "type": "object"
     },
@@ -213,11 +254,45 @@
         "minimum": 1,
         "type": "integer"
       },
+      "freeForm": {
+        "default": false,
+        "description": "If true, the core harness allows free-form actions (get_legal_moves may return None) on turns where the action space is not enumerable. Defaults to false for OpenSpiel games.",
+        "type": "boolean"
+      },
+      "illegalMoveForfeit": {
+        "default": true,
+        "description": "If true (default), when an LLM harness exhausts its retries without producing a legal move, it submits an invalid action so this player forfeits via the env's INVALID path (matching the game_arena convention). If false, the harness re-raises the parse failure, which voids the whole episode. Only affects exhaustion from illegal/unparsable moves; uncaught exceptions still propagate either way.",
+        "type": "boolean"
+      },
+      "includeGenerateReturns": {
+        "default": false,
+        "description": "If true, include a legacy generate_returns field on each action with per-LLM-call metadata (model, token counts, finish reason, duration). Useful for cost tracking and visualization pipelines.",
+        "type": "boolean"
+      },
+      "includeLegalActions": {
+        "default": false,
+        "description": "If true, include legalActions and legalActionStrings in observations. Defaults to false since these can be derived from serializedGameAndState.",
+        "type": "boolean"
+      },
+      "initialActions": {
+        "description": "Actions applied to initial state before play begins to set up starting position.",
+        "type": "array"
+      },
+      "loadPresetHands": {
+        "default": false,
+        "description": "Repeated poker only. Load preset hand chance actions from preset_hands.jsonl.",
+        "type": "boolean"
+      },
       "metadata": {
         "default": {},
         "description": "Arbitrary metadata.",
         "properties": {},
         "type": "object"
+      },
+      "observationType": {
+        "default": "observation",
+        "description": "Type of observation string: 'observation' or 'information_state'.",
+        "type": "string"
       },
       "openSpielGameName": {
         "default": "chess",
@@ -225,9 +300,7 @@
         "type": "string"
       },
       "openSpielGameParameters": {
-        "default": {
-          "chess960": false
-        },
+        "default": { "chess960": false },
         "description": "Game parameters for Open Spiel game.",
         "properties": {},
         "type": "object"
@@ -237,11 +310,44 @@
         "description": "The full game string including parameters.",
         "type": "string"
       },
+      "presetHands": {
+        "description": "Repeated poker only. List of per-hand chance action sequences to use instead of random chance.",
+        "type": "array"
+      },
       "runTimeout": {
         "default": 172800,
         "description": "Maximum runtime (seconds) of an episode (not necessarily DONE).",
         "minimum": 0,
         "type": "number"
+      },
+      "savePrompt": {
+        "default": true,
+        "description": "If disabled, skip logging LLM prompts in the replay file.",
+        "type": "boolean"
+      },
+      "saveResponse": {
+        "default": true,
+        "description": "If disabled, skip logging raw LLM responses in the replay file. Extracted thoughts (which typically contain everything but the final move tag) are still logged on the action, so the legal response is effectively preserved.",
+        "type": "boolean"
+      },
+      "seed": {
+        "description": "Integer used to select a starting position (when useOpenings is true) and to seed chance-node sampling so episodes are reproducible.",
+        "type": "number"
+      },
+      "strictMode": {
+        "default": false,
+        "description": "If true, agents must return only {'submission': int} (no extra fields like 'thoughts'), and per-agent TIMEOUT/ERROR/INVALID counts as a loss for the offending agent only \u2014 other agents are marked DONE with a winning reward. The offender keeps its natural ERROR or TIMEOUT status (matching how every other Kaggle competition reports per-player failures). If false (default), any agent error halts and voids the entire episode, matching the lenient research-mode behavior.",
+        "type": "boolean"
+      },
+      "useImage": {
+        "default": false,
+        "description": "If true, indicates the observation is intended to be rendered as an image. Note that currently the agent harness is responsible for the actual rendering; no image is passed in the observation.",
+        "type": "boolean"
+      },
+      "useOpenings": {
+        "default": false,
+        "description": "Whether to start from a position in an opening book.",
+        "type": "boolean"
       }
     },
     "info": {},
@@ -257,11 +363,11 @@
           "type": "boolean"
         },
         "legalActionStrings": {
-          "description": "List of OpenSpiel legal actions strings.",
+          "description": "List of OpenSpiel legal action strings. Only included if includeLegalActions is true.",
           "type": "array"
         },
         "legalActions": {
-          "description": "List of OpenSpiel legal action integers.",
+          "description": "List of OpenSpiel legal action integers. Only included if includeLegalActions is true.",
           "type": "array"
         },
         "observationString": {
@@ -304,110 +410,58 @@
         "type": "integer"
       }
     },
-    "reward": {
-      "default": 0.0,
-      "type": ["number", "null"]
-    }
+    "reward": { "default": 0.0, "type": ["number", "null"] }
   },
   "statuses": ["DONE", "DONE"],
   "steps": [
     [
       {
-        "action": {
-          "submission": -1
-        },
+        "action": { "submission": -1 },
         "info": {},
-        "observation": {
-          "remainingOverageTime": 12,
-          "step": 0
-        },
+        "observation": { "remainingOverageTime": 12, "step": 0 },
         "reward": 0.0,
         "status": "ACTIVE"
       },
       {
-        "action": {
-          "submission": -1
-        },
+        "action": { "submission": -1 },
         "info": {},
-        "observation": {
-          "remainingOverageTime": 12
-        },
+        "observation": { "remainingOverageTime": 12 },
         "reward": 0.0,
         "status": "ACTIVE"
       }
     ],
     [
       {
-        "action": {
-          "actionString": null,
-          "generate_returns": [],
-          "status": "OK; Setup step; model not called.",
-          "submission": -1,
-          "thoughts": null
-        },
+        "action": { "status": "INACTIVE", "submission": null },
         "info": {},
         "observation": {
           "currentPlayer": 1,
           "isTerminal": false,
-          "legalActionStrings": [],
-          "legalActions": [],
           "observationString": "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1",
           "playerId": 0,
           "remainingOverageTime": 12,
-          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess()\n[State]\nFEN: rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1\n\n\n",
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n\n\n",
           "step": 1
         },
         "reward": null,
         "status": "INACTIVE"
       },
       {
-        "action": {
-          "actionString": null,
-          "generate_returns": [],
-          "status": "OK; Setup step; model not called.",
-          "submission": -1,
-          "thoughts": null
-        },
+        "action": { "status": "INACTIVE", "submission": null },
         "info": {
           "actionApplied": null,
           "actionSubmitted": null,
           "actionSubmittedToString": null,
-          "agentSelfReportedStatus": "OK; Setup step; model not called.",
+          "agentSelfReportedStatus": "INACTIVE",
           "timeTaken": null
         },
         "observation": {
           "currentPlayer": 1,
           "isTerminal": false,
-          "legalActionStrings": [
-            "a3",
-            "a4",
-            "Na3",
-            "Nc3",
-            "b3",
-            "b4",
-            "c3",
-            "c4",
-            "d3",
-            "d4",
-            "e3",
-            "e4",
-            "f3",
-            "f4",
-            "Nf3",
-            "Nh3",
-            "g3",
-            "g4",
-            "h3",
-            "h4"
-          ],
-          "legalActions": [
-            89, 90, 652, 656, 673, 674, 1257, 1258, 1841, 1842, 2425, 2426,
-            3009, 3010, 3572, 3576, 3593, 3594, 4177, 4178
-          ],
           "observationString": "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1",
           "playerId": 1,
           "remainingOverageTime": 12,
-          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess()\n[State]\nFEN: rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1\n\n\n"
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n\n\n"
         },
         "reward": null,
         "status": "ACTIVE"
@@ -415,43 +469,15 @@
     ],
     [
       {
-        "action": {
-          "submission": -1
-        },
+        "action": { "submission": -1 },
         "info": {},
         "observation": {
           "currentPlayer": 0,
           "isTerminal": false,
-          "legalActionStrings": [
-            "a6",
-            "a5",
-            "Na6",
-            "Nc6",
-            "b6",
-            "b5",
-            "c6",
-            "c5",
-            "d6",
-            "d5",
-            "e6",
-            "e5",
-            "f6",
-            "f5",
-            "Nf6",
-            "Nh6",
-            "g6",
-            "g5",
-            "h6",
-            "h5"
-          ],
-          "legalActions": [
-            89, 90, 652, 656, 673, 674, 1257, 1258, 1841, 1842, 2425, 2426,
-            3009, 3010, 3572, 3576, 3593, 3594, 4177, 4178
-          ],
           "observationString": "rnbqkbnr/pppppppp/8/8/4P3/8/PPPP1PPP/RNBQKBNR b KQkq - 0 1",
           "playerId": 0,
           "remainingOverageTime": 12,
-          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess()\n[State]\nFEN: rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1\n2426\n\n",
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n\n",
           "step": 2
         },
         "reward": null,
@@ -460,29 +486,38 @@
       {
         "action": {
           "actionString": "e4",
-          "generate_returns": [
-            "{\n  \"main_response\": \"To choose White\\u2019s first move I consider the usual opening principles:  \\n\\u2022 Occupy or control the centre.  \\n\\u2022 Develop pieces quickly.  \\n\\u2022 Keep options open for king safety (castling).\\n\\nCandidate moves from the starting position:  \\n1. e4 \\u2013 immediately claims the centre, opens lines for the queen and king\\u2019s bishop.  \\n2. d4 \\u2013 also takes the centre, but keeps the king\\u2019s bishop shut for now.  \\n3. Nf3 \\u2013 develops a knight and attacks e5, but does not occupy the centre with a pawn.  \\n4. c4 \\u2013 aims for a strong central presence (English Opening), but slightly slower.\\n\\nAmong these, 1.e4 is the most forcing, scores well in databases, and leads to many reputable open\\u2010game lines. It is fully consistent with opening principles and is of equal or better theoretical value than any alternative.\\n\\nLegality check:  \\n\\u2022 Square e2 is occupied by a White pawn.  \\n\\u2022 Square e4 is empty.  \\n\\u2022 Moving two squares forward from the starting rank on the first move is legal.  \\nTherefore 1.e4 is legal.\\n\\nI will therefore play 1.e4.\\n\\nFinal Answer: e4\",\n  \"main_response_and_thoughts\": \"\",\n  \"request_for_logging\": {\n    \"model\": \"o3-2025-04-16\",\n    \"messages\": [\n      {\n        \"role\": \"user\",\n        \"content\": [\n          {\n            \"type\": \"text\",\n            \"text\": \"Let's play chess. The current game state in Forsyth-Edwards Notation (FEN) notation is:\\nrnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1\\nThe moves played so far are:\\n1.\\nYou are playing as player White.\\nIt is now your turn. Play your strongest move. The move MUST be legal. Reason step by step to come up with your move, then output your final answer in the format \\\"Final Answer: X\\\" where X is your chosen move in standard algebraic notation (SAN).\\n\"\n          }\n        ]\n      }\n    ],\n    \"config\": {\n      \"temperature\": \"NOT_GIVEN\",\n      \"top_p\": \"NOT_GIVEN\",\n      \"max_tokens\": \"NOT_GIVEN\",\n      \"reasoning_effort\": \"NOT_GIVEN\"\n    }\n  },\n  \"response_for_logging\": {\n    \"id\": \"chatcmpl-C4WoNpfAFRneVPtNiobzX1oTCrwCI\",\n    \"choices\": [\n      {\n        \"finish_reason\": \"stop\",\n        \"index\": 0,\n        \"message\": {\n          \"content\": \"To choose White\\u2019s first move I consider the usual opening principles:  \\n\\u2022 Occupy or control the centre.  \\n\\u2022 Develop pieces quickly.  \\n\\u2022 Keep options open for king safety (castling).\\n\\nCandidate moves from the starting position:  \\n1. e4 \\u2013 immediately claims the centre, opens lines for the queen and king\\u2019s bishop.  \\n2. d4 \\u2013 also takes the centre, but keeps the king\\u2019s bishop shut for now.  \\n3. Nf3 \\u2013 develops a knight and attacks e5, but does not occupy the centre with a pawn.  \\n4. c4 \\u2013 aims for a strong central presence (English Opening), but slightly slower.\\n\\nAmong these, 1.e4 is the most forcing, scores well in databases, and leads to many reputable open\\u2010game lines. It is fully consistent with opening principles and is of equal or better theoretical value than any alternative.\\n\\nLegality check:  \\n\\u2022 Square e2 is occupied by a White pawn.  \\n\\u2022 Square e4 is empty.  \\n\\u2022 Moving two squares forward from the starting rank on the first move is legal.  \\nTherefore 1.e4 is legal.\\n\\nI will therefore play 1.e4.\\n\\nFinal Answer: e4\",\n          \"refusal\": null,\n          \"role\": \"assistant\",\n          \"annotations\": []\n        }\n      }\n    ],\n    \"created\": 1755195475,\n    \"model\": \"o3-2025-04-16\",\n    \"object\": \"chat.completion\",\n    \"service_tier\": \"default\",\n    \"system_fingerprint\": null,\n    \"usage\": {\n      \"completion_tokens\": 454,\n      \"prompt_tokens\": 142,\n      \"total_tokens\": 596,\n      \"completion_tokens_details\": {\n        \"accepted_prediction_tokens\": 0,\n        \"audio_tokens\": 0,\n        \"reasoning_tokens\": 192,\n        \"rejected_prediction_tokens\": 0\n      },\n      \"prompt_tokens_details\": {\n        \"audio_tokens\": 0,\n        \"cached_tokens\": 0\n      }\n    }\n  },\n  \"generation_tokens\": 454,\n  \"prompt_tokens\": 142,\n  \"reasoning_tokens\": 192,\n  \"duration_success_only_secs\": 9.670661960997677\n}"
+          "call_details": [
+            {
+              "duration_secs": 3.717,
+              "finish_reason": "stop",
+              "first_token_secs": 2.242,
+              "generation_tokens": 370,
+              "model": "openai/google/gemini-3.1-flash-lite-preview",
+              "prompt": "You are a chess expert\n\nLet's play chess. The current game state in Forsyth-Edwards Notation (FEN) notation is:\nrnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1\nThe moves played so far are:\n1.\nYou are playing as player White.\nIt is now your turn. Play your strongest move. The move MUST be legal. Reason step by step to come up with your move, then output your final answer in the format \"Final Answer: X\" where X is your chosen move in standard algebraic notation (SAN).\n",
+              "prompt_tokens": 134,
+              "reasoning_tokens": 0,
+              "response": "To determine the best opening move for White, I will evaluate the standard opening principles: controlling the center, developing pieces, and preparing for castling.\n\n1.  **Candidate Moves:**\n    *   **1. e4:** The most popular move. It immediately controls the d5 square, opens lines for the Queen and the light-squared Bishop, and fights for the center.\n    *   **1. d4:** Also an excellent move. It controls e5, supports the d4 pawn with the Queen, and opens the diagonal for the dark-squared Bishop.\n    *   **1. Nf3 / 1. c4:** Flexible moves that exert influence on the center without committing the central pawns immediately.\n\n2.  **Evaluation:**\n    *   **1. e4** is widely considered the most ambitious move, often leading to open, tactical games where piece activity is prioritized. It is the classic choice to challenge for the center immediately.\n    *   **1. d4** is the traditional choice for a slightly more positional and solid approach.\n\n3.  **Conclusion:**\n    As White, playing 1. e4 is statistically the most popular and theoretically sound move to dictate the pace of the game from the very first turn. It adheres to the primary principles of opening theory: seizing central space and facilitating rapid development.\n\nStep-by-step reasoning:\n- The center (e4, d4, e5, d5) is the most critical area of the board.\n- Placing a pawn on e4 exerts immediate control over the center and allows for the development of the f1 bishop and the queen.\n- It is the most common move in high-level chess, offering White a slight initiative.\n\nFinal Answer: e4",
+              "total_tokens": 504
+            }
           ],
           "status": "OK",
           "submission": 2426,
-          "thoughts": "To choose White\u2019s first move I consider the usual opening principles:  \n\u2022 Occupy or control the centre.  \n\u2022 Develop pieces quickly.  \n\u2022 Keep options open for king safety (castling).\n\nCandidate moves from the starting position:  \n1. e4 \u2013 immediately claims the centre, opens lines for the queen and king\u2019s bishop.  \n2. d4 \u2013 also takes the centre, but keeps the king\u2019s bishop shut for now.  \n3. Nf3 \u2013 develops a knight and attacks e5, but does not occupy the centre with a pawn.  \n4. c4 \u2013 aims for a strong central presence (English Opening), but slightly slower.\n\nAmong these, 1.e4 is the most forcing, scores well in databases, and leads to many reputable open\u2010game lines. It is fully consistent with opening principles and is of equal or better theoretical value than any alternative.\n\nLegality check:  \n\u2022 Square e2 is occupied by a White pawn.  \n\u2022 Square e4 is empty.  \n\u2022 Moving two squares forward from the starting rank on the first move is legal.  \nTherefore 1.e4 is legal.\n\nI will therefore play 1.e4.\n\nFinal Answer: e4"
+          "thoughts": "To determine the best opening move for White, I will evaluate the standard opening principles: controlling the center, developing pieces, and preparing for castling.\n\n1.  **Candidate Moves:**\n    *   **1. e4:** The most popular move. It immediately controls the d5 square, opens lines for the Queen and the light-squared Bishop, and fights for the center.\n    *   **1. d4:** Also an excellent move. It controls e5, supports the d4 pawn with the Queen, and opens the diagonal for the dark-squared Bishop.\n    *   **1. Nf3 / 1. c4:** Flexible moves that exert influence on the center without committing the central pawns immediately.\n\n2.  **Evaluation:**\n    *   **1. e4** is widely considered the most ambitious move, often leading to open, tactical games where piece activity is prioritized. It is the classic choice to challenge for the center immediately.\n    *   **1. d4** is the traditional choice for a slightly more positional and solid approach.\n\n3.  **Conclusion:**\n    As White, playing 1. e4 is statistically the most popular and theoretically sound move to dictate the pace of the game from the very first turn. It adheres to the primary principles of opening theory: seizing central space and facilitating rapid development.\n\nStep-by-step reasoning:\n- The center (e4, d4, e5, d5) is the most critical area of the board.\n- Placing a pawn on e4 exerts immediate control over the center and allows for the development of the f1 bishop and the queen.\n- It is the most common move in high-level chess, offering White a slight initiative.\n\nFinal Answer: e4"
         },
         "info": {
           "actionApplied": 2426,
           "actionSubmitted": 2426,
           "actionSubmittedToString": "e4",
           "agentSelfReportedStatus": "OK",
-          "timeTaken": 9.701
+          "timeTaken": 4.242
         },
         "observation": {
           "currentPlayer": 0,
           "isTerminal": false,
-          "legalActionStrings": [],
-          "legalActions": [],
           "observationString": "rnbqkbnr/pppppppp/8/8/4P3/8/PPPP1PPP/RNBQKBNR b KQkq - 0 1",
           "playerId": 1,
           "remainingOverageTime": 12,
-          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess()\n[State]\nFEN: rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1\n2426\n\n"
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n\n"
         },
         "reward": null,
         "status": "INACTIVE"
@@ -491,84 +526,54 @@
     [
       {
         "action": {
-          "actionString": "c5",
-          "generate_returns": [
-            "{\n  \"main_response\": \"Let's analyze the position after 1.e4.\\n\\n**FEN:**  \\nrnbqkbnr/pppppppp/8/8/4P3/8/PPPP1PPP/RNBQKBNR b KQkq - 0 1\\n\\nIt is Black's turn.\\n\\n### Step-by-step Reasoning\\n\\n1. **Common replies to 1.e4:**  \\n   The most common responses are:\\n   - 1...c5 (Sicilian Defense)\\n   - 1...e5 (Open Game, Double King's Pawn)\\n   - 1...e6 (French Defense)\\n   - 1...c6 (Caro-Kann Defense)\\n   - 1...d6 (Pirc/Modern)\\n   - 1...g6 (Robatsch/Modern Defense)\\n   - 1...d5 (Center Counter/Scandinavian)\\n\\n2. **Evaluating Choices**:  \\n   - **1...e5:** Classical, symmetrical, leads to Open Games.\\n   - **1...c5:** Leads to asymmetrical positions, fights for the center, very challenging, and arguably the most popular at high level (Sicilian).\\n   - **1...e6:** French, solid but can be passive for Black.\\n   - **1...c6:** Caro-Kann, also solid with less immediate pressure.\\n   - **1...d5:** Immediately challenges e4, but White can gain some initiative after exd5 Qxd5 Nc3.\\n\\n3. **Strength of Each Move:**\\n   - The **Sicilian Defense (1...c5)** is statistically the strongest reply at every level, as it prevents White from consolidating a big center, creates tough counterplay, and has been played by world champions for generations.\\n\\n### Final Decision\\n\\nBased on the above, the strongest move for Black is **1...c5** (the Sicilian Defense).\\n\\n**Final Answer: c5**\",\n  \"main_response_and_thoughts\": \"\",\n  \"request_for_logging\": {\n    \"model\": \"gpt-4.1-2025-04-14\",\n    \"messages\": [\n      {\n        \"role\": \"user\",\n        \"content\": [\n          {\n            \"type\": \"text\",\n            \"text\": \"Let's play chess. The current game state in Forsyth-Edwards Notation (FEN) notation is:\\nrnbqkbnr/pppppppp/8/8/4P3/8/PPPP1PPP/RNBQKBNR b KQkq - 0 1\\nThe moves played so far are:\\n1. e4\\nYou are playing as player Black.\\nIt is now your turn. Play your strongest move. The move MUST be legal. Reason step by step to come up with your move, then output your final answer in the format \\\"Final Answer: X\\\" where X is your chosen move in standard algebraic notation (SAN).\\n\"\n          }\n        ]\n      }\n    ],\n    \"config\": {\n      \"temperature\": \"NOT_GIVEN\",\n      \"top_p\": \"NOT_GIVEN\",\n      \"max_tokens\": \"NOT_GIVEN\",\n      \"reasoning_effort\": \"NOT_GIVEN\"\n    }\n  },\n  \"response_for_logging\": {\n    \"id\": \"chatcmpl-C4WoXpuqbAnesSGTYlfMMfW7k6G0R\",\n    \"choices\": [\n      {\n        \"finish_reason\": \"stop\",\n        \"index\": 0,\n        \"logprobs\": null,\n        \"message\": {\n          \"content\": \"Let's analyze the position after 1.e4.\\n\\n**FEN:**  \\nrnbqkbnr/pppppppp/8/8/4P3/8/PPPP1PPP/RNBQKBNR b KQkq - 0 1\\n\\nIt is Black's turn.\\n\\n### Step-by-step Reasoning\\n\\n1. **Common replies to 1.e4:**  \\n   The most common responses are:\\n   - 1...c5 (Sicilian Defense)\\n   - 1...e5 (Open Game, Double King's Pawn)\\n   - 1...e6 (French Defense)\\n   - 1...c6 (Caro-Kann Defense)\\n   - 1...d6 (Pirc/Modern)\\n   - 1...g6 (Robatsch/Modern Defense)\\n   - 1...d5 (Center Counter/Scandinavian)\\n\\n2. **Evaluating Choices**:  \\n   - **1...e5:** Classical, symmetrical, leads to Open Games.\\n   - **1...c5:** Leads to asymmetrical positions, fights for the center, very challenging, and arguably the most popular at high level (Sicilian).\\n   - **1...e6:** French, solid but can be passive for Black.\\n   - **1...c6:** Caro-Kann, also solid with less immediate pressure.\\n   - **1...d5:** Immediately challenges e4, but White can gain some initiative after exd5 Qxd5 Nc3.\\n\\n3. **Strength of Each Move:**\\n   - The **Sicilian Defense (1...c5)** is statistically the strongest reply at every level, as it prevents White from consolidating a big center, creates tough counterplay, and has been played by world champions for generations.\\n\\n### Final Decision\\n\\nBased on the above, the strongest move for Black is **1...c5** (the Sicilian Defense).\\n\\n**Final Answer: c5**\",\n          \"refusal\": null,\n          \"role\": \"assistant\",\n          \"annotations\": []\n        }\n      }\n    ],\n    \"created\": 1755195485,\n    \"model\": \"gpt-4.1-2025-04-14\",\n    \"object\": \"chat.completion\",\n    \"service_tier\": \"default\",\n    \"system_fingerprint\": \"fp_7d949b30bb\",\n    \"usage\": {\n      \"completion_tokens\": 405,\n      \"prompt_tokens\": 148,\n      \"total_tokens\": 553,\n      \"completion_tokens_details\": {\n        \"accepted_prediction_tokens\": 0,\n        \"audio_tokens\": 0,\n        \"reasoning_tokens\": 0,\n        \"rejected_prediction_tokens\": 0\n      },\n      \"prompt_tokens_details\": {\n        \"audio_tokens\": 0,\n        \"cached_tokens\": 0\n      }\n    }\n  },\n  \"generation_tokens\": 405,\n  \"prompt_tokens\": 148,\n  \"reasoning_tokens\": 0,\n  \"duration_success_only_secs\": 8.752019104998908\n}"
+          "actionString": "e5",
+          "call_details": [
+            {
+              "duration_secs": 3.594,
+              "finish_reason": "stop",
+              "first_token_secs": 2.225,
+              "generation_tokens": 310,
+              "model": "openai/google/gemini-3.1-flash-lite-preview",
+              "prompt": "\ud83d\udc4c\ud83d\udc40\ud83d\udc4c\ud83d\udc40\ud83d\udc4c\ud83d\udc40\ud83d\udc4c\ud83d\udc40\ud83d\udc4c\ud83d\udc40 good shit go\u0c66\u0501 sHit\ud83d\udc4c thats \u2714 some good\ud83d\udc4c\ud83d\udc4cshit right\ud83d\udc4c\ud83d\udc4cthere\ud83d\udc4c\ud83d\udc4c\ud83d\udc4c right\u2714there \u2714\u2714if i do \u01bda\u04af so my self \ud83d\udcaf i say so \ud83d\udcaf thats what im talking about right there right there (chorus: \u02b3\u1da6\u1d4d\u02b0\u1d57 \u1d57\u02b0\u1d49\u02b3\u1d49) mMMMM\u13b7\u041c\ud83d\udcaf \ud83d\udc4c\ud83d\udc4c \ud83d\udc4c\u041dO0\u041e\u0b20OOOOO\u041e\u0b20\u0b20Oooo\u1d52\u1d52\u1d52\u1d52\u1d52\u1d52\u1d52\u1d52\u1d52\ud83d\udc4c \ud83d\udc4c\ud83d\udc4c \ud83d\udc4c \ud83d\udcaf \ud83d\udc4c \ud83d\udc40 \ud83d\udc40 \ud83d\udc40 \ud83d\udc4c\ud83d\udc4c\n\nLet's play chess. The current game state in Forsyth-Edwards Notation (FEN) notation is:\nrnbqkbnr/pppppppp/8/8/4P3/8/PPPP1PPP/RNBQKBNR b KQkq - 0 1\nThe moves played so far are:\n1. e4\nYou are playing as player Black.\nIt is now your turn. Play your strongest move. The move MUST be legal. Reason step by step to come up with your move, then output your final answer in the format \"Final Answer: X\" where X is your chosen move in standard algebraic notation (SAN).\n",
+              "prompt_tokens": 259,
+              "reasoning_tokens": 0,
+              "response": "The current position is the standard opening after White's move 1. e4. As Black, I need to respond by controlling the center, developing my pieces, and preparing for castling.\n\n**Evaluation and Reasoning:**\n1. **e5 (King's Pawn Game):** This is the most common and statistically robust response. It challenges White's control of the center immediately, prevents White from playing d4 without a fight, and opens lines for the Queen and Bishop.\n2. **c5 (Sicilian Defense):** An extremely strong and popular aggressive response, aiming to fight for the center from the flank. It leads to complex, tactical positions.\n3. **e6 (French Defense) / c6 (Caro-Kann):** Solid, defensive choices, but slightly more passive compared to e5 or c5.\n\nGiven the goal to play the \"strongest\" move, **1... e5** is the classical standard, leading to open, principled games that are highly regarded by engine evaluations and grandmaster theory alike. It directly contests the d4 square and maintains symmetry.\n\n**Step-by-step logic:**\n*   White has occupied e4.\n*   Black must contest the center.\n*   1... e5 develops, controls d4, and mirrors White's intentions.\n*   This leads into the main line of the King's Pawn openings, which remains objectively one of the best ways to play for Black.\n\nFinal Answer: e5",
+              "total_tokens": 569
+            }
           ],
           "status": "OK",
-          "submission": 1258,
-          "thoughts": "Let's analyze the position after 1.e4.\n\n**FEN:**  \nrnbqkbnr/pppppppp/8/8/4P3/8/PPPP1PPP/RNBQKBNR b KQkq - 0 1\n\nIt is Black's turn.\n\n### Step-by-step Reasoning\n\n1. **Common replies to 1.e4:**  \n   The most common responses are:\n   - 1...c5 (Sicilian Defense)\n   - 1...e5 (Open Game, Double King's Pawn)\n   - 1...e6 (French Defense)\n   - 1...c6 (Caro-Kann Defense)\n   - 1...d6 (Pirc/Modern)\n   - 1...g6 (Robatsch/Modern Defense)\n   - 1...d5 (Center Counter/Scandinavian)\n\n2. **Evaluating Choices**:  \n   - **1...e5:** Classical, symmetrical, leads to Open Games.\n   - **1...c5:** Leads to asymmetrical positions, fights for the center, very challenging, and arguably the most popular at high level (Sicilian).\n   - **1...e6:** French, solid but can be passive for Black.\n   - **1...c6:** Caro-Kann, also solid with less immediate pressure.\n   - **1...d5:** Immediately challenges e4, but White can gain some initiative after exd5 Qxd5 Nc3.\n\n3. **Strength of Each Move:**\n   - The **Sicilian Defense (1...c5)** is statistically the strongest reply at every level, as it prevents White from consolidating a big center, creates tough counterplay, and has been played by world champions for generations.\n\n### Final Decision\n\nBased on the above, the strongest move for Black is **1...c5** (the Sicilian Defense).\n\n**Final Answer: c5**"
+          "submission": 2426,
+          "thoughts": "The current position is the standard opening after White's move 1. e4. As Black, I need to respond by controlling the center, developing my pieces, and preparing for castling.\n\n**Evaluation and Reasoning:**\n1. **e5 (King's Pawn Game):** This is the most common and statistically robust response. It challenges White's control of the center immediately, prevents White from playing d4 without a fight, and opens lines for the Queen and Bishop.\n2. **c5 (Sicilian Defense):** An extremely strong and popular aggressive response, aiming to fight for the center from the flank. It leads to complex, tactical positions.\n3. **e6 (French Defense) / c6 (Caro-Kann):** Solid, defensive choices, but slightly more passive compared to e5 or c5.\n\nGiven the goal to play the \"strongest\" move, **1... e5** is the classical standard, leading to open, principled games that are highly regarded by engine evaluations and grandmaster theory alike. It directly contests the d4 square and maintains symmetry.\n\n**Step-by-step logic:**\n*   White has occupied e4.\n*   Black must contest the center.\n*   1... e5 develops, controls d4, and mirrors White's intentions.\n*   This leads into the main line of the King's Pawn openings, which remains objectively one of the best ways to play for Black.\n\nFinal Answer: e5"
         },
         "info": {
-          "actionApplied": 1258,
-          "actionSubmitted": 1258,
-          "actionSubmittedToString": "c5",
+          "actionApplied": 2426,
+          "actionSubmitted": 2426,
+          "actionSubmittedToString": "e5",
           "agentSelfReportedStatus": "OK",
-          "timeTaken": 8.783
+          "timeTaken": 4.289
         },
         "observation": {
           "currentPlayer": 1,
           "isTerminal": false,
-          "legalActionStrings": [],
-          "legalActions": [],
-          "observationString": "rnbqkbnr/pp1ppppp/8/2p5/4P3/8/PPPP1PPP/RNBQKBNR w KQkq - 0 2",
+          "observationString": "rnbqkbnr/pppp1ppp/8/4p3/4P3/8/PPPP1PPP/RNBQKBNR w KQkq - 0 2",
           "playerId": 0,
           "remainingOverageTime": 12,
-          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess()\n[State]\nFEN: rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1\n2426\n1258\n\n",
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n2426\n\n",
           "step": 3
         },
         "reward": null,
         "status": "INACTIVE"
       },
       {
-        "action": {
-          "submission": -1
-        },
+        "action": { "submission": -1 },
         "info": {},
         "observation": {
           "currentPlayer": 1,
           "isTerminal": false,
-          "legalActionStrings": [
-            "a3",
-            "a4",
-            "Na3",
-            "Nc3",
-            "b3",
-            "b4",
-            "c3",
-            "c4",
-            "Qe2",
-            "Qf3",
-            "Qg4",
-            "Qh5",
-            "d3",
-            "d4",
-            "Ke2",
-            "e5",
-            "Ba6",
-            "Bb5",
-            "Bc4",
-            "Bd3",
-            "Be2",
-            "f3",
-            "f4",
-            "Ne2",
-            "Nf3",
-            "Nh3",
-            "g3",
-            "g4",
-            "h3",
-            "h4"
-          ],
-          "legalActions": [
-            89, 90, 652, 656, 673, 674, 1257, 1258, 1796, 1797, 1798, 1799,
-            1841, 1842, 2352, 2571, 2973, 2974, 2975, 2976, 2977, 3009, 3010,
-            3570, 3572, 3576, 3593, 3594, 4177, 4178
-          ],
-          "observationString": "rnbqkbnr/pp1ppppp/8/2p5/4P3/8/PPPP1PPP/RNBQKBNR w KQkq - 0 2",
+          "observationString": "rnbqkbnr/pppp1ppp/8/4p3/4P3/8/PPPP1PPP/RNBQKBNR w KQkq - 0 2",
           "playerId": 1,
           "remainingOverageTime": 12,
-          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess()\n[State]\nFEN: rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1\n2426\n1258\n\n"
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n2426\n\n"
         },
         "reward": null,
         "status": "ACTIVE"
@@ -576,45 +581,15 @@
     ],
     [
       {
-        "action": {
-          "submission": -1
-        },
+        "action": { "submission": -1 },
         "info": {},
         "observation": {
           "currentPlayer": 0,
           "isTerminal": false,
-          "legalActionStrings": [
-            "a6",
-            "a5",
-            "Na6",
-            "Nc6",
-            "b6",
-            "b5",
-            "c4",
-            "Qa5",
-            "Qb6",
-            "Qc7",
-            "d6",
-            "d5",
-            "e6",
-            "e5",
-            "f6",
-            "f5",
-            "Nf6",
-            "Nh6",
-            "g6",
-            "g5",
-            "h6",
-            "h5"
-          ],
-          "legalActions": [
-            89, 90, 652, 656, 673, 674, 1403, 1807, 1808, 1809, 1841, 1842,
-            2425, 2426, 3009, 3010, 3572, 3576, 3593, 3594, 4177, 4178
-          ],
-          "observationString": "rnbqkbnr/pp1ppppp/8/2p5/4P3/5N2/PPPP1PPP/RNBQKB1R b KQkq - 1 2",
+          "observationString": "rnbqkbnr/pppp1ppp/8/4p3/4P3/5N2/PPPP1PPP/RNBQKB1R b KQkq - 1 2",
           "playerId": 0,
           "remainingOverageTime": 12,
-          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess()\n[State]\nFEN: rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1\n2426\n1258\n3572\n\n",
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n2426\n3572\n\n",
           "step": 4
         },
         "reward": null,
@@ -623,29 +598,38 @@
       {
         "action": {
           "actionString": "Nf3",
-          "generate_returns": [
-            "{\n  \"main_response\": \"We are in the mainline Sicilian Defence after 1.e4 c5.\\n\\n1. Identify candidate moves for White\\u2019s second move:\\n   \\u2022 2.Nf3 \\u2013 develops a knight toward the center, controls d4 and e5, prepares 3.d4 to challenge Black\\u2019s c-pawn, and keeps castling options open.\\n   \\u2022 2.d4 \\u2013 the Smith-Morra Gambit, sacrificing a pawn for rapid development.\\n   \\u2022 2.Nc3 \\u2013 the Closed Sicilian setup.\\n   \\u2022 2.c3 \\u2013 the Alapin Variation, aiming for d4 without pawn loss.\\n\\n2. Compare the candidates:\\n   \\u2022 2.Nf3 is the most flexible and universally accepted mainline move. It develops a piece, attacks the e5 square, and puts immediate pressure on d4.  \\n   \\u2022 2.d4 offers sharp play but gives up a pawn.  \\n   \\u2022 2.Nc3 keeps options but blocks the c-pawn and concedes Black easy equality if White later goes d4.  \\n   \\u2022 2.c3 is solid but less ambitious.\\n\\n3. Verify legality of 2.Nf3:\\n   \\u2022 The knight on g1 moves in an L-shape to f3.  \\n   \\u2022 Square f3 is empty.  \\n   \\u2022 No rules are violated.\\n\\n4. Confirm there are no checks or captures; hence SAN is simply \\u201cNf3\\u201d.\\n\\nTherefore, the strongest and most conventional move is 2.Nf3.\\n\\nFinal Answer: Nf3\",\n  \"main_response_and_thoughts\": \"\",\n  \"request_for_logging\": {\n    \"model\": \"o3-2025-04-16\",\n    \"messages\": [\n      {\n        \"role\": \"user\",\n        \"content\": [\n          {\n            \"type\": \"text\",\n            \"text\": \"Let's play chess. The current game state in Forsyth-Edwards Notation (FEN) notation is:\\nrnbqkbnr/pp1ppppp/8/2p5/4P3/8/PPPP1PPP/RNBQKBNR w KQkq - 0 2\\nThe moves played so far are:\\n1. e4 c5 2.\\nYou are playing as player White.\\nIt is now your turn. Play your strongest move. The move MUST be legal. Reason step by step to come up with your move, then output your final answer in the format \\\"Final Answer: X\\\" where X is your chosen move in standard algebraic notation (SAN).\\n\"\n          }\n        ]\n      }\n    ],\n    \"config\": {\n      \"temperature\": \"NOT_GIVEN\",\n      \"top_p\": \"NOT_GIVEN\",\n      \"max_tokens\": \"NOT_GIVEN\",\n      \"reasoning_effort\": \"NOT_GIVEN\"\n    }\n  },\n  \"response_for_logging\": {\n    \"id\": \"chatcmpl-C4Wofb5JbgUHviRPWHnvkwO424PZ4\",\n    \"choices\": [\n      {\n        \"finish_reason\": \"stop\",\n        \"index\": 0,\n        \"message\": {\n          \"content\": \"We are in the mainline Sicilian Defence after 1.e4 c5.\\n\\n1. Identify candidate moves for White\\u2019s second move:\\n   \\u2022 2.Nf3 \\u2013 develops a knight toward the center, controls d4 and e5, prepares 3.d4 to challenge Black\\u2019s c-pawn, and keeps castling options open.\\n   \\u2022 2.d4 \\u2013 the Smith-Morra Gambit, sacrificing a pawn for rapid development.\\n   \\u2022 2.Nc3 \\u2013 the Closed Sicilian setup.\\n   \\u2022 2.c3 \\u2013 the Alapin Variation, aiming for d4 without pawn loss.\\n\\n2. Compare the candidates:\\n   \\u2022 2.Nf3 is the most flexible and universally accepted mainline move. It develops a piece, attacks the e5 square, and puts immediate pressure on d4.  \\n   \\u2022 2.d4 offers sharp play but gives up a pawn.  \\n   \\u2022 2.Nc3 keeps options but blocks the c-pawn and concedes Black easy equality if White later goes d4.  \\n   \\u2022 2.c3 is solid but less ambitious.\\n\\n3. Verify legality of 2.Nf3:\\n   \\u2022 The knight on g1 moves in an L-shape to f3.  \\n   \\u2022 Square f3 is empty.  \\n   \\u2022 No rules are violated.\\n\\n4. Confirm there are no checks or captures; hence SAN is simply \\u201cNf3\\u201d.\\n\\nTherefore, the strongest and most conventional move is 2.Nf3.\\n\\nFinal Answer: Nf3\",\n          \"refusal\": null,\n          \"role\": \"assistant\",\n          \"annotations\": []\n        }\n      }\n    ],\n    \"created\": 1755195493,\n    \"model\": \"o3-2025-04-16\",\n    \"object\": \"chat.completion\",\n    \"service_tier\": \"default\",\n    \"system_fingerprint\": null,\n    \"usage\": {\n      \"completion_tokens\": 714,\n      \"prompt_tokens\": 154,\n      \"total_tokens\": 868,\n      \"completion_tokens_details\": {\n        \"accepted_prediction_tokens\": 0,\n        \"audio_tokens\": 0,\n        \"reasoning_tokens\": 384,\n        \"rejected_prediction_tokens\": 0\n      },\n      \"prompt_tokens_details\": {\n        \"audio_tokens\": 0,\n        \"cached_tokens\": 0\n      }\n    }\n  },\n  \"generation_tokens\": 714,\n  \"prompt_tokens\": 154,\n  \"reasoning_tokens\": 384,\n  \"duration_success_only_secs\": 16.764486129002762\n}"
+          "call_details": [
+            {
+              "duration_secs": 2.387,
+              "finish_reason": "stop",
+              "first_token_secs": 0.761,
+              "generation_tokens": 326,
+              "model": "openai/google/gemini-3.1-flash-lite-preview",
+              "prompt": "You are a chess expert\n\nLet's play chess. The current game state in Forsyth-Edwards Notation (FEN) notation is:\nrnbqkbnr/pppp1ppp/8/4p3/4P3/8/PPPP1PPP/RNBQKBNR w KQkq - 0 2\nThe moves played so far are:\n1. e4 e5 2.\nYou are playing as player White.\nIt is now your turn. Play your strongest move. The move MUST be legal. Reason step by step to come up with your move, then output your final answer in the format \"Final Answer: X\" where X is your chosen move in standard algebraic notation (SAN).\n",
+              "prompt_tokens": 147,
+              "reasoning_tokens": 0,
+              "response": "The current position is the standard starting position after 1. e4 e5. It is White's turn to move.\n\n**Evaluation:**\nThe position is perfectly equal, 0.00. Both players have opened the center and are ready to develop their minor pieces.\n\n**Candidate Moves:**\n1. **Nf3:** The most principled move. It develops the knight to its best square, attacks the black pawn on e5, and prepares for kingside castling. It is the most popular and theoretically sound move at all levels of play.\n2. **Nc3 (Vienna Game):** A solid alternative that maintains flexibility. It prepares to support the center and often leads to interesting strategic play.\n3. **Bc4 (Bishop's Opening):** A classical approach that eyes the f7 square, the weakest point in Black's camp.\n\n**Reasoning:**\nWhile Nc3 and Bc4 are perfectly good, **Nf3** is the most direct and testing move. By attacking the e5 pawn immediately, it forces Black to make a decision regarding its defense (usually ...Nc6 or ...d6), allowing White to dictate the early tempo of the game. It aligns with the fundamental chess principle of developing pieces toward the center while creating immediate threats.\n\n**Strategic Plan:**\nAfter 2. Nf3, Black will almost certainly respond with 2... Nc6. From there, I will aim to control the center, develop the light-squared bishop, and prepare to castle kingside to secure the king.\n\nFinal Answer: Nf3",
+              "total_tokens": 473
+            }
           ],
           "status": "OK",
           "submission": 3572,
-          "thoughts": "We are in the mainline Sicilian Defence after 1.e4 c5.\n\n1. Identify candidate moves for White\u2019s second move:\n   \u2022 2.Nf3 \u2013 develops a knight toward the center, controls d4 and e5, prepares 3.d4 to challenge Black\u2019s c-pawn, and keeps castling options open.\n   \u2022 2.d4 \u2013 the Smith-Morra Gambit, sacrificing a pawn for rapid development.\n   \u2022 2.Nc3 \u2013 the Closed Sicilian setup.\n   \u2022 2.c3 \u2013 the Alapin Variation, aiming for d4 without pawn loss.\n\n2. Compare the candidates:\n   \u2022 2.Nf3 is the most flexible and universally accepted mainline move. It develops a piece, attacks the e5 square, and puts immediate pressure on d4.  \n   \u2022 2.d4 offers sharp play but gives up a pawn.  \n   \u2022 2.Nc3 keeps options but blocks the c-pawn and concedes Black easy equality if White later goes d4.  \n   \u2022 2.c3 is solid but less ambitious.\n\n3. Verify legality of 2.Nf3:\n   \u2022 The knight on g1 moves in an L-shape to f3.  \n   \u2022 Square f3 is empty.  \n   \u2022 No rules are violated.\n\n4. Confirm there are no checks or captures; hence SAN is simply \u201cNf3\u201d.\n\nTherefore, the strongest and most conventional move is 2.Nf3.\n\nFinal Answer: Nf3"
+          "thoughts": "The current position is the standard starting position after 1. e4 e5. It is White's turn to move.\n\n**Evaluation:**\nThe position is perfectly equal, 0.00. Both players have opened the center and are ready to develop their minor pieces.\n\n**Candidate Moves:**\n1. **Nf3:** The most principled move. It develops the knight to its best square, attacks the black pawn on e5, and prepares for kingside castling. It is the most popular and theoretically sound move at all levels of play.\n2. **Nc3 (Vienna Game):** A solid alternative that maintains flexibility. It prepares to support the center and often leads to interesting strategic play.\n3. **Bc4 (Bishop's Opening):** A classical approach that eyes the f7 square, the weakest point in Black's camp.\n\n**Reasoning:**\nWhile Nc3 and Bc4 are perfectly good, **Nf3** is the most direct and testing move. By attacking the e5 pawn immediately, it forces Black to make a decision regarding its defense (usually ...Nc6 or ...d6), allowing White to dictate the early tempo of the game. It aligns with the fundamental chess principle of developing pieces toward the center while creating immediate threats.\n\n**Strategic Plan:**\nAfter 2. Nf3, Black will almost certainly respond with 2... Nc6. From there, I will aim to control the center, develop the light-squared bishop, and prepare to castle kingside to secure the king.\n\nFinal Answer: Nf3"
         },
         "info": {
           "actionApplied": 3572,
           "actionSubmitted": 3572,
           "actionSubmittedToString": "Nf3",
           "agentSelfReportedStatus": "OK",
-          "timeTaken": 16.793
+          "timeTaken": 2.971
         },
         "observation": {
           "currentPlayer": 0,
           "isTerminal": false,
-          "legalActionStrings": [],
-          "legalActions": [],
-          "observationString": "rnbqkbnr/pp1ppppp/8/2p5/4P3/5N2/PPPP1PPP/RNBQKB1R b KQkq - 1 2",
+          "observationString": "rnbqkbnr/pppp1ppp/8/4p3/4P3/5N2/PPPP1PPP/RNBQKB1R b KQkq - 1 2",
           "playerId": 1,
           "remainingOverageTime": 12,
-          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess()\n[State]\nFEN: rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1\n2426\n1258\n3572\n\n"
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n2426\n3572\n\n"
         },
         "reward": null,
         "status": "INACTIVE"
@@ -655,81 +639,53 @@
       {
         "action": {
           "actionString": "Nc6",
-          "generate_returns": [
-            "{\n  \"main_response\": \"Let\\u2019s reason through the position after 1. e4 c5 2. Nf3:\\n\\n**Position summary (after 2. Nf3, Black to move):**\\n- White has played 1. e4 (occupying the center) and 2. Nf3, attacking Black\\u2019s e5 square and preparing to support d4.\\n- Black played 1...c5 (Sicilian Defense), countering White's center.\\n- It's now Black's second move.\\n\\nLet me consider standard plans in this position:\\n- The most common continuations for Black here are: d6, Nc6, e6, g6, and sometimes a6.\\n- The move d6 supports the c5 pawn, prepares to develop the knight to c6 without worrying about Nb5, and prepares Nf6.\\n- Nc6 is also a natural development move controlling the center and preparing e6 or d6.\\n\\nLet\\u2019s think step by step:\\n1. **Nc6**: Develops a piece and contests the center. Most common.\\n2. **d6**: Solid, but slightly less flexible than Nc6 immediately, though it prevents e5 and supports c5.\\n3. **e6**: Retreats to a French structure, less flexible and blocks the c8 bishop.\\n4. **g6**: Hypermodern, preparing to fianchetto, but more committal.\\n5. **a6**: Prevents Nb5 but not usually urgent here.\\n6. **Nf6**: Developing, attacks e4, but can be met with e5, kicking the knight.\\n\\nConsulting mainline Sicilian theory, after 2. Nf3, the principal move is 2...Nc6 leading to the Open Sicilian. This continues developing pieces and puts immediate pressure on the e4 pawn.\\n\\n**Legality check:**\\n- After 2...Nc6, all rules are satisfied and there is no tactical refutation.\\n\\nTherefore, the strongest move here is:\\n\\n**Final Answer: Nc6**\",\n  \"main_response_and_thoughts\": \"\",\n  \"request_for_logging\": {\n    \"model\": \"gpt-4.1-2025-04-14\",\n    \"messages\": [\n      {\n        \"role\": \"user\",\n        \"content\": [\n          {\n            \"type\": \"text\",\n            \"text\": \"Let's play chess. The current game state in Forsyth-Edwards Notation (FEN) notation is:\\nrnbqkbnr/pp1ppppp/8/2p5/4P3/5N2/PPPP1PPP/RNBQKB1R b KQkq - 1 2\\nThe moves played so far are:\\n1. e4 c5 2. Nf3\\nYou are playing as player Black.\\nIt is now your turn. Play your strongest move. The move MUST be legal. Reason step by step to come up with your move, then output your final answer in the format \\\"Final Answer: X\\\" where X is your chosen move in standard algebraic notation (SAN).\\n\"\n          }\n        ]\n      }\n    ],\n    \"config\": {\n      \"temperature\": \"NOT_GIVEN\",\n      \"top_p\": \"NOT_GIVEN\",\n      \"max_tokens\": \"NOT_GIVEN\",\n      \"reasoning_effort\": \"NOT_GIVEN\"\n    }\n  },\n  \"response_for_logging\": {\n    \"id\": \"chatcmpl-C4WowWgnFm2Qt1O7j0QkWUA3jqTq3\",\n    \"choices\": [\n      {\n        \"finish_reason\": \"stop\",\n        \"index\": 0,\n        \"logprobs\": null,\n        \"message\": {\n          \"content\": \"Let\\u2019s reason through the position after 1. e4 c5 2. Nf3:\\n\\n**Position summary (after 2. Nf3, Black to move):**\\n- White has played 1. e4 (occupying the center) and 2. Nf3, attacking Black\\u2019s e5 square and preparing to support d4.\\n- Black played 1...c5 (Sicilian Defense), countering White's center.\\n- It's now Black's second move.\\n\\nLet me consider standard plans in this position:\\n- The most common continuations for Black here are: d6, Nc6, e6, g6, and sometimes a6.\\n- The move d6 supports the c5 pawn, prepares to develop the knight to c6 without worrying about Nb5, and prepares Nf6.\\n- Nc6 is also a natural development move controlling the center and preparing e6 or d6.\\n\\nLet\\u2019s think step by step:\\n1. **Nc6**: Develops a piece and contests the center. Most common.\\n2. **d6**: Solid, but slightly less flexible than Nc6 immediately, though it prevents e5 and supports c5.\\n3. **e6**: Retreats to a French structure, less flexible and blocks the c8 bishop.\\n4. **g6**: Hypermodern, preparing to fianchetto, but more committal.\\n5. **a6**: Prevents Nb5 but not usually urgent here.\\n6. **Nf6**: Developing, attacks e4, but can be met with e5, kicking the knight.\\n\\nConsulting mainline Sicilian theory, after 2. Nf3, the principal move is 2...Nc6 leading to the Open Sicilian. This continues developing pieces and puts immediate pressure on the e4 pawn.\\n\\n**Legality check:**\\n- After 2...Nc6, all rules are satisfied and there is no tactical refutation.\\n\\nTherefore, the strongest move here is:\\n\\n**Final Answer: Nc6**\",\n          \"refusal\": null,\n          \"role\": \"assistant\",\n          \"annotations\": []\n        }\n      }\n    ],\n    \"created\": 1755195510,\n    \"model\": \"gpt-4.1-2025-04-14\",\n    \"object\": \"chat.completion\",\n    \"service_tier\": \"default\",\n    \"system_fingerprint\": \"fp_7d949b30bb\",\n    \"usage\": {\n      \"completion_tokens\": 420,\n      \"prompt_tokens\": 161,\n      \"total_tokens\": 581,\n      \"completion_tokens_details\": {\n        \"accepted_prediction_tokens\": 0,\n        \"audio_tokens\": 0,\n        \"reasoning_tokens\": 0,\n        \"rejected_prediction_tokens\": 0\n      },\n      \"prompt_tokens_details\": {\n        \"audio_tokens\": 0,\n        \"cached_tokens\": 0\n      }\n    }\n  },\n  \"generation_tokens\": 420,\n  \"prompt_tokens\": 161,\n  \"reasoning_tokens\": 0,\n  \"duration_success_only_secs\": 7.904948307004815\n}"
+          "call_details": [
+            {
+              "duration_secs": 7.023,
+              "finish_reason": "stop",
+              "first_token_secs": 5.062,
+              "generation_tokens": 387,
+              "model": "openai/google/gemini-3.1-flash-lite-preview",
+              "prompt": "\ud83d\udc4c\ud83d\udc40\ud83d\udc4c\ud83d\udc40\ud83d\udc4c\ud83d\udc40\ud83d\udc4c\ud83d\udc40\ud83d\udc4c\ud83d\udc40 good shit go\u0c66\u0501 sHit\ud83d\udc4c thats \u2714 some good\ud83d\udc4c\ud83d\udc4cshit right\ud83d\udc4c\ud83d\udc4cthere\ud83d\udc4c\ud83d\udc4c\ud83d\udc4c right\u2714there \u2714\u2714if i do \u01bda\u04af so my self \ud83d\udcaf i say so \ud83d\udcaf thats what im talking about right there right there (chorus: \u02b3\u1da6\u1d4d\u02b0\u1d57 \u1d57\u02b0\u1d49\u02b3\u1d49) mMMMM\u13b7\u041c\ud83d\udcaf \ud83d\udc4c\ud83d\udc4c \ud83d\udc4c\u041dO0\u041e\u0b20OOOOO\u041e\u0b20\u0b20Oooo\u1d52\u1d52\u1d52\u1d52\u1d52\u1d52\u1d52\u1d52\u1d52\ud83d\udc4c \ud83d\udc4c\ud83d\udc4c \ud83d\udc4c \ud83d\udcaf \ud83d\udc4c \ud83d\udc40 \ud83d\udc40 \ud83d\udc40 \ud83d\udc4c\ud83d\udc4c\n\nLet's play chess. The current game state in Forsyth-Edwards Notation (FEN) notation is:\nrnbqkbnr/pppp1ppp/8/4p3/4P3/5N2/PPPP1PPP/RNBQKB1R b KQkq - 1 2\nThe moves played so far are:\n1. e4 e5 2. Nf3\nYou are playing as player Black.\nIt is now your turn. Play your strongest move. The move MUST be legal. Reason step by step to come up with your move, then output your final answer in the format \"Final Answer: X\" where X is your chosen move in standard algebraic notation (SAN).\n",
+              "prompt_tokens": 272,
+              "reasoning_tokens": 0,
+              "response": "The current position is `rnbqkbnr/pppp1ppp/8/4p3/4P3/5N2/PPPP1PPP/RNBQKB1R b KQkq - 1 2`. It is Black's turn to move.\n\n**Evaluation and Reasoning:**\n1. **The Position:** This is the most common position in chess, the Open Game, arising after 1. e4 e5 2. Nf3. White has developed their knight to f3, attacking my e5-pawn.\n2. **Candidate Moves:**\n    *   **2... Nc6:** This is the most principled and popular move. It develops the knight to its best square, controlling the center (d4 and e5) and defending the e5-pawn. It leads to main lines like the Ruy Lopez, Italian Game, or Scotch Game.\n    *   **2... d6:** The Philidor Defense. A solid but passive move that solidifies the center but restricts the light-squared bishop.\n    *   **2... Nf6:** The Petrov Defense. A very solid and symmetrical response that immediately counter-attacks White's e4-pawn. It is theoretically sound and very popular at the highest levels.\n    *   **2... f6:** Damiano Defense. Generally considered a mistake because it weakens the kingside and restricts the knight's natural development.\n\n**Selection:**\nThe move **2... Nc6** is the gold standard for responding to 2. Nf3. It is the most flexible, develops a piece, and maintains equality while preparing to fight for control of the center. It allows me to respond to whatever setup White chooses (Bishop to c4 for the Italian, Bishop to b5 for the Ruy Lopez, or d4 for the Scotch).\n\nFinal Answer: Nc6",
+              "total_tokens": 659
+            }
           ],
           "status": "OK",
           "submission": 656,
-          "thoughts": "Let\u2019s reason through the position after 1. e4 c5 2. Nf3:\n\n**Position summary (after 2. Nf3, Black to move):**\n- White has played 1. e4 (occupying the center) and 2. Nf3, attacking Black\u2019s e5 square and preparing to support d4.\n- Black played 1...c5 (Sicilian Defense), countering White's center.\n- It's now Black's second move.\n\nLet me consider standard plans in this position:\n- The most common continuations for Black here are: d6, Nc6, e6, g6, and sometimes a6.\n- The move d6 supports the c5 pawn, prepares to develop the knight to c6 without worrying about Nb5, and prepares Nf6.\n- Nc6 is also a natural development move controlling the center and preparing e6 or d6.\n\nLet\u2019s think step by step:\n1. **Nc6**: Develops a piece and contests the center. Most common.\n2. **d6**: Solid, but slightly less flexible than Nc6 immediately, though it prevents e5 and supports c5.\n3. **e6**: Retreats to a French structure, less flexible and blocks the c8 bishop.\n4. **g6**: Hypermodern, preparing to fianchetto, but more committal.\n5. **a6**: Prevents Nb5 but not usually urgent here.\n6. **Nf6**: Developing, attacks e4, but can be met with e5, kicking the knight.\n\nConsulting mainline Sicilian theory, after 2. Nf3, the principal move is 2...Nc6 leading to the Open Sicilian. This continues developing pieces and puts immediate pressure on the e4 pawn.\n\n**Legality check:**\n- After 2...Nc6, all rules are satisfied and there is no tactical refutation.\n\nTherefore, the strongest move here is:\n\n**Final Answer: Nc6**"
+          "thoughts": "The current position is `rnbqkbnr/pppp1ppp/8/4p3/4P3/5N2/PPPP1PPP/RNBQKB1R b KQkq - 1 2`. It is Black's turn to move.\n\n**Evaluation and Reasoning:**\n1. **The Position:** This is the most common position in chess, the Open Game, arising after 1. e4 e5 2. Nf3. White has developed their knight to f3, attacking my e5-pawn.\n2. **Candidate Moves:**\n    *   **2... Nc6:** This is the most principled and popular move. It develops the knight to its best square, controlling the center (d4 and e5) and defending the e5-pawn. It leads to main lines like the Ruy Lopez, Italian Game, or Scotch Game.\n    *   **2... d6:** The Philidor Defense. A solid but passive move that solidifies the center but restricts the light-squared bishop.\n    *   **2... Nf6:** The Petrov Defense. A very solid and symmetrical response that immediately counter-attacks White's e4-pawn. It is theoretically sound and very popular at the highest levels.\n    *   **2... f6:** Damiano Defense. Generally considered a mistake because it weakens the kingside and restricts the knight's natural development.\n\n**Selection:**\nThe move **2... Nc6** is the gold standard for responding to 2. Nf3. It is the most flexible, develops a piece, and maintains equality while preparing to fight for control of the center. It allows me to respond to whatever setup White chooses (Bishop to c4 for the Italian, Bishop to b5 for the Ruy Lopez, or d4 for the Scotch).\n\nFinal Answer: Nc6"
         },
         "info": {
           "actionApplied": 656,
           "actionSubmitted": 656,
           "actionSubmittedToString": "Nc6",
           "agentSelfReportedStatus": "OK",
-          "timeTaken": 7.933
+          "timeTaken": 7.475
         },
         "observation": {
           "currentPlayer": 1,
           "isTerminal": false,
-          "legalActionStrings": [],
-          "legalActions": [],
-          "observationString": "r1bqkbnr/pp1ppppp/2n5/2p5/4P3/5N2/PPPP1PPP/RNBQKB1R w KQkq - 2 3",
+          "observationString": "r1bqkbnr/pppp1ppp/2n5/4p3/4P3/5N2/PPPP1PPP/RNBQKB1R w KQkq - 2 3",
           "playerId": 0,
           "remainingOverageTime": 12,
-          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess()\n[State]\nFEN: rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1\n2426\n1258\n3572\n656\n\n",
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n2426\n3572\n656\n\n",
           "step": 5
         },
         "reward": null,
         "status": "INACTIVE"
       },
       {
-        "action": {
-          "submission": -1
-        },
+        "action": { "submission": -1 },
         "info": {},
         "observation": {
           "currentPlayer": 1,
           "isTerminal": false,
-          "legalActionStrings": [
-            "a3",
-            "a4",
-            "Na3",
-            "Nc3",
-            "b3",
-            "b4",
-            "c3",
-            "c4",
-            "Qe2",
-            "d3",
-            "d4",
-            "Ke2",
-            "e5",
-            "Ba6",
-            "Bb5",
-            "Bc4",
-            "Bd3",
-            "Be2",
-            "Nd4",
-            "Ne5",
-            "Nh4",
-            "Ng1",
-            "Ng5",
-            "g3",
-            "g4",
-            "Rg1",
-            "h3",
-            "h4"
-          ],
-          "legalActions": [
-            89, 90, 652, 656, 673, 674, 1257, 1258, 1796, 1841, 1842, 2352,
-            2571, 2973, 2974, 2975, 2976, 2977, 3132, 3134, 3136, 3137, 3138,
-            3593, 3594, 4117, 4177, 4178
-          ],
-          "observationString": "r1bqkbnr/pp1ppppp/2n5/2p5/4P3/5N2/PPPP1PPP/RNBQKB1R w KQkq - 2 3",
+          "observationString": "r1bqkbnr/pppp1ppp/2n5/4p3/4P3/5N2/PPPP1PPP/RNBQKB1R w KQkq - 2 3",
           "playerId": 1,
           "remainingOverageTime": 12,
-          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess()\n[State]\nFEN: rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1\n2426\n1258\n3572\n656\n\n"
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n2426\n3572\n656\n\n"
         },
         "reward": null,
         "status": "ACTIVE"
@@ -737,51 +693,15 @@
     ],
     [
       {
-        "action": {
-          "submission": -1
-        },
+        "action": { "submission": -1 },
         "info": {},
         "observation": {
           "currentPlayer": 0,
           "isTerminal": false,
-          "legalActionStrings": [
-            "Rb8",
-            "a6",
-            "a5",
-            "b6",
-            "b5",
-            "Na5",
-            "Nb8",
-            "Nb4",
-            "Ne5",
-            "Nxd4",
-            "c4",
-            "cxd4",
-            "Qa5+",
-            "Qb6",
-            "Qc7",
-            "d6",
-            "d5",
-            "e6",
-            "e5",
-            "f6",
-            "f5",
-            "Nf6",
-            "Nh6",
-            "g6",
-            "g5",
-            "h6",
-            "h5"
-          ],
-          "legalActions": [
-            30, 89, 90, 673, 674, 1380, 1381, 1382, 1384, 1386, 1403, 1431,
-            1807, 1808, 1809, 1841, 1842, 2425, 2426, 3009, 3010, 3572, 3576,
-            3593, 3594, 4177, 4178
-          ],
-          "observationString": "r1bqkbnr/pp1ppppp/2n5/2p5/3PP3/5N2/PPP2PPP/RNBQKB1R b KQkq - 0 3",
+          "observationString": "r1bqkbnr/pppp1ppp/2n5/1B2p3/4P3/5N2/PPPP1PPP/RNBQK2R b KQkq - 3 3",
           "playerId": 0,
           "remainingOverageTime": 12,
-          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess()\n[State]\nFEN: rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1\n2426\n1258\n3572\n656\n1842\n\n",
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n2426\n3572\n656\n2974\n\n",
           "step": 6
         },
         "reward": null,
@@ -789,30 +709,39 @@
       },
       {
         "action": {
-          "actionString": "d4",
-          "generate_returns": [
-            "{\n  \"main_response\": \"To select the best move, first examine the position and standard plans in the Sicilian after 1 e4 c5 2 Nf3 Nc6.\\n\\n1. Opening principles  \\n   \\u2022 White usually aims for quick central occupation.  \\n   \\u2022 In the Sicilian, the main theoretical branch is the \\u201cOpen Sicilian,\\u201d reached by d2\\u2013d4, immediately challenging Black\\u2019s c-pawn.\\n\\n2. Candidate moves  \\n   a) 3.d4 \\u2013 the most popular and theoretically critical, opening the center.  \\n   b) 3.Bb5 \\u2013 the Rossolimo, also reputable but less forcing.  \\n   c) 3.Nc3 \\u2013 a Closed Sicilian setup, more restrained.  \\n\\n3. Evaluation  \\n   \\u2022 3.d4 strikes at the center right away, maximizes piece activity, and is endorsed by opening theory as White\\u2019s main line.  \\n   \\u2022 3.Bb5 is sound but allows Black more structural choices.  \\n   \\u2022 3.Nc3 is solid but less ambitious.\\n\\nGiven the objective of playing the strongest, most principled continuation, 3.d4 is the optimal choice.\\n\\nFinal Answer: d4\",\n  \"main_response_and_thoughts\": \"\",\n  \"request_for_logging\": {\n    \"model\": \"o3-2025-04-16\",\n    \"messages\": [\n      {\n        \"role\": \"user\",\n        \"content\": [\n          {\n            \"type\": \"text\",\n            \"text\": \"Let's play chess. The current game state in Forsyth-Edwards Notation (FEN) notation is:\\nr1bqkbnr/pp1ppppp/2n5/2p5/4P3/5N2/PPPP1PPP/RNBQKB1R w KQkq - 2 3\\nThe moves played so far are:\\n1. e4 c5 2. Nf3 Nc6 3.\\nYou are playing as player White.\\nIt is now your turn. Play your strongest move. The move MUST be legal. Reason step by step to come up with your move, then output your final answer in the format \\\"Final Answer: X\\\" where X is your chosen move in standard algebraic notation (SAN).\\n\"\n          }\n        ]\n      }\n    ],\n    \"config\": {\n      \"temperature\": \"NOT_GIVEN\",\n      \"top_p\": \"NOT_GIVEN\",\n      \"max_tokens\": \"NOT_GIVEN\",\n      \"reasoning_effort\": \"NOT_GIVEN\"\n    }\n  },\n  \"response_for_logging\": {\n    \"id\": \"chatcmpl-C4Wp40JfCEtlyCTMSwC7QnnF6bbRn\",\n    \"choices\": [\n      {\n        \"finish_reason\": \"stop\",\n        \"index\": 0,\n        \"message\": {\n          \"content\": \"To select the best move, first examine the position and standard plans in the Sicilian after 1 e4 c5 2 Nf3 Nc6.\\n\\n1. Opening principles  \\n   \\u2022 White usually aims for quick central occupation.  \\n   \\u2022 In the Sicilian, the main theoretical branch is the \\u201cOpen Sicilian,\\u201d reached by d2\\u2013d4, immediately challenging Black\\u2019s c-pawn.\\n\\n2. Candidate moves  \\n   a) 3.d4 \\u2013 the most popular and theoretically critical, opening the center.  \\n   b) 3.Bb5 \\u2013 the Rossolimo, also reputable but less forcing.  \\n   c) 3.Nc3 \\u2013 a Closed Sicilian setup, more restrained.  \\n\\n3. Evaluation  \\n   \\u2022 3.d4 strikes at the center right away, maximizes piece activity, and is endorsed by opening theory as White\\u2019s main line.  \\n   \\u2022 3.Bb5 is sound but allows Black more structural choices.  \\n   \\u2022 3.Nc3 is solid but less ambitious.\\n\\nGiven the objective of playing the strongest, most principled continuation, 3.d4 is the optimal choice.\\n\\nFinal Answer: d4\",\n          \"refusal\": null,\n          \"role\": \"assistant\",\n          \"annotations\": []\n        }\n      }\n    ],\n    \"created\": 1755195518,\n    \"model\": \"o3-2025-04-16\",\n    \"object\": \"chat.completion\",\n    \"service_tier\": \"default\",\n    \"system_fingerprint\": null,\n    \"usage\": {\n      \"completion_tokens\": 837,\n      \"prompt_tokens\": 167,\n      \"total_tokens\": 1004,\n      \"completion_tokens_details\": {\n        \"accepted_prediction_tokens\": 0,\n        \"audio_tokens\": 0,\n        \"reasoning_tokens\": 576,\n        \"rejected_prediction_tokens\": 0\n      },\n      \"prompt_tokens_details\": {\n        \"audio_tokens\": 0,\n        \"cached_tokens\": 0\n      }\n    }\n  },\n  \"generation_tokens\": 837,\n  \"prompt_tokens\": 167,\n  \"reasoning_tokens\": 576,\n  \"duration_success_only_secs\": 11.991624780996062\n}"
+          "actionString": "Bb5",
+          "call_details": [
+            {
+              "duration_secs": 2.49,
+              "finish_reason": "stop",
+              "first_token_secs": 0.941,
+              "generation_tokens": 322,
+              "model": "openai/google/gemini-3.1-flash-lite-preview",
+              "prompt": "You are a chess expert\n\nLet's play chess. The current game state in Forsyth-Edwards Notation (FEN) notation is:\nr1bqkbnr/pppp1ppp/2n5/4p3/4P3/5N2/PPPP1PPP/RNBQKB1R w KQkq - 2 3\nThe moves played so far are:\n1. e4 e5 2. Nf3 Nc6 3.\nYou are playing as player White.\nIt is now your turn. Play your strongest move. The move MUST be legal. Reason step by step to come up with your move, then output your final answer in the format \"Final Answer: X\" where X is your chosen move in standard algebraic notation (SAN).\n",
+              "prompt_tokens": 160,
+              "reasoning_tokens": 0,
+              "response": "The current position is the standard starting point of the Italian Game or the Ruy Lopez, depending on the next move. White has three primary, high-level choices:\n\n1. **3. Bb5 (Ruy Lopez/Spanish Opening):** This is statistically the most popular and arguably the strongest move. It puts immediate pressure on the knight defending the e5-pawn, which indirectly exerts pressure on the e5-pawn itself. It is a highly strategic choice leading to deep theoretical lines.\n2. **3. Bc4 (Italian Game):** This is also a very strong, classical, and principled move. It develops the bishop to an active square, controlling the center and eyeing the weak f7-pawn. It is excellent for players seeking open, attacking games.\n3. **3. Nc3 (Three Knights Game):** A solid developing move, but generally considered slightly less ambitious than the two options above, as it allows Black more flexibility.\n\n**Reasoning:**\nWhile both 3. Bb5 and 3. Bc4 are excellent, **3. Bb5** is widely considered the most testing move in the Ruy Lopez. It has been the top choice of world champions for over a century due to its long-term positional pressure and the complexity it forces upon Black. It adheres to the fundamental principles of development, king safety, and central control.\n\nGiven the choice, 3. Bb5 is the most standard and \"strongest\" recommendation in master-level play for this specific position.\n\nFinal Answer: Bb5",
+              "total_tokens": 482
+            }
           ],
           "status": "OK",
-          "submission": 1842,
-          "thoughts": "To select the best move, first examine the position and standard plans in the Sicilian after 1 e4 c5 2 Nf3 Nc6.\n\n1. Opening principles  \n   \u2022 White usually aims for quick central occupation.  \n   \u2022 In the Sicilian, the main theoretical branch is the \u201cOpen Sicilian,\u201d reached by d2\u2013d4, immediately challenging Black\u2019s c-pawn.\n\n2. Candidate moves  \n   a) 3.d4 \u2013 the most popular and theoretically critical, opening the center.  \n   b) 3.Bb5 \u2013 the Rossolimo, also reputable but less forcing.  \n   c) 3.Nc3 \u2013 a Closed Sicilian setup, more restrained.  \n\n3. Evaluation  \n   \u2022 3.d4 strikes at the center right away, maximizes piece activity, and is endorsed by opening theory as White\u2019s main line.  \n   \u2022 3.Bb5 is sound but allows Black more structural choices.  \n   \u2022 3.Nc3 is solid but less ambitious.\n\nGiven the objective of playing the strongest, most principled continuation, 3.d4 is the optimal choice.\n\nFinal Answer: d4"
+          "submission": 2974,
+          "thoughts": "The current position is the standard starting point of the Italian Game or the Ruy Lopez, depending on the next move. White has three primary, high-level choices:\n\n1. **3. Bb5 (Ruy Lopez/Spanish Opening):** This is statistically the most popular and arguably the strongest move. It puts immediate pressure on the knight defending the e5-pawn, which indirectly exerts pressure on the e5-pawn itself. It is a highly strategic choice leading to deep theoretical lines.\n2. **3. Bc4 (Italian Game):** This is also a very strong, classical, and principled move. It develops the bishop to an active square, controlling the center and eyeing the weak f7-pawn. It is excellent for players seeking open, attacking games.\n3. **3. Nc3 (Three Knights Game):** A solid developing move, but generally considered slightly less ambitious than the two options above, as it allows Black more flexibility.\n\n**Reasoning:**\nWhile both 3. Bb5 and 3. Bc4 are excellent, **3. Bb5** is widely considered the most testing move in the Ruy Lopez. It has been the top choice of world champions for over a century due to its long-term positional pressure and the complexity it forces upon Black. It adheres to the fundamental principles of development, king safety, and central control.\n\nGiven the choice, 3. Bb5 is the most standard and \"strongest\" recommendation in master-level play for this specific position.\n\nFinal Answer: Bb5"
         },
         "info": {
-          "actionApplied": 1842,
-          "actionSubmitted": 1842,
-          "actionSubmittedToString": "d4",
+          "actionApplied": 2974,
+          "actionSubmitted": 2974,
+          "actionSubmittedToString": "Bb5",
           "agentSelfReportedStatus": "OK",
-          "timeTaken": 12.022
+          "timeTaken": 2.925
         },
         "observation": {
           "currentPlayer": 0,
           "isTerminal": false,
-          "legalActionStrings": [],
-          "legalActions": [],
-          "observationString": "r1bqkbnr/pp1ppppp/2n5/2p5/3PP3/5N2/PPP2PPP/RNBQKB1R b KQkq - 0 3",
+          "observationString": "r1bqkbnr/pppp1ppp/2n5/1B2p3/4P3/5N2/PPPP1PPP/RNBQK2R b KQkq - 3 3",
           "playerId": 1,
           "remainingOverageTime": 12,
-          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess()\n[State]\nFEN: rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1\n2426\n1258\n3572\n656\n1842\n\n"
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n2426\n3572\n656\n2974\n\n"
         },
         "reward": null,
         "status": "INACTIVE"
@@ -821,92 +750,54 @@
     [
       {
         "action": {
-          "actionString": "cxd4",
-          "generate_returns": [
-            "{\n  \"main_response\": \"Let's analyze the position after 1. e4 c5 2. Nf3 Nc6 3. d4:\\n\\n**FEN**: r1bqkbnr/pp1ppppp/2n5/2p5/3PP3/5N2/PPP2PPP/RNBQKB1R b KQkq - 0 3\\n\\n**Board:**\\n```\\n8 r  .  b  q  k  b  n  r\\n7 p  p  .  p  p  p  p  p\\n6 .  .  n  .  .  .  .  .\\n5 .  .  p  .  .  .  .  .\\n4 .  .  .  P  P  .  .  .\\n3 .  .  .  .  .  N  .  .\\n2 P  P  P  .  .  P  P  P\\n1 R  N  B  Q  K  B  .  R\\n  a  b  c  d  e  f  g  h\\n```\\n\\n**White's last move:** 3. d4  \\nNow, it\\u2019s Black\\u2019s turn.\\n\\n---\\n\\n**Step-by-Step Reasoning:**\\n\\n1. **White threatens:** The pawn on d4 attacks Black's pawn on c5. If Black does nothing, White can play dxc5, winning a pawn.  \\n2. **Options for Black:**\\n   - **cxd4**: Exchange pawns in the center, the most popular and theoretically sound move.\\n   - **Nf6**: Developing a piece, but allows d5 by White, gaining space.\\n   - **e6**: Prepares to develop the dark-square bishop, but White still can play d5.\\n   - **Qa5+**: A check, but easily blocked by Nc3 or Bd2.\\n   - **g6, d6**: Typical Sicilian moves, but less immediate than taking on d4.\\n3. **Best Practice in Open Sicilian:** After 3. d4, standard play is to exchange on d4: 3... cxd4 4. Nxd4, entering the Open Sicilian.\\n\\n4. **Check legality:**  \\n   - cxd4 captures White\\u2019s pawn on d4.\\n   - The c-pawn is on c5 and d4 has a white pawn; the capture is legal.\\n\\n5. **Evaluation:**  \\n   - cxd4 is the main line.\\n   - It maintains balance, doesn\\u2019t allow White to seize a central advantage, opens lines for Black, and is entirely safe and standard.\\n\\n---\\n\\n**Conclusion:** The strongest, most principled move is **cxd4**.\\n\\n---\\n\\nFinal Answer: cxd4\",\n  \"main_response_and_thoughts\": \"\",\n  \"request_for_logging\": {\n    \"model\": \"gpt-4.1-2025-04-14\",\n    \"messages\": [\n      {\n        \"role\": \"user\",\n        \"content\": [\n          {\n            \"type\": \"text\",\n            \"text\": \"Let's play chess. The current game state in Forsyth-Edwards Notation (FEN) notation is:\\nr1bqkbnr/pp1ppppp/2n5/2p5/3PP3/5N2/PPP2PPP/RNBQKB1R b KQkq - 0 3\\nThe moves played so far are:\\n1. e4 c5 2. Nf3 Nc6 3. d4\\nYou are playing as player Black.\\nIt is now your turn. Play your strongest move. The move MUST be legal. Reason step by step to come up with your move, then output your final answer in the format \\\"Final Answer: X\\\" where X is your chosen move in standard algebraic notation (SAN).\\n\"\n          }\n        ]\n      }\n    ],\n    \"config\": {\n      \"temperature\": \"NOT_GIVEN\",\n      \"top_p\": \"NOT_GIVEN\",\n      \"max_tokens\": \"NOT_GIVEN\",\n      \"reasoning_effort\": \"NOT_GIVEN\"\n    }\n  },\n  \"response_for_logging\": {\n    \"id\": \"chatcmpl-C4WpGJ0TePQuASmKrGMy1qV1s7iHT\",\n    \"choices\": [\n      {\n        \"finish_reason\": \"stop\",\n        \"index\": 0,\n        \"logprobs\": null,\n        \"message\": {\n          \"content\": \"Let's analyze the position after 1. e4 c5 2. Nf3 Nc6 3. d4:\\n\\n**FEN**: r1bqkbnr/pp1ppppp/2n5/2p5/3PP3/5N2/PPP2PPP/RNBQKB1R b KQkq - 0 3\\n\\n**Board:**\\n```\\n8 r  .  b  q  k  b  n  r\\n7 p  p  .  p  p  p  p  p\\n6 .  .  n  .  .  .  .  .\\n5 .  .  p  .  .  .  .  .\\n4 .  .  .  P  P  .  .  .\\n3 .  .  .  .  .  N  .  .\\n2 P  P  P  .  .  P  P  P\\n1 R  N  B  Q  K  B  .  R\\n  a  b  c  d  e  f  g  h\\n```\\n\\n**White's last move:** 3. d4  \\nNow, it\\u2019s Black\\u2019s turn.\\n\\n---\\n\\n**Step-by-Step Reasoning:**\\n\\n1. **White threatens:** The pawn on d4 attacks Black's pawn on c5. If Black does nothing, White can play dxc5, winning a pawn.  \\n2. **Options for Black:**\\n   - **cxd4**: Exchange pawns in the center, the most popular and theoretically sound move.\\n   - **Nf6**: Developing a piece, but allows d5 by White, gaining space.\\n   - **e6**: Prepares to develop the dark-square bishop, but White still can play d5.\\n   - **Qa5+**: A check, but easily blocked by Nc3 or Bd2.\\n   - **g6, d6**: Typical Sicilian moves, but less immediate than taking on d4.\\n3. **Best Practice in Open Sicilian:** After 3. d4, standard play is to exchange on d4: 3... cxd4 4. Nxd4, entering the Open Sicilian.\\n\\n4. **Check legality:**  \\n   - cxd4 captures White\\u2019s pawn on d4.\\n   - The c-pawn is on c5 and d4 has a white pawn; the capture is legal.\\n\\n5. **Evaluation:**  \\n   - cxd4 is the main line.\\n   - It maintains balance, doesn\\u2019t allow White to seize a central advantage, opens lines for Black, and is entirely safe and standard.\\n\\n---\\n\\n**Conclusion:** The strongest, most principled move is **cxd4**.\\n\\n---\\n\\nFinal Answer: cxd4\",\n          \"refusal\": null,\n          \"role\": \"assistant\",\n          \"annotations\": []\n        }\n      }\n    ],\n    \"created\": 1755195530,\n    \"model\": \"gpt-4.1-2025-04-14\",\n    \"object\": \"chat.completion\",\n    \"service_tier\": \"default\",\n    \"system_fingerprint\": \"fp_7d949b30bb\",\n    \"usage\": {\n      \"completion_tokens\": 582,\n      \"prompt_tokens\": 170,\n      \"total_tokens\": 752,\n      \"completion_tokens_details\": {\n        \"accepted_prediction_tokens\": 0,\n        \"audio_tokens\": 0,\n        \"reasoning_tokens\": 0,\n        \"rejected_prediction_tokens\": 0\n      },\n      \"prompt_tokens_details\": {\n        \"audio_tokens\": 0,\n        \"cached_tokens\": 0\n      }\n    }\n  },\n  \"generation_tokens\": 582,\n  \"prompt_tokens\": 170,\n  \"reasoning_tokens\": 0,\n  \"duration_success_only_secs\": 9.20247976900282\n}"
+          "actionString": "a6",
+          "call_details": [
+            {
+              "duration_secs": 2.504,
+              "finish_reason": "stop",
+              "first_token_secs": 0.633,
+              "generation_tokens": 422,
+              "model": "openai/google/gemini-3.1-flash-lite-preview",
+              "prompt": "\ud83d\udc4c\ud83d\udc40\ud83d\udc4c\ud83d\udc40\ud83d\udc4c\ud83d\udc40\ud83d\udc4c\ud83d\udc40\ud83d\udc4c\ud83d\udc40 good shit go\u0c66\u0501 sHit\ud83d\udc4c thats \u2714 some good\ud83d\udc4c\ud83d\udc4cshit right\ud83d\udc4c\ud83d\udc4cthere\ud83d\udc4c\ud83d\udc4c\ud83d\udc4c right\u2714there \u2714\u2714if i do \u01bda\u04af so my self \ud83d\udcaf i say so \ud83d\udcaf thats what im talking about right there right there (chorus: \u02b3\u1da6\u1d4d\u02b0\u1d57 \u1d57\u02b0\u1d49\u02b3\u1d49) mMMMM\u13b7\u041c\ud83d\udcaf \ud83d\udc4c\ud83d\udc4c \ud83d\udc4c\u041dO0\u041e\u0b20OOOOO\u041e\u0b20\u0b20Oooo\u1d52\u1d52\u1d52\u1d52\u1d52\u1d52\u1d52\u1d52\u1d52\ud83d\udc4c \ud83d\udc4c\ud83d\udc4c \ud83d\udc4c \ud83d\udcaf \ud83d\udc4c \ud83d\udc40 \ud83d\udc40 \ud83d\udc40 \ud83d\udc4c\ud83d\udc4c\n\nLet's play chess. The current game state in Forsyth-Edwards Notation (FEN) notation is:\nr1bqkbnr/pppp1ppp/2n5/1B2p3/4P3/5N2/PPPP1PPP/RNBQK2R b KQkq - 3 3\nThe moves played so far are:\n1. e4 e5 2. Nf3 Nc6 3. Bb5\nYou are playing as player Black.\nIt is now your turn. Play your strongest move. The move MUST be legal. Reason step by step to come up with your move, then output your final answer in the format \"Final Answer: X\" where X is your chosen move in standard algebraic notation (SAN).\n",
+              "prompt_tokens": 283,
+              "reasoning_tokens": 0,
+              "response": "The current position is the Ruy Lopez, one of the most well-studied openings in chess. The position is `r1bqkbnr/pppp1ppp/2n5/1B2p3/4P3/5N2/PPPP1PPP/RNBQK2R b KQkq - 3 3`.\n\n**Evaluation and Analysis:**\n1. **The Ruy Lopez (3. Bb5):** White is putting pressure on the e5-pawn by threatening the knight on c6, which defends e5.\n2. **Main Line (3... Nf6):** The Berlin Defense is the most solid and theoretically robust response. It challenges White's e4 pawn and aims to neutralize the pressure.\n3. **Alternative (3... a6):** The Morphy Defense is the most common move. It forces the bishop to make a decision (retreat to a4 or capture on c6). After 4. Ba4, the game continues into complex strategic territory.\n4. **Strategic considerations:** \n    * 3... Nf6 (The Berlin) leads to a very solid structure and is widely considered one of the best responses at the grandmaster level.\n    * 3... a6 is more flexible and maintains the tension.\n\nBoth 3... Nf6 and 3... a6 are top-tier engine moves. I will select **3... a6** as it is the most classical and principled way to challenge the bishop immediately, maintaining maximum flexibility for Black.\n\n**Step-by-step reasoning for 3... a6:**\n* It forces White to declare the intentions of the light-squared bishop.\n* If White plays 4. Ba4, we continue with the standard development (Nf6 or d6).\n* If White plays 4. Bxc6, we recapture 4... dxc6, giving Black the bishop pair in exchange for a slightly compromised pawn structure, which is a well-known, playable endgame scenario.\n\nFinal Answer: a6",
+              "total_tokens": 705
+            }
           ],
           "status": "OK",
-          "submission": 1431,
-          "thoughts": "Let's analyze the position after 1. e4 c5 2. Nf3 Nc6 3. d4:\n\n**FEN**: r1bqkbnr/pp1ppppp/2n5/2p5/3PP3/5N2/PPP2PPP/RNBQKB1R b KQkq - 0 3\n\n**Board:**\n```\n8 r  .  b  q  k  b  n  r\n7 p  p  .  p  p  p  p  p\n6 .  .  n  .  .  .  .  .\n5 .  .  p  .  .  .  .  .\n4 .  .  .  P  P  .  .  .\n3 .  .  .  .  .  N  .  .\n2 P  P  P  .  .  P  P  P\n1 R  N  B  Q  K  B  .  R\n  a  b  c  d  e  f  g  h\n```\n\n**White's last move:** 3. d4  \nNow, it\u2019s Black\u2019s turn.\n\n---\n\n**Step-by-Step Reasoning:**\n\n1. **White threatens:** The pawn on d4 attacks Black's pawn on c5. If Black does nothing, White can play dxc5, winning a pawn.  \n2. **Options for Black:**\n   - **cxd4**: Exchange pawns in the center, the most popular and theoretically sound move.\n   - **Nf6**: Developing a piece, but allows d5 by White, gaining space.\n   - **e6**: Prepares to develop the dark-square bishop, but White still can play d5.\n   - **Qa5+**: A check, but easily blocked by Nc3 or Bd2.\n   - **g6, d6**: Typical Sicilian moves, but less immediate than taking on d4.\n3. **Best Practice in Open Sicilian:** After 3. d4, standard play is to exchange on d4: 3... cxd4 4. Nxd4, entering the Open Sicilian.\n\n4. **Check legality:**  \n   - cxd4 captures White\u2019s pawn on d4.\n   - The c-pawn is on c5 and d4 has a white pawn; the capture is legal.\n\n5. **Evaluation:**  \n   - cxd4 is the main line.\n   - It maintains balance, doesn\u2019t allow White to seize a central advantage, opens lines for Black, and is entirely safe and standard.\n\n---\n\n**Conclusion:** The strongest, most principled move is **cxd4**.\n\n---\n\nFinal Answer: cxd4"
+          "submission": 89,
+          "thoughts": "The current position is the Ruy Lopez, one of the most well-studied openings in chess. The position is `r1bqkbnr/pppp1ppp/2n5/1B2p3/4P3/5N2/PPPP1PPP/RNBQK2R b KQkq - 3 3`.\n\n**Evaluation and Analysis:**\n1. **The Ruy Lopez (3. Bb5):** White is putting pressure on the e5-pawn by threatening the knight on c6, which defends e5.\n2. **Main Line (3... Nf6):** The Berlin Defense is the most solid and theoretically robust response. It challenges White's e4 pawn and aims to neutralize the pressure.\n3. **Alternative (3... a6):** The Morphy Defense is the most common move. It forces the bishop to make a decision (retreat to a4 or capture on c6). After 4. Ba4, the game continues into complex strategic territory.\n4. **Strategic considerations:** \n    * 3... Nf6 (The Berlin) leads to a very solid structure and is widely considered one of the best responses at the grandmaster level.\n    * 3... a6 is more flexible and maintains the tension.\n\nBoth 3... Nf6 and 3... a6 are top-tier engine moves. I will select **3... a6** as it is the most classical and principled way to challenge the bishop immediately, maintaining maximum flexibility for Black.\n\n**Step-by-step reasoning for 3... a6:**\n* It forces White to declare the intentions of the light-squared bishop.\n* If White plays 4. Ba4, we continue with the standard development (Nf6 or d6).\n* If White plays 4. Bxc6, we recapture 4... dxc6, giving Black the bishop pair in exchange for a slightly compromised pawn structure, which is a well-known, playable endgame scenario.\n\nFinal Answer: a6"
         },
         "info": {
-          "actionApplied": 1431,
-          "actionSubmitted": 1431,
-          "actionSubmittedToString": "cxd4",
+          "actionApplied": 89,
+          "actionSubmitted": 89,
+          "actionSubmittedToString": "a6",
           "agentSelfReportedStatus": "OK",
-          "timeTaken": 9.231
+          "timeTaken": 2.98
         },
         "observation": {
           "currentPlayer": 1,
           "isTerminal": false,
-          "legalActionStrings": [],
-          "legalActions": [],
-          "observationString": "r1bqkbnr/pp1ppppp/2n5/8/3pP3/5N2/PPP2PPP/RNBQKB1R w KQkq - 0 4",
+          "observationString": "r1bqkbnr/1ppp1ppp/p1n5/1B2p3/4P3/5N2/PPPP1PPP/RNBQK2R w KQkq - 0 4",
           "playerId": 0,
           "remainingOverageTime": 12,
-          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess()\n[State]\nFEN: rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1\n2426\n1258\n3572\n656\n1842\n1431\n\n",
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n2426\n3572\n656\n2974\n89\n\n",
           "step": 7
         },
         "reward": null,
         "status": "INACTIVE"
       },
       {
-        "action": {
-          "submission": -1
-        },
+        "action": { "submission": -1 },
         "info": {},
         "observation": {
           "currentPlayer": 1,
           "isTerminal": false,
-          "legalActionStrings": [
-            "a3",
-            "a4",
-            "Na3",
-            "Nbd2",
-            "Nc3",
-            "b3",
-            "b4",
-            "Bd2",
-            "Be3",
-            "Bf4",
-            "Bg5",
-            "Bh6",
-            "c3",
-            "c4",
-            "Qd2",
-            "Qd3",
-            "Qxd4",
-            "Qe2",
-            "Ke2",
-            "Kd2",
-            "e5",
-            "Ba6",
-            "Bb5",
-            "Bc4",
-            "Bd3",
-            "Be2",
-            "Nfd2",
-            "Nxd4",
-            "Ne5",
-            "Nh4",
-            "Ng1",
-            "Ng5",
-            "g3",
-            "g4",
-            "Rg1",
-            "h3",
-            "h4"
-          ],
-          "legalActions": [
-            89, 90, 652, 654, 656, 673, 674, 1212, 1213, 1214, 1215, 1216, 1257,
-            1258, 1768, 1769, 1770, 1796, 2352, 2393, 2571, 2973, 2974, 2975,
-            2976, 2977, 3131, 3132, 3134, 3136, 3137, 3138, 3593, 3594, 4117,
-            4177, 4178
-          ],
-          "observationString": "r1bqkbnr/pp1ppppp/2n5/8/3pP3/5N2/PPP2PPP/RNBQKB1R w KQkq - 0 4",
+          "observationString": "r1bqkbnr/1ppp1ppp/p1n5/1B2p3/4P3/5N2/PPPP1PPP/RNBQK2R w KQkq - 0 4",
           "playerId": 1,
           "remainingOverageTime": 12,
-          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess()\n[State]\nFEN: rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1\n2426\n1258\n3572\n656\n1842\n1431\n\n"
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n2426\n3572\n656\n2974\n89\n\n"
         },
         "reward": null,
         "status": "ACTIVE"
@@ -914,49 +805,15 @@
     ],
     [
       {
-        "action": {
-          "submission": -1
-        },
+        "action": { "submission": -1 },
         "info": {},
         "observation": {
           "currentPlayer": 0,
           "isTerminal": false,
-          "legalActionStrings": [
-            "Rb8",
-            "a6",
-            "a5",
-            "b6",
-            "b5",
-            "Na5",
-            "Nb8",
-            "Nb4",
-            "Ne5",
-            "Nxd4",
-            "Qa5+",
-            "Qb6",
-            "Qc7",
-            "d6",
-            "d5",
-            "e6",
-            "e5",
-            "f6",
-            "f5",
-            "Nf6",
-            "Nh6",
-            "g6",
-            "g5",
-            "h6",
-            "h5"
-          ],
-          "legalActions": [
-            30, 89, 90, 673, 674, 1380, 1381, 1382, 1384, 1386, 1807, 1808,
-            1809, 1841, 1842, 2425, 2426, 3009, 3010, 3572, 3576, 3593, 3594,
-            4177, 4178
-          ],
-          "observationString": "r1bqkbnr/pp1ppppp/2n5/8/3NP3/8/PPP2PPP/RNBQKB1R b KQkq - 0 4",
+          "observationString": "r1bqkbnr/1ppp1ppp/p1n5/4p3/B3P3/5N2/PPPP1PPP/RNBQK2R b KQkq - 1 4",
           "playerId": 0,
           "remainingOverageTime": 12,
-          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess()\n[State]\nFEN: rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1\n2426\n1258\n3572\n656\n1842\n1431\n3132\n\n",
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n2426\n3572\n656\n2974\n89\n919\n\n",
           "step": 8
         },
         "reward": null,
@@ -964,30 +821,39 @@
       },
       {
         "action": {
-          "actionString": "Nxd4",
-          "generate_returns": [
-            "{\n  \"main_response\": \"First, identify what is happening on the board.\\n\\n\\u2022 Black\\u2019s pawn from c5 has just captured on d4, so a black pawn now sits on d4.  \\n\\u2022 White\\u2019s knight stands on f3. A knight moves in an \\u201cL\\u201d: two squares in one direction and one perpendicular. From f3 a legal knight jump is to d4 (two files left, one rank up), exactly the square occupied by the black pawn.  \\n\\u2022 Capturing that pawn both regains the material and places a well-centralised knight on d4, the standard reply in the Open Sicilian.  \\n\\u2022 No other White piece can currently recapture the pawn, and not recapturing would leave Black a healthy extra pawn in the centre. Hence the recapture is clearly the strongest move.  \\n\\u2022 The move is legal, does not leave White in check, and is the main theoretical continuation.\\n\\nTherefore White should play:\\n\\nFinal Answer: Nxd4\",\n  \"main_response_and_thoughts\": \"\",\n  \"request_for_logging\": {\n    \"model\": \"o3-2025-04-16\",\n    \"messages\": [\n      {\n        \"role\": \"user\",\n        \"content\": [\n          {\n            \"type\": \"text\",\n            \"text\": \"Let's play chess. The current game state in Forsyth-Edwards Notation (FEN) notation is:\\nr1bqkbnr/pp1ppppp/2n5/8/3pP3/5N2/PPP2PPP/RNBQKB1R w KQkq - 0 4\\nThe moves played so far are:\\n1. e4 c5 2. Nf3 Nc6 3. d4 cxd4 4.\\nYou are playing as player White.\\nIt is now your turn. Play your strongest move. The move MUST be legal. Reason step by step to come up with your move, then output your final answer in the format \\\"Final Answer: X\\\" where X is your chosen move in standard algebraic notation (SAN).\\n\"\n          }\n        ]\n      }\n    ],\n    \"config\": {\n      \"temperature\": \"NOT_GIVEN\",\n      \"top_p\": \"NOT_GIVEN\",\n      \"max_tokens\": \"NOT_GIVEN\",\n      \"reasoning_effort\": \"NOT_GIVEN\"\n    }\n  },\n  \"response_for_logging\": {\n    \"id\": \"chatcmpl-C4WpPhHt9f0c11Eg4219Vk0LcIBLP\",\n    \"choices\": [\n      {\n        \"finish_reason\": \"stop\",\n        \"index\": 0,\n        \"message\": {\n          \"content\": \"First, identify what is happening on the board.\\n\\n\\u2022 Black\\u2019s pawn from c5 has just captured on d4, so a black pawn now sits on d4.  \\n\\u2022 White\\u2019s knight stands on f3. A knight moves in an \\u201cL\\u201d: two squares in one direction and one perpendicular. From f3 a legal knight jump is to d4 (two files left, one rank up), exactly the square occupied by the black pawn.  \\n\\u2022 Capturing that pawn both regains the material and places a well-centralised knight on d4, the standard reply in the Open Sicilian.  \\n\\u2022 No other White piece can currently recapture the pawn, and not recapturing would leave Black a healthy extra pawn in the centre. Hence the recapture is clearly the strongest move.  \\n\\u2022 The move is legal, does not leave White in check, and is the main theoretical continuation.\\n\\nTherefore White should play:\\n\\nFinal Answer: Nxd4\",\n          \"refusal\": null,\n          \"role\": \"assistant\",\n          \"annotations\": []\n        }\n      }\n    ],\n    \"created\": 1755195539,\n    \"model\": \"o3-2025-04-16\",\n    \"object\": \"chat.completion\",\n    \"service_tier\": \"default\",\n    \"system_fingerprint\": null,\n    \"usage\": {\n      \"completion_tokens\": 1235,\n      \"prompt_tokens\": 173,\n      \"total_tokens\": 1408,\n      \"completion_tokens_details\": {\n        \"accepted_prediction_tokens\": 0,\n        \"audio_tokens\": 0,\n        \"reasoning_tokens\": 1024,\n        \"rejected_prediction_tokens\": 0\n      },\n      \"prompt_tokens_details\": {\n        \"audio_tokens\": 0,\n        \"cached_tokens\": 0\n      }\n    }\n  },\n  \"generation_tokens\": 1235,\n  \"prompt_tokens\": 173,\n  \"reasoning_tokens\": 1024,\n  \"duration_success_only_secs\": 15.61725274699711\n}"
+          "actionString": "Ba4",
+          "call_details": [
+            {
+              "duration_secs": 2.653,
+              "finish_reason": "stop",
+              "first_token_secs": 0.927,
+              "generation_tokens": 345,
+              "model": "openai/google/gemini-3.1-flash-lite-preview",
+              "prompt": "You are a chess expert\n\nLet's play chess. The current game state in Forsyth-Edwards Notation (FEN) notation is:\nr1bqkbnr/1ppp1ppp/p1n5/1B2p3/4P3/5N2/PPPP1PPP/RNBQK2R w KQkq - 0 4\nThe moves played so far are:\n1. e4 e5 2. Nf3 Nc6 3. Bb5 a6 4.\nYou are playing as player White.\nIt is now your turn. Play your strongest move. The move MUST be legal. Reason step by step to come up with your move, then output your final answer in the format \"Final Answer: X\" where X is your chosen move in standard algebraic notation (SAN).\n",
+              "prompt_tokens": 170,
+              "reasoning_tokens": 0,
+              "response": "The current position is a standard Ruy Lopez (Spanish Opening) position after 3... a6. White has a few primary options here:\n\n1. **4. Bxc6**: The Exchange Variation. This is a very solid, positional approach. It immediately forces Black to double their pawns (dxc6), leading to an imbalance. White typically aims for a structure where they have a healthier pawn majority on the kingside.\n2. **4. Ba4**: The main line. This is the most popular and flexible move. White maintains the pin on the knight, keeps the tension, and prepares to castle. It leads to the most complex and theoretical lines (like the Closed Ruy Lopez or the Open Ruy Lopez).\n\n**Reasoning:**\nWhile 4. Bxc6 is perfectly playable and avoids a lot of theory, 4. Ba4 is considered the most principled and strongest move for White in the Ruy Lopez. It forces Black to continue playing against the pin, maintains the pressure on the e5-pawn, and keeps the bishop on a strong diagonal where it can often retreat to b3 or c2 if attacked. Most top-level games continue with 4. Ba4.\n\nStep-by-step evaluation:\n- The bishop on b5 is attacked by the move 3... a6.\n- Retiring to a4 is the most flexible response, keeping the pressure on the knight at c6 and preparing future development (d3 or d4, castle, etc.).\n- The position remains balanced, and 4. Ba4 offers White the best chances to press for a long-term advantage.\n\nFinal Answer: Ba4",
+              "total_tokens": 515
+            }
           ],
           "status": "OK",
-          "submission": 3132,
-          "thoughts": "First, identify what is happening on the board.\n\n\u2022 Black\u2019s pawn from c5 has just captured on d4, so a black pawn now sits on d4.  \n\u2022 White\u2019s knight stands on f3. A knight moves in an \u201cL\u201d: two squares in one direction and one perpendicular. From f3 a legal knight jump is to d4 (two files left, one rank up), exactly the square occupied by the black pawn.  \n\u2022 Capturing that pawn both regains the material and places a well-centralised knight on d4, the standard reply in the Open Sicilian.  \n\u2022 No other White piece can currently recapture the pawn, and not recapturing would leave Black a healthy extra pawn in the centre. Hence the recapture is clearly the strongest move.  \n\u2022 The move is legal, does not leave White in check, and is the main theoretical continuation.\n\nTherefore White should play:\n\nFinal Answer: Nxd4"
+          "submission": 919,
+          "thoughts": "The current position is a standard Ruy Lopez (Spanish Opening) position after 3... a6. White has a few primary options here:\n\n1. **4. Bxc6**: The Exchange Variation. This is a very solid, positional approach. It immediately forces Black to double their pawns (dxc6), leading to an imbalance. White typically aims for a structure where they have a healthier pawn majority on the kingside.\n2. **4. Ba4**: The main line. This is the most popular and flexible move. White maintains the pin on the knight, keeps the tension, and prepares to castle. It leads to the most complex and theoretical lines (like the Closed Ruy Lopez or the Open Ruy Lopez).\n\n**Reasoning:**\nWhile 4. Bxc6 is perfectly playable and avoids a lot of theory, 4. Ba4 is considered the most principled and strongest move for White in the Ruy Lopez. It forces Black to continue playing against the pin, maintains the pressure on the e5-pawn, and keeps the bishop on a strong diagonal where it can often retreat to b3 or c2 if attacked. Most top-level games continue with 4. Ba4.\n\nStep-by-step evaluation:\n- The bishop on b5 is attacked by the move 3... a6.\n- Retiring to a4 is the most flexible response, keeping the pressure on the knight at c6 and preparing future development (d3 or d4, castle, etc.).\n- The position remains balanced, and 4. Ba4 offers White the best chances to press for a long-term advantage.\n\nFinal Answer: Ba4"
         },
         "info": {
-          "actionApplied": 3132,
-          "actionSubmitted": 3132,
-          "actionSubmittedToString": "Nxd4",
+          "actionApplied": 919,
+          "actionSubmitted": 919,
+          "actionSubmittedToString": "Ba4",
           "agentSelfReportedStatus": "OK",
-          "timeTaken": 15.645
+          "timeTaken": 3.105
         },
         "observation": {
           "currentPlayer": 0,
           "isTerminal": false,
-          "legalActionStrings": [],
-          "legalActions": [],
-          "observationString": "r1bqkbnr/pp1ppppp/2n5/8/3NP3/8/PPP2PPP/RNBQKB1R b KQkq - 0 4",
+          "observationString": "r1bqkbnr/1ppp1ppp/p1n5/4p3/B3P3/5N2/PPPP1PPP/RNBQK2R b KQkq - 1 4",
           "playerId": 1,
           "remainingOverageTime": 12,
-          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess()\n[State]\nFEN: rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1\n2426\n1258\n3572\n656\n1842\n1431\n3132\n\n"
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n2426\n3572\n656\n2974\n89\n919\n\n"
         },
         "reward": null,
         "status": "INACTIVE"
@@ -997,99 +863,4772 @@
       {
         "action": {
           "actionString": "Nf6",
-          "generate_returns": [
-            "{\n  \"main_response\": \"Let's break down the current position.\\n\\n### FEN\\n```\\nr1bqkbnr/pp1ppppp/2n5/8/3NP3/8/PPP2PPP/RNBQKB1R b KQkq - 0 4\\n```\\n\\n### Move History\\n1. e4 c5\\n2. Nf3 Nc6\\n3. d4 cxd4\\n4. Nxd4\\n\\nWhite has just played Nxd4, regaining the pawn.\\n\\n### Board layout:\\n\\n- Black to move\\n- Pieces developed: Both knights (Nc6 Nd4)\\n- Center: White has a strong knight on d4.\\n- It's standard open Sicilian (Open Sicilian, after 4. Nxd4)\\n\\n### Candidate Moves\\n\\nLet me consider common and best responses for Black in this position:\\n\\n1. **...Nf6**  \\n   Attacks e4 and develops a piece. This is the most common move, putting pressure on White's center and preparing for ...e6 or ...d6.\\n\\n2. **...e6**  \\n   Prepares to develop the dark bishop and solidifies the center. However, it doesn't challenge White's center immediately.\\n\\n3. **...g6**  \\n   Prepares to fianchetto, common in the Dragon (accelerated or normal). After 5. Nc3 Bg7, it\\u2019s a standard setup.\\n\\n4. **...Qc7 or ...a6**  \\n   These are also common moves (Paulsen, Kan, or Taimanov systems), but generally played after ...e6.\\n\\n### What is most principled?\\n\\nThe most direct and principled is **...Nf6**. It immediately attacks the e4 pawn, continues development, and keeps all options open. After 5. Nc3, Black can still choose among a number of Sicilian lines (Classical, Scheveningen, Dragon, etc.).\\n\\n**Is ...Nf6 legal?**\\n\\nLet's make sure:\\n- The knight moves from g8 to f6. No piece is blocking.\\n- e4 is attacked.\\n\\nYes, this is legal.\\n\\n### Justification\\n\\n- Develops a piece (knight)\\n- Increases central pressure\\n- Prepares ...e6 or ...g6 or even ...d6 next\\n\\nHence, the strongest and most flexible move in this position is:\\n\\n**Final Answer: Nf6**\",\n  \"main_response_and_thoughts\": \"\",\n  \"request_for_logging\": {\n    \"model\": \"gpt-4.1-2025-04-14\",\n    \"messages\": [\n      {\n        \"role\": \"user\",\n        \"content\": [\n          {\n            \"type\": \"text\",\n            \"text\": \"Let's play chess. The current game state in Forsyth-Edwards Notation (FEN) notation is:\\nr1bqkbnr/pp1ppppp/2n5/8/3NP3/8/PPP2PPP/RNBQKB1R b KQkq - 0 4\\nThe moves played so far are:\\n1. e4 c5 2. Nf3 Nc6 3. d4 cxd4 4. Nxd4\\nYou are playing as player Black.\\nIt is now your turn. Play your strongest move. The move MUST be legal. Reason step by step to come up with your move, then output your final answer in the format \\\"Final Answer: X\\\" where X is your chosen move in standard algebraic notation (SAN).\\n\"\n          }\n        ]\n      }\n    ],\n    \"config\": {\n      \"temperature\": \"NOT_GIVEN\",\n      \"top_p\": \"NOT_GIVEN\",\n      \"max_tokens\": \"NOT_GIVEN\",\n      \"reasoning_effort\": \"NOT_GIVEN\"\n    }\n  },\n  \"response_for_logging\": {\n    \"id\": \"chatcmpl-C4WpfZWtczkAzPrhGI4BX36oqefNc\",\n    \"choices\": [\n      {\n        \"finish_reason\": \"stop\",\n        \"index\": 0,\n        \"logprobs\": null,\n        \"message\": {\n          \"content\": \"Let's break down the current position.\\n\\n### FEN\\n```\\nr1bqkbnr/pp1ppppp/2n5/8/3NP3/8/PPP2PPP/RNBQKB1R b KQkq - 0 4\\n```\\n\\n### Move History\\n1. e4 c5\\n2. Nf3 Nc6\\n3. d4 cxd4\\n4. Nxd4\\n\\nWhite has just played Nxd4, regaining the pawn.\\n\\n### Board layout:\\n\\n- Black to move\\n- Pieces developed: Both knights (Nc6 Nd4)\\n- Center: White has a strong knight on d4.\\n- It's standard open Sicilian (Open Sicilian, after 4. Nxd4)\\n\\n### Candidate Moves\\n\\nLet me consider common and best responses for Black in this position:\\n\\n1. **...Nf6**  \\n   Attacks e4 and develops a piece. This is the most common move, putting pressure on White's center and preparing for ...e6 or ...d6.\\n\\n2. **...e6**  \\n   Prepares to develop the dark bishop and solidifies the center. However, it doesn't challenge White's center immediately.\\n\\n3. **...g6**  \\n   Prepares to fianchetto, common in the Dragon (accelerated or normal). After 5. Nc3 Bg7, it\\u2019s a standard setup.\\n\\n4. **...Qc7 or ...a6**  \\n   These are also common moves (Paulsen, Kan, or Taimanov systems), but generally played after ...e6.\\n\\n### What is most principled?\\n\\nThe most direct and principled is **...Nf6**. It immediately attacks the e4 pawn, continues development, and keeps all options open. After 5. Nc3, Black can still choose among a number of Sicilian lines (Classical, Scheveningen, Dragon, etc.).\\n\\n**Is ...Nf6 legal?**\\n\\nLet's make sure:\\n- The knight moves from g8 to f6. No piece is blocking.\\n- e4 is attacked.\\n\\nYes, this is legal.\\n\\n### Justification\\n\\n- Develops a piece (knight)\\n- Increases central pressure\\n- Prepares ...e6 or ...g6 or even ...d6 next\\n\\nHence, the strongest and most flexible move in this position is:\\n\\n**Final Answer: Nf6**\",\n          \"refusal\": null,\n          \"role\": \"assistant\",\n          \"annotations\": []\n        }\n      }\n    ],\n    \"created\": 1755195555,\n    \"model\": \"gpt-4.1-2025-04-14\",\n    \"object\": \"chat.completion\",\n    \"service_tier\": \"default\",\n    \"system_fingerprint\": \"fp_7d949b30bb\",\n    \"usage\": {\n      \"completion_tokens\": 497,\n      \"prompt_tokens\": 175,\n      \"total_tokens\": 672,\n      \"completion_tokens_details\": {\n        \"accepted_prediction_tokens\": 0,\n        \"audio_tokens\": 0,\n        \"reasoning_tokens\": 0,\n        \"rejected_prediction_tokens\": 0\n      },\n      \"prompt_tokens_details\": {\n        \"audio_tokens\": 0,\n        \"cached_tokens\": 0\n      }\n    }\n  },\n  \"generation_tokens\": 497,\n  \"prompt_tokens\": 175,\n  \"reasoning_tokens\": 0,\n  \"duration_success_only_secs\": 11.201628533002804\n}"
+          "call_details": [
+            {
+              "duration_secs": 2.789,
+              "finish_reason": "stop",
+              "first_token_secs": 0.589,
+              "generation_tokens": 392,
+              "model": "openai/google/gemini-3.1-flash-lite-preview",
+              "prompt": "\ud83d\udc4c\ud83d\udc40\ud83d\udc4c\ud83d\udc40\ud83d\udc4c\ud83d\udc40\ud83d\udc4c\ud83d\udc40\ud83d\udc4c\ud83d\udc40 good shit go\u0c66\u0501 sHit\ud83d\udc4c thats \u2714 some good\ud83d\udc4c\ud83d\udc4cshit right\ud83d\udc4c\ud83d\udc4cthere\ud83d\udc4c\ud83d\udc4c\ud83d\udc4c right\u2714there \u2714\u2714if i do \u01bda\u04af so my self \ud83d\udcaf i say so \ud83d\udcaf thats what im talking about right there right there (chorus: \u02b3\u1da6\u1d4d\u02b0\u1d57 \u1d57\u02b0\u1d49\u02b3\u1d49) mMMMM\u13b7\u041c\ud83d\udcaf \ud83d\udc4c\ud83d\udc4c \ud83d\udc4c\u041dO0\u041e\u0b20OOOOO\u041e\u0b20\u0b20Oooo\u1d52\u1d52\u1d52\u1d52\u1d52\u1d52\u1d52\u1d52\u1d52\ud83d\udc4c \ud83d\udc4c\ud83d\udc4c \ud83d\udc4c \ud83d\udcaf \ud83d\udc4c \ud83d\udc40 \ud83d\udc40 \ud83d\udc40 \ud83d\udc4c\ud83d\udc4c\n\nLet's play chess. The current game state in Forsyth-Edwards Notation (FEN) notation is:\nr1bqkbnr/1ppp1ppp/p1n5/4p3/B3P3/5N2/PPPP1PPP/RNBQK2R b KQkq - 1 4\nThe moves played so far are:\n1. e4 e5 2. Nf3 Nc6 3. Bb5 a6 4. Ba4\nYou are playing as player Black.\nIt is now your turn. Play your strongest move. The move MUST be legal. Reason step by step to come up with your move, then output your final answer in the format \"Final Answer: X\" where X is your chosen move in standard algebraic notation (SAN).\n",
+              "prompt_tokens": 291,
+              "reasoning_tokens": 0,
+              "response": "The current position is `r1bqkbnr/1ppp1ppp/p1n5/4p3/B3P3/5N2/PPPP1PPP/RNBQK2R b KQkq - 1 4`. This is the standard position of the Ruy Lopez, Morphy Defense.\n\n**Evaluation and Strategy:**\n1.  **Opening Theory:** Black has several strong continuations here. The most common and statistically strongest moves are 4... Nf6 (the Berlin Defense) and 4... b5 (the main line, forcing the bishop to retreat).\n2.  **4... Nf6:** This is a very solid, world-class choice. It immediately attacks the e4 pawn and prepares for castling. If White plays 5. O-O, Black can choose between the Open Ruy Lopez (5... Nxe4) or the closed lines (5... Be7).\n3.  **4... b5:** This immediately gains space on the queenside and forces White to decide where to put the bishop (usually b3 or c2). It's very aggressive and forces the issue early.\n4.  **Decision:** 4... Nf6 is a very principled and safe way to handle the Ruy Lopez. It puts pressure on White's center immediately. Given the high-level nature of this opening, 4... Nf6 is widely considered one of the top choices.\n\n**Reasoning:**\n*   4... Nf6 challenges White's control of e4 directly.\n*   It is a standard, book move that leads to rich and balanced positions.\n*   It avoids any immediate \"tricks\" or specific complications that might arise from other, less standard lines.\n\nI will choose 4... Nf6 as the most robust move to maintain equality and develop the kingside pieces.\n\nFinal Answer: Nf6",
+              "total_tokens": 683
+            }
           ],
           "status": "OK",
           "submission": 3572,
-          "thoughts": "Let's break down the current position.\n\n### FEN\n```\nr1bqkbnr/pp1ppppp/2n5/8/3NP3/8/PPP2PPP/RNBQKB1R b KQkq - 0 4\n```\n\n### Move History\n1. e4 c5\n2. Nf3 Nc6\n3. d4 cxd4\n4. Nxd4\n\nWhite has just played Nxd4, regaining the pawn.\n\n### Board layout:\n\n- Black to move\n- Pieces developed: Both knights (Nc6 Nd4)\n- Center: White has a strong knight on d4.\n- It's standard open Sicilian (Open Sicilian, after 4. Nxd4)\n\n### Candidate Moves\n\nLet me consider common and best responses for Black in this position:\n\n1. **...Nf6**  \n   Attacks e4 and develops a piece. This is the most common move, putting pressure on White's center and preparing for ...e6 or ...d6.\n\n2. **...e6**  \n   Prepares to develop the dark bishop and solidifies the center. However, it doesn't challenge White's center immediately.\n\n3. **...g6**  \n   Prepares to fianchetto, common in the Dragon (accelerated or normal). After 5. Nc3 Bg7, it\u2019s a standard setup.\n\n4. **...Qc7 or ...a6**  \n   These are also common moves (Paulsen, Kan, or Taimanov systems), but generally played after ...e6.\n\n### What is most principled?\n\nThe most direct and principled is **...Nf6**. It immediately attacks the e4 pawn, continues development, and keeps all options open. After 5. Nc3, Black can still choose among a number of Sicilian lines (Classical, Scheveningen, Dragon, etc.).\n\n**Is ...Nf6 legal?**\n\nLet's make sure:\n- The knight moves from g8 to f6. No piece is blocking.\n- e4 is attacked.\n\nYes, this is legal.\n\n### Justification\n\n- Develops a piece (knight)\n- Increases central pressure\n- Prepares ...e6 or ...g6 or even ...d6 next\n\nHence, the strongest and most flexible move in this position is:\n\n**Final Answer: Nf6**"
+          "thoughts": "The current position is `r1bqkbnr/1ppp1ppp/p1n5/4p3/B3P3/5N2/PPPP1PPP/RNBQK2R b KQkq - 1 4`. This is the standard position of the Ruy Lopez, Morphy Defense.\n\n**Evaluation and Strategy:**\n1.  **Opening Theory:** Black has several strong continuations here. The most common and statistically strongest moves are 4... Nf6 (the Berlin Defense) and 4... b5 (the main line, forcing the bishop to retreat).\n2.  **4... Nf6:** This is a very solid, world-class choice. It immediately attacks the e4 pawn and prepares for castling. If White plays 5. O-O, Black can choose between the Open Ruy Lopez (5... Nxe4) or the closed lines (5... Be7).\n3.  **4... b5:** This immediately gains space on the queenside and forces White to decide where to put the bishop (usually b3 or c2). It's very aggressive and forces the issue early.\n4.  **Decision:** 4... Nf6 is a very principled and safe way to handle the Ruy Lopez. It puts pressure on White's center immediately. Given the high-level nature of this opening, 4... Nf6 is widely considered one of the top choices.\n\n**Reasoning:**\n*   4... Nf6 challenges White's control of e4 directly.\n*   It is a standard, book move that leads to rich and balanced positions.\n*   It avoids any immediate \"tricks\" or specific complications that might arise from other, less standard lines.\n\nI will choose 4... Nf6 as the most robust move to maintain equality and develop the kingside pieces.\n\nFinal Answer: Nf6"
         },
         "info": {
           "actionApplied": 3572,
           "actionSubmitted": 3572,
           "actionSubmittedToString": "Nf6",
           "agentSelfReportedStatus": "OK",
-          "timeTaken": 11.233
+          "timeTaken": 3.19
         },
         "observation": {
           "currentPlayer": 1,
           "isTerminal": false,
-          "legalActionStrings": [],
-          "legalActions": [],
-          "observationString": "r1bqkb1r/pp1ppppp/2n2n2/8/3NP3/8/PPP2PPP/RNBQKB1R w KQkq - 1 5",
+          "observationString": "r1bqkb1r/1ppp1ppp/p1n2n2/4p3/B3P3/5N2/PPPP1PPP/RNBQK2R w KQkq - 2 5",
           "playerId": 0,
           "remainingOverageTime": 12,
-          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess()\n[State]\nFEN: rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1\n2426\n1258\n3572\n656\n1842\n1431\n3132\n3572\n\n",
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n2426\n3572\n656\n2974\n89\n919\n3572\n\n",
           "step": 9
         },
-        "reward": 1.0,
-        "status": "DONE"
+        "reward": null,
+        "status": "INACTIVE"
       },
       {
-        "action": {
-          "submission": -1
-        },
+        "action": { "submission": -1 },
         "info": {},
         "observation": {
           "currentPlayer": 1,
           "isTerminal": false,
-          "legalActionStrings": [
-            "a3",
-            "a4",
-            "Na3",
-            "Nd2",
-            "Nc3",
-            "b3",
-            "b4",
-            "Bd2",
-            "Be3",
-            "Bf4",
-            "Bg5",
-            "Bh6",
-            "c3",
-            "c4",
-            "Qd2",
-            "Qd3",
-            "Qe2",
-            "Qf3",
-            "Qg4",
-            "Qh5",
-            "Nb3",
-            "Nb5",
-            "Nxc6",
-            "Nf3",
-            "Nf5",
-            "Ne2",
-            "Ne6",
-            "Ke2",
-            "Kd2",
-            "e5",
-            "Ba6",
-            "Bb5",
-            "Bc4",
-            "Bd3",
-            "Be2",
-            "f3",
-            "f4",
-            "g3",
-            "g4",
-            "Rg1",
-            "h3",
-            "h4"
-          ],
-          "legalActions": [
-            89, 90, 652, 654, 656, 673, 674, 1212, 1213, 1214, 1215, 1216, 1257,
-            1258, 1768, 1769, 1796, 1797, 1798, 1799, 2036, 2037, 2039, 2040,
-            2041, 2042, 2043, 2352, 2393, 2571, 2973, 2974, 2975, 2976, 2977,
-            3009, 3010, 3593, 3594, 4117, 4177, 4178
-          ],
-          "observationString": "r1bqkb1r/pp1ppppp/2n2n2/8/3NP3/8/PPP2PPP/RNBQKB1R w KQkq - 1 5",
+          "observationString": "r1bqkb1r/1ppp1ppp/p1n2n2/4p3/B3P3/5N2/PPPP1PPP/RNBQK2R w KQkq - 2 5",
           "playerId": 1,
           "remainingOverageTime": 12,
-          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess()\n[State]\nFEN: rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1\n2426\n1258\n3572\n656\n1842\n1431\n3132\n3572\n\n"
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n2426\n3572\n656\n2974\n89\n919\n3572\n\n"
         },
-        "reward": -1.0,
-        "status": "TIMEOUT"
+        "reward": null,
+        "status": "ACTIVE"
+      }
+    ],
+    [
+      {
+        "action": { "submission": -1 },
+        "info": {},
+        "observation": {
+          "currentPlayer": 0,
+          "isTerminal": false,
+          "observationString": "r1bqkb1r/1ppp1ppp/p1n2n2/4p3/B3P3/5N2/PPPP1PPP/RNBQ1RK1 b kq - 3 5",
+          "playerId": 0,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n2426\n3572\n656\n2974\n89\n919\n3572\n4673\n\n",
+          "step": 10
+        },
+        "reward": null,
+        "status": "ACTIVE"
+      },
+      {
+        "action": {
+          "actionString": "O-O",
+          "call_details": [
+            {
+              "duration_secs": 2.909,
+              "finish_reason": "stop",
+              "first_token_secs": 1.123,
+              "generation_tokens": 356,
+              "model": "openai/google/gemini-3.1-flash-lite-preview",
+              "prompt": "You are a chess expert\n\nLet's play chess. The current game state in Forsyth-Edwards Notation (FEN) notation is:\nr1bqkb1r/1ppp1ppp/p1n2n2/4p3/B3P3/5N2/PPPP1PPP/RNBQK2R w KQkq - 2 5\nThe moves played so far are:\n1. e4 e5 2. Nf3 Nc6 3. Bb5 a6 4. Ba4 Nf6 5.\nYou are playing as player White.\nIt is now your turn. Play your strongest move. The move MUST be legal. Reason step by step to come up with your move, then output your final answer in the format \"Final Answer: X\" where X is your chosen move in standard algebraic notation (SAN).\n",
+              "prompt_tokens": 179,
+              "reasoning_tokens": 0,
+              "response": "The current position is the standard starting position of the **Ruy Lopez, Morphy Defense**. It is White's turn to move.\n\n### Analysis:\n1. **The Position**: White has developed the knight and bishop, controlling the center and preparing for kingside castling. Black has responded with the main lines of the Morphy Defense.\n2. **Candidate Moves**:\n   *   **O-O**: The main line and statistically the most popular/strongest move. It secures the king and prepares to play Re1, defending the e4-pawn.\n   *   **d3**: The Anti-Marshall or slow systems. Solid, but less ambitious than castling.\n   *   **Nc3**: Leads to Four Knights variations if Black responds with Nf6 (though here Nf6 is already played).\n   *   **Qe2**: A prophylactic move often associated with the Wormald Attack or Steinitz variations.\n\n### Evaluation:\n*   **O-O (Castling)** is the gold standard. It follows opening principles: get the king to safety and bring the rook into the game. It allows White to maintain maximum flexibility to deal with Black's setup (e.g., whether Black plays ...Be7, ...Bc5, or the Breyer/Zaitsev setups).\n*   If White plays 5. O-O, Black usually responds with 5... Be7, 5... Bc5, or 5... Nxe4 (the Open Ruy Lopez). White is well-prepared for all of these responses. \n\nCastling is the most principled, common, and flexible continuation in this specific position.\n\nFinal Answer: O-O",
+              "total_tokens": 535
+            }
+          ],
+          "status": "OK",
+          "submission": 4673,
+          "thoughts": "The current position is the standard starting position of the **Ruy Lopez, Morphy Defense**. It is White's turn to move.\n\n### Analysis:\n1. **The Position**: White has developed the knight and bishop, controlling the center and preparing for kingside castling. Black has responded with the main lines of the Morphy Defense.\n2. **Candidate Moves**:\n   *   **O-O**: The main line and statistically the most popular/strongest move. It secures the king and prepares to play Re1, defending the e4-pawn.\n   *   **d3**: The Anti-Marshall or slow systems. Solid, but less ambitious than castling.\n   *   **Nc3**: Leads to Four Knights variations if Black responds with Nf6 (though here Nf6 is already played).\n   *   **Qe2**: A prophylactic move often associated with the Wormald Attack or Steinitz variations.\n\n### Evaluation:\n*   **O-O (Castling)** is the gold standard. It follows opening principles: get the king to safety and bring the rook into the game. It allows White to maintain maximum flexibility to deal with Black's setup (e.g., whether Black plays ...Be7, ...Bc5, or the Breyer/Zaitsev setups).\n*   If White plays 5. O-O, Black usually responds with 5... Be7, 5... Bc5, or 5... Nxe4 (the Open Ruy Lopez). White is well-prepared for all of these responses. \n\nCastling is the most principled, common, and flexible continuation in this specific position.\n\nFinal Answer: O-O"
+        },
+        "info": {
+          "actionApplied": 4673,
+          "actionSubmitted": 4673,
+          "actionSubmittedToString": "O-O",
+          "agentSelfReportedStatus": "OK",
+          "timeTaken": 3.429
+        },
+        "observation": {
+          "currentPlayer": 0,
+          "isTerminal": false,
+          "observationString": "r1bqkb1r/1ppp1ppp/p1n2n2/4p3/B3P3/5N2/PPPP1PPP/RNBQ1RK1 b kq - 3 5",
+          "playerId": 1,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n2426\n3572\n656\n2974\n89\n919\n3572\n4673\n\n"
+        },
+        "reward": null,
+        "status": "INACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "actionString": "Be7",
+          "call_details": [
+            {
+              "duration_secs": 2.598,
+              "finish_reason": "stop",
+              "first_token_secs": 0.616,
+              "generation_tokens": 419,
+              "model": "openai/google/gemini-3.1-flash-lite-preview",
+              "prompt": "\ud83d\udc4c\ud83d\udc40\ud83d\udc4c\ud83d\udc40\ud83d\udc4c\ud83d\udc40\ud83d\udc4c\ud83d\udc40\ud83d\udc4c\ud83d\udc40 good shit go\u0c66\u0501 sHit\ud83d\udc4c thats \u2714 some good\ud83d\udc4c\ud83d\udc4cshit right\ud83d\udc4c\ud83d\udc4cthere\ud83d\udc4c\ud83d\udc4c\ud83d\udc4c right\u2714there \u2714\u2714if i do \u01bda\u04af so my self \ud83d\udcaf i say so \ud83d\udcaf thats what im talking about right there right there (chorus: \u02b3\u1da6\u1d4d\u02b0\u1d57 \u1d57\u02b0\u1d49\u02b3\u1d49) mMMMM\u13b7\u041c\ud83d\udcaf \ud83d\udc4c\ud83d\udc4c \ud83d\udc4c\u041dO0\u041e\u0b20OOOOO\u041e\u0b20\u0b20Oooo\u1d52\u1d52\u1d52\u1d52\u1d52\u1d52\u1d52\u1d52\u1d52\ud83d\udc4c \ud83d\udc4c\ud83d\udc4c \ud83d\udc4c \ud83d\udcaf \ud83d\udc4c \ud83d\udc40 \ud83d\udc40 \ud83d\udc40 \ud83d\udc4c\ud83d\udc4c\n\nLet's play chess. The current game state in Forsyth-Edwards Notation (FEN) notation is:\nr1bqkb1r/1ppp1ppp/p1n2n2/4p3/B3P3/5N2/PPPP1PPP/RNBQ1RK1 b kq - 3 5\nThe moves played so far are:\n1. e4 e5 2. Nf3 Nc6 3. Bb5 a6 4. Ba4 Nf6 5. O-O\nYou are playing as player Black.\nIt is now your turn. Play your strongest move. The move MUST be legal. Reason step by step to come up with your move, then output your final answer in the format \"Final Answer: X\" where X is your chosen move in standard algebraic notation (SAN).\n",
+              "prompt_tokens": 303,
+              "reasoning_tokens": 0,
+              "response": "The current position is `r1bqkb1r/1ppp1ppp/p1n2n2/4p3/B3P3/5N2/PPPP1PPP/RNBQ1RK1 b kq - 3 5`. This is the Ruy Lopez, Closed Variation (or specifically, the main line before Black commits to ...Be7 or ...Bc5).\n\n**Evaluation and Analysis:**\n1. **The Position:** Black has a solid position. White has castled and has a standard setup. Black needs to continue development, focusing on the center and the bishop on f8.\n2. **Candidate Moves:**\n    *   **5... Be7:** This is the most classical and reliable move. It prepares to castle kingside and maintains the structural integrity of the position. It is the main line of the Ruy Lopez.\n    *   **5... Bc5:** The M\u00f6ller Defense. This is more aggressive, aiming to put pressure on the f2 square immediately, but it allows White to challenge the bishop with c3 and d4.\n    *   **5... b5:** Forces the bishop to return to b3, which is standard but often played after ...Be7 anyway.\n3. **Reasoning:**\n    *   **5... Be7** is the gold standard in the Ruy Lopez. It is a solid, flexible move that prioritizes king safety and completing development. In the master-level databases, this is overwhelmingly the most played and highest-scoring move for Black. It prepares to castle and avoids the immediate tactical complications that can arise from 5... Bc5.\n    *   After 5... Be7, White usually continues with 6. Re1, and Black responds with 6... b5 7. Bb3 d6, leading to the Closed Ruy Lopez main lines.\n\n**Conclusion:** 5... Be7 is the most principled and strongest move according to chess theory and engine evaluation.\n\nFinal Answer: Be7",
+              "total_tokens": 722
+            }
+          ],
+          "status": "OK",
+          "submission": 2977,
+          "thoughts": "The current position is `r1bqkb1r/1ppp1ppp/p1n2n2/4p3/B3P3/5N2/PPPP1PPP/RNBQ1RK1 b kq - 3 5`. This is the Ruy Lopez, Closed Variation (or specifically, the main line before Black commits to ...Be7 or ...Bc5).\n\n**Evaluation and Analysis:**\n1. **The Position:** Black has a solid position. White has castled and has a standard setup. Black needs to continue development, focusing on the center and the bishop on f8.\n2. **Candidate Moves:**\n    *   **5... Be7:** This is the most classical and reliable move. It prepares to castle kingside and maintains the structural integrity of the position. It is the main line of the Ruy Lopez.\n    *   **5... Bc5:** The M\u00f6ller Defense. This is more aggressive, aiming to put pressure on the f2 square immediately, but it allows White to challenge the bishop with c3 and d4.\n    *   **5... b5:** Forces the bishop to return to b3, which is standard but often played after ...Be7 anyway.\n3. **Reasoning:**\n    *   **5... Be7** is the gold standard in the Ruy Lopez. It is a solid, flexible move that prioritizes king safety and completing development. In the master-level databases, this is overwhelmingly the most played and highest-scoring move for Black. It prepares to castle and avoids the immediate tactical complications that can arise from 5... Bc5.\n    *   After 5... Be7, White usually continues with 6. Re1, and Black responds with 6... b5 7. Bb3 d6, leading to the Closed Ruy Lopez main lines.\n\n**Conclusion:** 5... Be7 is the most principled and strongest move according to chess theory and engine evaluation.\n\nFinal Answer: Be7"
+        },
+        "info": {
+          "actionApplied": 2977,
+          "actionSubmitted": 2977,
+          "actionSubmittedToString": "Be7",
+          "agentSelfReportedStatus": "OK",
+          "timeTaken": 3.051
+        },
+        "observation": {
+          "currentPlayer": 1,
+          "isTerminal": false,
+          "observationString": "r1bqk2r/1pppbppp/p1n2n2/4p3/B3P3/5N2/PPPP1PPP/RNBQ1RK1 w kq - 4 6",
+          "playerId": 0,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n2426\n3572\n656\n2974\n89\n919\n3572\n4673\n2977\n\n",
+          "step": 11
+        },
+        "reward": null,
+        "status": "INACTIVE"
+      },
+      {
+        "action": { "submission": -1 },
+        "info": {},
+        "observation": {
+          "currentPlayer": 1,
+          "isTerminal": false,
+          "observationString": "r1bqk2r/1pppbppp/p1n2n2/4p3/B3P3/5N2/PPPP1PPP/RNBQ1RK1 w kq - 4 6",
+          "playerId": 1,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n2426\n3572\n656\n2974\n89\n919\n3572\n4673\n2977\n\n"
+        },
+        "reward": null,
+        "status": "ACTIVE"
+      }
+    ],
+    [
+      {
+        "action": { "submission": -1 },
+        "info": {},
+        "observation": {
+          "currentPlayer": 0,
+          "isTerminal": false,
+          "observationString": "r1bqk2r/1pppbppp/p1n2n2/4p3/B3P3/5N2/PPPP1PPP/RNBQR1K1 b kq - 5 6",
+          "playerId": 0,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n2426\n3572\n656\n2974\n89\n919\n3572\n4673\n2977\n2949\n\n",
+          "step": 12
+        },
+        "reward": null,
+        "status": "ACTIVE"
+      },
+      {
+        "action": {
+          "actionString": "Re1",
+          "call_details": [
+            {
+              "duration_secs": 2.515,
+              "finish_reason": "stop",
+              "first_token_secs": 0.822,
+              "generation_tokens": 414,
+              "model": "openai/google/gemini-3.1-flash-lite-preview",
+              "prompt": "You are a chess expert\n\nLet's play chess. The current game state in Forsyth-Edwards Notation (FEN) notation is:\nr1bqk2r/1pppbppp/p1n2n2/4p3/B3P3/5N2/PPPP1PPP/RNBQ1RK1 w kq - 4 6\nThe moves played so far are:\n1. e4 e5 2. Nf3 Nc6 3. Bb5 a6 4. Ba4 Nf6 5. O-O Be7 6.\nYou are playing as player White.\nIt is now your turn. Play your strongest move. The move MUST be legal. Reason step by step to come up with your move, then output your final answer in the format \"Final Answer: X\" where X is your chosen move in standard algebraic notation (SAN).\n",
+              "prompt_tokens": 188,
+              "reasoning_tokens": 0,
+              "response": "The current position is a standard Ruy Lopez, Closed Variation. White has just castled, and it is my turn to move.\n\n**Evaluation of the Position:**\n*   **White:** White has developed harmoniously, castled early, and maintains control of the center. The knight on f3 and the bishop on a4 are well-placed.\n*   **Black:** Black has played the Morphy Defense (3... a6) followed by the Closed Defense structure (5... Be7). Black's development is solid.\n*   **Key Plans:** In this position, the most common and theoretically strongest move for White is **Re1**. This move anticipates the upcoming struggle for the e4 pawn, which Black will likely attack with ...b5 and ...d6. By moving the rook to e1, White protects the e4 pawn indirectly and prepares to retreat the bishop to f1 if challenged by ...b5, while keeping the central tension.\n\n**Candidate Moves:**\n1. **Re1**: The main line. It prepares to support the center and allows the bishop on a4 to retreat to f1 if Black plays ...b5.\n2. **d3**: A solid alternative (the Anti-Marshall or systems leading to a slower maneuvering game), but Re1 is more ambitious and testing.\n3. **Nc3**: A developing move that keeps options open, but Re1 is generally considered more precise in the Ruy Lopez main lines.\n\n**Reasoning for Re1:**\nThe move 6. Re1 is the gold standard in the Ruy Lopez. It anticipates the natural Black response 6... b5 7. Bb3 d6. It also clears the f1 square for the bishop, which is a key component of White's typical maneuver in this structure. Without Re1, the e4 pawn can become a target, and White lacks the flexibility to reposition the bishop effectively.\n\nI choose 6. Re1.\n\nFinal Answer: Re1",
+              "total_tokens": 602
+            }
+          ],
+          "status": "OK",
+          "submission": 2949,
+          "thoughts": "The current position is a standard Ruy Lopez, Closed Variation. White has just castled, and it is my turn to move.\n\n**Evaluation of the Position:**\n*   **White:** White has developed harmoniously, castled early, and maintains control of the center. The knight on f3 and the bishop on a4 are well-placed.\n*   **Black:** Black has played the Morphy Defense (3... a6) followed by the Closed Defense structure (5... Be7). Black's development is solid.\n*   **Key Plans:** In this position, the most common and theoretically strongest move for White is **Re1**. This move anticipates the upcoming struggle for the e4 pawn, which Black will likely attack with ...b5 and ...d6. By moving the rook to e1, White protects the e4 pawn indirectly and prepares to retreat the bishop to f1 if challenged by ...b5, while keeping the central tension.\n\n**Candidate Moves:**\n1. **Re1**: The main line. It prepares to support the center and allows the bishop on a4 to retreat to f1 if Black plays ...b5.\n2. **d3**: A solid alternative (the Anti-Marshall or systems leading to a slower maneuvering game), but Re1 is more ambitious and testing.\n3. **Nc3**: A developing move that keeps options open, but Re1 is generally considered more precise in the Ruy Lopez main lines.\n\n**Reasoning for Re1:**\nThe move 6. Re1 is the gold standard in the Ruy Lopez. It anticipates the natural Black response 6... b5 7. Bb3 d6. It also clears the f1 square for the bishop, which is a key component of White's typical maneuver in this structure. Without Re1, the e4 pawn can become a target, and White lacks the flexibility to reposition the bishop effectively.\n\nI choose 6. Re1.\n\nFinal Answer: Re1"
+        },
+        "info": {
+          "actionApplied": 2949,
+          "actionSubmitted": 2949,
+          "actionSubmittedToString": "Re1",
+          "agentSelfReportedStatus": "OK",
+          "timeTaken": 2.995
+        },
+        "observation": {
+          "currentPlayer": 0,
+          "isTerminal": false,
+          "observationString": "r1bqk2r/1pppbppp/p1n2n2/4p3/B3P3/5N2/PPPP1PPP/RNBQR1K1 b kq - 5 6",
+          "playerId": 1,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n2426\n3572\n656\n2974\n89\n919\n3572\n4673\n2977\n2949\n\n"
+        },
+        "reward": null,
+        "status": "INACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "actionString": "b5",
+          "call_details": [
+            {
+              "duration_secs": 2.666,
+              "finish_reason": "stop",
+              "first_token_secs": 0.816,
+              "generation_tokens": 426,
+              "model": "openai/google/gemini-3.1-flash-lite-preview",
+              "prompt": "\ud83d\udc4c\ud83d\udc40\ud83d\udc4c\ud83d\udc40\ud83d\udc4c\ud83d\udc40\ud83d\udc4c\ud83d\udc40\ud83d\udc4c\ud83d\udc40 good shit go\u0c66\u0501 sHit\ud83d\udc4c thats \u2714 some good\ud83d\udc4c\ud83d\udc4cshit right\ud83d\udc4c\ud83d\udc4cthere\ud83d\udc4c\ud83d\udc4c\ud83d\udc4c right\u2714there \u2714\u2714if i do \u01bda\u04af so my self \ud83d\udcaf i say so \ud83d\udcaf thats what im talking about right there right there (chorus: \u02b3\u1da6\u1d4d\u02b0\u1d57 \u1d57\u02b0\u1d49\u02b3\u1d49) mMMMM\u13b7\u041c\ud83d\udcaf \ud83d\udc4c\ud83d\udc4c \ud83d\udc4c\u041dO0\u041e\u0b20OOOOO\u041e\u0b20\u0b20Oooo\u1d52\u1d52\u1d52\u1d52\u1d52\u1d52\u1d52\u1d52\u1d52\ud83d\udc4c \ud83d\udc4c\ud83d\udc4c \ud83d\udc4c \ud83d\udcaf \ud83d\udc4c \ud83d\udc40 \ud83d\udc40 \ud83d\udc40 \ud83d\udc4c\ud83d\udc4c\n\nLet's play chess. The current game state in Forsyth-Edwards Notation (FEN) notation is:\nr1bqk2r/1pppbppp/p1n2n2/4p3/B3P3/5N2/PPPP1PPP/RNBQR1K1 b kq - 5 6\nThe moves played so far are:\n1. e4 e5 2. Nf3 Nc6 3. Bb5 a6 4. Ba4 Nf6 5. O-O Be7 6. Re1\nYou are playing as player Black.\nIt is now your turn. Play your strongest move. The move MUST be legal. Reason step by step to come up with your move, then output your final answer in the format \"Final Answer: X\" where X is your chosen move in standard algebraic notation (SAN).\n",
+              "prompt_tokens": 310,
+              "reasoning_tokens": 0,
+              "response": "The current position is a standard Ruy Lopez, Closed Variation. The move 6. Re1 is the most common response, aiming to support the e4 pawn and prepare for potential threats on the e-file.\n\n**Evaluation and Strategy:**\n1. **The Position:** Black is well-developed. The Ruy Lopez structure is solid.\n2. **Candidate Moves:** \n    *   **6... b5:** This is the most principled and common move. It gains space on the queenside, forces the bishop to retreat (usually to b3), and prepares for the development of the bishop to b7 or c5.\n    *   **6... d6:** A solid, standard move to reinforce e5 and prepare further development.\n    *   **6... O-O:** Developing the king to safety is always a top priority in this opening.\n\n**Analysis of 6... b5:**\n*   6... b5 7. Bb3. This is the main line. Black then typically plays 7... d6, leading to the main theoretical battlegrounds of the Ruy Lopez.\n*   By playing b5, Black forces White to make a decision about the bishop's placement early and gains tempo to facilitate the development of the light-squared bishop.\n*   The engine evaluation for 6... b5 is typically balanced, acknowledging it as the most active and \"correct\" path in the Ruy Lopez.\n\n**Conclusion:**\nMoving the b-pawn to b5 is the most thematic and structurally sound continuation in this position. It prepares to support the center while gaining space on the queenside.\n\n1. **Reasoning:** 6... b5 forces the bishop away, sets up the standard Ruy Lopez structure, and prepares for ...d6, which provides stability and opens diagonals for the minor pieces.\n2. **Calculation:** 6... b5 7. Bb3 d6 is the standard sequence leading to a well-studied and balanced middlegame.\n\nFinal Answer: b5",
+              "total_tokens": 736
+            }
+          ],
+          "status": "OK",
+          "submission": 674,
+          "thoughts": "The current position is a standard Ruy Lopez, Closed Variation. The move 6. Re1 is the most common response, aiming to support the e4 pawn and prepare for potential threats on the e-file.\n\n**Evaluation and Strategy:**\n1. **The Position:** Black is well-developed. The Ruy Lopez structure is solid.\n2. **Candidate Moves:** \n    *   **6... b5:** This is the most principled and common move. It gains space on the queenside, forces the bishop to retreat (usually to b3), and prepares for the development of the bishop to b7 or c5.\n    *   **6... d6:** A solid, standard move to reinforce e5 and prepare further development.\n    *   **6... O-O:** Developing the king to safety is always a top priority in this opening.\n\n**Analysis of 6... b5:**\n*   6... b5 7. Bb3. This is the main line. Black then typically plays 7... d6, leading to the main theoretical battlegrounds of the Ruy Lopez.\n*   By playing b5, Black forces White to make a decision about the bishop's placement early and gains tempo to facilitate the development of the light-squared bishop.\n*   The engine evaluation for 6... b5 is typically balanced, acknowledging it as the most active and \"correct\" path in the Ruy Lopez.\n\n**Conclusion:**\nMoving the b-pawn to b5 is the most thematic and structurally sound continuation in this position. It prepares to support the center while gaining space on the queenside.\n\n1. **Reasoning:** 6... b5 forces the bishop away, sets up the standard Ruy Lopez structure, and prepares for ...d6, which provides stability and opens diagonals for the minor pieces.\n2. **Calculation:** 6... b5 7. Bb3 d6 is the standard sequence leading to a well-studied and balanced middlegame.\n\nFinal Answer: b5"
+        },
+        "info": {
+          "actionApplied": 674,
+          "actionSubmitted": 674,
+          "actionSubmittedToString": "b5",
+          "agentSelfReportedStatus": "OK",
+          "timeTaken": 3.147
+        },
+        "observation": {
+          "currentPlayer": 1,
+          "isTerminal": false,
+          "observationString": "r1bqk2r/2ppbppp/p1n2n2/1p2p3/B3P3/5N2/PPPP1PPP/RNBQR1K1 w kq - 0 7",
+          "playerId": 0,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n2426\n3572\n656\n2974\n89\n919\n3572\n4673\n2977\n2949\n674\n\n",
+          "step": 13
+        },
+        "reward": null,
+        "status": "INACTIVE"
+      },
+      {
+        "action": { "submission": -1 },
+        "info": {},
+        "observation": {
+          "currentPlayer": 1,
+          "isTerminal": false,
+          "observationString": "r1bqk2r/2ppbppp/p1n2n2/1p2p3/B3P3/5N2/PPPP1PPP/RNBQR1K1 w kq - 0 7",
+          "playerId": 1,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n2426\n3572\n656\n2974\n89\n919\n3572\n4673\n2977\n2949\n674\n\n"
+        },
+        "reward": null,
+        "status": "ACTIVE"
+      }
+    ],
+    [
+      {
+        "action": { "submission": -1 },
+        "info": {},
+        "observation": {
+          "currentPlayer": 0,
+          "isTerminal": false,
+          "observationString": "r1bqk2r/2ppbppp/p1n2n2/1p2p3/4P3/1B3N2/PPPP1PPP/RNBQR1K1 b kq - 1 7",
+          "playerId": 0,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n2426\n3572\n656\n2974\n89\n919\n3572\n4673\n2977\n2949\n674\n277\n\n",
+          "step": 14
+        },
+        "reward": null,
+        "status": "ACTIVE"
+      },
+      {
+        "action": {
+          "actionString": "Bb3",
+          "call_details": [
+            {
+              "duration_secs": 2.481,
+              "finish_reason": "stop",
+              "first_token_secs": 0.834,
+              "generation_tokens": 360,
+              "model": "openai/google/gemini-3.1-flash-lite-preview",
+              "prompt": "You are a chess expert\n\nLet's play chess. The current game state in Forsyth-Edwards Notation (FEN) notation is:\nr1bqk2r/2ppbppp/p1n2n2/1p2p3/B3P3/5N2/PPPP1PPP/RNBQR1K1 w kq - 0 7\nThe moves played so far are:\n1. e4 e5 2. Nf3 Nc6 3. Bb5 a6 4. Ba4 Nf6 5. O-O Be7 6. Re1 b5 7.\nYou are playing as player White.\nIt is now your turn. Play your strongest move. The move MUST be legal. Reason step by step to come up with your move, then output your final answer in the format \"Final Answer: X\" where X is your chosen move in standard algebraic notation (SAN).\n",
+              "prompt_tokens": 196,
+              "reasoning_tokens": 0,
+              "response": "The current position is a standard Ruy Lopez, Closed Variation. It is White's turn to move after 7. Bb3.\n\n**Analysis:**\n1. **The Position:** The position is standard. Black has just played 6...b5, pushing the bishop back.\n2. **Candidate Moves:**\n    *   **Bb3:** This is the absolute main line and the most principled move. It retreats the bishop to a safe square where it eyes the f7-pawn and supports the e4-pawn.\n    *   **Bc2:** Sometimes played to keep the bishop on the diagonal, but Bb3 is significantly more common and flexible.\n3. **Reasoning:**\n    *   Playing **Bb3** is the standard theoretical response. It maintains the pressure on the f7 square and prepares to challenge Black's center if they continue with d6 or Na5.\n    *   After 7. Bb3, Black typically responds with 7...d6, leading to the main line of the Ruy Lopez.\n    *   There is no reason to deviate from the most successful and well-studied move in this well-known opening structure.\n\n**Evaluation:**\nWhite has a slight edge due to the space advantage in the center and the harmonic development of pieces. Continuing with the main line is the best way to maintain this pressure.\n\nStep-by-step:\n1. Identify the need to retreat the attacked bishop.\n2. The square b3 is the optimal placement for the bishop in the Ruy Lopez, maintaining activity and safety.\n3. Confirm legality: The move Bb3 is legal and moves the bishop from a4 to b3.\n\nFinal Answer: Bb3",
+              "total_tokens": 556
+            }
+          ],
+          "status": "OK",
+          "submission": 277,
+          "thoughts": "The current position is a standard Ruy Lopez, Closed Variation. It is White's turn to move after 7. Bb3.\n\n**Analysis:**\n1. **The Position:** The position is standard. Black has just played 6...b5, pushing the bishop back.\n2. **Candidate Moves:**\n    *   **Bb3:** This is the absolute main line and the most principled move. It retreats the bishop to a safe square where it eyes the f7-pawn and supports the e4-pawn.\n    *   **Bc2:** Sometimes played to keep the bishop on the diagonal, but Bb3 is significantly more common and flexible.\n3. **Reasoning:**\n    *   Playing **Bb3** is the standard theoretical response. It maintains the pressure on the f7 square and prepares to challenge Black's center if they continue with d6 or Na5.\n    *   After 7. Bb3, Black typically responds with 7...d6, leading to the main line of the Ruy Lopez.\n    *   There is no reason to deviate from the most successful and well-studied move in this well-known opening structure.\n\n**Evaluation:**\nWhite has a slight edge due to the space advantage in the center and the harmonic development of pieces. Continuing with the main line is the best way to maintain this pressure.\n\nStep-by-step:\n1. Identify the need to retreat the attacked bishop.\n2. The square b3 is the optimal placement for the bishop in the Ruy Lopez, maintaining activity and safety.\n3. Confirm legality: The move Bb3 is legal and moves the bishop from a4 to b3.\n\nFinal Answer: Bb3"
+        },
+        "info": {
+          "actionApplied": 277,
+          "actionSubmitted": 277,
+          "actionSubmittedToString": "Bb3",
+          "agentSelfReportedStatus": "OK",
+          "timeTaken": 3.105
+        },
+        "observation": {
+          "currentPlayer": 0,
+          "isTerminal": false,
+          "observationString": "r1bqk2r/2ppbppp/p1n2n2/1p2p3/4P3/1B3N2/PPPP1PPP/RNBQR1K1 b kq - 1 7",
+          "playerId": 1,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n2426\n3572\n656\n2974\n89\n919\n3572\n4673\n2977\n2949\n674\n277\n\n"
+        },
+        "reward": null,
+        "status": "INACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "actionString": "d6",
+          "call_details": [
+            {
+              "duration_secs": 2.701,
+              "finish_reason": "stop",
+              "first_token_secs": 0.6,
+              "generation_tokens": 473,
+              "model": "openai/google/gemini-3.1-flash-lite-preview",
+              "prompt": "\ud83d\udc4c\ud83d\udc40\ud83d\udc4c\ud83d\udc40\ud83d\udc4c\ud83d\udc40\ud83d\udc4c\ud83d\udc40\ud83d\udc4c\ud83d\udc40 good shit go\u0c66\u0501 sHit\ud83d\udc4c thats \u2714 some good\ud83d\udc4c\ud83d\udc4cshit right\ud83d\udc4c\ud83d\udc4cthere\ud83d\udc4c\ud83d\udc4c\ud83d\udc4c right\u2714there \u2714\u2714if i do \u01bda\u04af so my self \ud83d\udcaf i say so \ud83d\udcaf thats what im talking about right there right there (chorus: \u02b3\u1da6\u1d4d\u02b0\u1d57 \u1d57\u02b0\u1d49\u02b3\u1d49) mMMMM\u13b7\u041c\ud83d\udcaf \ud83d\udc4c\ud83d\udc4c \ud83d\udc4c\u041dO0\u041e\u0b20OOOOO\u041e\u0b20\u0b20Oooo\u1d52\u1d52\u1d52\u1d52\u1d52\u1d52\u1d52\u1d52\u1d52\ud83d\udc4c \ud83d\udc4c\ud83d\udc4c \ud83d\udc4c \ud83d\udcaf \ud83d\udc4c \ud83d\udc40 \ud83d\udc40 \ud83d\udc40 \ud83d\udc4c\ud83d\udc4c\n\nLet's play chess. The current game state in Forsyth-Edwards Notation (FEN) notation is:\nr1bqk2r/2ppbppp/p1n2n2/1p2p3/4P3/1B3N2/PPPP1PPP/RNBQR1K1 b kq - 1 7\nThe moves played so far are:\n1. e4 e5 2. Nf3 Nc6 3. Bb5 a6 4. Ba4 Nf6 5. O-O Be7 6. Re1 b5 7. Bb3\nYou are playing as player Black.\nIt is now your turn. Play your strongest move. The move MUST be legal. Reason step by step to come up with your move, then output your final answer in the format \"Final Answer: X\" where X is your chosen move in standard algebraic notation (SAN).\n",
+              "prompt_tokens": 319,
+              "reasoning_tokens": 0,
+              "response": "The current position is `r1bqk2r/2ppbppp/p1n2n2/1p2p3/4P3/1B3N2/PPPP1PPP/RNBQR1K1 b kq - 1 7`. It is Black's turn to move.\n\n### Analysis:\n1. **Position Overview:** We are in a standard Ruy Lopez, Closed Variation setup (though not yet closed). White has played the main line, and Black has developed harmoniously.\n2. **Black's Objectives:** Black needs to complete development, secure the center, and prepare for the middlegame.\n3. **Candidate Moves:**\n    *   **d6:** This is the most common and principled move in this position. It supports the e5-pawn, allows the light-squared bishop to develop (eventually), and prepares to contest the center. It leads into the main lines of the Ruy Lopez.\n    *   **O-O:** Castling is always a solid choice to bring the king to safety. However, in the Ruy Lopez, Black often prioritizes d6 to solidify the pawn structure first.\n    *   **Na5:** This move is sometimes played to challenge the bishop on b3, but it can be premature if White is prepared to respond correctly.\n    *   **Bb7:** A fianchetto approach, but less standard than d6 in this specific structure.\n\n### Reasoning:\nThe move **7... d6** is the universally accepted best move in this position. It prepares the development of the dark-squared bishop, solidifies the e5 pawn against any future tactical themes, and is the cornerstone move of the Chigorin or Zaitsev/Breyer variations of the Ruy Lopez. It keeps the game flexible and maintains equality.\n\nLet's verify the tactical safety:\n*   If White plays 8. c3, Black can continue with O-O or Na5.\n*   If White plays 8. d4, Black is well-prepared to maintain the center with Bg4 or exd4.\n\nThe move `d6` is the most reliable, positional, and high-engine-eval move here.\n\nFinal Answer: d6",
+              "total_tokens": 792
+            }
+          ],
+          "status": "OK",
+          "submission": 1841,
+          "thoughts": "The current position is `r1bqk2r/2ppbppp/p1n2n2/1p2p3/4P3/1B3N2/PPPP1PPP/RNBQR1K1 b kq - 1 7`. It is Black's turn to move.\n\n### Analysis:\n1. **Position Overview:** We are in a standard Ruy Lopez, Closed Variation setup (though not yet closed). White has played the main line, and Black has developed harmoniously.\n2. **Black's Objectives:** Black needs to complete development, secure the center, and prepare for the middlegame.\n3. **Candidate Moves:**\n    *   **d6:** This is the most common and principled move in this position. It supports the e5-pawn, allows the light-squared bishop to develop (eventually), and prepares to contest the center. It leads into the main lines of the Ruy Lopez.\n    *   **O-O:** Castling is always a solid choice to bring the king to safety. However, in the Ruy Lopez, Black often prioritizes d6 to solidify the pawn structure first.\n    *   **Na5:** This move is sometimes played to challenge the bishop on b3, but it can be premature if White is prepared to respond correctly.\n    *   **Bb7:** A fianchetto approach, but less standard than d6 in this specific structure.\n\n### Reasoning:\nThe move **7... d6** is the universally accepted best move in this position. It prepares the development of the dark-squared bishop, solidifies the e5 pawn against any future tactical themes, and is the cornerstone move of the Chigorin or Zaitsev/Breyer variations of the Ruy Lopez. It keeps the game flexible and maintains equality.\n\nLet's verify the tactical safety:\n*   If White plays 8. c3, Black can continue with O-O or Na5.\n*   If White plays 8. d4, Black is well-prepared to maintain the center with Bg4 or exd4.\n\nThe move `d6` is the most reliable, positional, and high-engine-eval move here.\n\nFinal Answer: d6"
+        },
+        "info": {
+          "actionApplied": 1841,
+          "actionSubmitted": 1841,
+          "actionSubmittedToString": "d6",
+          "agentSelfReportedStatus": "OK",
+          "timeTaken": 3.192
+        },
+        "observation": {
+          "currentPlayer": 1,
+          "isTerminal": false,
+          "observationString": "r1bqk2r/2p1bppp/p1np1n2/1p2p3/4P3/1B3N2/PPPP1PPP/RNBQR1K1 w kq - 0 8",
+          "playerId": 0,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n2426\n3572\n656\n2974\n89\n919\n3572\n4673\n2977\n2949\n674\n277\n1841\n\n",
+          "step": 15
+        },
+        "reward": null,
+        "status": "INACTIVE"
+      },
+      {
+        "action": { "submission": -1 },
+        "info": {},
+        "observation": {
+          "currentPlayer": 1,
+          "isTerminal": false,
+          "observationString": "r1bqk2r/2p1bppp/p1np1n2/1p2p3/4P3/1B3N2/PPPP1PPP/RNBQR1K1 w kq - 0 8",
+          "playerId": 1,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n2426\n3572\n656\n2974\n89\n919\n3572\n4673\n2977\n2949\n674\n277\n1841\n\n"
+        },
+        "reward": null,
+        "status": "ACTIVE"
+      }
+    ],
+    [
+      {
+        "action": { "submission": -1 },
+        "info": {},
+        "observation": {
+          "currentPlayer": 0,
+          "isTerminal": false,
+          "observationString": "r1bqk2r/2p1bppp/p1np1n2/1p2p3/4P3/1BP2N2/PP1P1PPP/RNBQR1K1 b kq - 0 8",
+          "playerId": 0,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n2426\n3572\n656\n2974\n89\n919\n3572\n4673\n2977\n2949\n674\n277\n1841\n1257\n\n",
+          "step": 16
+        },
+        "reward": null,
+        "status": "ACTIVE"
+      },
+      {
+        "action": {
+          "actionString": "c3",
+          "call_details": [
+            {
+              "duration_secs": 2.284,
+              "finish_reason": "stop",
+              "first_token_secs": 0.694,
+              "generation_tokens": 399,
+              "model": "openai/google/gemini-3.1-flash-lite-preview",
+              "prompt": "You are a chess expert\n\nLet's play chess. The current game state in Forsyth-Edwards Notation (FEN) notation is:\nr1bqk2r/2p1bppp/p1np1n2/1p2p3/4P3/1B3N2/PPPP1PPP/RNBQR1K1 w kq - 0 8\nThe moves played so far are:\n1. e4 e5 2. Nf3 Nc6 3. Bb5 a6 4. Ba4 Nf6 5. O-O Be7 6. Re1 b5 7. Bb3 d6 8.\nYou are playing as player White.\nIt is now your turn. Play your strongest move. The move MUST be legal. Reason step by step to come up with your move, then output your final answer in the format \"Final Answer: X\" where X is your chosen move in standard algebraic notation (SAN).\n",
+              "prompt_tokens": 206,
+              "reasoning_tokens": 0,
+              "response": "The current position is a standard main-line Ruy Lopez, specifically the Closed Ruy Lopez. White has developed harmoniously, and Black has established a solid pawn structure with ...d6 and ...b5.\n\n**Evaluation and Strategy:**\n1. **The c3 move:** The most standard and statistically strongest move in this position is **c3**. This serves multiple purposes:\n   - It prepares the d4 push, which is the thematic central break in the Ruy Lopez.\n   - It provides a \"luft\" (escape square) for the bishop on b3, preventing it from being trapped or harassed by ...Na5.\n   - It controls the d4 square.\n\n2. **Alternative options:** \n   - **a4:** Also a common move, aiming to challenge Black's queenside structure immediately. However, c3 is more principled in maintaining the center.\n   - **h3:** A useful prophylactic move to prevent ...Bg4, but usually played after c3 or when Black has committed to a specific setup.\n\n3. **Analysis of c3:**\n   - After 8. c3, Black typically responds with 8... O-O. White then follows up with 9. h3 (to prevent Bg4) or 9. d4. This leads to the main lines of the Closed Ruy Lopez where both sides have clear plans.\n\n**Conclusion:**\nMoving 8. c3 is the most principled and theoretically sound move in this position. It prepares the central break and secures the bishop on b3.\n\nStep-by-step reasoning:\n1. Identify the position as the Closed Ruy Lopez.\n2. Recognize that the most critical theoretical move to prepare d4 and secure the bishop is 8. c3.\n3. Validate that 8. c3 is legal and consistent with high-level opening theory.\n\nFinal Answer: c3",
+              "total_tokens": 605
+            }
+          ],
+          "status": "OK",
+          "submission": 1257,
+          "thoughts": "The current position is a standard main-line Ruy Lopez, specifically the Closed Ruy Lopez. White has developed harmoniously, and Black has established a solid pawn structure with ...d6 and ...b5.\n\n**Evaluation and Strategy:**\n1. **The c3 move:** The most standard and statistically strongest move in this position is **c3**. This serves multiple purposes:\n   - It prepares the d4 push, which is the thematic central break in the Ruy Lopez.\n   - It provides a \"luft\" (escape square) for the bishop on b3, preventing it from being trapped or harassed by ...Na5.\n   - It controls the d4 square.\n\n2. **Alternative options:** \n   - **a4:** Also a common move, aiming to challenge Black's queenside structure immediately. However, c3 is more principled in maintaining the center.\n   - **h3:** A useful prophylactic move to prevent ...Bg4, but usually played after c3 or when Black has committed to a specific setup.\n\n3. **Analysis of c3:**\n   - After 8. c3, Black typically responds with 8... O-O. White then follows up with 9. h3 (to prevent Bg4) or 9. d4. This leads to the main lines of the Closed Ruy Lopez where both sides have clear plans.\n\n**Conclusion:**\nMoving 8. c3 is the most principled and theoretically sound move in this position. It prepares the central break and secures the bishop on b3.\n\nStep-by-step reasoning:\n1. Identify the position as the Closed Ruy Lopez.\n2. Recognize that the most critical theoretical move to prepare d4 and secure the bishop is 8. c3.\n3. Validate that 8. c3 is legal and consistent with high-level opening theory.\n\nFinal Answer: c3"
+        },
+        "info": {
+          "actionApplied": 1257,
+          "actionSubmitted": 1257,
+          "actionSubmittedToString": "c3",
+          "agentSelfReportedStatus": "OK",
+          "timeTaken": 2.745
+        },
+        "observation": {
+          "currentPlayer": 0,
+          "isTerminal": false,
+          "observationString": "r1bqk2r/2p1bppp/p1np1n2/1p2p3/4P3/1BP2N2/PP1P1PPP/RNBQR1K1 b kq - 0 8",
+          "playerId": 1,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n2426\n3572\n656\n2974\n89\n919\n3572\n4673\n2977\n2949\n674\n277\n1841\n1257\n\n"
+        },
+        "reward": null,
+        "status": "INACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "actionString": "O-O",
+          "call_details": [
+            {
+              "duration_secs": 3.019,
+              "finish_reason": "stop",
+              "first_token_secs": 0.643,
+              "generation_tokens": 471,
+              "model": "openai/google/gemini-3.1-flash-lite-preview",
+              "prompt": "\ud83d\udc4c\ud83d\udc40\ud83d\udc4c\ud83d\udc40\ud83d\udc4c\ud83d\udc40\ud83d\udc4c\ud83d\udc40\ud83d\udc4c\ud83d\udc40 good shit go\u0c66\u0501 sHit\ud83d\udc4c thats \u2714 some good\ud83d\udc4c\ud83d\udc4cshit right\ud83d\udc4c\ud83d\udc4cthere\ud83d\udc4c\ud83d\udc4c\ud83d\udc4c right\u2714there \u2714\u2714if i do \u01bda\u04af so my self \ud83d\udcaf i say so \ud83d\udcaf thats what im talking about right there right there (chorus: \u02b3\u1da6\u1d4d\u02b0\u1d57 \u1d57\u02b0\u1d49\u02b3\u1d49) mMMMM\u13b7\u041c\ud83d\udcaf \ud83d\udc4c\ud83d\udc4c \ud83d\udc4c\u041dO0\u041e\u0b20OOOOO\u041e\u0b20\u0b20Oooo\u1d52\u1d52\u1d52\u1d52\u1d52\u1d52\u1d52\u1d52\u1d52\ud83d\udc4c \ud83d\udc4c\ud83d\udc4c \ud83d\udc4c \ud83d\udcaf \ud83d\udc4c \ud83d\udc40 \ud83d\udc40 \ud83d\udc40 \ud83d\udc4c\ud83d\udc4c\n\nLet's play chess. The current game state in Forsyth-Edwards Notation (FEN) notation is:\nr1bqk2r/2p1bppp/p1np1n2/1p2p3/4P3/1BP2N2/PP1P1PPP/RNBQR1K1 b kq - 0 8\nThe moves played so far are:\n1. e4 e5 2. Nf3 Nc6 3. Bb5 a6 4. Ba4 Nf6 5. O-O Be7 6. Re1 b5 7. Bb3 d6 8. c3\nYou are playing as player Black.\nIt is now your turn. Play your strongest move. The move MUST be legal. Reason step by step to come up with your move, then output your final answer in the format \"Final Answer: X\" where X is your chosen move in standard algebraic notation (SAN).\n",
+              "prompt_tokens": 330,
+              "reasoning_tokens": 0,
+              "response": "The current position is `r1bqk2r/2p1bppp/p1np1n2/1p2p3/4P3/1BP2N2/PP1P1PPP/RNBQR1K1 b kq - 0 8`. It is Black's turn to move.\n\n### Analysis:\n1. **The Position:** We are in a standard Ruy Lopez (Spanish Opening), Closed variation structure. White has just played 8. c3, preparing d4. \n2. **Black's Strategy:** In this position, Black has several standard responses:\n    * **8... O-O:** The most common and robust choice, continuing development and preparing for the central struggle.\n    * **8... Na5:** A thematic maneuver to chase the Bishop away, though it often leads to a slightly different character of the game.\n    * **8... Bg4:** An active alternative, putting pressure on the knight on f3.\n3. **Engine/Theoretical Consensus:** 8... O-O is the main line and the most principled move. It completes king safety and prepares for the battle over the center after White plays d4.\n\n### Reasoning:\n*   **8... O-O** is the most highly regarded move in the database and by engines. It is flexible and solid. After 9. h3, Black typically continues with 9... Na5 or 9... Re8.\n*   Other moves like 8... Na5 or 8... Bg4 are perfectly playable, but 8... O-O is the standard of excellence in this Ruy Lopez structure. It ensures the king is tucked away before starting any concrete tactical operations in the center.\n\n### Step-by-step for 8... O-O:\n1.  **Development:** Black completes the kingside development.\n2.  **Safety:** The King is moved to safety.\n3.  **Flexibility:** It does not commit to a specific plan (like ...Na5 or ...Bg4) until seeing how White chooses to proceed with the d2-d4 push or further prophylactic moves.\n\nI choose 8... O-O.\n\nFinal Answer: O-O",
+              "total_tokens": 801
+            }
+          ],
+          "status": "OK",
+          "submission": 4673,
+          "thoughts": "The current position is `r1bqk2r/2p1bppp/p1np1n2/1p2p3/4P3/1BP2N2/PP1P1PPP/RNBQR1K1 b kq - 0 8`. It is Black's turn to move.\n\n### Analysis:\n1. **The Position:** We are in a standard Ruy Lopez (Spanish Opening), Closed variation structure. White has just played 8. c3, preparing d4. \n2. **Black's Strategy:** In this position, Black has several standard responses:\n    * **8... O-O:** The most common and robust choice, continuing development and preparing for the central struggle.\n    * **8... Na5:** A thematic maneuver to chase the Bishop away, though it often leads to a slightly different character of the game.\n    * **8... Bg4:** An active alternative, putting pressure on the knight on f3.\n3. **Engine/Theoretical Consensus:** 8... O-O is the main line and the most principled move. It completes king safety and prepares for the battle over the center after White plays d4.\n\n### Reasoning:\n*   **8... O-O** is the most highly regarded move in the database and by engines. It is flexible and solid. After 9. h3, Black typically continues with 9... Na5 or 9... Re8.\n*   Other moves like 8... Na5 or 8... Bg4 are perfectly playable, but 8... O-O is the standard of excellence in this Ruy Lopez structure. It ensures the king is tucked away before starting any concrete tactical operations in the center.\n\n### Step-by-step for 8... O-O:\n1.  **Development:** Black completes the kingside development.\n2.  **Safety:** The King is moved to safety.\n3.  **Flexibility:** It does not commit to a specific plan (like ...Na5 or ...Bg4) until seeing how White chooses to proceed with the d2-d4 push or further prophylactic moves.\n\nI choose 8... O-O.\n\nFinal Answer: O-O"
+        },
+        "info": {
+          "actionApplied": 4673,
+          "actionSubmitted": 4673,
+          "actionSubmittedToString": "O-O",
+          "agentSelfReportedStatus": "OK",
+          "timeTaken": 3.604
+        },
+        "observation": {
+          "currentPlayer": 1,
+          "isTerminal": false,
+          "observationString": "r1bq1rk1/2p1bppp/p1np1n2/1p2p3/4P3/1BP2N2/PP1P1PPP/RNBQR1K1 w - - 1 9",
+          "playerId": 0,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n2426\n3572\n656\n2974\n89\n919\n3572\n4673\n2977\n2949\n674\n277\n1841\n1257\n4673\n\n",
+          "step": 17
+        },
+        "reward": null,
+        "status": "INACTIVE"
+      },
+      {
+        "action": { "submission": -1 },
+        "info": {},
+        "observation": {
+          "currentPlayer": 1,
+          "isTerminal": false,
+          "observationString": "r1bq1rk1/2p1bppp/p1np1n2/1p2p3/4P3/1BP2N2/PP1P1PPP/RNBQR1K1 w - - 1 9",
+          "playerId": 1,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n2426\n3572\n656\n2974\n89\n919\n3572\n4673\n2977\n2949\n674\n277\n1841\n1257\n4673\n\n"
+        },
+        "reward": null,
+        "status": "ACTIVE"
+      }
+    ],
+    [
+      {
+        "action": { "submission": -1 },
+        "info": {},
+        "observation": {
+          "currentPlayer": 0,
+          "isTerminal": false,
+          "observationString": "r1bq1rk1/2p1bppp/p1np1n2/1p2p3/4P3/1BP2N1P/PP1P1PP1/RNBQR1K1 b - - 0 9",
+          "playerId": 0,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n2426\n3572\n656\n2974\n89\n919\n3572\n4673\n2977\n2949\n674\n277\n1841\n1257\n4673\n4177\n\n",
+          "step": 18
+        },
+        "reward": null,
+        "status": "ACTIVE"
+      },
+      {
+        "action": {
+          "actionString": "h3",
+          "call_details": [
+            {
+              "duration_secs": 2.682,
+              "finish_reason": "stop",
+              "first_token_secs": 0.827,
+              "generation_tokens": 374,
+              "model": "openai/google/gemini-3.1-flash-lite-preview",
+              "prompt": "You are a chess expert\n\nLet's play chess. The current game state in Forsyth-Edwards Notation (FEN) notation is:\nr1bq1rk1/2p1bppp/p1np1n2/1p2p3/4P3/1BP2N2/PP1P1PPP/RNBQR1K1 w - - 1 9\nThe moves played so far are:\n1. e4 e5 2. Nf3 Nc6 3. Bb5 a6 4. Ba4 Nf6 5. O-O Be7 6. Re1 b5 7. Bb3 d6 8. c3 O-O 9.\nYou are playing as player White.\nIt is now your turn. Play your strongest move. The move MUST be legal. Reason step by step to come up with your move, then output your final answer in the format \"Final Answer: X\" where X is your chosen move in standard algebraic notation (SAN).\n",
+              "prompt_tokens": 216,
+              "reasoning_tokens": 0,
+              "response": "The current position is a standard Ruy Lopez, Closed Variation. White has just completed the setup with 8. c3, and Black has castled. It is White's turn to move.\n\n**Evaluation and Strategy:**\n1. **The move 9. h3:** This is the main line and the most principled move. It prevents Black from playing ...Bg4 (pinning the knight) and ...Ng4, while also preparing to support the center and potentially expanding on the queenside or center later. \n2. **Alternative (9. d4):** This is also playable, but 9. h3 is the most common and flexible way to maintain the tension while preparing to stabilize the center.\n3. **Strategic considerations:** White aims to build a solid center with d4 eventually, but before doing so, restricting Black's minor pieces (specifically the bishop on c8) with h3 is standard theory. It also gives the king a \"luft\" square.\n\n**Step-by-step reasoning:**\n*   **The position:** The pieces are harmoniously developed. White needs to finalize the center control and prepare for the middlegame.\n*   **The move h3:** By playing h3, White forces Black to decide how to proceed with the development of the light-squared bishop or knight without the fear of annoying pins on the f3 knight. It is a prophylactic measure that is essential in almost all high-level games from this starting position.\n*   **Engine consensus:** 9. h3 is overwhelmingly favored by master-level games and engines (Stockfish 16) as it retains the best winning chances while avoiding tactical pitfalls associated with premature central pushes.\n\nTherefore, 9. h3 is the most precise move.\n\nFinal Answer: h3",
+              "total_tokens": 590
+            }
+          ],
+          "status": "OK",
+          "submission": 4177,
+          "thoughts": "The current position is a standard Ruy Lopez, Closed Variation. White has just completed the setup with 8. c3, and Black has castled. It is White's turn to move.\n\n**Evaluation and Strategy:**\n1. **The move 9. h3:** This is the main line and the most principled move. It prevents Black from playing ...Bg4 (pinning the knight) and ...Ng4, while also preparing to support the center and potentially expanding on the queenside or center later. \n2. **Alternative (9. d4):** This is also playable, but 9. h3 is the most common and flexible way to maintain the tension while preparing to stabilize the center.\n3. **Strategic considerations:** White aims to build a solid center with d4 eventually, but before doing so, restricting Black's minor pieces (specifically the bishop on c8) with h3 is standard theory. It also gives the king a \"luft\" square.\n\n**Step-by-step reasoning:**\n*   **The position:** The pieces are harmoniously developed. White needs to finalize the center control and prepare for the middlegame.\n*   **The move h3:** By playing h3, White forces Black to decide how to proceed with the development of the light-squared bishop or knight without the fear of annoying pins on the f3 knight. It is a prophylactic measure that is essential in almost all high-level games from this starting position.\n*   **Engine consensus:** 9. h3 is overwhelmingly favored by master-level games and engines (Stockfish 16) as it retains the best winning chances while avoiding tactical pitfalls associated with premature central pushes.\n\nTherefore, 9. h3 is the most precise move.\n\nFinal Answer: h3"
+        },
+        "info": {
+          "actionApplied": 4177,
+          "actionSubmitted": 4177,
+          "actionSubmittedToString": "h3",
+          "agentSelfReportedStatus": "OK",
+          "timeTaken": 3.13
+        },
+        "observation": {
+          "currentPlayer": 0,
+          "isTerminal": false,
+          "observationString": "r1bq1rk1/2p1bppp/p1np1n2/1p2p3/4P3/1BP2N1P/PP1P1PP1/RNBQR1K1 b - - 0 9",
+          "playerId": 1,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n2426\n3572\n656\n2974\n89\n919\n3572\n4673\n2977\n2949\n674\n277\n1841\n1257\n4673\n4177\n\n"
+        },
+        "reward": null,
+        "status": "INACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "actionString": "Na5",
+          "call_details": [
+            {
+              "duration_secs": 3.095,
+              "finish_reason": "stop",
+              "first_token_secs": 0.768,
+              "generation_tokens": 517,
+              "model": "openai/google/gemini-3.1-flash-lite-preview",
+              "prompt": "\ud83d\udc4c\ud83d\udc40\ud83d\udc4c\ud83d\udc40\ud83d\udc4c\ud83d\udc40\ud83d\udc4c\ud83d\udc40\ud83d\udc4c\ud83d\udc40 good shit go\u0c66\u0501 sHit\ud83d\udc4c thats \u2714 some good\ud83d\udc4c\ud83d\udc4cshit right\ud83d\udc4c\ud83d\udc4cthere\ud83d\udc4c\ud83d\udc4c\ud83d\udc4c right\u2714there \u2714\u2714if i do \u01bda\u04af so my self \ud83d\udcaf i say so \ud83d\udcaf thats what im talking about right there right there (chorus: \u02b3\u1da6\u1d4d\u02b0\u1d57 \u1d57\u02b0\u1d49\u02b3\u1d49) mMMMM\u13b7\u041c\ud83d\udcaf \ud83d\udc4c\ud83d\udc4c \ud83d\udc4c\u041dO0\u041e\u0b20OOOOO\u041e\u0b20\u0b20Oooo\u1d52\u1d52\u1d52\u1d52\u1d52\u1d52\u1d52\u1d52\u1d52\ud83d\udc4c \ud83d\udc4c\ud83d\udc4c \ud83d\udc4c \ud83d\udcaf \ud83d\udc4c \ud83d\udc40 \ud83d\udc40 \ud83d\udc40 \ud83d\udc4c\ud83d\udc4c\n\nLet's play chess. The current game state in Forsyth-Edwards Notation (FEN) notation is:\nr1bq1rk1/2p1bppp/p1np1n2/1p2p3/4P3/1BP2N1P/PP1P1PP1/RNBQR1K1 b - - 0 9\nThe moves played so far are:\n1. e4 e5 2. Nf3 Nc6 3. Bb5 a6 4. Ba4 Nf6 5. O-O Be7 6. Re1 b5 7. Bb3 d6 8. c3 O-O 9. h3\nYou are playing as player Black.\nIt is now your turn. Play your strongest move. The move MUST be legal. Reason step by step to come up with your move, then output your final answer in the format \"Final Answer: X\" where X is your chosen move in standard algebraic notation (SAN).\n",
+              "prompt_tokens": 340,
+              "reasoning_tokens": 0,
+              "response": "The current position is `r1bq1rk1/2p1bppp/p1np1n2/1p2p3/4P3/1BP2N1P/PP1P1PP1/RNBQR1K1 b - - 0 9`. It is Black's turn to move.\n\n### Evaluation and Strategy\nThis is a standard position in the Ruy Lopez, Closed Variation. Black has successfully neutralized White's pressure on the center and is now looking for a setup to contest the middle or prepare for expansion. \n\nCandidate moves for Black:\n1. **...Na5**: This is a very common move in the Ruy Lopez. It forces the White light-squared bishop to move (usually back to c2), which relieves the tension on the d6 pawn and prepares c5 or d5 breaks.\n2. **...Bb7**: This puts pressure on the e4 pawn, forcing White to defend it (usually with d3). It is a solid, developmental move.\n3. **...Re8**: A prophylactic move, common in the Chigorin system, to support the e5 pawn and allow the bishop to retreat to f8 if necessary.\n\n### Analysis\n*   **...Na5**: This is the most thematic move in this specific position (the Chigorin/Main Line approach). By forcing the bishop to c2, Black gains time and flexibility. After 9... Na5 10. Bc2 c5, Black establishes a strong center and has good prospects for counterplay on the queenside and center.\n*   **...Bb7**: Also very solid, but it allows White to solidify the center with 10. d3.\n*   **...Re8**: A bit slow compared to the immediate pressure generated by ...Na5.\n\nGiven the standard theoretical path in this Ruy Lopez structure, **9... Na5** is universally recognized as the most active and principled move to continue the battle for the center.\n\n### Step-by-step reasoning:\n1. The position is a standard Ruy Lopez.\n2. The move ...Na5 challenges the placement of the White bishop on b3.\n3. After 10. Bc2, Black will play ...c5, establishing a classical setup that effectively controls the center and prepares for future development.\n4. This move is consistent with the highest level of opening theory in this variation.\n\nFinal Answer: Na5",
+              "total_tokens": 857
+            }
+          ],
+          "status": "OK",
+          "submission": 1380,
+          "thoughts": "The current position is `r1bq1rk1/2p1bppp/p1np1n2/1p2p3/4P3/1BP2N1P/PP1P1PP1/RNBQR1K1 b - - 0 9`. It is Black's turn to move.\n\n### Evaluation and Strategy\nThis is a standard position in the Ruy Lopez, Closed Variation. Black has successfully neutralized White's pressure on the center and is now looking for a setup to contest the middle or prepare for expansion. \n\nCandidate moves for Black:\n1. **...Na5**: This is a very common move in the Ruy Lopez. It forces the White light-squared bishop to move (usually back to c2), which relieves the tension on the d6 pawn and prepares c5 or d5 breaks.\n2. **...Bb7**: This puts pressure on the e4 pawn, forcing White to defend it (usually with d3). It is a solid, developmental move.\n3. **...Re8**: A prophylactic move, common in the Chigorin system, to support the e5 pawn and allow the bishop to retreat to f8 if necessary.\n\n### Analysis\n*   **...Na5**: This is the most thematic move in this specific position (the Chigorin/Main Line approach). By forcing the bishop to c2, Black gains time and flexibility. After 9... Na5 10. Bc2 c5, Black establishes a strong center and has good prospects for counterplay on the queenside and center.\n*   **...Bb7**: Also very solid, but it allows White to solidify the center with 10. d3.\n*   **...Re8**: A bit slow compared to the immediate pressure generated by ...Na5.\n\nGiven the standard theoretical path in this Ruy Lopez structure, **9... Na5** is universally recognized as the most active and principled move to continue the battle for the center.\n\n### Step-by-step reasoning:\n1. The position is a standard Ruy Lopez.\n2. The move ...Na5 challenges the placement of the White bishop on b3.\n3. After 10. Bc2, Black will play ...c5, establishing a classical setup that effectively controls the center and prepares for future development.\n4. This move is consistent with the highest level of opening theory in this variation.\n\nFinal Answer: Na5"
+        },
+        "info": {
+          "actionApplied": 1380,
+          "actionSubmitted": 1380,
+          "actionSubmittedToString": "Na5",
+          "agentSelfReportedStatus": "OK",
+          "timeTaken": 3.571
+        },
+        "observation": {
+          "currentPlayer": 1,
+          "isTerminal": false,
+          "observationString": "r1bq1rk1/2p1bppp/p2p1n2/np2p3/4P3/1BP2N1P/PP1P1PP1/RNBQR1K1 w - - 1 10",
+          "playerId": 0,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n2426\n3572\n656\n2974\n89\n919\n3572\n4673\n2977\n2949\n674\n277\n1841\n1257\n4673\n4177\n1380\n\n",
+          "step": 19
+        },
+        "reward": null,
+        "status": "INACTIVE"
+      },
+      {
+        "action": { "submission": -1 },
+        "info": {},
+        "observation": {
+          "currentPlayer": 1,
+          "isTerminal": false,
+          "observationString": "r1bq1rk1/2p1bppp/p2p1n2/np2p3/4P3/1BP2N1P/PP1P1PP1/RNBQR1K1 w - - 1 10",
+          "playerId": 1,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n2426\n3572\n656\n2974\n89\n919\n3572\n4673\n2977\n2949\n674\n277\n1841\n1257\n4673\n4177\n1380\n\n"
+        },
+        "reward": null,
+        "status": "ACTIVE"
+      }
+    ],
+    [
+      {
+        "action": { "submission": -1 },
+        "info": {},
+        "observation": {
+          "currentPlayer": 0,
+          "isTerminal": false,
+          "observationString": "r1bq1rk1/2p1bppp/p2p1n2/np2p3/4P3/2P2N1P/PPBP1PP1/RNBQR1K1 b - - 2 10",
+          "playerId": 0,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n2426\n3572\n656\n2974\n89\n919\n3572\n4673\n2977\n2949\n674\n277\n1841\n1257\n4673\n4177\n1380\n788\n\n",
+          "step": 20
+        },
+        "reward": null,
+        "status": "ACTIVE"
+      },
+      {
+        "action": {
+          "actionString": "Bc2",
+          "call_details": [
+            {
+              "duration_secs": 4.931,
+              "finish_reason": "stop",
+              "first_token_secs": 2.928,
+              "generation_tokens": 398,
+              "model": "openai/google/gemini-3.1-flash-lite-preview",
+              "prompt": "You are a chess expert\n\nLet's play chess. The current game state in Forsyth-Edwards Notation (FEN) notation is:\nr1bq1rk1/2p1bppp/p2p1n2/np2p3/4P3/1BP2N1P/PP1P1PP1/RNBQR1K1 w - - 1 10\nThe moves played so far are:\n1. e4 e5 2. Nf3 Nc6 3. Bb5 a6 4. Ba4 Nf6 5. O-O Be7 6. Re1 b5 7. Bb3 d6 8. c3 O-O 9. h3 Na5 10.\nYou are playing as player White.\nIt is now your turn. Play your strongest move. The move MUST be legal. Reason step by step to come up with your move, then output your final answer in the format \"Final Answer: X\" where X is your chosen move in standard algebraic notation (SAN).\n",
+              "prompt_tokens": 226,
+              "reasoning_tokens": 0,
+              "response": "The current position is a standard Ruy Lopez, Chigorin Variation. The previous move was 9... Na5, attacking the bishop on b3.\n\n**Analysis:**\n1. **The Bishop on b3:** The bishop is under attack by the knight on a5. The standard and most principled move in this position is to retreat the bishop to c2. This keeps the bishop active along the a2-g8 diagonal, maintains pressure on the e5-pawn, and prepares to support the center expansion with d4.\n2. **Alternative options:** Moving the bishop to c2 is the universal choice for top-level players in this exact position. Other squares like d1 or a2 are suboptimal; a2 blocks the rook's potential influence or wastes time, and d1 is too passive.\n3. **Strategic goals:** By playing 10. Bc2, White prepares the d2-d4 push, which is the main plan in the Chigorin Variation to challenge Black's central control. Black will typically respond with 10... c5, leading to the main theoretical lines of the Ruy Lopez.\n\n**Reasoning:**\n- 10. Bc2 is the thematic retreat. It saves the bishop, keeps it safe from the knight, and preserves the structural integrity of White's setup.\n- This allows White to maintain flexibility in the center and prepare for the d4 break, which is essential to fight for an advantage.\n- The move is theoretically sound and highly recommended by engine evaluations and grandmaster practice.\n\nStep-by-step:\n- Identify the threat: 9... Na5 attacks the bishop on b3.\n- Identify the response: Retreating the bishop to c2 is standard.\n- Evaluate the position: With 10. Bc2, White is ready to play d4 in the near future.\n\nFinal Answer: Bc2",
+              "total_tokens": 624
+            }
+          ],
+          "status": "OK",
+          "submission": 788,
+          "thoughts": "The current position is a standard Ruy Lopez, Chigorin Variation. The previous move was 9... Na5, attacking the bishop on b3.\n\n**Analysis:**\n1. **The Bishop on b3:** The bishop is under attack by the knight on a5. The standard and most principled move in this position is to retreat the bishop to c2. This keeps the bishop active along the a2-g8 diagonal, maintains pressure on the e5-pawn, and prepares to support the center expansion with d4.\n2. **Alternative options:** Moving the bishop to c2 is the universal choice for top-level players in this exact position. Other squares like d1 or a2 are suboptimal; a2 blocks the rook's potential influence or wastes time, and d1 is too passive.\n3. **Strategic goals:** By playing 10. Bc2, White prepares the d2-d4 push, which is the main plan in the Chigorin Variation to challenge Black's central control. Black will typically respond with 10... c5, leading to the main theoretical lines of the Ruy Lopez.\n\n**Reasoning:**\n- 10. Bc2 is the thematic retreat. It saves the bishop, keeps it safe from the knight, and preserves the structural integrity of White's setup.\n- This allows White to maintain flexibility in the center and prepare for the d4 break, which is essential to fight for an advantage.\n- The move is theoretically sound and highly recommended by engine evaluations and grandmaster practice.\n\nStep-by-step:\n- Identify the threat: 9... Na5 attacks the bishop on b3.\n- Identify the response: Retreating the bishop to c2 is standard.\n- Evaluate the position: With 10. Bc2, White is ready to play d4 in the near future.\n\nFinal Answer: Bc2"
+        },
+        "info": {
+          "actionApplied": 788,
+          "actionSubmitted": 788,
+          "actionSubmittedToString": "Bc2",
+          "agentSelfReportedStatus": "OK",
+          "timeTaken": 5.374
+        },
+        "observation": {
+          "currentPlayer": 0,
+          "isTerminal": false,
+          "observationString": "r1bq1rk1/2p1bppp/p2p1n2/np2p3/4P3/2P2N1P/PPBP1PP1/RNBQR1K1 b - - 2 10",
+          "playerId": 1,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n2426\n3572\n656\n2974\n89\n919\n3572\n4673\n2977\n2949\n674\n277\n1841\n1257\n4673\n4177\n1380\n788\n\n"
+        },
+        "reward": null,
+        "status": "INACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "actionString": "c5",
+          "call_details": [
+            {
+              "duration_secs": 2.986,
+              "finish_reason": "stop",
+              "first_token_secs": 0.709,
+              "generation_tokens": 482,
+              "model": "openai/google/gemini-3.1-flash-lite-preview",
+              "prompt": "\ud83d\udc4c\ud83d\udc40\ud83d\udc4c\ud83d\udc40\ud83d\udc4c\ud83d\udc40\ud83d\udc4c\ud83d\udc40\ud83d\udc4c\ud83d\udc40 good shit go\u0c66\u0501 sHit\ud83d\udc4c thats \u2714 some good\ud83d\udc4c\ud83d\udc4cshit right\ud83d\udc4c\ud83d\udc4cthere\ud83d\udc4c\ud83d\udc4c\ud83d\udc4c right\u2714there \u2714\u2714if i do \u01bda\u04af so my self \ud83d\udcaf i say so \ud83d\udcaf thats what im talking about right there right there (chorus: \u02b3\u1da6\u1d4d\u02b0\u1d57 \u1d57\u02b0\u1d49\u02b3\u1d49) mMMMM\u13b7\u041c\ud83d\udcaf \ud83d\udc4c\ud83d\udc4c \ud83d\udc4c\u041dO0\u041e\u0b20OOOOO\u041e\u0b20\u0b20Oooo\u1d52\u1d52\u1d52\u1d52\u1d52\u1d52\u1d52\u1d52\u1d52\ud83d\udc4c \ud83d\udc4c\ud83d\udc4c \ud83d\udc4c \ud83d\udcaf \ud83d\udc4c \ud83d\udc40 \ud83d\udc40 \ud83d\udc40 \ud83d\udc4c\ud83d\udc4c\n\nLet's play chess. The current game state in Forsyth-Edwards Notation (FEN) notation is:\nr1bq1rk1/2p1bppp/p2p1n2/np2p3/4P3/2P2N1P/PPBP1PP1/RNBQR1K1 b - - 2 10\nThe moves played so far are:\n1. e4 e5 2. Nf3 Nc6 3. Bb5 a6 4. Ba4 Nf6 5. O-O Be7 6. Re1 b5 7. Bb3 d6 8. c3 O-O 9. h3 Na5 10. Bc2\nYou are playing as player Black.\nIt is now your turn. Play your strongest move. The move MUST be legal. Reason step by step to come up with your move, then output your final answer in the format \"Final Answer: X\" where X is your chosen move in standard algebraic notation (SAN).\n",
+              "prompt_tokens": 347,
+              "reasoning_tokens": 0,
+              "response": "The current position is `r1bq1rk1/2p1bppp/p2p1n2/np2p3/4P3/2P2N1P/PPBP1PP1/RNBQR1K1 b - - 2 10`. It is Black's turn to move.\n\n### Analysis:\n1. **Positional Assessment**: We are in the Ruy Lopez, Chigorin Variation. White has just played 10. Bc2, retreating the bishop to its characteristic diagonal. \n2. **Black's Strategy**: Black has the knight on a5, which is somewhat misplaced but puts pressure on the c4 square and prepares to challenge the center or support the queenside. Standard plans for Black involve clarifying the center, centralizing pieces, and preparing to counter-attack.\n3. **Candidate Moves**:\n    * **10... c5**: This is the most standard and thematic move in this position. It challenges the center, prepares for the development of the queen's knight (possibly to c6 or d7), and claims space. It is the main line of the Ruy Lopez Chigorin.\n    * **10... Bb7**: Develops the bishop to a very active diagonal, eyeing the e4 pawn. This is also a very strong and common move.\n    * **10... Re8**: Prepares to support the e5 pawn and create a \"luft\" for the king, though it is usually played a bit later or in slightly different variations.\n\n### Evaluation:\n* **10... c5** is widely considered the most principled response. It directly contests the center and dictates the structure. After 10... c5, White usually plays 11. d4, leading to the main theoretical battlegrounds of the Ruy Lopez.\n* **10... Bb7** is also excellent, but 10... c5 often forces the issue in the center more directly. Given the current structure, 10... c5 is the standard engine recommendation and the most common move in master-level play to finalize the queenside pawn structure.\n\nI will proceed with 10... c5 as it is the most structurally sound and strategically rich move for Black.\n\nFinal Answer: c5",
+              "total_tokens": 829
+            }
+          ],
+          "status": "OK",
+          "submission": 1258,
+          "thoughts": "The current position is `r1bq1rk1/2p1bppp/p2p1n2/np2p3/4P3/2P2N1P/PPBP1PP1/RNBQR1K1 b - - 2 10`. It is Black's turn to move.\n\n### Analysis:\n1. **Positional Assessment**: We are in the Ruy Lopez, Chigorin Variation. White has just played 10. Bc2, retreating the bishop to its characteristic diagonal. \n2. **Black's Strategy**: Black has the knight on a5, which is somewhat misplaced but puts pressure on the c4 square and prepares to challenge the center or support the queenside. Standard plans for Black involve clarifying the center, centralizing pieces, and preparing to counter-attack.\n3. **Candidate Moves**:\n    * **10... c5**: This is the most standard and thematic move in this position. It challenges the center, prepares for the development of the queen's knight (possibly to c6 or d7), and claims space. It is the main line of the Ruy Lopez Chigorin.\n    * **10... Bb7**: Develops the bishop to a very active diagonal, eyeing the e4 pawn. This is also a very strong and common move.\n    * **10... Re8**: Prepares to support the e5 pawn and create a \"luft\" for the king, though it is usually played a bit later or in slightly different variations.\n\n### Evaluation:\n* **10... c5** is widely considered the most principled response. It directly contests the center and dictates the structure. After 10... c5, White usually plays 11. d4, leading to the main theoretical battlegrounds of the Ruy Lopez.\n* **10... Bb7** is also excellent, but 10... c5 often forces the issue in the center more directly. Given the current structure, 10... c5 is the standard engine recommendation and the most common move in master-level play to finalize the queenside pawn structure.\n\nI will proceed with 10... c5 as it is the most structurally sound and strategically rich move for Black.\n\nFinal Answer: c5"
+        },
+        "info": {
+          "actionApplied": 1258,
+          "actionSubmitted": 1258,
+          "actionSubmittedToString": "c5",
+          "agentSelfReportedStatus": "OK",
+          "timeTaken": 3.442
+        },
+        "observation": {
+          "currentPlayer": 1,
+          "isTerminal": false,
+          "observationString": "r1bq1rk1/4bppp/p2p1n2/npp1p3/4P3/2P2N1P/PPBP1PP1/RNBQR1K1 w - - 0 11",
+          "playerId": 0,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n2426\n3572\n656\n2974\n89\n919\n3572\n4673\n2977\n2949\n674\n277\n1841\n1257\n4673\n4177\n1380\n788\n1258\n\n",
+          "step": 21
+        },
+        "reward": null,
+        "status": "INACTIVE"
+      },
+      {
+        "action": { "submission": -1 },
+        "info": {},
+        "observation": {
+          "currentPlayer": 1,
+          "isTerminal": false,
+          "observationString": "r1bq1rk1/4bppp/p2p1n2/npp1p3/4P3/2P2N1P/PPBP1PP1/RNBQR1K1 w - - 0 11",
+          "playerId": 1,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n2426\n3572\n656\n2974\n89\n919\n3572\n4673\n2977\n2949\n674\n277\n1841\n1257\n4673\n4177\n1380\n788\n1258\n\n"
+        },
+        "reward": null,
+        "status": "ACTIVE"
+      }
+    ],
+    [
+      {
+        "action": { "submission": -1 },
+        "info": {},
+        "observation": {
+          "currentPlayer": 0,
+          "isTerminal": false,
+          "observationString": "r1bq1rk1/4bppp/p2p1n2/npp1p3/3PP3/2P2N1P/PPB2PP1/RNBQR1K1 b - - 0 11",
+          "playerId": 0,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n2426\n3572\n656\n2974\n89\n919\n3572\n4673\n2977\n2949\n674\n277\n1841\n1257\n4673\n4177\n1380\n788\n1258\n1842\n\n",
+          "step": 22
+        },
+        "reward": null,
+        "status": "ACTIVE"
+      },
+      {
+        "action": {
+          "actionString": "d4",
+          "call_details": [
+            {
+              "duration_secs": 2.859,
+              "finish_reason": "stop",
+              "first_token_secs": 0.781,
+              "generation_tokens": 475,
+              "model": "openai/google/gemini-3.1-flash-lite-preview",
+              "prompt": "You are a chess expert\n\nLet's play chess. The current game state in Forsyth-Edwards Notation (FEN) notation is:\nr1bq1rk1/4bppp/p2p1n2/npp1p3/4P3/2P2N1P/PPBP1PP1/RNBQR1K1 w - - 0 11\nThe moves played so far are:\n1. e4 e5 2. Nf3 Nc6 3. Bb5 a6 4. Ba4 Nf6 5. O-O Be7 6. Re1 b5 7. Bb3 d6 8. c3 O-O 9. h3 Na5 10. Bc2 c5 11.\nYou are playing as player White.\nIt is now your turn. Play your strongest move. The move MUST be legal. Reason step by step to come up with your move, then output your final answer in the format \"Final Answer: X\" where X is your chosen move in standard algebraic notation (SAN).\n",
+              "prompt_tokens": 232,
+              "reasoning_tokens": 0,
+              "response": "The current position is a standard Ruy Lopez, Chigorin Variation. White has just played 10. Bc2 and Black has responded with 10... c5. It is White's turn to move.\n\n**Evaluation and Strategy:**\n1. **The Center:** The central tension is characteristic of the Closed Ruy Lopez. White's pawn on e4 and Black's on e5 are the focal points.\n2. **Standard Maneuvers:** The most common and principled plan for White in this structure is to relocate the knight from f3 to d2 (Nbd2), which prepares for Nf1, aiming to reach g3 or e3, and opens the c2-square for the bishop or potentially supports an eventual d4 push.\n3. **Candidate Moves:**\n    *   **11. d4:** This is the main theoretical move. It challenges Black's center immediately. If Black plays 11... cxd4 12. cxd4, we arrive at a standard structure where White has a central space advantage.\n    *   **11. Nbd2:** This is a slow, prophylactic approach, keeping the center closed while repositioning the knight to a more flexible square.\n\n**Reasoning:**\nWhile 11. Nbd2 is very solid, 11. d4 is considered the most critical and ambitious test of Black's setup. It forces Black to clarify the central pawn tension immediately. Historically, 11. d4 is the move that top-level players prioritize to fight for the advantage in the Ruy Lopez. It is consistent with the strategic goal of gaining space and initiating play in the center.\n\nLooking at the position, 11. d4:\n- Opens lines for the light-squared bishop.\n- Challenges Black's control of e5.\n- If Black plays 11... Qc7, White continues with 12. Nbd2.\n- If Black plays 11... cxd4, White recaptures 12. cxd4, and the game proceeds into well-known territory where White has good prospects.\n\nGiven the theoretical weight and the objective to play the strongest move, 11. d4 is the best choice.\n\nFinal Answer: d4",
+              "total_tokens": 707
+            }
+          ],
+          "status": "OK",
+          "submission": 1842,
+          "thoughts": "The current position is a standard Ruy Lopez, Chigorin Variation. White has just played 10. Bc2 and Black has responded with 10... c5. It is White's turn to move.\n\n**Evaluation and Strategy:**\n1. **The Center:** The central tension is characteristic of the Closed Ruy Lopez. White's pawn on e4 and Black's on e5 are the focal points.\n2. **Standard Maneuvers:** The most common and principled plan for White in this structure is to relocate the knight from f3 to d2 (Nbd2), which prepares for Nf1, aiming to reach g3 or e3, and opens the c2-square for the bishop or potentially supports an eventual d4 push.\n3. **Candidate Moves:**\n    *   **11. d4:** This is the main theoretical move. It challenges Black's center immediately. If Black plays 11... cxd4 12. cxd4, we arrive at a standard structure where White has a central space advantage.\n    *   **11. Nbd2:** This is a slow, prophylactic approach, keeping the center closed while repositioning the knight to a more flexible square.\n\n**Reasoning:**\nWhile 11. Nbd2 is very solid, 11. d4 is considered the most critical and ambitious test of Black's setup. It forces Black to clarify the central pawn tension immediately. Historically, 11. d4 is the move that top-level players prioritize to fight for the advantage in the Ruy Lopez. It is consistent with the strategic goal of gaining space and initiating play in the center.\n\nLooking at the position, 11. d4:\n- Opens lines for the light-squared bishop.\n- Challenges Black's control of e5.\n- If Black plays 11... Qc7, White continues with 12. Nbd2.\n- If Black plays 11... cxd4, White recaptures 12. cxd4, and the game proceeds into well-known territory where White has good prospects.\n\nGiven the theoretical weight and the objective to play the strongest move, 11. d4 is the best choice.\n\nFinal Answer: d4"
+        },
+        "info": {
+          "actionApplied": 1842,
+          "actionSubmitted": 1842,
+          "actionSubmittedToString": "d4",
+          "agentSelfReportedStatus": "OK",
+          "timeTaken": 3.294
+        },
+        "observation": {
+          "currentPlayer": 0,
+          "isTerminal": false,
+          "observationString": "r1bq1rk1/4bppp/p2p1n2/npp1p3/3PP3/2P2N1P/PPB2PP1/RNBQR1K1 b - - 0 11",
+          "playerId": 1,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n2426\n3572\n656\n2974\n89\n919\n3572\n4673\n2977\n2949\n674\n277\n1841\n1257\n4673\n4177\n1380\n788\n1258\n1842\n\n"
+        },
+        "reward": null,
+        "status": "INACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "actionString": "Qc7",
+          "call_details": [
+            {
+              "duration_secs": 2.926,
+              "finish_reason": "stop",
+              "first_token_secs": 0.678,
+              "generation_tokens": 482,
+              "model": "openai/google/gemini-3.1-flash-lite-preview",
+              "prompt": "\ud83d\udc4c\ud83d\udc40\ud83d\udc4c\ud83d\udc40\ud83d\udc4c\ud83d\udc40\ud83d\udc4c\ud83d\udc40\ud83d\udc4c\ud83d\udc40 good shit go\u0c66\u0501 sHit\ud83d\udc4c thats \u2714 some good\ud83d\udc4c\ud83d\udc4cshit right\ud83d\udc4c\ud83d\udc4cthere\ud83d\udc4c\ud83d\udc4c\ud83d\udc4c right\u2714there \u2714\u2714if i do \u01bda\u04af so my self \ud83d\udcaf i say so \ud83d\udcaf thats what im talking about right there right there (chorus: \u02b3\u1da6\u1d4d\u02b0\u1d57 \u1d57\u02b0\u1d49\u02b3\u1d49) mMMMM\u13b7\u041c\ud83d\udcaf \ud83d\udc4c\ud83d\udc4c \ud83d\udc4c\u041dO0\u041e\u0b20OOOOO\u041e\u0b20\u0b20Oooo\u1d52\u1d52\u1d52\u1d52\u1d52\u1d52\u1d52\u1d52\u1d52\ud83d\udc4c \ud83d\udc4c\ud83d\udc4c \ud83d\udc4c \ud83d\udcaf \ud83d\udc4c \ud83d\udc40 \ud83d\udc40 \ud83d\udc40 \ud83d\udc4c\ud83d\udc4c\n\nLet's play chess. The current game state in Forsyth-Edwards Notation (FEN) notation is:\nr1bq1rk1/4bppp/p2p1n2/npp1p3/3PP3/2P2N1P/PPB2PP1/RNBQR1K1 b - - 0 11\nThe moves played so far are:\n1. e4 e5 2. Nf3 Nc6 3. Bb5 a6 4. Ba4 Nf6 5. O-O Be7 6. Re1 b5 7. Bb3 d6 8. c3 O-O 9. h3 Na5 10. Bc2 c5 11. d4\nYou are playing as player Black.\nIt is now your turn. Play your strongest move. The move MUST be legal. Reason step by step to come up with your move, then output your final answer in the format \"Final Answer: X\" where X is your chosen move in standard algebraic notation (SAN).\n",
+              "prompt_tokens": 354,
+              "reasoning_tokens": 0,
+              "response": "The current position is `r1bq1rk1/4bppp/p2p1n2/npp1p3/3PP3/2P2N1P/PPB2PP1/RNBQR1K1 b - - 0 11`. It is Black's turn to move.\n\n### Analysis:\n1.  **Opening Context**: This is a Ruy Lopez, Chigorin Variation setup where White has played `d4` to challenge the center. \n2.  **Candidate Moves**:\n    *   **...Qc7**: A very standard developing move in the Ruy Lopez. It defends the e5 pawn indirectly, clears the d8 square for a rook, and prepares for potential pressure.\n    *   **...Bb7**: Developing the bishop to a strong diagonal. It puts pressure on e4 if Black clears the center.\n    *   **...exd4**: This leads to an open center. After `11... exd4 12. cxd4 cxd4 13. Nxd4`, the game becomes quite balanced and sharp.\n    *   **...Nc6**: Retreating the knight. While logical, it is passive compared to the other options.\n\n### Evaluation:\n*   **11... Qc7** is the most highly regarded move in this specific position according to grandmaster theory and engine analysis. It maintains the tension in the center and prepares to consolidate Black's position.\n*   The center is currently liquid. White is threatening `dxe5`. If Black plays `11... Qc7`, Black is ready to meet `dxe5` with `dxe5`, keeping the structure solid. If White plays `d5`, Black can re-route the knight or continue development.\n\n### Step-by-step reasoning:\n*   Black has a well-coordinated position.\n*   The move `11... Qc7` supports the e5 pawn, prepares to bring the Rook to the d-file, and allows flexibility for the dark-squared bishop.\n*   It is the most flexible and principled move in this Ruy Lopez structure.\n\nEngine analysis confirms that `11... Qc7` maintains equality and provides the best prospects for counterplay.\n\nFinal Answer: Qc7",
+              "total_tokens": 836
+            }
+          ],
+          "status": "OK",
+          "submission": 1809,
+          "thoughts": "The current position is `r1bq1rk1/4bppp/p2p1n2/npp1p3/3PP3/2P2N1P/PPB2PP1/RNBQR1K1 b - - 0 11`. It is Black's turn to move.\n\n### Analysis:\n1.  **Opening Context**: This is a Ruy Lopez, Chigorin Variation setup where White has played `d4` to challenge the center. \n2.  **Candidate Moves**:\n    *   **...Qc7**: A very standard developing move in the Ruy Lopez. It defends the e5 pawn indirectly, clears the d8 square for a rook, and prepares for potential pressure.\n    *   **...Bb7**: Developing the bishop to a strong diagonal. It puts pressure on e4 if Black clears the center.\n    *   **...exd4**: This leads to an open center. After `11... exd4 12. cxd4 cxd4 13. Nxd4`, the game becomes quite balanced and sharp.\n    *   **...Nc6**: Retreating the knight. While logical, it is passive compared to the other options.\n\n### Evaluation:\n*   **11... Qc7** is the most highly regarded move in this specific position according to grandmaster theory and engine analysis. It maintains the tension in the center and prepares to consolidate Black's position.\n*   The center is currently liquid. White is threatening `dxe5`. If Black plays `11... Qc7`, Black is ready to meet `dxe5` with `dxe5`, keeping the structure solid. If White plays `d5`, Black can re-route the knight or continue development.\n\n### Step-by-step reasoning:\n*   Black has a well-coordinated position.\n*   The move `11... Qc7` supports the e5 pawn, prepares to bring the Rook to the d-file, and allows flexibility for the dark-squared bishop.\n*   It is the most flexible and principled move in this Ruy Lopez structure.\n\nEngine analysis confirms that `11... Qc7` maintains equality and provides the best prospects for counterplay.\n\nFinal Answer: Qc7"
+        },
+        "info": {
+          "actionApplied": 1809,
+          "actionSubmitted": 1809,
+          "actionSubmittedToString": "Qc7",
+          "agentSelfReportedStatus": "OK",
+          "timeTaken": 3.388
+        },
+        "observation": {
+          "currentPlayer": 1,
+          "isTerminal": false,
+          "observationString": "r1b2rk1/2q1bppp/p2p1n2/npp1p3/3PP3/2P2N1P/PPB2PP1/RNBQR1K1 w - - 1 12",
+          "playerId": 0,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n2426\n3572\n656\n2974\n89\n919\n3572\n4673\n2977\n2949\n674\n277\n1841\n1257\n4673\n4177\n1380\n788\n1258\n1842\n1809\n\n",
+          "step": 23
+        },
+        "reward": null,
+        "status": "INACTIVE"
+      },
+      {
+        "action": { "submission": -1 },
+        "info": {},
+        "observation": {
+          "currentPlayer": 1,
+          "isTerminal": false,
+          "observationString": "r1b2rk1/2q1bppp/p2p1n2/npp1p3/3PP3/2P2N1P/PPB2PP1/RNBQR1K1 w - - 1 12",
+          "playerId": 1,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n2426\n3572\n656\n2974\n89\n919\n3572\n4673\n2977\n2949\n674\n277\n1841\n1257\n4673\n4177\n1380\n788\n1258\n1842\n1809\n\n"
+        },
+        "reward": null,
+        "status": "ACTIVE"
+      }
+    ],
+    [
+      {
+        "action": { "submission": -1 },
+        "info": {},
+        "observation": {
+          "currentPlayer": 0,
+          "isTerminal": false,
+          "observationString": "r1b2rk1/2q1bppp/p2p1n2/nppPp3/4P3/2P2N1P/PPB2PP1/RNBQR1K1 b - - 0 12",
+          "playerId": 0,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n2426\n3572\n656\n2974\n89\n919\n3572\n4673\n2977\n2949\n674\n277\n1841\n1257\n4673\n4177\n1380\n788\n1258\n1842\n1809\n1987\n\n",
+          "step": 24
+        },
+        "reward": null,
+        "status": "ACTIVE"
+      },
+      {
+        "action": {
+          "actionString": "d5",
+          "call_details": [
+            {
+              "duration_secs": 8.621,
+              "finish_reason": "stop",
+              "first_token_secs": 6.712,
+              "generation_tokens": 412,
+              "model": "openai/google/gemini-3.1-flash-lite-preview",
+              "prompt": "You are a chess expert\n\nLet's play chess. The current game state in Forsyth-Edwards Notation (FEN) notation is:\nr1b2rk1/2q1bppp/p2p1n2/npp1p3/3PP3/2P2N1P/PPB2PP1/RNBQR1K1 w - - 1 12\nThe moves played so far are:\n1. e4 e5 2. Nf3 Nc6 3. Bb5 a6 4. Ba4 Nf6 5. O-O Be7 6. Re1 b5 7. Bb3 d6 8. c3 O-O 9. h3 Na5 10. Bc2 c5 11. d4 Qc7 12.\nYou are playing as player White.\nIt is now your turn. Play your strongest move. The move MUST be legal. Reason step by step to come up with your move, then output your final answer in the format \"Final Answer: X\" where X is your chosen move in standard algebraic notation (SAN).\n",
+              "prompt_tokens": 242,
+              "reasoning_tokens": 0,
+              "response": "The current position is a standard Ruy Lopez, Closed Variation. White has a central space advantage and a solid position.\n\n**Evaluation and Strategy:**\n1. **The Position:** White has just played `d4` in response to `c5`, which is a thematic challenge to Black's setup. Black's last move was `Qc7`, reinforcing the center and preparing to develop.\n2. **Candidate Moves:**\n   * **d5:** This is the most principled and common response. It locks the center, gains further space, and restricts Black's pieces. It forces Black to clarify their structure (e.g., `...c4` or `...Bd7`).\n   * **dxe5:** This would simplify the center prematurely. After `dxe5`, Black can often equalize comfortably by recapturing with the d-pawn or even the knight, and the position loses some of its tension.\n   * **Nbd2:** Developing the knight to a standard square, supporting the center, and preparing for future maneuvering. However, `d5` is more pressing.\n   * **Be3:** Developing the bishop to a strong diagonal, but `d5` is more critical at this specific moment to maintain the initiative.\n\n**Analysis of `d5`:**\n* By playing `d5`, White fixes the central structure. Black will likely respond with `...Bd7` or `...Nb7/c4`.\n* It restricts the `f6` knight and gives White a clear plan: build pressure on the kingside or look for a queenside expansion later. \n* It is the most challenging move for Black, adhering to the standard theoretical lines of this variation.\n\n**Conclusion:**\n`d5` is the most testing move in this position, preserving the tension and maintaining White's central advantage. It is the move recommended by both high-level theory and engine evaluations for this specific FEN.\n\nFinal Answer: d5",
+              "total_tokens": 654
+            }
+          ],
+          "status": "OK",
+          "submission": 1987,
+          "thoughts": "The current position is a standard Ruy Lopez, Closed Variation. White has a central space advantage and a solid position.\n\n**Evaluation and Strategy:**\n1. **The Position:** White has just played `d4` in response to `c5`, which is a thematic challenge to Black's setup. Black's last move was `Qc7`, reinforcing the center and preparing to develop.\n2. **Candidate Moves:**\n   * **d5:** This is the most principled and common response. It locks the center, gains further space, and restricts Black's pieces. It forces Black to clarify their structure (e.g., `...c4` or `...Bd7`).\n   * **dxe5:** This would simplify the center prematurely. After `dxe5`, Black can often equalize comfortably by recapturing with the d-pawn or even the knight, and the position loses some of its tension.\n   * **Nbd2:** Developing the knight to a standard square, supporting the center, and preparing for future maneuvering. However, `d5` is more pressing.\n   * **Be3:** Developing the bishop to a strong diagonal, but `d5` is more critical at this specific moment to maintain the initiative.\n\n**Analysis of `d5`:**\n* By playing `d5`, White fixes the central structure. Black will likely respond with `...Bd7` or `...Nb7/c4`.\n* It restricts the `f6` knight and gives White a clear plan: build pressure on the kingside or look for a queenside expansion later. \n* It is the most challenging move for Black, adhering to the standard theoretical lines of this variation.\n\n**Conclusion:**\n`d5` is the most testing move in this position, preserving the tension and maintaining White's central advantage. It is the move recommended by both high-level theory and engine evaluations for this specific FEN.\n\nFinal Answer: d5"
+        },
+        "info": {
+          "actionApplied": 1987,
+          "actionSubmitted": 1987,
+          "actionSubmittedToString": "d5",
+          "agentSelfReportedStatus": "OK",
+          "timeTaken": 9.061
+        },
+        "observation": {
+          "currentPlayer": 0,
+          "isTerminal": false,
+          "observationString": "r1b2rk1/2q1bppp/p2p1n2/nppPp3/4P3/2P2N1P/PPB2PP1/RNBQR1K1 b - - 0 12",
+          "playerId": 1,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n2426\n3572\n656\n2974\n89\n919\n3572\n4673\n2977\n2949\n674\n277\n1841\n1257\n4673\n4177\n1380\n788\n1258\n1842\n1809\n1987\n\n"
+        },
+        "reward": null,
+        "status": "INACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "actionString": "Nc4",
+          "call_details": [
+            {
+              "duration_secs": 3.013,
+              "finish_reason": "stop",
+              "first_token_secs": 0.73,
+              "generation_tokens": 487,
+              "model": "openai/google/gemini-3.1-flash-lite-preview",
+              "prompt": "\ud83d\udc4c\ud83d\udc40\ud83d\udc4c\ud83d\udc40\ud83d\udc4c\ud83d\udc40\ud83d\udc4c\ud83d\udc40\ud83d\udc4c\ud83d\udc40 good shit go\u0c66\u0501 sHit\ud83d\udc4c thats \u2714 some good\ud83d\udc4c\ud83d\udc4cshit right\ud83d\udc4c\ud83d\udc4cthere\ud83d\udc4c\ud83d\udc4c\ud83d\udc4c right\u2714there \u2714\u2714if i do \u01bda\u04af so my self \ud83d\udcaf i say so \ud83d\udcaf thats what im talking about right there right there (chorus: \u02b3\u1da6\u1d4d\u02b0\u1d57 \u1d57\u02b0\u1d49\u02b3\u1d49) mMMMM\u13b7\u041c\ud83d\udcaf \ud83d\udc4c\ud83d\udc4c \ud83d\udc4c\u041dO0\u041e\u0b20OOOOO\u041e\u0b20\u0b20Oooo\u1d52\u1d52\u1d52\u1d52\u1d52\u1d52\u1d52\u1d52\u1d52\ud83d\udc4c \ud83d\udc4c\ud83d\udc4c \ud83d\udc4c \ud83d\udcaf \ud83d\udc4c \ud83d\udc40 \ud83d\udc40 \ud83d\udc40 \ud83d\udc4c\ud83d\udc4c\n\nLet's play chess. The current game state in Forsyth-Edwards Notation (FEN) notation is:\nr1b2rk1/2q1bppp/p2p1n2/nppPp3/4P3/2P2N1P/PPB2PP1/RNBQR1K1 b - - 0 12\nThe moves played so far are:\n1. e4 e5 2. Nf3 Nc6 3. Bb5 a6 4. Ba4 Nf6 5. O-O Be7 6. Re1 b5 7. Bb3 d6 8. c3 O-O 9. h3 Na5 10. Bc2 c5 11. d4 Qc7 12. d5\nYou are playing as player Black.\nIt is now your turn. Play your strongest move. The move MUST be legal. Reason step by step to come up with your move, then output your final answer in the format \"Final Answer: X\" where X is your chosen move in standard algebraic notation (SAN).\n",
+              "prompt_tokens": 363,
+              "reasoning_tokens": 0,
+              "response": "The current position is `r1b2rk1/2q1bppp/p2p1n2/nppPp3/4P3/2P2N1P/PPB2PP1/RNBQR1K1 b - - 0 12`. It is Black's turn to move.\n\n### Evaluation and Strategy:\n1. **Position Analysis:** The game is a Ruy Lopez, Closed Variation. White has just played 12. d5, closing the center. This fixes the pawn structure and dictates the strategic themes: White will likely pursue play on the kingside or try to maneuver pieces to the center, while Black has a space advantage on the queenside and should look to organize a counterplay, typically involving ...Nc4 or ...c4.\n2. **Candidate Moves:**\n    *   **12... Nc4:** This is a standard and very strong move. It places the knight on an active square, eyes the b2-pawn, and prepares to challenge White's control. It prevents White from easily playing b3, as the knight is well-placed.\n    *   **12... Bd7:** A solid developing move, preparing to connect the rooks or support the queenside.\n    *   **12... c4:** This locks the queenside pawn structure further. It prevents b3 for now but might allow White to play b4 later, which can be annoying.\n3. **Reasoning:** 12... Nc4 is the most principled move. It immediately exerts pressure on the position. If White plays b3, the knight can retreat to b6 or stay active. It forces White to address the knight's presence. In the Ruy Lopez, this maneuver is highly thematic, putting the knight on a square where it disrupts White's development of the queenside pieces.\n\n### Step-by-step evaluation:\n*   The center is closed (d5).\n*   Black has a knight on a5 currently doing little. Bringing it back to the center via c4 is the most effective way to activate it.\n*   12... Nc4 forces White to consider the stability of their queenside.\n*   Engines typically favor this maneuver in this specific structure to control the board.\n\nFinal Answer: Nc4",
+              "total_tokens": 850
+            }
+          ],
+          "status": "OK",
+          "submission": 289,
+          "thoughts": "The current position is `r1b2rk1/2q1bppp/p2p1n2/nppPp3/4P3/2P2N1P/PPB2PP1/RNBQR1K1 b - - 0 12`. It is Black's turn to move.\n\n### Evaluation and Strategy:\n1. **Position Analysis:** The game is a Ruy Lopez, Closed Variation. White has just played 12. d5, closing the center. This fixes the pawn structure and dictates the strategic themes: White will likely pursue play on the kingside or try to maneuver pieces to the center, while Black has a space advantage on the queenside and should look to organize a counterplay, typically involving ...Nc4 or ...c4.\n2. **Candidate Moves:**\n    *   **12... Nc4:** This is a standard and very strong move. It places the knight on an active square, eyes the b2-pawn, and prepares to challenge White's control. It prevents White from easily playing b3, as the knight is well-placed.\n    *   **12... Bd7:** A solid developing move, preparing to connect the rooks or support the queenside.\n    *   **12... c4:** This locks the queenside pawn structure further. It prevents b3 for now but might allow White to play b4 later, which can be annoying.\n3. **Reasoning:** 12... Nc4 is the most principled move. It immediately exerts pressure on the position. If White plays b3, the knight can retreat to b6 or stay active. It forces White to address the knight's presence. In the Ruy Lopez, this maneuver is highly thematic, putting the knight on a square where it disrupts White's development of the queenside pieces.\n\n### Step-by-step evaluation:\n*   The center is closed (d5).\n*   Black has a knight on a5 currently doing little. Bringing it back to the center via c4 is the most effective way to activate it.\n*   12... Nc4 forces White to consider the stability of their queenside.\n*   Engines typically favor this maneuver in this specific structure to control the board.\n\nFinal Answer: Nc4"
+        },
+        "info": {
+          "actionApplied": 289,
+          "actionSubmitted": 289,
+          "actionSubmittedToString": "Nc4",
+          "agentSelfReportedStatus": "OK",
+          "timeTaken": 3.466
+        },
+        "observation": {
+          "currentPlayer": 1,
+          "isTerminal": false,
+          "observationString": "r1b2rk1/2q1bppp/p2p1n2/1ppPp3/2n1P3/2P2N1P/PPB2PP1/RNBQR1K1 w - - 1 13",
+          "playerId": 0,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n2426\n3572\n656\n2974\n89\n919\n3572\n4673\n2977\n2949\n674\n277\n1841\n1257\n4673\n4177\n1380\n788\n1258\n1842\n1809\n1987\n289\n\n",
+          "step": 25
+        },
+        "reward": null,
+        "status": "INACTIVE"
+      },
+      {
+        "action": { "submission": -1 },
+        "info": {},
+        "observation": {
+          "currentPlayer": 1,
+          "isTerminal": false,
+          "observationString": "r1b2rk1/2q1bppp/p2p1n2/1ppPp3/2n1P3/2P2N1P/PPB2PP1/RNBQR1K1 w - - 1 13",
+          "playerId": 1,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n2426\n3572\n656\n2974\n89\n919\n3572\n4673\n2977\n2949\n674\n277\n1841\n1257\n4673\n4177\n1380\n788\n1258\n1842\n1809\n1987\n289\n\n"
+        },
+        "reward": null,
+        "status": "ACTIVE"
+      }
+    ],
+    [
+      {
+        "action": { "submission": -1 },
+        "info": {},
+        "observation": {
+          "currentPlayer": 0,
+          "isTerminal": false,
+          "observationString": "r1b2rk1/2q1bppp/p2p1n2/1ppPp3/2n1P3/1PP2N1P/P1B2PP1/RNBQR1K1 b - - 0 13",
+          "playerId": 0,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n2426\n3572\n656\n2974\n89\n919\n3572\n4673\n2977\n2949\n674\n277\n1841\n1257\n4673\n4177\n1380\n788\n1258\n1842\n1809\n1987\n289\n673\n\n",
+          "step": 26
+        },
+        "reward": null,
+        "status": "ACTIVE"
+      },
+      {
+        "action": {
+          "actionString": "b3",
+          "call_details": [
+            {
+              "duration_secs": 2.683,
+              "finish_reason": "stop",
+              "first_token_secs": 0.678,
+              "generation_tokens": 461,
+              "model": "openai/google/gemini-3.1-flash-lite-preview",
+              "prompt": "You are a chess expert\n\nLet's play chess. The current game state in Forsyth-Edwards Notation (FEN) notation is:\nr1b2rk1/2q1bppp/p2p1n2/1ppPp3/2n1P3/2P2N1P/PPB2PP1/RNBQR1K1 w - - 1 13\nThe moves played so far are:\n1. e4 e5 2. Nf3 Nc6 3. Bb5 a6 4. Ba4 Nf6 5. O-O Be7 6. Re1 b5 7. Bb3 d6 8. c3 O-O 9. h3 Na5 10. Bc2 c5 11. d4 Qc7 12. d5 Nc4 13.\nYou are playing as player White.\nIt is now your turn. Play your strongest move. The move MUST be legal. Reason step by step to come up with your move, then output your final answer in the format \"Final Answer: X\" where X is your chosen move in standard algebraic notation (SAN).\n",
+              "prompt_tokens": 251,
+              "reasoning_tokens": 0,
+              "response": "The current position is `r1b2rk1/2q1bppp/p2p1n2/1ppPp3/2n1P3/2P2N1P/PPB2PP1/RNBQR1K1 w - - 1 13`. It is White's turn to move.\n\n**Evaluation and Strategy:**\n1. **Position Analysis:** The position arises from a Ruy Lopez, Chigorin Variation. Black's knight on c4 is a nuisance, but it is somewhat isolated. White has a central space advantage.\n2. **Candidate Moves:**\n    *   **b3:** This is the most principled move. It challenges the knight on c4 immediately, forcing it to move. If 13... Nb6, White has successfully pushed the knight back, gaining space and stability on the queenside.\n    *   **b4:** This is a thematic Ruy Lopez idea to challenge Black's queenside structure, but given that the knight is currently on c4, 13. b3 is generally more precise to deal with the immediate threat/annoyance.\n    *   **Nbd2:** This develops the knight to a better square and prepares to challenge the c4-knight or bolster the center, but 13. b3 is more direct in addressing the piece on c4.\n\n**Reasoning for 13. b3:**\n*   The knight on c4 is White's main concern. By playing 13. b3, White forces Black to decide where to place the knight.\n*   If 13... Nb6, the knight is less active, and White can continue with development (e.g., Nbd2, b4 later, or a4).\n*   This move fits the standard structural requirements of this Ruy Lopez variation, clearing the path for the development of the b1 knight (often via d2) and securing the queenside.\n\n**Conclusion:**\n13. b3 is the standard, strongest move in this position to neutralize the immediate pressure of the knight on c4 and improve White's queenside structure.\n\nFinal Answer: b3",
+              "total_tokens": 712
+            }
+          ],
+          "status": "OK",
+          "submission": 673,
+          "thoughts": "The current position is `r1b2rk1/2q1bppp/p2p1n2/1ppPp3/2n1P3/2P2N1P/PPB2PP1/RNBQR1K1 w - - 1 13`. It is White's turn to move.\n\n**Evaluation and Strategy:**\n1. **Position Analysis:** The position arises from a Ruy Lopez, Chigorin Variation. Black's knight on c4 is a nuisance, but it is somewhat isolated. White has a central space advantage.\n2. **Candidate Moves:**\n    *   **b3:** This is the most principled move. It challenges the knight on c4 immediately, forcing it to move. If 13... Nb6, White has successfully pushed the knight back, gaining space and stability on the queenside.\n    *   **b4:** This is a thematic Ruy Lopez idea to challenge Black's queenside structure, but given that the knight is currently on c4, 13. b3 is generally more precise to deal with the immediate threat/annoyance.\n    *   **Nbd2:** This develops the knight to a better square and prepares to challenge the c4-knight or bolster the center, but 13. b3 is more direct in addressing the piece on c4.\n\n**Reasoning for 13. b3:**\n*   The knight on c4 is White's main concern. By playing 13. b3, White forces Black to decide where to place the knight.\n*   If 13... Nb6, the knight is less active, and White can continue with development (e.g., Nbd2, b4 later, or a4).\n*   This move fits the standard structural requirements of this Ruy Lopez variation, clearing the path for the development of the b1 knight (often via d2) and securing the queenside.\n\n**Conclusion:**\n13. b3 is the standard, strongest move in this position to neutralize the immediate pressure of the knight on c4 and improve White's queenside structure.\n\nFinal Answer: b3"
+        },
+        "info": {
+          "actionApplied": 673,
+          "actionSubmitted": 673,
+          "actionSubmittedToString": "b3",
+          "agentSelfReportedStatus": "OK",
+          "timeTaken": 3.082
+        },
+        "observation": {
+          "currentPlayer": 0,
+          "isTerminal": false,
+          "observationString": "r1b2rk1/2q1bppp/p2p1n2/1ppPp3/2n1P3/1PP2N1P/P1B2PP1/RNBQR1K1 b - - 0 13",
+          "playerId": 1,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n2426\n3572\n656\n2974\n89\n919\n3572\n4673\n2977\n2949\n674\n277\n1841\n1257\n4673\n4177\n1380\n788\n1258\n1842\n1809\n1987\n289\n673\n\n"
+        },
+        "reward": null,
+        "status": "INACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "actionString": "Nb6",
+          "call_details": [
+            {
+              "duration_secs": 2.875,
+              "finish_reason": "stop",
+              "first_token_secs": 0.805,
+              "generation_tokens": 498,
+              "model": "openai/google/gemini-3.1-flash-lite-preview",
+              "prompt": "\ud83d\udc4c\ud83d\udc40\ud83d\udc4c\ud83d\udc40\ud83d\udc4c\ud83d\udc40\ud83d\udc4c\ud83d\udc40\ud83d\udc4c\ud83d\udc40 good shit go\u0c66\u0501 sHit\ud83d\udc4c thats \u2714 some good\ud83d\udc4c\ud83d\udc4cshit right\ud83d\udc4c\ud83d\udc4cthere\ud83d\udc4c\ud83d\udc4c\ud83d\udc4c right\u2714there \u2714\u2714if i do \u01bda\u04af so my self \ud83d\udcaf i say so \ud83d\udcaf thats what im talking about right there right there (chorus: \u02b3\u1da6\u1d4d\u02b0\u1d57 \u1d57\u02b0\u1d49\u02b3\u1d49) mMMMM\u13b7\u041c\ud83d\udcaf \ud83d\udc4c\ud83d\udc4c \ud83d\udc4c\u041dO0\u041e\u0b20OOOOO\u041e\u0b20\u0b20Oooo\u1d52\u1d52\u1d52\u1d52\u1d52\u1d52\u1d52\u1d52\u1d52\ud83d\udc4c \ud83d\udc4c\ud83d\udc4c \ud83d\udc4c \ud83d\udcaf \ud83d\udc4c \ud83d\udc40 \ud83d\udc40 \ud83d\udc40 \ud83d\udc4c\ud83d\udc4c\n\nLet's play chess. The current game state in Forsyth-Edwards Notation (FEN) notation is:\nr1b2rk1/2q1bppp/p2p1n2/1ppPp3/2n1P3/1PP2N1P/P1B2PP1/RNBQR1K1 b - - 0 13\nThe moves played so far are:\n1. e4 e5 2. Nf3 Nc6 3. Bb5 a6 4. Ba4 Nf6 5. O-O Be7 6. Re1 b5 7. Bb3 d6 8. c3 O-O 9. h3 Na5 10. Bc2 c5 11. d4 Qc7 12. d5 Nc4 13. b3\nYou are playing as player Black.\nIt is now your turn. Play your strongest move. The move MUST be legal. Reason step by step to come up with your move, then output your final answer in the format \"Final Answer: X\" where X is your chosen move in standard algebraic notation (SAN).\n",
+              "prompt_tokens": 374,
+              "reasoning_tokens": 0,
+              "response": "The current FEN is `r1b2rk1/2q1bppp/p2p1n2/1ppPp3/2n1P3/1PP2N1P/P1B2PP1/RNBQR1K1 b - - 0 13`. It is Black's turn to move.\n\n**Evaluation and Analysis:**\n1. **The Situation:** White has just played `b3`, attacking the knight on `c4`. This knight is currently well-placed but under pressure. \n2. **Candidate Moves:**\n    *   **...Nb6:** This is the standard, most natural retreat. The knight pulls back to a safe square while keeping an eye on the center and the `d5` pawn. It maintains the tension in the position.\n    *   **...Na5:** This is possible, but `b3` was played specifically to kick the knight away from `c4`, and returning to `a5` effectively acknowledges the move while putting the knight on a somewhat passive edge square.\n    *   **...Nb6:** After `13... Nb6`, White might look to consolidate or build on the kingside with moves like `a4`, attempting to challenge Black's queenside structure.\n\n**Reasoning:**\n*   `13... Nb6` is the most flexible and strategic move. It retreats the knight from the attacked square while keeping it involved in the game. From `b6`, the knight can potentially jump into `a4` (if the a-pawn moves) or `d7` depending on how the game develops.\n*   Retreating to `b6` is safer and keeps the knight active compared to retreating to `a5` where it has fewer prospects.\n*   The position remains balanced and follows standard Ruy Lopez (Chigorin/Closed variations) themes where Black maneuvers pieces to manage the space disadvantage.\n\n**Step-by-step logic:**\n1. The knight on `c4` is attacked by the b3-pawn.\n2. It must move. \n3. `Nb6` is the most solid retreat square, keeping the piece active for future central influence or queenside play.\n4. `Nb6` avoids unnecessary complications and maintains the integrity of Black's structure.\n\nFinal Answer: Nb6",
+              "total_tokens": 872
+            }
+          ],
+          "status": "OK",
+          "submission": 1527,
+          "thoughts": "The current FEN is `r1b2rk1/2q1bppp/p2p1n2/1ppPp3/2n1P3/1PP2N1P/P1B2PP1/RNBQR1K1 b - - 0 13`. It is Black's turn to move.\n\n**Evaluation and Analysis:**\n1. **The Situation:** White has just played `b3`, attacking the knight on `c4`. This knight is currently well-placed but under pressure. \n2. **Candidate Moves:**\n    *   **...Nb6:** This is the standard, most natural retreat. The knight pulls back to a safe square while keeping an eye on the center and the `d5` pawn. It maintains the tension in the position.\n    *   **...Na5:** This is possible, but `b3` was played specifically to kick the knight away from `c4`, and returning to `a5` effectively acknowledges the move while putting the knight on a somewhat passive edge square.\n    *   **...Nb6:** After `13... Nb6`, White might look to consolidate or build on the kingside with moves like `a4`, attempting to challenge Black's queenside structure.\n\n**Reasoning:**\n*   `13... Nb6` is the most flexible and strategic move. It retreats the knight from the attacked square while keeping it involved in the game. From `b6`, the knight can potentially jump into `a4` (if the a-pawn moves) or `d7` depending on how the game develops.\n*   Retreating to `b6` is safer and keeps the knight active compared to retreating to `a5` where it has fewer prospects.\n*   The position remains balanced and follows standard Ruy Lopez (Chigorin/Closed variations) themes where Black maneuvers pieces to manage the space disadvantage.\n\n**Step-by-step logic:**\n1. The knight on `c4` is attacked by the b3-pawn.\n2. It must move. \n3. `Nb6` is the most solid retreat square, keeping the piece active for future central influence or queenside play.\n4. `Nb6` avoids unnecessary complications and maintains the integrity of Black's structure.\n\nFinal Answer: Nb6"
+        },
+        "info": {
+          "actionApplied": 1527,
+          "actionSubmitted": 1527,
+          "actionSubmittedToString": "Nb6",
+          "agentSelfReportedStatus": "OK",
+          "timeTaken": 3.327
+        },
+        "observation": {
+          "currentPlayer": 1,
+          "isTerminal": false,
+          "observationString": "r1b2rk1/2q1bppp/pn1p1n2/1ppPp3/4P3/1PP2N1P/P1B2PP1/RNBQR1K1 w - - 1 14",
+          "playerId": 0,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n2426\n3572\n656\n2974\n89\n919\n3572\n4673\n2977\n2949\n674\n277\n1841\n1257\n4673\n4177\n1380\n788\n1258\n1842\n1809\n1987\n289\n673\n1527\n\n",
+          "step": 27
+        },
+        "reward": null,
+        "status": "INACTIVE"
+      },
+      {
+        "action": { "submission": -1 },
+        "info": {},
+        "observation": {
+          "currentPlayer": 1,
+          "isTerminal": false,
+          "observationString": "r1b2rk1/2q1bppp/pn1p1n2/1ppPp3/4P3/1PP2N1P/P1B2PP1/RNBQR1K1 w - - 1 14",
+          "playerId": 1,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n2426\n3572\n656\n2974\n89\n919\n3572\n4673\n2977\n2949\n674\n277\n1841\n1257\n4673\n4177\n1380\n788\n1258\n1842\n1809\n1987\n289\n673\n1527\n\n"
+        },
+        "reward": null,
+        "status": "ACTIVE"
+      }
+    ],
+    [
+      {
+        "action": { "submission": -1 },
+        "info": {},
+        "observation": {
+          "currentPlayer": 0,
+          "isTerminal": false,
+          "observationString": "r1b2rk1/2q1bppp/pn1p1n2/1ppPp3/4P3/1PP2N1P/P1BN1PP1/R1BQR1K1 b - - 2 14",
+          "playerId": 0,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n2426\n3572\n656\n2974\n89\n919\n3572\n4673\n2977\n2949\n674\n277\n1841\n1257\n4673\n4177\n1380\n788\n1258\n1842\n1809\n1987\n289\n673\n1527\n654\n\n",
+          "step": 28
+        },
+        "reward": null,
+        "status": "ACTIVE"
+      },
+      {
+        "action": {
+          "actionString": "Nbd2",
+          "call_details": [
+            {
+              "duration_secs": 2.826,
+              "finish_reason": "stop",
+              "first_token_secs": 0.743,
+              "generation_tokens": 427,
+              "model": "openai/google/gemini-3.1-flash-lite-preview",
+              "prompt": "You are a chess expert\n\nLet's play chess. The current game state in Forsyth-Edwards Notation (FEN) notation is:\nr1b2rk1/2q1bppp/pn1p1n2/1ppPp3/4P3/1PP2N1P/P1B2PP1/RNBQR1K1 w - - 1 14\nThe moves played so far are:\n1. e4 e5 2. Nf3 Nc6 3. Bb5 a6 4. Ba4 Nf6 5. O-O Be7 6. Re1 b5 7. Bb3 d6 8. c3 O-O 9. h3 Na5 10. Bc2 c5 11. d4 Qc7 12. d5 Nc4 13. b3 Nb6 14.\nYou are playing as player White.\nIt is now your turn. Play your strongest move. The move MUST be legal. Reason step by step to come up with your move, then output your final answer in the format \"Final Answer: X\" where X is your chosen move in standard algebraic notation (SAN).\n",
+              "prompt_tokens": 258,
+              "reasoning_tokens": 0,
+              "response": "The current position is a standard Ruy Lopez, Closed Variation, where Black has played the Chigorin-style maneuver with ...Na5 and ...Nb6. White has established a space advantage with the d5-pawn, and the structure is relatively locked.\n\n**Analysis:**\n1. **Strategic Goal:** White needs to develop the queenside pieces and prepare for either a central break or kingside activity. The current bishop on c2 is well-placed for a future f4 push, but it is currently blocked by its own pawn chain.\n2. **Candidate Moves:**\n    * **a4:** This is a very standard and thematic move in this structure. It challenges Black's queenside expansion (b5) and forces a decision. If Black plays ...b4, the position changes, and White can look to play c4 or reposition the knight.\n    * **Nbd2:** This is the most natural developing move. It supports the center and prepares to reroute the knight to f1, which is a classic Ruy Lopez maneuver (Nf1-g3/e3), putting pressure on the kingside or supporting the center.\n    * **Be3:** Another standard developing move, though it allows ...c4, which might be annoying.\n\n**Evaluation:**\n* **Nbd2** is the most flexible and sound move. It completes the development of the minor pieces and prepares the knight maneuver to support the kingside or potentially jump to f3/h2/g3. It is universally considered the main line in these positions to improve the pieces before pushing pawns.\n* **a4** is also excellent, but usually, it is played after the knight is already developed to d2, as the knight on b1 doesn't actively support the a-file push yet.\n\nBy playing **Nbd2**, White prepares to bring the knight into the game (likely to f1) while keeping the structure solid. This is the most principled approach in this specific Ruy Lopez setup.\n\nFinal Answer: Nbd2",
+              "total_tokens": 685
+            }
+          ],
+          "status": "OK",
+          "submission": 654,
+          "thoughts": "The current position is a standard Ruy Lopez, Closed Variation, where Black has played the Chigorin-style maneuver with ...Na5 and ...Nb6. White has established a space advantage with the d5-pawn, and the structure is relatively locked.\n\n**Analysis:**\n1. **Strategic Goal:** White needs to develop the queenside pieces and prepare for either a central break or kingside activity. The current bishop on c2 is well-placed for a future f4 push, but it is currently blocked by its own pawn chain.\n2. **Candidate Moves:**\n    * **a4:** This is a very standard and thematic move in this structure. It challenges Black's queenside expansion (b5) and forces a decision. If Black plays ...b4, the position changes, and White can look to play c4 or reposition the knight.\n    * **Nbd2:** This is the most natural developing move. It supports the center and prepares to reroute the knight to f1, which is a classic Ruy Lopez maneuver (Nf1-g3/e3), putting pressure on the kingside or supporting the center.\n    * **Be3:** Another standard developing move, though it allows ...c4, which might be annoying.\n\n**Evaluation:**\n* **Nbd2** is the most flexible and sound move. It completes the development of the minor pieces and prepares the knight maneuver to support the kingside or potentially jump to f3/h2/g3. It is universally considered the main line in these positions to improve the pieces before pushing pawns.\n* **a4** is also excellent, but usually, it is played after the knight is already developed to d2, as the knight on b1 doesn't actively support the a-file push yet.\n\nBy playing **Nbd2**, White prepares to bring the knight into the game (likely to f1) while keeping the structure solid. This is the most principled approach in this specific Ruy Lopez setup.\n\nFinal Answer: Nbd2"
+        },
+        "info": {
+          "actionApplied": 654,
+          "actionSubmitted": 654,
+          "actionSubmittedToString": "Nbd2",
+          "agentSelfReportedStatus": "OK",
+          "timeTaken": 3.275
+        },
+        "observation": {
+          "currentPlayer": 0,
+          "isTerminal": false,
+          "observationString": "r1b2rk1/2q1bppp/pn1p1n2/1ppPp3/4P3/1PP2N1P/P1BN1PP1/R1BQR1K1 b - - 2 14",
+          "playerId": 1,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n2426\n3572\n656\n2974\n89\n919\n3572\n4673\n2977\n2949\n674\n277\n1841\n1257\n4673\n4177\n1380\n788\n1258\n1842\n1809\n1987\n289\n673\n1527\n654\n\n"
+        },
+        "reward": null,
+        "status": "INACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "actionString": "Ne8",
+          "call_details": [
+            {
+              "duration_secs": 3.499,
+              "finish_reason": "stop",
+              "first_token_secs": 0.687,
+              "generation_tokens": 577,
+              "model": "openai/google/gemini-3.1-flash-lite-preview",
+              "prompt": "\ud83d\udc4c\ud83d\udc40\ud83d\udc4c\ud83d\udc40\ud83d\udc4c\ud83d\udc40\ud83d\udc4c\ud83d\udc40\ud83d\udc4c\ud83d\udc40 good shit go\u0c66\u0501 sHit\ud83d\udc4c thats \u2714 some good\ud83d\udc4c\ud83d\udc4cshit right\ud83d\udc4c\ud83d\udc4cthere\ud83d\udc4c\ud83d\udc4c\ud83d\udc4c right\u2714there \u2714\u2714if i do \u01bda\u04af so my self \ud83d\udcaf i say so \ud83d\udcaf thats what im talking about right there right there (chorus: \u02b3\u1da6\u1d4d\u02b0\u1d57 \u1d57\u02b0\u1d49\u02b3\u1d49) mMMMM\u13b7\u041c\ud83d\udcaf \ud83d\udc4c\ud83d\udc4c \ud83d\udc4c\u041dO0\u041e\u0b20OOOOO\u041e\u0b20\u0b20Oooo\u1d52\u1d52\u1d52\u1d52\u1d52\u1d52\u1d52\u1d52\u1d52\ud83d\udc4c \ud83d\udc4c\ud83d\udc4c \ud83d\udc4c \ud83d\udcaf \ud83d\udc4c \ud83d\udc40 \ud83d\udc40 \ud83d\udc40 \ud83d\udc4c\ud83d\udc4c\n\nLet's play chess. The current game state in Forsyth-Edwards Notation (FEN) notation is:\nr1b2rk1/2q1bppp/pn1p1n2/1ppPp3/4P3/1PP2N1P/P1BN1PP1/R1BQR1K1 b - - 2 14\nThe moves played so far are:\n1. e4 e5 2. Nf3 Nc6 3. Bb5 a6 4. Ba4 Nf6 5. O-O Be7 6. Re1 b5 7. Bb3 d6 8. c3 O-O 9. h3 Na5 10. Bc2 c5 11. d4 Qc7 12. d5 Nc4 13. b3 Nb6 14. Nbd2\nYou are playing as player Black.\nIt is now your turn. Play your strongest move. The move MUST be legal. Reason step by step to come up with your move, then output your final answer in the format \"Final Answer: X\" where X is your chosen move in standard algebraic notation (SAN).\n",
+              "prompt_tokens": 382,
+              "reasoning_tokens": 0,
+              "response": "The current position is `r1b2rk1/2q1bppp/pn1p1n2/1ppPp3/4P3/1PP2N1P/P1BN1PP1/R1BQR1K1 b - - 2 14`.\n\n**Evaluation and Analysis:**\n1. **Position Overview:** The game is a Ruy Lopez, Chigorin Variation structure that has transitioned into a closed center. White has pushed d5, and Black's knight is currently misplaced on b6.\n2. **Black's Strategy:** Black needs to improve the placement of the pieces, particularly the knight on b6, and prepare potential counterplay on the queenside or center. \n3. **Candidate Moves:**\n    * **...c4:** This is a thematic move in these structures to fix the queenside or open lines. However, White can respond with b4 or bxc4.\n    * **...Bd7:** Developing the light-squared bishop to a more active diagonal.\n    * **...Ne8:** A classic maneuver in these Ruy Lopez structures to reroute the knight to d6, where it eyes the f5 and c4 squares, and to clear the f-file for potential play.\n    * **...a5:** Expanding on the queenside to restrict White's options.\n\n**Deep Dive:**\nThe knight on b6 is awkward. Moving it back toward the center is a priority. Playing `...Ne8` is highly standard in this specific pawn structure. It clears the f8 square for the bishop if needed, supports the f7-f5 push (though that is risky), and prepares to put the knight on d6 via f6 or just regrouping. \n\nAnother strong idea is `...Bd7`, improving the bishop's position immediately. However, `...Ne8` is the most flexible prophylactic and maneuvering move to improve the coordination of the pieces. Let's look at `...Bd7`: if White plays Nf1, Black continues maneuvering.\n\nGiven the closed nature of the position, `...Ne8` followed by `...g6` or `...Bd7` is the most solid approach for Black to maintain balance while improving the piece configuration.\n\nStep-by-step reasoning for `Ne8`:\n1. The knight on b6 is doing little.\n2. Moving it to e8 allows the f8-bishop to connect the rooks or move to d7.\n3. The knight on e8 eyes the d6 and f6 squares, which are key outposts in the closed center.\n4. It prepares to challenge the d5-pawn or support a future f5 break.\n\nFinal Answer: Ne8",
+              "total_tokens": 959
+            }
+          ],
+          "status": "OK",
+          "submission": 3133,
+          "thoughts": "The current position is `r1b2rk1/2q1bppp/pn1p1n2/1ppPp3/4P3/1PP2N1P/P1BN1PP1/R1BQR1K1 b - - 2 14`.\n\n**Evaluation and Analysis:**\n1. **Position Overview:** The game is a Ruy Lopez, Chigorin Variation structure that has transitioned into a closed center. White has pushed d5, and Black's knight is currently misplaced on b6.\n2. **Black's Strategy:** Black needs to improve the placement of the pieces, particularly the knight on b6, and prepare potential counterplay on the queenside or center. \n3. **Candidate Moves:**\n    * **...c4:** This is a thematic move in these structures to fix the queenside or open lines. However, White can respond with b4 or bxc4.\n    * **...Bd7:** Developing the light-squared bishop to a more active diagonal.\n    * **...Ne8:** A classic maneuver in these Ruy Lopez structures to reroute the knight to d6, where it eyes the f5 and c4 squares, and to clear the f-file for potential play.\n    * **...a5:** Expanding on the queenside to restrict White's options.\n\n**Deep Dive:**\nThe knight on b6 is awkward. Moving it back toward the center is a priority. Playing `...Ne8` is highly standard in this specific pawn structure. It clears the f8 square for the bishop if needed, supports the f7-f5 push (though that is risky), and prepares to put the knight on d6 via f6 or just regrouping. \n\nAnother strong idea is `...Bd7`, improving the bishop's position immediately. However, `...Ne8` is the most flexible prophylactic and maneuvering move to improve the coordination of the pieces. Let's look at `...Bd7`: if White plays Nf1, Black continues maneuvering.\n\nGiven the closed nature of the position, `...Ne8` followed by `...g6` or `...Bd7` is the most solid approach for Black to maintain balance while improving the piece configuration.\n\nStep-by-step reasoning for `Ne8`:\n1. The knight on b6 is doing little.\n2. Moving it to e8 allows the f8-bishop to connect the rooks or move to d7.\n3. The knight on e8 eyes the d6 and f6 squares, which are key outposts in the closed center.\n4. It prepares to challenge the d5-pawn or support a future f5 break.\n\nFinal Answer: Ne8"
+        },
+        "info": {
+          "actionApplied": 3133,
+          "actionSubmitted": 3133,
+          "actionSubmittedToString": "Ne8",
+          "agentSelfReportedStatus": "OK",
+          "timeTaken": 4.009
+        },
+        "observation": {
+          "currentPlayer": 1,
+          "isTerminal": false,
+          "observationString": "r1b1nrk1/2q1bppp/pn1p4/1ppPp3/4P3/1PP2N1P/P1BN1PP1/R1BQR1K1 w - - 3 15",
+          "playerId": 0,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n2426\n3572\n656\n2974\n89\n919\n3572\n4673\n2977\n2949\n674\n277\n1841\n1257\n4673\n4177\n1380\n788\n1258\n1842\n1809\n1987\n289\n673\n1527\n654\n3133\n\n",
+          "step": 29
+        },
+        "reward": null,
+        "status": "INACTIVE"
+      },
+      {
+        "action": { "submission": -1 },
+        "info": {},
+        "observation": {
+          "currentPlayer": 1,
+          "isTerminal": false,
+          "observationString": "r1b1nrk1/2q1bppp/pn1p4/1ppPp3/4P3/1PP2N1P/P1BN1PP1/R1BQR1K1 w - - 3 15",
+          "playerId": 1,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n2426\n3572\n656\n2974\n89\n919\n3572\n4673\n2977\n2949\n674\n277\n1841\n1257\n4673\n4177\n1380\n788\n1258\n1842\n1809\n1987\n289\n673\n1527\n654\n3133\n\n"
+        },
+        "reward": null,
+        "status": "ACTIVE"
+      }
+    ],
+    [
+      {
+        "action": { "submission": -1 },
+        "info": {},
+        "observation": {
+          "currentPlayer": 0,
+          "isTerminal": false,
+          "observationString": "r1b1nrk1/2q1bppp/pn1p4/1ppPp3/4P3/1PP2N1P/P1B2PP1/R1BQRNK1 b - - 4 15",
+          "playerId": 0,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n2426\n3572\n656\n2974\n89\n919\n3572\n4673\n2977\n2949\n674\n277\n1841\n1257\n4673\n4177\n1380\n788\n1258\n1842\n1809\n1987\n289\n673\n1527\n654\n3133\n1894\n\n",
+          "step": 30
+        },
+        "reward": null,
+        "status": "ACTIVE"
+      },
+      {
+        "action": {
+          "actionString": "Nf1",
+          "call_details": [
+            {
+              "duration_secs": 3.226,
+              "finish_reason": "stop",
+              "first_token_secs": 0.809,
+              "generation_tokens": 484,
+              "model": "openai/google/gemini-3.1-flash-lite-preview",
+              "prompt": "You are a chess expert\n\nLet's play chess. The current game state in Forsyth-Edwards Notation (FEN) notation is:\nr1b1nrk1/2q1bppp/pn1p4/1ppPp3/4P3/1PP2N1P/P1BN1PP1/R1BQR1K1 w - - 3 15\nThe moves played so far are:\n1. e4 e5 2. Nf3 Nc6 3. Bb5 a6 4. Ba4 Nf6 5. O-O Be7 6. Re1 b5 7. Bb3 d6 8. c3 O-O 9. h3 Na5 10. Bc2 c5 11. d4 Qc7 12. d5 Nc4 13. b3 Nb6 14. Nbd2 Ne8 15.\nYou are playing as player White.\nIt is now your turn. Play your strongest move. The move MUST be legal. Reason step by step to come up with your move, then output your final answer in the format \"Final Answer: X\" where X is your chosen move in standard algebraic notation (SAN).\n",
+              "prompt_tokens": 267,
+              "reasoning_tokens": 0,
+              "response": "The current position is a standard Ruy Lopez, Closed Variation, where Black has adopted a setup involving ...Nc4 and ...Nb6. White has established a space advantage with the d5 pawn.\n\n**Evaluation and Strategy:**\n1. **Position Analysis:** The pawn structure is locked in the center. White has a solid position. Black\u2019s knight on b6 is currently slightly displaced but eyes the c4 and d5 squares. White's knight on d2 is looking for a better post, potentially f1 to eventually reach g3 or e3.\n2. **Key Objectives:** \n   - Improving the knight on d2 is a priority. Moving it to f1 is standard in these structures to reroute towards the kingside.\n   - White should maintain the tension and keep an eye on the kingside.\n   - The c2 bishop is well-placed, and the a2-g8 diagonal remains important.\n3. **Candidate Moves:**\n   - **Nf1:** This is the most thematic move in this structure. It clears the d2 square for other pieces or maneuverability and prepares to bring the knight to g3 or e3 to support the kingside or challenge black's pieces.\n   - **a4:** Aiming to challenge Black's queenside structure immediately. However, it might lead to unnecessary complications or allow Black to solidify the b-file.\n   - **c4:** This would close the queenside further, which might benefit White if the plan is to play on the kingside, but it also releases the tension in a way that might grant Black counterplay on the c-file.\n\n**Reasoning for Nf1:**\nThe move 15. Nf1 is the most principled choice. It follows the standard maneuver in the Ruy Lopez where the knight on d2 is redundant once the c-pawn has moved and the center is fixed. By playing Nf1, White creates the possibility of Ng3, which puts pressure on f5 and e4, or Ne3 to support the d5/f5 breaks. It is a prophylactic and constructive move that improves the coordination of the White pieces.\n\nChecking for immediate tactical threats: Black has no immediate threats. The position is stable, and improving piece placement is the best strategic path.\n\nFinal Answer: Nf1",
+              "total_tokens": 751
+            }
+          ],
+          "status": "OK",
+          "submission": 1894,
+          "thoughts": "The current position is a standard Ruy Lopez, Closed Variation, where Black has adopted a setup involving ...Nc4 and ...Nb6. White has established a space advantage with the d5 pawn.\n\n**Evaluation and Strategy:**\n1. **Position Analysis:** The pawn structure is locked in the center. White has a solid position. Black\u2019s knight on b6 is currently slightly displaced but eyes the c4 and d5 squares. White's knight on d2 is looking for a better post, potentially f1 to eventually reach g3 or e3.\n2. **Key Objectives:** \n   - Improving the knight on d2 is a priority. Moving it to f1 is standard in these structures to reroute towards the kingside.\n   - White should maintain the tension and keep an eye on the kingside.\n   - The c2 bishop is well-placed, and the a2-g8 diagonal remains important.\n3. **Candidate Moves:**\n   - **Nf1:** This is the most thematic move in this structure. It clears the d2 square for other pieces or maneuverability and prepares to bring the knight to g3 or e3 to support the kingside or challenge black's pieces.\n   - **a4:** Aiming to challenge Black's queenside structure immediately. However, it might lead to unnecessary complications or allow Black to solidify the b-file.\n   - **c4:** This would close the queenside further, which might benefit White if the plan is to play on the kingside, but it also releases the tension in a way that might grant Black counterplay on the c-file.\n\n**Reasoning for Nf1:**\nThe move 15. Nf1 is the most principled choice. It follows the standard maneuver in the Ruy Lopez where the knight on d2 is redundant once the c-pawn has moved and the center is fixed. By playing Nf1, White creates the possibility of Ng3, which puts pressure on f5 and e4, or Ne3 to support the d5/f5 breaks. It is a prophylactic and constructive move that improves the coordination of the White pieces.\n\nChecking for immediate tactical threats: Black has no immediate threats. The position is stable, and improving piece placement is the best strategic path.\n\nFinal Answer: Nf1"
+        },
+        "info": {
+          "actionApplied": 1894,
+          "actionSubmitted": 1894,
+          "actionSubmittedToString": "Nf1",
+          "agentSelfReportedStatus": "OK",
+          "timeTaken": 3.709
+        },
+        "observation": {
+          "currentPlayer": 0,
+          "isTerminal": false,
+          "observationString": "r1b1nrk1/2q1bppp/pn1p4/1ppPp3/4P3/1PP2N1P/P1B2PP1/R1BQRNK1 b - - 4 15",
+          "playerId": 1,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n2426\n3572\n656\n2974\n89\n919\n3572\n4673\n2977\n2949\n674\n277\n1841\n1257\n4673\n4177\n1380\n788\n1258\n1842\n1809\n1987\n289\n673\n1527\n654\n3133\n1894\n\n"
+        },
+        "reward": null,
+        "status": "INACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "actionString": "f5",
+          "call_details": [
+            {
+              "duration_secs": 3.571,
+              "finish_reason": "stop",
+              "first_token_secs": 0.804,
+              "generation_tokens": 567,
+              "model": "openai/google/gemini-3.1-flash-lite-preview",
+              "prompt": "\ud83d\udc4c\ud83d\udc40\ud83d\udc4c\ud83d\udc40\ud83d\udc4c\ud83d\udc40\ud83d\udc4c\ud83d\udc40\ud83d\udc4c\ud83d\udc40 good shit go\u0c66\u0501 sHit\ud83d\udc4c thats \u2714 some good\ud83d\udc4c\ud83d\udc4cshit right\ud83d\udc4c\ud83d\udc4cthere\ud83d\udc4c\ud83d\udc4c\ud83d\udc4c right\u2714there \u2714\u2714if i do \u01bda\u04af so my self \ud83d\udcaf i say so \ud83d\udcaf thats what im talking about right there right there (chorus: \u02b3\u1da6\u1d4d\u02b0\u1d57 \u1d57\u02b0\u1d49\u02b3\u1d49) mMMMM\u13b7\u041c\ud83d\udcaf \ud83d\udc4c\ud83d\udc4c \ud83d\udc4c\u041dO0\u041e\u0b20OOOOO\u041e\u0b20\u0b20Oooo\u1d52\u1d52\u1d52\u1d52\u1d52\u1d52\u1d52\u1d52\u1d52\ud83d\udc4c \ud83d\udc4c\ud83d\udc4c \ud83d\udc4c \ud83d\udcaf \ud83d\udc4c \ud83d\udc40 \ud83d\udc40 \ud83d\udc40 \ud83d\udc4c\ud83d\udc4c\n\nLet's play chess. The current game state in Forsyth-Edwards Notation (FEN) notation is:\nr1b1nrk1/2q1bppp/pn1p4/1ppPp3/4P3/1PP2N1P/P1B2PP1/R1BQRNK1 b - - 4 15\nThe moves played so far are:\n1. e4 e5 2. Nf3 Nc6 3. Bb5 a6 4. Ba4 Nf6 5. O-O Be7 6. Re1 b5 7. Bb3 d6 8. c3 O-O 9. h3 Na5 10. Bc2 c5 11. d4 Qc7 12. d5 Nc4 13. b3 Nb6 14. Nbd2 Ne8 15. Nf1\nYou are playing as player Black.\nIt is now your turn. Play your strongest move. The move MUST be legal. Reason step by step to come up with your move, then output your final answer in the format \"Final Answer: X\" where X is your chosen move in standard algebraic notation (SAN).\n",
+              "prompt_tokens": 388,
+              "reasoning_tokens": 0,
+              "response": "The current position is `r1b1nrk1/2q1bppp/pn1p4/1ppPp3/4P3/1PP2N1P/P1B2PP1/R1BQRNK1 b - - 4 15`. It is Black's turn to move.\n\n**Evaluation and Analysis:**\n1. **Position Overview:** The position arises from a Ruy Lopez, Chigorin Variation, with a locked center (d5 and e4/e5 pawns). White has played conservatively with Nbd2-f1 and h3. Black has a solid structure and good control over the center.\n2. **Black's Strategy:** \n   - Black needs to prepare for expansion or improve piece placement.\n   - The knight on e8 is currently passive, and the bishop on c8 is restricted.\n   - Pushing ...f5 is a standard thematic idea in these structures to challenge White's control and open lines for the pieces.\n3. **Candidate Moves:**\n   - **...f5:** This is the most active and principled move. It challenges White's space and creates immediate counterplay. If 16. exf5, Black recaptures with the bishop (Bxf5) or knight (Rxf5), gaining central activity.\n   - **...Bd7:** A useful developing move to improve the bishop and connect the rooks, but less forcing than ...f5.\n   - **...g6:** Prepares to bring the knight to g7 or f7 and supports the kingside, but is a bit slow.\n4. **Detailed look at ...f5:**\n   - If 15... f5, White has to decide how to respond to the tension. \n   - 16. exf5 Bxf5 17. Bxf5 Rxf5. Black achieves an open f-file and an active bishop.\n   - 16. Ng3 fxe4 17. Nxe4 Nf6 is also a standard thematic path, where Black achieves equality.\n   - The move ...f5 is the most common and statistically strongest move in this type of structure to break the rigidity of the center.\n\n**Reasoning for ...f5:**\nThe move ...f5 is highly thematic. In these closed Ruy Lopez structures, if Black doesn't challenge the center with ...f5 (or sometimes ...c4), White will eventually consolidate and play for a kingside attack or a breakthrough on the queenside. By playing ...f5 now, Black forces the issue, tests White's center, and improves the scope of the kingside pieces.\n\nFinal Answer: f5",
+              "total_tokens": 955
+            }
+          ],
+          "status": "OK",
+          "submission": 3010,
+          "thoughts": "The current position is `r1b1nrk1/2q1bppp/pn1p4/1ppPp3/4P3/1PP2N1P/P1B2PP1/R1BQRNK1 b - - 4 15`. It is Black's turn to move.\n\n**Evaluation and Analysis:**\n1. **Position Overview:** The position arises from a Ruy Lopez, Chigorin Variation, with a locked center (d5 and e4/e5 pawns). White has played conservatively with Nbd2-f1 and h3. Black has a solid structure and good control over the center.\n2. **Black's Strategy:** \n   - Black needs to prepare for expansion or improve piece placement.\n   - The knight on e8 is currently passive, and the bishop on c8 is restricted.\n   - Pushing ...f5 is a standard thematic idea in these structures to challenge White's control and open lines for the pieces.\n3. **Candidate Moves:**\n   - **...f5:** This is the most active and principled move. It challenges White's space and creates immediate counterplay. If 16. exf5, Black recaptures with the bishop (Bxf5) or knight (Rxf5), gaining central activity.\n   - **...Bd7:** A useful developing move to improve the bishop and connect the rooks, but less forcing than ...f5.\n   - **...g6:** Prepares to bring the knight to g7 or f7 and supports the kingside, but is a bit slow.\n4. **Detailed look at ...f5:**\n   - If 15... f5, White has to decide how to respond to the tension. \n   - 16. exf5 Bxf5 17. Bxf5 Rxf5. Black achieves an open f-file and an active bishop.\n   - 16. Ng3 fxe4 17. Nxe4 Nf6 is also a standard thematic path, where Black achieves equality.\n   - The move ...f5 is the most common and statistically strongest move in this type of structure to break the rigidity of the center.\n\n**Reasoning for ...f5:**\nThe move ...f5 is highly thematic. In these closed Ruy Lopez structures, if Black doesn't challenge the center with ...f5 (or sometimes ...c4), White will eventually consolidate and play for a kingside attack or a breakthrough on the queenside. By playing ...f5 now, Black forces the issue, tests White's center, and improves the scope of the kingside pieces.\n\nFinal Answer: f5"
+        },
+        "info": {
+          "actionApplied": 3010,
+          "actionSubmitted": 3010,
+          "actionSubmittedToString": "f5",
+          "agentSelfReportedStatus": "OK",
+          "timeTaken": 4.059
+        },
+        "observation": {
+          "currentPlayer": 1,
+          "isTerminal": false,
+          "observationString": "r1b1nrk1/2q1b1pp/pn1p4/1ppPpp2/4P3/1PP2N1P/P1B2PP1/R1BQRNK1 w - - 0 16",
+          "playerId": 0,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n2426\n3572\n656\n2974\n89\n919\n3572\n4673\n2977\n2949\n674\n277\n1841\n1257\n4673\n4177\n1380\n788\n1258\n1842\n1809\n1987\n289\n673\n1527\n654\n3133\n1894\n3010\n\n",
+          "step": 31
+        },
+        "reward": null,
+        "status": "INACTIVE"
+      },
+      {
+        "action": { "submission": -1 },
+        "info": {},
+        "observation": {
+          "currentPlayer": 1,
+          "isTerminal": false,
+          "observationString": "r1b1nrk1/2q1b1pp/pn1p4/1ppPpp2/4P3/1PP2N1P/P1B2PP1/R1BQRNK1 w - - 0 16",
+          "playerId": 1,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n2426\n3572\n656\n2974\n89\n919\n3572\n4673\n2977\n2949\n674\n277\n1841\n1257\n4673\n4177\n1380\n788\n1258\n1842\n1809\n1987\n289\n673\n1527\n654\n3133\n1894\n3010\n\n"
+        },
+        "reward": null,
+        "status": "ACTIVE"
+      }
+    ],
+    [
+      {
+        "action": { "submission": -1 },
+        "info": {},
+        "observation": {
+          "currentPlayer": 0,
+          "isTerminal": false,
+          "observationString": "r1b1nrk1/2q1b1pp/pn1p4/1ppPpP2/8/1PP2N1P/P1B2PP1/R1BQRNK1 b - - 0 16",
+          "playerId": 0,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n2426\n3572\n656\n2974\n89\n919\n3572\n4673\n2977\n2949\n674\n277\n1841\n1257\n4673\n4177\n1380\n788\n1258\n1842\n1809\n1987\n289\n673\n1527\n654\n3133\n1894\n3010\n2599\n\n",
+          "step": 32
+        },
+        "reward": null,
+        "status": "ACTIVE"
+      },
+      {
+        "action": {
+          "actionString": "exf5",
+          "call_details": [
+            {
+              "duration_secs": 3.429,
+              "finish_reason": "stop",
+              "first_token_secs": 0.716,
+              "generation_tokens": 462,
+              "model": "openai/google/gemini-3.1-flash-lite-preview",
+              "prompt": "You are a chess expert\n\nLet's play chess. The current game state in Forsyth-Edwards Notation (FEN) notation is:\nr1b1nrk1/2q1b1pp/pn1p4/1ppPpp2/4P3/1PP2N1P/P1B2PP1/R1BQRNK1 w - - 0 16\nThe moves played so far are:\n1. e4 e5 2. Nf3 Nc6 3. Bb5 a6 4. Ba4 Nf6 5. O-O Be7 6. Re1 b5 7. Bb3 d6 8. c3 O-O 9. h3 Na5 10. Bc2 c5 11. d4 Qc7 12. d5 Nc4 13. b3 Nb6 14. Nbd2 Ne8 15. Nf1 f5 16.\nYou are playing as player White.\nIt is now your turn. Play your strongest move. The move MUST be legal. Reason step by step to come up with your move, then output your final answer in the format \"Final Answer: X\" where X is your chosen move in standard algebraic notation (SAN).\n",
+              "prompt_tokens": 276,
+              "reasoning_tokens": 0,
+              "response": "The current position is a tense struggle typical of the Ruy Lopez, Chigorin Variation structure. Black has lashed out with 15... f5, challenging my center. \n\n**Evaluation and Analysis:**\n1. **The Tension:** Black\u2019s move 15... f5 seeks to undermine my central pawn structure (d5/e4). If I capture 16. exf5, Black recaptures 16... Bxf5, and the game becomes very sharp.\n2. **Positional Considerations:** My knight on f1 is currently passive but well-placed to maneuver toward g3 or e3. The bishop on c2 is a long-term asset, eyeing the h7 square. \n3. **Candidate Moves:**\n    *   **16. exf5:** This is the most principled move. It resolves the central tension and opens lines. If 16. exf5 Bxf5, I can follow up with 17. Ng3 (hitting the bishop) or 17. Bxf5 Rxf5 18. Qd3. This seems the most robust way to maintain parity and structural integrity.\n    *   **16. Ng3:** This ignores the immediate tension and prepares to challenge the f5-pawn later. However, after 16... fxe4 17. Nxe4, Black obtains good play.\n    *   **16. c4:** This closes the queenside further, but it allows Black to consolidate their kingside initiative with ...fxe4.\n\n**Reasoning for 16. exf5:**\nBy capturing on f5, I force Black to clarify the structure. If Black recaptures with the bishop (16... Bxf5), I have the move 17. Bxf5 Rxf5 18. Ng3 Rf8 19. Qd3. If Black recaptures with the rook or another piece, I am in a solid position to re-evaluate based on the resulting file opening. This move is the most direct way to challenge Black's plan and prevent them from dictating the structure too easily. It maintains the balance and ensures that the center does not become overly cramped.\n\nFinal Answer: exf5",
+              "total_tokens": 738
+            }
+          ],
+          "status": "OK",
+          "submission": 2599,
+          "thoughts": "The current position is a tense struggle typical of the Ruy Lopez, Chigorin Variation structure. Black has lashed out with 15... f5, challenging my center. \n\n**Evaluation and Analysis:**\n1. **The Tension:** Black\u2019s move 15... f5 seeks to undermine my central pawn structure (d5/e4). If I capture 16. exf5, Black recaptures 16... Bxf5, and the game becomes very sharp.\n2. **Positional Considerations:** My knight on f1 is currently passive but well-placed to maneuver toward g3 or e3. The bishop on c2 is a long-term asset, eyeing the h7 square. \n3. **Candidate Moves:**\n    *   **16. exf5:** This is the most principled move. It resolves the central tension and opens lines. If 16. exf5 Bxf5, I can follow up with 17. Ng3 (hitting the bishop) or 17. Bxf5 Rxf5 18. Qd3. This seems the most robust way to maintain parity and structural integrity.\n    *   **16. Ng3:** This ignores the immediate tension and prepares to challenge the f5-pawn later. However, after 16... fxe4 17. Nxe4, Black obtains good play.\n    *   **16. c4:** This closes the queenside further, but it allows Black to consolidate their kingside initiative with ...fxe4.\n\n**Reasoning for 16. exf5:**\nBy capturing on f5, I force Black to clarify the structure. If Black recaptures with the bishop (16... Bxf5), I have the move 17. Bxf5 Rxf5 18. Ng3 Rf8 19. Qd3. If Black recaptures with the rook or another piece, I am in a solid position to re-evaluate based on the resulting file opening. This move is the most direct way to challenge Black's plan and prevent them from dictating the structure too easily. It maintains the balance and ensures that the center does not become overly cramped.\n\nFinal Answer: exf5"
+        },
+        "info": {
+          "actionApplied": 2599,
+          "actionSubmitted": 2599,
+          "actionSubmittedToString": "exf5",
+          "agentSelfReportedStatus": "OK",
+          "timeTaken": 3.89
+        },
+        "observation": {
+          "currentPlayer": 0,
+          "isTerminal": false,
+          "observationString": "r1b1nrk1/2q1b1pp/pn1p4/1ppPpP2/8/1PP2N1P/P1B2PP1/R1BQRNK1 b - - 0 16",
+          "playerId": 1,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n2426\n3572\n656\n2974\n89\n919\n3572\n4673\n2977\n2949\n674\n277\n1841\n1257\n4673\n4177\n1380\n788\n1258\n1842\n1809\n1987\n289\n673\n1527\n654\n3133\n1894\n3010\n2599\n\n"
+        },
+        "reward": null,
+        "status": "INACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "actionString": "Bxf5",
+          "call_details": [
+            {
+              "duration_secs": 3.076,
+              "finish_reason": "stop",
+              "first_token_secs": 0.612,
+              "generation_tokens": 574,
+              "model": "openai/google/gemini-3.1-flash-lite-preview",
+              "prompt": "\ud83d\udc4c\ud83d\udc40\ud83d\udc4c\ud83d\udc40\ud83d\udc4c\ud83d\udc40\ud83d\udc4c\ud83d\udc40\ud83d\udc4c\ud83d\udc40 good shit go\u0c66\u0501 sHit\ud83d\udc4c thats \u2714 some good\ud83d\udc4c\ud83d\udc4cshit right\ud83d\udc4c\ud83d\udc4cthere\ud83d\udc4c\ud83d\udc4c\ud83d\udc4c right\u2714there \u2714\u2714if i do \u01bda\u04af so my self \ud83d\udcaf i say so \ud83d\udcaf thats what im talking about right there right there (chorus: \u02b3\u1da6\u1d4d\u02b0\u1d57 \u1d57\u02b0\u1d49\u02b3\u1d49) mMMMM\u13b7\u041c\ud83d\udcaf \ud83d\udc4c\ud83d\udc4c \ud83d\udc4c\u041dO0\u041e\u0b20OOOOO\u041e\u0b20\u0b20Oooo\u1d52\u1d52\u1d52\u1d52\u1d52\u1d52\u1d52\u1d52\u1d52\ud83d\udc4c \ud83d\udc4c\ud83d\udc4c \ud83d\udc4c \ud83d\udcaf \ud83d\udc4c \ud83d\udc40 \ud83d\udc40 \ud83d\udc40 \ud83d\udc4c\ud83d\udc4c\n\nLet's play chess. The current game state in Forsyth-Edwards Notation (FEN) notation is:\nr1b1nrk1/2q1b1pp/pn1p4/1ppPpP2/8/1PP2N1P/P1B2PP1/R1BQRNK1 b - - 0 16\nThe moves played so far are:\n1. e4 e5 2. Nf3 Nc6 3. Bb5 a6 4. Ba4 Nf6 5. O-O Be7 6. Re1 b5 7. Bb3 d6 8. c3 O-O 9. h3 Na5 10. Bc2 c5 11. d4 Qc7 12. d5 Nc4 13. b3 Nb6 14. Nbd2 Ne8 15. Nf1 f5 16. exf5\nYou are playing as player Black.\nIt is now your turn. Play your strongest move. The move MUST be legal. Reason step by step to come up with your move, then output your final answer in the format \"Final Answer: X\" where X is your chosen move in standard algebraic notation (SAN).\n",
+              "prompt_tokens": 396,
+              "reasoning_tokens": 0,
+              "response": "The current position is `r1b1nrk1/2q1b1pp/pn1p4/1ppPpP2/8/1PP2N1P/P1B2PP1/R1BQRNK1 b - - 0 16`. It is Black's turn to move.\n\n**Evaluation and Analysis:**\n1. **Material:** Equal.\n2. **Positional Factors:** White has just played `16. exf5`. Black must recapture the pawn on f5. There are two primary ways to recapture: `16... Bxf5` or `16... Rxf5`.\n3. **Candidate Move: 16... Bxf5**\n   - After `16... Bxf5`, White might respond with `17. Bxf5 Rxf5`.\n   - This seems to be the most natural and safe developing move. It brings the light-squared bishop back into the game and controls important squares.\n4. **Candidate Move: 16... Rxf5**\n   - This move keeps the bishop on e7, which is currently guarding the king and the f6/d6 structure. However, the rook on f5 might become a target for white's pieces (e.g., `Ng3` or `Nh2-g4`).\n5. **Strategic Considerations:** \n   - Black needs to consolidate the center and prepare for potential kingside play. \n   - After `16... Bxf5`, Black is well-placed to challenge the center and maintain control.\n   - White\u2019s bishop on c2 is a strong piece, and trading it off with `...Bxf5` is a sensible strategic goal.\n\n**Detailed look at 16... Bxf5:**\nIf `16... Bxf5`, White can play `17. Bxf5 Rxf5`. The position remains balanced. If White plays `17. Ng3`, Black can retreat the bishop to d7 or g6. This seems to be the most active and solid continuation.\n\nComparing the two: `16... Bxf5` is objectively superior as it develops a piece, challenges White's bishop, and prepares to control the open f-file with the rook after the inevitable trade.\n\n**Step-by-step reasoning:**\n- The pawn on f5 must be captured to restore material balance and prevent White from holding a passed pawn or creating further threats.\n- Capturing with the bishop (`Bxf5`) improves the position of the bishop and invites a trade that simplifies the position, which generally favors Black given the slightly cramped space.\n- The move is safe and standard for this type of Ruy Lopez/Spanish structure.\n\nFinal Answer: Bxf5",
+              "total_tokens": 970
+            }
+          ],
+          "status": "OK",
+          "submission": 1214,
+          "thoughts": "The current position is `r1b1nrk1/2q1b1pp/pn1p4/1ppPpP2/8/1PP2N1P/P1B2PP1/R1BQRNK1 b - - 0 16`. It is Black's turn to move.\n\n**Evaluation and Analysis:**\n1. **Material:** Equal.\n2. **Positional Factors:** White has just played `16. exf5`. Black must recapture the pawn on f5. There are two primary ways to recapture: `16... Bxf5` or `16... Rxf5`.\n3. **Candidate Move: 16... Bxf5**\n   - After `16... Bxf5`, White might respond with `17. Bxf5 Rxf5`.\n   - This seems to be the most natural and safe developing move. It brings the light-squared bishop back into the game and controls important squares.\n4. **Candidate Move: 16... Rxf5**\n   - This move keeps the bishop on e7, which is currently guarding the king and the f6/d6 structure. However, the rook on f5 might become a target for white's pieces (e.g., `Ng3` or `Nh2-g4`).\n5. **Strategic Considerations:** \n   - Black needs to consolidate the center and prepare for potential kingside play. \n   - After `16... Bxf5`, Black is well-placed to challenge the center and maintain control.\n   - White\u2019s bishop on c2 is a strong piece, and trading it off with `...Bxf5` is a sensible strategic goal.\n\n**Detailed look at 16... Bxf5:**\nIf `16... Bxf5`, White can play `17. Bxf5 Rxf5`. The position remains balanced. If White plays `17. Ng3`, Black can retreat the bishop to d7 or g6. This seems to be the most active and solid continuation.\n\nComparing the two: `16... Bxf5` is objectively superior as it develops a piece, challenges White's bishop, and prepares to control the open f-file with the rook after the inevitable trade.\n\n**Step-by-step reasoning:**\n- The pawn on f5 must be captured to restore material balance and prevent White from holding a passed pawn or creating further threats.\n- Capturing with the bishop (`Bxf5`) improves the position of the bishop and invites a trade that simplifies the position, which generally favors Black given the slightly cramped space.\n- The move is safe and standard for this type of Ruy Lopez/Spanish structure.\n\nFinal Answer: Bxf5"
+        },
+        "info": {
+          "actionApplied": 1214,
+          "actionSubmitted": 1214,
+          "actionSubmittedToString": "Bxf5",
+          "agentSelfReportedStatus": "OK",
+          "timeTaken": 3.481
+        },
+        "observation": {
+          "currentPlayer": 1,
+          "isTerminal": false,
+          "observationString": "r3nrk1/2q1b1pp/pn1p4/1ppPpb2/8/1PP2N1P/P1B2PP1/R1BQRNK1 w - - 0 17",
+          "playerId": 0,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n2426\n3572\n656\n2974\n89\n919\n3572\n4673\n2977\n2949\n674\n277\n1841\n1257\n4673\n4177\n1380\n788\n1258\n1842\n1809\n1987\n289\n673\n1527\n654\n3133\n1894\n3010\n2599\n1214\n\n",
+          "step": 33
+        },
+        "reward": null,
+        "status": "INACTIVE"
+      },
+      {
+        "action": { "submission": -1 },
+        "info": {},
+        "observation": {
+          "currentPlayer": 1,
+          "isTerminal": false,
+          "observationString": "r3nrk1/2q1b1pp/pn1p4/1ppPpb2/8/1PP2N1P/P1B2PP1/R1BQRNK1 w - - 0 17",
+          "playerId": 1,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n2426\n3572\n656\n2974\n89\n919\n3572\n4673\n2977\n2949\n674\n277\n1841\n1257\n4673\n4177\n1380\n788\n1258\n1842\n1809\n1987\n289\n673\n1527\n654\n3133\n1894\n3010\n2599\n1214\n\n"
+        },
+        "reward": null,
+        "status": "ACTIVE"
+      }
+    ],
+    [
+      {
+        "action": { "submission": -1 },
+        "info": {},
+        "observation": {
+          "currentPlayer": 0,
+          "isTerminal": false,
+          "observationString": "r3nrk1/2q1b1pp/pn1p4/1ppPpB2/8/1PP2N1P/P4PP1/R1BQRNK1 b - - 0 17",
+          "playerId": 0,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n2426\n3572\n656\n2974\n89\n919\n3572\n4673\n2977\n2949\n674\n277\n1841\n1257\n4673\n4177\n1380\n788\n1258\n1842\n1809\n1987\n289\n673\n1527\n654\n3133\n1894\n3010\n2599\n1214\n1287\n\n",
+          "step": 34
+        },
+        "reward": null,
+        "status": "ACTIVE"
+      },
+      {
+        "action": {
+          "actionString": "Bxf5",
+          "call_details": [
+            {
+              "duration_secs": 2.836,
+              "finish_reason": "stop",
+              "first_token_secs": 0.639,
+              "generation_tokens": 521,
+              "model": "openai/google/gemini-3.1-flash-lite-preview",
+              "prompt": "You are a chess expert\n\nLet's play chess. The current game state in Forsyth-Edwards Notation (FEN) notation is:\nr3nrk1/2q1b1pp/pn1p4/1ppPpb2/8/1PP2N1P/P1B2PP1/R1BQRNK1 w - - 0 17\nThe moves played so far are:\n1. e4 e5 2. Nf3 Nc6 3. Bb5 a6 4. Ba4 Nf6 5. O-O Be7 6. Re1 b5 7. Bb3 d6 8. c3 O-O 9. h3 Na5 10. Bc2 c5 11. d4 Qc7 12. d5 Nc4 13. b3 Nb6 14. Nbd2 Ne8 15. Nf1 f5 16. exf5 Bxf5 17.\nYou are playing as player White.\nIt is now your turn. Play your strongest move. The move MUST be legal. Reason step by step to come up with your move, then output your final answer in the format \"Final Answer: X\" where X is your chosen move in standard algebraic notation (SAN).\n",
+              "prompt_tokens": 280,
+              "reasoning_tokens": 0,
+              "response": "The current FEN is `r3nrk1/2q1b1pp/pn1p4/1ppPpb2/8/1PP2N1P/P1B2PP1/R1BQRNK1 w - - 0 17`. It is white's turn to move.\n\n### Evaluation and Analysis:\n1.  **Position Overview:** The position is relatively balanced. Black has a solid structure after capturing on f5, and white needs to address the pressure on the c2-bishop and the potential activity of Black's pieces.\n2.  **Candidate Moves:**\n    *   **Bxf5:** This is the most natural and strongest move. It removes the active bishop on f5 that is currently eyeing the white kingside and putting pressure on the center. After `17. Bxf5 Rxf5`, White can continue to consolidate or challenge the center.\n    *   **Ng3:** This is also a strong candidate. It hits the bishop on f5 and eyes the f5-square or h5-square, preparing to reorganize. However, `Bxf5` is more forcing and clarifies the central structure immediately.\n    *   **Qe2:** A useful prophylactic move, but it's less active than dealing with the f5-bishop directly.\n\n### Reasoning for `Bxf5`:\n*   The bishop on f5 is Black's most active minor piece. By exchanging, White simplifies the position and removes the primary defender of the d6-pawn and a piece that could become dangerous in a kingside attack.\n*   After `17. Bxf5 Rxf5`, White can play `Ng3` or `Ne3` to control the center.\n*   `Bxf5` effectively neutralizes Black's tactical ideas involving the f5-bishop.\n\n### Step-by-step:\n1.  Analyze the board: The bishop on c2 is attacked indirectly by the pawn structure, and the bishop on f5 is well-placed for Black.\n2.  Consider the exchange: `Bxf5` trades the dark-squared bishops.\n3.  Evaluate the resulting position: White maintains control over the center and avoids any immediate tactical threats from Black's pieces. It prepares for maneuvering the knights (Ng3/Ne3) to improve White's position.\n\nFinal check: 17. Bxf5 is legal and strategically sound.\n\nFinal Answer: Bxf5",
+              "total_tokens": 801
+            }
+          ],
+          "status": "OK",
+          "submission": 1287,
+          "thoughts": "The current FEN is `r3nrk1/2q1b1pp/pn1p4/1ppPpb2/8/1PP2N1P/P1B2PP1/R1BQRNK1 w - - 0 17`. It is white's turn to move.\n\n### Evaluation and Analysis:\n1.  **Position Overview:** The position is relatively balanced. Black has a solid structure after capturing on f5, and white needs to address the pressure on the c2-bishop and the potential activity of Black's pieces.\n2.  **Candidate Moves:**\n    *   **Bxf5:** This is the most natural and strongest move. It removes the active bishop on f5 that is currently eyeing the white kingside and putting pressure on the center. After `17. Bxf5 Rxf5`, White can continue to consolidate or challenge the center.\n    *   **Ng3:** This is also a strong candidate. It hits the bishop on f5 and eyes the f5-square or h5-square, preparing to reorganize. However, `Bxf5` is more forcing and clarifies the central structure immediately.\n    *   **Qe2:** A useful prophylactic move, but it's less active than dealing with the f5-bishop directly.\n\n### Reasoning for `Bxf5`:\n*   The bishop on f5 is Black's most active minor piece. By exchanging, White simplifies the position and removes the primary defender of the d6-pawn and a piece that could become dangerous in a kingside attack.\n*   After `17. Bxf5 Rxf5`, White can play `Ng3` or `Ne3` to control the center.\n*   `Bxf5` effectively neutralizes Black's tactical ideas involving the f5-bishop.\n\n### Step-by-step:\n1.  Analyze the board: The bishop on c2 is attacked indirectly by the pawn structure, and the bishop on f5 is well-placed for Black.\n2.  Consider the exchange: `Bxf5` trades the dark-squared bishops.\n3.  Evaluate the resulting position: White maintains control over the center and avoids any immediate tactical threats from Black's pieces. It prepares for maneuvering the knights (Ng3/Ne3) to improve White's position.\n\nFinal check: 17. Bxf5 is legal and strategically sound.\n\nFinal Answer: Bxf5"
+        },
+        "info": {
+          "actionApplied": 1287,
+          "actionSubmitted": 1287,
+          "actionSubmittedToString": "Bxf5",
+          "agentSelfReportedStatus": "OK",
+          "timeTaken": 3.264
+        },
+        "observation": {
+          "currentPlayer": 0,
+          "isTerminal": false,
+          "observationString": "r3nrk1/2q1b1pp/pn1p4/1ppPpB2/8/1PP2N1P/P4PP1/R1BQRNK1 b - - 0 17",
+          "playerId": 1,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n2426\n3572\n656\n2974\n89\n919\n3572\n4673\n2977\n2949\n674\n277\n1841\n1257\n4673\n4177\n1380\n788\n1258\n1842\n1809\n1987\n289\n673\n1527\n654\n3133\n1894\n3010\n2599\n1214\n1287\n\n"
+        },
+        "reward": null,
+        "status": "INACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "actionString": "Rxf5",
+          "call_details": [
+            {
+              "duration_secs": 3.05,
+              "finish_reason": "stop",
+              "first_token_secs": 0.744,
+              "generation_tokens": 471,
+              "model": "openai/google/gemini-3.1-flash-lite-preview",
+              "prompt": "\ud83d\udc4c\ud83d\udc40\ud83d\udc4c\ud83d\udc40\ud83d\udc4c\ud83d\udc40\ud83d\udc4c\ud83d\udc40\ud83d\udc4c\ud83d\udc40 good shit go\u0c66\u0501 sHit\ud83d\udc4c thats \u2714 some good\ud83d\udc4c\ud83d\udc4cshit right\ud83d\udc4c\ud83d\udc4cthere\ud83d\udc4c\ud83d\udc4c\ud83d\udc4c right\u2714there \u2714\u2714if i do \u01bda\u04af so my self \ud83d\udcaf i say so \ud83d\udcaf thats what im talking about right there right there (chorus: \u02b3\u1da6\u1d4d\u02b0\u1d57 \u1d57\u02b0\u1d49\u02b3\u1d49) mMMMM\u13b7\u041c\ud83d\udcaf \ud83d\udc4c\ud83d\udc4c \ud83d\udc4c\u041dO0\u041e\u0b20OOOOO\u041e\u0b20\u0b20Oooo\u1d52\u1d52\u1d52\u1d52\u1d52\u1d52\u1d52\u1d52\u1d52\ud83d\udc4c \ud83d\udc4c\ud83d\udc4c \ud83d\udc4c \ud83d\udcaf \ud83d\udc4c \ud83d\udc40 \ud83d\udc40 \ud83d\udc40 \ud83d\udc4c\ud83d\udc4c\n\nLet's play chess. The current game state in Forsyth-Edwards Notation (FEN) notation is:\nr3nrk1/2q1b1pp/pn1p4/1ppPpB2/8/1PP2N1P/P4PP1/R1BQRNK1 b - - 0 17\nThe moves played so far are:\n1. e4 e5 2. Nf3 Nc6 3. Bb5 a6 4. Ba4 Nf6 5. O-O Be7 6. Re1 b5 7. Bb3 d6 8. c3 O-O 9. h3 Na5 10. Bc2 c5 11. d4 Qc7 12. d5 Nc4 13. b3 Nb6 14. Nbd2 Ne8 15. Nf1 f5 16. exf5 Bxf5 17. Bxf5\nYou are playing as player Black.\nIt is now your turn. Play your strongest move. The move MUST be legal. Reason step by step to come up with your move, then output your final answer in the format \"Final Answer: X\" where X is your chosen move in standard algebraic notation (SAN).\n",
+              "prompt_tokens": 400,
+              "reasoning_tokens": 0,
+              "response": "The current position is `r3nrk1/2q1b1pp/pn1p4/1ppPpB2/8/1PP2N1P/P4PP1/R1BQRNK1 b - - 0 17`.\n\n**Evaluation:**\nThe position is roughly equal, slightly favoring Black due to the solid structure and the pressure on the d5 pawn. White has just captured on f5 with the bishop, and Black must recapture.\n\n**Candidate moves for Black:**\n1. **...Rxf5**: Recapturing with the rook is standard. It activates the rook along the 5th rank and maintains control over the center.\n2. **...Nf6**: Developing the knight is good, but capturing the piece is priority to maintain material equality.\n\n**Analysis of ...Rxf5:**\n*   After `17... Rxf5`, Black maintains a strong central presence.\n*   The knight on f6 is currently developed to e8; moving it to f6 later will be a strong follow-up.\n*   The pawn on d5 is a weakness for White that Black can target with pieces like the queen or knights.\n*   White's next move might be `Ng3` or `Ne3` to challenge the rook.\n*   If `17... Rxf5 18. Ng3 Rf8`, the game continues with a balanced struggle.\n\n**Detailed consideration:**\nRecapturing with the rook is the most principled move. It controls the f-file (or the 5th rank in terms of mobility) and prepares to coordinate with the rest of the army. Other captures (like `...gxf5`) are not possible here as the piece captured was a bishop on f5.\n\nThe evaluation engines confirm `Rxf5` as the best response to maintain equality and prepare for the middlegame.\n\n**Step-by-step reasoning:**\n1. White has just traded the dark-squared bishop for the pawn on f5.\n2. Black must recapture to maintain material balance.\n3. `Rxf5` is the only logical recapture that improves the position of the rook and prepares for further piece activation.\n\nFinal Answer: Rxf5",
+              "total_tokens": 871
+            }
+          ],
+          "status": "OK",
+          "submission": 2938,
+          "thoughts": "The current position is `r3nrk1/2q1b1pp/pn1p4/1ppPpB2/8/1PP2N1P/P4PP1/R1BQRNK1 b - - 0 17`.\n\n**Evaluation:**\nThe position is roughly equal, slightly favoring Black due to the solid structure and the pressure on the d5 pawn. White has just captured on f5 with the bishop, and Black must recapture.\n\n**Candidate moves for Black:**\n1. **...Rxf5**: Recapturing with the rook is standard. It activates the rook along the 5th rank and maintains control over the center.\n2. **...Nf6**: Developing the knight is good, but capturing the piece is priority to maintain material equality.\n\n**Analysis of ...Rxf5:**\n*   After `17... Rxf5`, Black maintains a strong central presence.\n*   The knight on f6 is currently developed to e8; moving it to f6 later will be a strong follow-up.\n*   The pawn on d5 is a weakness for White that Black can target with pieces like the queen or knights.\n*   White's next move might be `Ng3` or `Ne3` to challenge the rook.\n*   If `17... Rxf5 18. Ng3 Rf8`, the game continues with a balanced struggle.\n\n**Detailed consideration:**\nRecapturing with the rook is the most principled move. It controls the f-file (or the 5th rank in terms of mobility) and prepares to coordinate with the rest of the army. Other captures (like `...gxf5`) are not possible here as the piece captured was a bishop on f5.\n\nThe evaluation engines confirm `Rxf5` as the best response to maintain equality and prepare for the middlegame.\n\n**Step-by-step reasoning:**\n1. White has just traded the dark-squared bishop for the pawn on f5.\n2. Black must recapture to maintain material balance.\n3. `Rxf5` is the only logical recapture that improves the position of the rook and prepares for further piece activation.\n\nFinal Answer: Rxf5"
+        },
+        "info": {
+          "actionApplied": 2938,
+          "actionSubmitted": 2938,
+          "actionSubmittedToString": "Rxf5",
+          "agentSelfReportedStatus": "OK",
+          "timeTaken": 3.547
+        },
+        "observation": {
+          "currentPlayer": 1,
+          "isTerminal": false,
+          "observationString": "r3n1k1/2q1b1pp/pn1p4/1ppPpr2/8/1PP2N1P/P4PP1/R1BQRNK1 w - - 0 18",
+          "playerId": 0,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n2426\n3572\n656\n2974\n89\n919\n3572\n4673\n2977\n2949\n674\n277\n1841\n1257\n4673\n4177\n1380\n788\n1258\n1842\n1809\n1987\n289\n673\n1527\n654\n3133\n1894\n3010\n2599\n1214\n1287\n2938\n\n",
+          "step": 35
+        },
+        "reward": null,
+        "status": "INACTIVE"
+      },
+      {
+        "action": { "submission": -1 },
+        "info": {},
+        "observation": {
+          "currentPlayer": 1,
+          "isTerminal": false,
+          "observationString": "r3n1k1/2q1b1pp/pn1p4/1ppPpr2/8/1PP2N1P/P4PP1/R1BQRNK1 w - - 0 18",
+          "playerId": 1,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n2426\n3572\n656\n2974\n89\n919\n3572\n4673\n2977\n2949\n674\n277\n1841\n1257\n4673\n4177\n1380\n788\n1258\n1842\n1809\n1987\n289\n673\n1527\n654\n3133\n1894\n3010\n2599\n1214\n1287\n2938\n\n"
+        },
+        "reward": null,
+        "status": "ACTIVE"
+      }
+    ],
+    [
+      {
+        "action": { "submission": -1 },
+        "info": {},
+        "observation": {
+          "currentPlayer": 0,
+          "isTerminal": false,
+          "observationString": "r3n1k1/2q1b1pp/pn1p4/1ppPpr2/8/1PP2NNP/P4PP1/R1BQR1K1 b - - 1 18",
+          "playerId": 0,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n2426\n3572\n656\n2974\n89\n919\n3572\n4673\n2977\n2949\n674\n277\n1841\n1257\n4673\n4177\n1380\n788\n1258\n1842\n1809\n1987\n289\n673\n1527\n654\n3133\n1894\n3010\n2599\n1214\n1287\n2938\n2992\n\n",
+          "step": 36
+        },
+        "reward": null,
+        "status": "ACTIVE"
+      },
+      {
+        "action": {
+          "actionString": "Ng3",
+          "call_details": [
+            {
+              "duration_secs": 3.102,
+              "finish_reason": "stop",
+              "first_token_secs": 0.858,
+              "generation_tokens": 450,
+              "model": "openai/google/gemini-3.1-flash-lite-preview",
+              "prompt": "You are a chess expert\n\nLet's play chess. The current game state in Forsyth-Edwards Notation (FEN) notation is:\nr3n1k1/2q1b1pp/pn1p4/1ppPpr2/8/1PP2N1P/P4PP1/R1BQRNK1 w - - 0 18\nThe moves played so far are:\n1. e4 e5 2. Nf3 Nc6 3. Bb5 a6 4. Ba4 Nf6 5. O-O Be7 6. Re1 b5 7. Bb3 d6 8. c3 O-O 9. h3 Na5 10. Bc2 c5 11. d4 Qc7 12. d5 Nc4 13. b3 Nb6 14. Nbd2 Ne8 15. Nf1 f5 16. exf5 Bxf5 17. Bxf5 Rxf5 18.\nYou are playing as player White.\nIt is now your turn. Play your strongest move. The move MUST be legal. Reason step by step to come up with your move, then output your final answer in the format \"Final Answer: X\" where X is your chosen move in standard algebraic notation (SAN).\n",
+              "prompt_tokens": 287,
+              "reasoning_tokens": 0,
+              "response": "The current FEN is `r3n1k1/2q1b1pp/pn1p4/1ppPpr2/8/1PP2N1P/P4PP1/R1BQRNK1 w - - 0 18`.\n\n**Evaluation and Strategy:**\n1.  **Position Overview:** White has a solid central structure. The position is somewhat locked, but White has a space advantage on the queenside and the center. Black's rooks are active, particularly the rook on f5.\n2.  **Candidate Moves:**\n    *   **Ng3:** This is the most logical and thematic move. It challenges the f5 rook directly, forcing it to move (likely to f7 or f8), and improves the position of the knight. It also clears the way for the queen and potentially prepares f4 or other central action.\n    *   **Ne3:** Another centralizing move, but Ng3 is more aggressive against the active Black piece.\n    *   **Qd3:** Developing the queen, preparing to pressure the kingside or support the center, but Ng3 feels more pressing.\n    *   **c4:** Challenging Black's queenside structure, but potentially weakening the d5 pawn.\n\n**Reasoning for Ng3:**\n*   The rook on f5 is currently Black's most active piece, exerting influence over the f-file and the center. By playing Ng3, White forces the rook to retreat. If 18. Ng3 Rf7, White has successfully pushed the rook back and improved the knight's position.\n*   This move fits the flow of the game. White's pieces were somewhat passive; moving the knight to g3 creates potential future threats and improves coordination.\n*   The move is prophylactic against any sudden Black threats on the kingside and keeps the tension favorable for White.\n\n**Execution:**\n18. Ng3 Rf7 19. c4 (or other consolidating moves). This seems like the most principled continuation to maintain the slight edge White possesses due to the space advantage.\n\nFinal Answer: Ng3",
+              "total_tokens": 737
+            }
+          ],
+          "status": "OK",
+          "submission": 2992,
+          "thoughts": "The current FEN is `r3n1k1/2q1b1pp/pn1p4/1ppPpr2/8/1PP2N1P/P4PP1/R1BQRNK1 w - - 0 18`.\n\n**Evaluation and Strategy:**\n1.  **Position Overview:** White has a solid central structure. The position is somewhat locked, but White has a space advantage on the queenside and the center. Black's rooks are active, particularly the rook on f5.\n2.  **Candidate Moves:**\n    *   **Ng3:** This is the most logical and thematic move. It challenges the f5 rook directly, forcing it to move (likely to f7 or f8), and improves the position of the knight. It also clears the way for the queen and potentially prepares f4 or other central action.\n    *   **Ne3:** Another centralizing move, but Ng3 is more aggressive against the active Black piece.\n    *   **Qd3:** Developing the queen, preparing to pressure the kingside or support the center, but Ng3 feels more pressing.\n    *   **c4:** Challenging Black's queenside structure, but potentially weakening the d5 pawn.\n\n**Reasoning for Ng3:**\n*   The rook on f5 is currently Black's most active piece, exerting influence over the f-file and the center. By playing Ng3, White forces the rook to retreat. If 18. Ng3 Rf7, White has successfully pushed the rook back and improved the knight's position.\n*   This move fits the flow of the game. White's pieces were somewhat passive; moving the knight to g3 creates potential future threats and improves coordination.\n*   The move is prophylactic against any sudden Black threats on the kingside and keeps the tension favorable for White.\n\n**Execution:**\n18. Ng3 Rf7 19. c4 (or other consolidating moves). This seems like the most principled continuation to maintain the slight edge White possesses due to the space advantage.\n\nFinal Answer: Ng3"
+        },
+        "info": {
+          "actionApplied": 2992,
+          "actionSubmitted": 2992,
+          "actionSubmittedToString": "Ng3",
+          "agentSelfReportedStatus": "OK",
+          "timeTaken": 3.561
+        },
+        "observation": {
+          "currentPlayer": 0,
+          "isTerminal": false,
+          "observationString": "r3n1k1/2q1b1pp/pn1p4/1ppPpr2/8/1PP2NNP/P4PP1/R1BQR1K1 b - - 1 18",
+          "playerId": 1,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n2426\n3572\n656\n2974\n89\n919\n3572\n4673\n2977\n2949\n674\n277\n1841\n1257\n4673\n4177\n1380\n788\n1258\n1842\n1809\n1987\n289\n673\n1527\n654\n3133\n1894\n3010\n2599\n1214\n1287\n2938\n2992\n\n"
+        },
+        "reward": null,
+        "status": "INACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "actionString": "Rf6",
+          "call_details": [
+            {
+              "duration_secs": 3.333,
+              "finish_reason": "stop",
+              "first_token_secs": 0.866,
+              "generation_tokens": 590,
+              "model": "openai/google/gemini-3.1-flash-lite-preview",
+              "prompt": "\ud83d\udc4c\ud83d\udc40\ud83d\udc4c\ud83d\udc40\ud83d\udc4c\ud83d\udc40\ud83d\udc4c\ud83d\udc40\ud83d\udc4c\ud83d\udc40 good shit go\u0c66\u0501 sHit\ud83d\udc4c thats \u2714 some good\ud83d\udc4c\ud83d\udc4cshit right\ud83d\udc4c\ud83d\udc4cthere\ud83d\udc4c\ud83d\udc4c\ud83d\udc4c right\u2714there \u2714\u2714if i do \u01bda\u04af so my self \ud83d\udcaf i say so \ud83d\udcaf thats what im talking about right there right there (chorus: \u02b3\u1da6\u1d4d\u02b0\u1d57 \u1d57\u02b0\u1d49\u02b3\u1d49) mMMMM\u13b7\u041c\ud83d\udcaf \ud83d\udc4c\ud83d\udc4c \ud83d\udc4c\u041dO0\u041e\u0b20OOOOO\u041e\u0b20\u0b20Oooo\u1d52\u1d52\u1d52\u1d52\u1d52\u1d52\u1d52\u1d52\u1d52\ud83d\udc4c \ud83d\udc4c\ud83d\udc4c \ud83d\udc4c \ud83d\udcaf \ud83d\udc4c \ud83d\udc40 \ud83d\udc40 \ud83d\udc40 \ud83d\udc4c\ud83d\udc4c\n\nLet's play chess. The current game state in Forsyth-Edwards Notation (FEN) notation is:\nr3n1k1/2q1b1pp/pn1p4/1ppPpr2/8/1PP2NNP/P4PP1/R1BQR1K1 b - - 1 18\nThe moves played so far are:\n1. e4 e5 2. Nf3 Nc6 3. Bb5 a6 4. Ba4 Nf6 5. O-O Be7 6. Re1 b5 7. Bb3 d6 8. c3 O-O 9. h3 Na5 10. Bc2 c5 11. d4 Qc7 12. d5 Nc4 13. b3 Nb6 14. Nbd2 Ne8 15. Nf1 f5 16. exf5 Bxf5 17. Bxf5 Rxf5 18. Ng3\nYou are playing as player Black.\nIt is now your turn. Play your strongest move. The move MUST be legal. Reason step by step to come up with your move, then output your final answer in the format \"Final Answer: X\" where X is your chosen move in standard algebraic notation (SAN).\n",
+              "prompt_tokens": 409,
+              "reasoning_tokens": 0,
+              "response": "The current FEN is `r3n1k1/2q1b1pp/pn1p4/1ppPpr2/8/1PP2NNP/P4PP1/R1BQR1K1 b - - 1 18`. It is Black's turn to move.\n\n**Evaluation and Analysis:**\n1. **The Rook:** The rook on f5 is currently attacked by the knight on g3. It must move.\n2. **Candidate squares for the Rook:**\n    *   **Rf6:** This is the most natural retreat. It keeps the rook on the f-file, maintains pressure on the kingside, and defends against potential threats.\n    *   **Rf7:** Also possible, but Rf6 feels more active and flexible.\n    *   **Rf8:** Too passive.\n    *   **Re5:** Interesting, puts pressure on the center, but allows White to challenge it or ignore it while improving their position.\n3. **Strategic considerations:**\n    *   Black has a solid position. The d6-c5 pawn chain restricts White's center.\n    *   White's knight on g3 is well-placed, eyeing f5 and h5.\n    *   Black needs to consolidate the kingside and prepare for potential maneuvers.\n    *   After `18... Rf6`, if White plays `19. Bg5`, Black can respond with `19... Rg6`. If White plays `19. Ne4`, Black can hold the position with `19... Rf7`.\n\n**Detailed evaluation of 18... Rf6:**\n- `18... Rf6` keeps the position balanced. It prepares to challenge the g5 square if White tries to develop the bishop there, and it keeps the f-file somewhat controlled.\n- White\u2019s most likely responses are `19. Bg5` or `19. Qd3` or `19. Ne4`.\n- If `19. Bg5 Rg6`, the position remains complex but balanced.\n- If `19. Ne4`, Black continues development or consolidation.\n\nComparing alternatives, `Rf6` is the most standard and solid move to deal with the immediate threat to the rook.\n\n**Step-by-step reasoning:**\n1. The rook on f5 is under attack by the knight on g3.\n2. The rook must move to a safe square.\n3. `Rf6` is the most active safe square, maintaining control over the f-file and providing flexibility for the rook to support defense or transition to other files.\n4. Other options are either passive or unnecessarily weaken the defensive structure.\n\nTherefore, `Rf6` is the strongest move.\n\nFinal Answer: Rf6",
+              "total_tokens": 999
+            }
+          ],
+          "status": "OK",
+          "submission": 3154,
+          "thoughts": "The current FEN is `r3n1k1/2q1b1pp/pn1p4/1ppPpr2/8/1PP2NNP/P4PP1/R1BQR1K1 b - - 1 18`. It is Black's turn to move.\n\n**Evaluation and Analysis:**\n1. **The Rook:** The rook on f5 is currently attacked by the knight on g3. It must move.\n2. **Candidate squares for the Rook:**\n    *   **Rf6:** This is the most natural retreat. It keeps the rook on the f-file, maintains pressure on the kingside, and defends against potential threats.\n    *   **Rf7:** Also possible, but Rf6 feels more active and flexible.\n    *   **Rf8:** Too passive.\n    *   **Re5:** Interesting, puts pressure on the center, but allows White to challenge it or ignore it while improving their position.\n3. **Strategic considerations:**\n    *   Black has a solid position. The d6-c5 pawn chain restricts White's center.\n    *   White's knight on g3 is well-placed, eyeing f5 and h5.\n    *   Black needs to consolidate the kingside and prepare for potential maneuvers.\n    *   After `18... Rf6`, if White plays `19. Bg5`, Black can respond with `19... Rg6`. If White plays `19. Ne4`, Black can hold the position with `19... Rf7`.\n\n**Detailed evaluation of 18... Rf6:**\n- `18... Rf6` keeps the position balanced. It prepares to challenge the g5 square if White tries to develop the bishop there, and it keeps the f-file somewhat controlled.\n- White\u2019s most likely responses are `19. Bg5` or `19. Qd3` or `19. Ne4`.\n- If `19. Bg5 Rg6`, the position remains complex but balanced.\n- If `19. Ne4`, Black continues development or consolidation.\n\nComparing alternatives, `Rf6` is the most standard and solid move to deal with the immediate threat to the rook.\n\n**Step-by-step reasoning:**\n1. The rook on f5 is under attack by the knight on g3.\n2. The rook must move to a safe square.\n3. `Rf6` is the most active safe square, maintaining control over the f-file and providing flexibility for the rook to support defense or transition to other files.\n4. Other options are either passive or unnecessarily weaken the defensive structure.\n\nTherefore, `Rf6` is the strongest move.\n\nFinal Answer: Rf6"
+        },
+        "info": {
+          "actionApplied": 3154,
+          "actionSubmitted": 3154,
+          "actionSubmittedToString": "Rf6",
+          "agentSelfReportedStatus": "OK",
+          "timeTaken": 3.831
+        },
+        "observation": {
+          "currentPlayer": 1,
+          "isTerminal": false,
+          "observationString": "r3n1k1/2q1b1pp/pn1p1r2/1ppPp3/8/1PP2NNP/P4PP1/R1BQR1K1 w - - 2 19",
+          "playerId": 0,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n2426\n3572\n656\n2974\n89\n919\n3572\n4673\n2977\n2949\n674\n277\n1841\n1257\n4673\n4177\n1380\n788\n1258\n1842\n1809\n1987\n289\n673\n1527\n654\n3133\n1894\n3010\n2599\n1214\n1287\n2938\n2992\n3154\n\n",
+          "step": 37
+        },
+        "reward": null,
+        "status": "INACTIVE"
+      },
+      {
+        "action": { "submission": -1 },
+        "info": {},
+        "observation": {
+          "currentPlayer": 1,
+          "isTerminal": false,
+          "observationString": "r3n1k1/2q1b1pp/pn1p1r2/1ppPp3/8/1PP2NNP/P4PP1/R1BQR1K1 w - - 2 19",
+          "playerId": 1,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n2426\n3572\n656\n2974\n89\n919\n3572\n4673\n2977\n2949\n674\n277\n1841\n1257\n4673\n4177\n1380\n788\n1258\n1842\n1809\n1987\n289\n673\n1527\n654\n3133\n1894\n3010\n2599\n1214\n1287\n2938\n2992\n3154\n\n"
+        },
+        "reward": null,
+        "status": "ACTIVE"
+      }
+    ],
+    [
+      {
+        "action": { "submission": -1 },
+        "info": {},
+        "observation": {
+          "currentPlayer": 0,
+          "isTerminal": false,
+          "observationString": "r3n1k1/2q1b1pp/pn1p1r2/1ppPp1N1/8/1PP3NP/P4PP1/R1BQR1K1 b - - 3 19",
+          "playerId": 0,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n2426\n3572\n656\n2974\n89\n919\n3572\n4673\n2977\n2949\n674\n277\n1841\n1257\n4673\n4177\n1380\n788\n1258\n1842\n1809\n1987\n289\n673\n1527\n654\n3133\n1894\n3010\n2599\n1214\n1287\n2938\n2992\n3154\n3138\n\n",
+          "step": 38
+        },
+        "reward": null,
+        "status": "ACTIVE"
+      },
+      {
+        "action": {
+          "actionString": "Ng5",
+          "call_details": [
+            {
+              "duration_secs": 3.401,
+              "finish_reason": "stop",
+              "first_token_secs": 0.727,
+              "generation_tokens": 553,
+              "model": "openai/google/gemini-3.1-flash-lite-preview",
+              "prompt": "You are a chess expert\n\nLet's play chess. The current game state in Forsyth-Edwards Notation (FEN) notation is:\nr3n1k1/2q1b1pp/pn1p1r2/1ppPp3/8/1PP2NNP/P4PP1/R1BQR1K1 w - - 2 19\nThe moves played so far are:\n1. e4 e5 2. Nf3 Nc6 3. Bb5 a6 4. Ba4 Nf6 5. O-O Be7 6. Re1 b5 7. Bb3 d6 8. c3 O-O 9. h3 Na5 10. Bc2 c5 11. d4 Qc7 12. d5 Nc4 13. b3 Nb6 14. Nbd2 Ne8 15. Nf1 f5 16. exf5 Bxf5 17. Bxf5 Rxf5 18. Ng3 Rf6 19.\nYou are playing as player White.\nIt is now your turn. Play your strongest move. The move MUST be legal. Reason step by step to come up with your move, then output your final answer in the format \"Final Answer: X\" where X is your chosen move in standard algebraic notation (SAN).\n",
+              "prompt_tokens": 296,
+              "reasoning_tokens": 0,
+              "response": "The current position is `r3n1k1/2q1b1pp/pn1p1r2/1ppPp3/8/1PP2NNP/P4PP1/R1BQR1K1 w - - 2 19`.\n\n**Evaluation and Strategy:**\nWhite has a solid position. The pawn structure is fixed in the center, and White has some space and potential for kingside play. Black's knight on b6 is somewhat misplaced, but Black's pieces are coordinated. White's knight on g3 is well-placed to eye f5 or h5.\n\n**Candidate Moves:**\n1. **Bg5:** This forces the rook on f6 to move or forces a trade. If ...Rg6, White can challenge the kingside control.\n2. **Qd3:** A natural developing/centralizing move, eyeing the queenside and preparing to connect the rooks.\n3. **Ng5:** A very active move, jumping into the hole on e6 or f7, and putting immediate pressure on Black's kingside. Given that the black knight is on e8, e6 is a sensitive square. If ...h6, then Ne6.\n4. **c4:** Challenges Black's queenside structure directly.\n\n**Detailed Analysis:**\n* **Ng5:** This is a strong, thematic move. If 19. Ng5, and Black plays 19... h6 (the most natural response), White can follow up with 20. Ne6. Then 20... Rxe6 21. dxe6. The resulting position gives White a dangerous passed pawn on e6 and strong control.\n* **Bg5:** 19. Bg5 Rg6. Then 20. Bxe7 Qxe7. This leads to a relatively balanced position, but it releases the tension early.\n\n**Conclusion:**\n19. Ng5 appears to be the most ambitious and challenging move for Black. It immediately exploits the weakness around the e6 square and utilizes the knight's powerful position on g3. It forces Black to respond accurately.\n\nStep-by-step logic:\n- The knight on g3 is looking for active squares.\n- e6 is a major weakness in Black's camp due to the lack of control after ...f5.\n- Ng5 creates an immediate threat of Ne6, disrupting Black's coordination.\n- If Black tries to block with ...h6, Ne6 is even more powerful, potentially disrupting the rook on f6 and eyeing the queen on c7.\n\nFinal Answer: Ng5",
+              "total_tokens": 849
+            }
+          ],
+          "status": "OK",
+          "submission": 3138,
+          "thoughts": "The current position is `r3n1k1/2q1b1pp/pn1p1r2/1ppPp3/8/1PP2NNP/P4PP1/R1BQR1K1 w - - 2 19`.\n\n**Evaluation and Strategy:**\nWhite has a solid position. The pawn structure is fixed in the center, and White has some space and potential for kingside play. Black's knight on b6 is somewhat misplaced, but Black's pieces are coordinated. White's knight on g3 is well-placed to eye f5 or h5.\n\n**Candidate Moves:**\n1. **Bg5:** This forces the rook on f6 to move or forces a trade. If ...Rg6, White can challenge the kingside control.\n2. **Qd3:** A natural developing/centralizing move, eyeing the queenside and preparing to connect the rooks.\n3. **Ng5:** A very active move, jumping into the hole on e6 or f7, and putting immediate pressure on Black's kingside. Given that the black knight is on e8, e6 is a sensitive square. If ...h6, then Ne6.\n4. **c4:** Challenges Black's queenside structure directly.\n\n**Detailed Analysis:**\n* **Ng5:** This is a strong, thematic move. If 19. Ng5, and Black plays 19... h6 (the most natural response), White can follow up with 20. Ne6. Then 20... Rxe6 21. dxe6. The resulting position gives White a dangerous passed pawn on e6 and strong control.\n* **Bg5:** 19. Bg5 Rg6. Then 20. Bxe7 Qxe7. This leads to a relatively balanced position, but it releases the tension early.\n\n**Conclusion:**\n19. Ng5 appears to be the most ambitious and challenging move for Black. It immediately exploits the weakness around the e6 square and utilizes the knight's powerful position on g3. It forces Black to respond accurately.\n\nStep-by-step logic:\n- The knight on g3 is looking for active squares.\n- e6 is a major weakness in Black's camp due to the lack of control after ...f5.\n- Ng5 creates an immediate threat of Ne6, disrupting Black's coordination.\n- If Black tries to block with ...h6, Ne6 is even more powerful, potentially disrupting the rook on f6 and eyeing the queen on c7.\n\nFinal Answer: Ng5"
+        },
+        "info": {
+          "actionApplied": 3138,
+          "actionSubmitted": 3138,
+          "actionSubmittedToString": "Ng5",
+          "agentSelfReportedStatus": "OK",
+          "timeTaken": 3.901
+        },
+        "observation": {
+          "currentPlayer": 0,
+          "isTerminal": false,
+          "observationString": "r3n1k1/2q1b1pp/pn1p1r2/1ppPp1N1/8/1PP3NP/P4PP1/R1BQR1K1 b - - 3 19",
+          "playerId": 1,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n2426\n3572\n656\n2974\n89\n919\n3572\n4673\n2977\n2949\n674\n277\n1841\n1257\n4673\n4177\n1380\n788\n1258\n1842\n1809\n1987\n289\n673\n1527\n654\n3133\n1894\n3010\n2599\n1214\n1287\n2938\n2992\n3154\n3138\n\n"
+        },
+        "reward": null,
+        "status": "INACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "actionString": "Rg6",
+          "call_details": [
+            {
+              "duration_secs": 3.354,
+              "finish_reason": "stop",
+              "first_token_secs": 0.746,
+              "generation_tokens": 562,
+              "model": "openai/google/gemini-3.1-flash-lite-preview",
+              "prompt": "\ud83d\udc4c\ud83d\udc40\ud83d\udc4c\ud83d\udc40\ud83d\udc4c\ud83d\udc40\ud83d\udc4c\ud83d\udc40\ud83d\udc4c\ud83d\udc40 good shit go\u0c66\u0501 sHit\ud83d\udc4c thats \u2714 some good\ud83d\udc4c\ud83d\udc4cshit right\ud83d\udc4c\ud83d\udc4cthere\ud83d\udc4c\ud83d\udc4c\ud83d\udc4c right\u2714there \u2714\u2714if i do \u01bda\u04af so my self \ud83d\udcaf i say so \ud83d\udcaf thats what im talking about right there right there (chorus: \u02b3\u1da6\u1d4d\u02b0\u1d57 \u1d57\u02b0\u1d49\u02b3\u1d49) mMMMM\u13b7\u041c\ud83d\udcaf \ud83d\udc4c\ud83d\udc4c \ud83d\udc4c\u041dO0\u041e\u0b20OOOOO\u041e\u0b20\u0b20Oooo\u1d52\u1d52\u1d52\u1d52\u1d52\u1d52\u1d52\u1d52\u1d52\ud83d\udc4c \ud83d\udc4c\ud83d\udc4c \ud83d\udc4c \ud83d\udcaf \ud83d\udc4c \ud83d\udc40 \ud83d\udc40 \ud83d\udc40 \ud83d\udc4c\ud83d\udc4c\n\nLet's play chess. The current game state in Forsyth-Edwards Notation (FEN) notation is:\nr3n1k1/2q1b1pp/pn1p1r2/1ppPp1N1/8/1PP3NP/P4PP1/R1BQR1K1 b - - 3 19\nThe moves played so far are:\n1. e4 e5 2. Nf3 Nc6 3. Bb5 a6 4. Ba4 Nf6 5. O-O Be7 6. Re1 b5 7. Bb3 d6 8. c3 O-O 9. h3 Na5 10. Bc2 c5 11. d4 Qc7 12. d5 Nc4 13. b3 Nb6 14. Nbd2 Ne8 15. Nf1 f5 16. exf5 Bxf5 17. Bxf5 Rxf5 18. Ng3 Rf6 19. Ng5\nYou are playing as player Black.\nIt is now your turn. Play your strongest move. The move MUST be legal. Reason step by step to come up with your move, then output your final answer in the format \"Final Answer: X\" where X is your chosen move in standard algebraic notation (SAN).\n",
+              "prompt_tokens": 419,
+              "reasoning_tokens": 0,
+              "response": "The current position is `r3n1k1/2q1b1pp/pn1p1r2/1ppPp1N1/8/1PP3NP/P4PP1/R1BQR1K1 b - - 3 19`. It is Black's turn to move.\n\n**Evaluation:**\nWhite has a very active knight on g5, pressuring f7 and e6. Black's position is cramped, but solid. The knight on g5 is annoying, but Black has ways to challenge it or neutralize its influence.\n\n**Candidate Moves for Black:**\n1. **... Qd7:** Connects the queen to the defense, prepares to challenge the g5 knight, and unpins/unblocks if necessary.\n2. **... Rg6:** Directly attacks the knight on g5. If the knight retreats, Black gains a tempo. If White tries to hold it (e.g., h4), Black can continue to develop or prepare further pressure on the kingside.\n3. **... h6:** Forces the knight to retreat immediately. White would likely play Ne6.\n4. **... Nc7:** A typical maneuver in this structure, aiming to centralize the knight and prepare to support the kingside or challenge the center.\n\n**Detailed Analysis:**\n*   **... Rg6:** This seems the most principled move. It immediately questions the aggressive Ng5. If 20. Ne6 (the standard response), Black has effectively kicked the knight away from the immediate pressure on f7/d6.\n*   **... Qd7:** A solid developing move. It allows flexibility. If White plays Ne6, Black can respond with ... Qxe6 (exchange sacrifice) or simply continue maneuvers.\n*   **... h6:** 20. Ne6 Qd7. This leads to a position where the knight is very strong on e6, but Black is ready to challenge it or play around it.\n\n**Choosing the best move:**\nThe move **... Rg6** puts immediate pressure on the White knight. If White plays 20. Ne6, the knight is well-placed but not directly attacking f7 in the same way. Black's position is slightly passive but defensible. Given the engine preference for minimizing immediate threats, contesting the Ng5 is the highest priority.\n\nAfter 19... Rg6:\nIf 20. Ne6, Black is fine.\nIf 20. h4, Black can play h6 or continue development.\n\nI will go with **... Rg6** to directly challenge the primary piece causing discomfort in Black's position.\n\nFinal Answer: Rg6",
+              "total_tokens": 981
+            }
+          ],
+          "status": "OK",
+          "submission": 3096,
+          "thoughts": "The current position is `r3n1k1/2q1b1pp/pn1p1r2/1ppPp1N1/8/1PP3NP/P4PP1/R1BQR1K1 b - - 3 19`. It is Black's turn to move.\n\n**Evaluation:**\nWhite has a very active knight on g5, pressuring f7 and e6. Black's position is cramped, but solid. The knight on g5 is annoying, but Black has ways to challenge it or neutralize its influence.\n\n**Candidate Moves for Black:**\n1. **... Qd7:** Connects the queen to the defense, prepares to challenge the g5 knight, and unpins/unblocks if necessary.\n2. **... Rg6:** Directly attacks the knight on g5. If the knight retreats, Black gains a tempo. If White tries to hold it (e.g., h4), Black can continue to develop or prepare further pressure on the kingside.\n3. **... h6:** Forces the knight to retreat immediately. White would likely play Ne6.\n4. **... Nc7:** A typical maneuver in this structure, aiming to centralize the knight and prepare to support the kingside or challenge the center.\n\n**Detailed Analysis:**\n*   **... Rg6:** This seems the most principled move. It immediately questions the aggressive Ng5. If 20. Ne6 (the standard response), Black has effectively kicked the knight away from the immediate pressure on f7/d6.\n*   **... Qd7:** A solid developing move. It allows flexibility. If White plays Ne6, Black can respond with ... Qxe6 (exchange sacrifice) or simply continue maneuvers.\n*   **... h6:** 20. Ne6 Qd7. This leads to a position where the knight is very strong on e6, but Black is ready to challenge it or play around it.\n\n**Choosing the best move:**\nThe move **... Rg6** puts immediate pressure on the White knight. If White plays 20. Ne6, the knight is well-placed but not directly attacking f7 in the same way. Black's position is slightly passive but defensible. Given the engine preference for minimizing immediate threats, contesting the Ng5 is the highest priority.\n\nAfter 19... Rg6:\nIf 20. Ne6, Black is fine.\nIf 20. h4, Black can play h6 or continue development.\n\nI will go with **... Rg6** to directly challenge the primary piece causing discomfort in Black's position.\n\nFinal Answer: Rg6"
+        },
+        "info": {
+          "actionApplied": 3096,
+          "actionSubmitted": 3096,
+          "actionSubmittedToString": "Rg6",
+          "agentSelfReportedStatus": "OK",
+          "timeTaken": 3.802
+        },
+        "observation": {
+          "currentPlayer": 1,
+          "isTerminal": false,
+          "observationString": "r3n1k1/2q1b1pp/pn1p2r1/1ppPp1N1/8/1PP3NP/P4PP1/R1BQR1K1 w - - 4 20",
+          "playerId": 0,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n2426\n3572\n656\n2974\n89\n919\n3572\n4673\n2977\n2949\n674\n277\n1841\n1257\n4673\n4177\n1380\n788\n1258\n1842\n1809\n1987\n289\n673\n1527\n654\n3133\n1894\n3010\n2599\n1214\n1287\n2938\n2992\n3154\n3138\n3096\n\n",
+          "step": 39
+        },
+        "reward": null,
+        "status": "INACTIVE"
+      },
+      {
+        "action": { "submission": -1 },
+        "info": {},
+        "observation": {
+          "currentPlayer": 1,
+          "isTerminal": false,
+          "observationString": "r3n1k1/2q1b1pp/pn1p2r1/1ppPp1N1/8/1PP3NP/P4PP1/R1BQR1K1 w - - 4 20",
+          "playerId": 1,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n2426\n3572\n656\n2974\n89\n919\n3572\n4673\n2977\n2949\n674\n277\n1841\n1257\n4673\n4177\n1380\n788\n1258\n1842\n1809\n1987\n289\n673\n1527\n654\n3133\n1894\n3010\n2599\n1214\n1287\n2938\n2992\n3154\n3138\n3096\n\n"
+        },
+        "reward": null,
+        "status": "ACTIVE"
+      }
+    ],
+    [
+      {
+        "action": { "submission": -1 },
+        "info": {},
+        "observation": {
+          "currentPlayer": 0,
+          "isTerminal": false,
+          "observationString": "r3n1k1/2q1b1pp/pn1pN1r1/1ppPp3/8/1PP3NP/P4PP1/R1BQR1K1 b - - 5 20",
+          "playerId": 0,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n2426\n3572\n656\n2974\n89\n919\n3572\n4673\n2977\n2949\n674\n277\n1841\n1257\n4673\n4177\n1380\n788\n1258\n1842\n1809\n1987\n289\n673\n1527\n654\n3133\n1894\n3010\n2599\n1214\n1287\n2938\n2992\n3154\n3138\n3096\n3862\n\n",
+          "step": 40
+        },
+        "reward": null,
+        "status": "ACTIVE"
+      },
+      {
+        "action": {
+          "actionString": "Ne6",
+          "call_details": [
+            {
+              "duration_secs": 3.311,
+              "finish_reason": "stop",
+              "first_token_secs": 0.803,
+              "generation_tokens": 487,
+              "model": "openai/google/gemini-3.1-flash-lite-preview",
+              "prompt": "You are a chess expert\n\nLet's play chess. The current game state in Forsyth-Edwards Notation (FEN) notation is:\nr3n1k1/2q1b1pp/pn1p2r1/1ppPp1N1/8/1PP3NP/P4PP1/R1BQR1K1 w - - 4 20\nThe moves played so far are:\n1. e4 e5 2. Nf3 Nc6 3. Bb5 a6 4. Ba4 Nf6 5. O-O Be7 6. Re1 b5 7. Bb3 d6 8. c3 O-O 9. h3 Na5 10. Bc2 c5 11. d4 Qc7 12. d5 Nc4 13. b3 Nb6 14. Nbd2 Ne8 15. Nf1 f5 16. exf5 Bxf5 17. Bxf5 Rxf5 18. Ng3 Rf6 19. Ng5 Rg6 20.\nYou are playing as player White.\nIt is now your turn. Play your strongest move. The move MUST be legal. Reason step by step to come up with your move, then output your final answer in the format \"Final Answer: X\" where X is your chosen move in standard algebraic notation (SAN).\n",
+              "prompt_tokens": 305,
+              "reasoning_tokens": 0,
+              "response": "The current position is `r3n1k1/2q1b1pp/pn1p2r1/1ppPp1N1/8/1PP3NP/P4PP1/R1BQR1K1 w - - 4 20`.\n\n**Evaluation and Analysis:**\n1. **Material and Structure:** The material is equal. White has a space advantage in the center with the d5 pawn. Black\u2019s pieces are somewhat cramped, but the g6 rook is active.\n2. **Key Tactical Themes:** White's knight on g5 is annoying for Black, putting pressure on f7 and blocking some development. Black's f-file and the g6 rook create potential kingside threats, but White's position is solid.\n3. **Candidate Moves:**\n    * **Ne6:** This is a very strong outpost. It puts direct pressure on the queen on c7 and forces Black to respond. If `20. Ne6 Rxe6 21. dxe6`, White wins the exchange and gains a strong passed pawn. If Black plays `20... Qd7`, White improves their position significantly.\n    * **h4:** Aiming to challenge the rook on g6 or prepare to expand on the kingside. However, it is slightly slower than the immediate central pressure.\n    * **Qd3:** Developing the queen and preparing to connect the rooks. A solid move, but less forcing than Ne6.\n\n**Evaluating Ne6:**\nAfter `20. Ne6`, Black has a few options:\n* If `20... Rxe6 21. dxe6`, White is clearly better.\n* If `20... Qd7`, White can follow up with `21. Qh5` (threatening mate) or continue with `21. c4` to consolidate.\n* Ne6 centralizes the knight perfectly, forces a concession, and takes control of the d4 square for future maneuvers. It is the most challenging move for Black.\n\n**Reasoning:**\nThe knight on g5 is well-placed, but it can be kicked by h6. By jumping to e6, White forces the issue immediately. This move is structurally and tactically superior because it disrupts Black's coordination.\n\nFinal Answer: Ne6",
+              "total_tokens": 792
+            }
+          ],
+          "status": "OK",
+          "submission": 3862,
+          "thoughts": "The current position is `r3n1k1/2q1b1pp/pn1p2r1/1ppPp1N1/8/1PP3NP/P4PP1/R1BQR1K1 w - - 4 20`.\n\n**Evaluation and Analysis:**\n1. **Material and Structure:** The material is equal. White has a space advantage in the center with the d5 pawn. Black\u2019s pieces are somewhat cramped, but the g6 rook is active.\n2. **Key Tactical Themes:** White's knight on g5 is annoying for Black, putting pressure on f7 and blocking some development. Black's f-file and the g6 rook create potential kingside threats, but White's position is solid.\n3. **Candidate Moves:**\n    * **Ne6:** This is a very strong outpost. It puts direct pressure on the queen on c7 and forces Black to respond. If `20. Ne6 Rxe6 21. dxe6`, White wins the exchange and gains a strong passed pawn. If Black plays `20... Qd7`, White improves their position significantly.\n    * **h4:** Aiming to challenge the rook on g6 or prepare to expand on the kingside. However, it is slightly slower than the immediate central pressure.\n    * **Qd3:** Developing the queen and preparing to connect the rooks. A solid move, but less forcing than Ne6.\n\n**Evaluating Ne6:**\nAfter `20. Ne6`, Black has a few options:\n* If `20... Rxe6 21. dxe6`, White is clearly better.\n* If `20... Qd7`, White can follow up with `21. Qh5` (threatening mate) or continue with `21. c4` to consolidate.\n* Ne6 centralizes the knight perfectly, forces a concession, and takes control of the d4 square for future maneuvers. It is the most challenging move for Black.\n\n**Reasoning:**\nThe knight on g5 is well-placed, but it can be kicked by h6. By jumping to e6, White forces the issue immediately. This move is structurally and tactically superior because it disrupts Black's coordination.\n\nFinal Answer: Ne6"
+        },
+        "info": {
+          "actionApplied": 3862,
+          "actionSubmitted": 3862,
+          "actionSubmittedToString": "Ne6",
+          "agentSelfReportedStatus": "OK",
+          "timeTaken": 3.84
+        },
+        "observation": {
+          "currentPlayer": 0,
+          "isTerminal": false,
+          "observationString": "r3n1k1/2q1b1pp/pn1pN1r1/1ppPp3/8/1PP3NP/P4PP1/R1BQR1K1 b - - 5 20",
+          "playerId": 1,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n2426\n3572\n656\n2974\n89\n919\n3572\n4673\n2977\n2949\n674\n277\n1841\n1257\n4673\n4177\n1380\n788\n1258\n1842\n1809\n1987\n289\n673\n1527\n654\n3133\n1894\n3010\n2599\n1214\n1287\n2938\n2992\n3154\n3138\n3096\n3862\n\n"
+        },
+        "reward": null,
+        "status": "INACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "actionString": "Qb7",
+          "call_details": [
+            {
+              "duration_secs": 3.798,
+              "finish_reason": "stop",
+              "first_token_secs": 0.811,
+              "generation_tokens": 703,
+              "model": "openai/google/gemini-3.1-flash-lite-preview",
+              "prompt": "\ud83d\udc4c\ud83d\udc40\ud83d\udc4c\ud83d\udc40\ud83d\udc4c\ud83d\udc40\ud83d\udc4c\ud83d\udc40\ud83d\udc4c\ud83d\udc40 good shit go\u0c66\u0501 sHit\ud83d\udc4c thats \u2714 some good\ud83d\udc4c\ud83d\udc4cshit right\ud83d\udc4c\ud83d\udc4cthere\ud83d\udc4c\ud83d\udc4c\ud83d\udc4c right\u2714there \u2714\u2714if i do \u01bda\u04af so my self \ud83d\udcaf i say so \ud83d\udcaf thats what im talking about right there right there (chorus: \u02b3\u1da6\u1d4d\u02b0\u1d57 \u1d57\u02b0\u1d49\u02b3\u1d49) mMMMM\u13b7\u041c\ud83d\udcaf \ud83d\udc4c\ud83d\udc4c \ud83d\udc4c\u041dO0\u041e\u0b20OOOOO\u041e\u0b20\u0b20Oooo\u1d52\u1d52\u1d52\u1d52\u1d52\u1d52\u1d52\u1d52\u1d52\ud83d\udc4c \ud83d\udc4c\ud83d\udc4c \ud83d\udc4c \ud83d\udcaf \ud83d\udc4c \ud83d\udc40 \ud83d\udc40 \ud83d\udc40 \ud83d\udc4c\ud83d\udc4c\n\nLet's play chess. The current game state in Forsyth-Edwards Notation (FEN) notation is:\nr3n1k1/2q1b1pp/pn1pN1r1/1ppPp3/8/1PP3NP/P4PP1/R1BQR1K1 b - - 5 20\nThe moves played so far are:\n1. e4 e5 2. Nf3 Nc6 3. Bb5 a6 4. Ba4 Nf6 5. O-O Be7 6. Re1 b5 7. Bb3 d6 8. c3 O-O 9. h3 Na5 10. Bc2 c5 11. d4 Qc7 12. d5 Nc4 13. b3 Nb6 14. Nbd2 Ne8 15. Nf1 f5 16. exf5 Bxf5 17. Bxf5 Rxf5 18. Ng3 Rf6 19. Ng5 Rg6 20. Ne6\nYou are playing as player Black.\nIt is now your turn. Play your strongest move. The move MUST be legal. Reason step by step to come up with your move, then output your final answer in the format \"Final Answer: X\" where X is your chosen move in standard algebraic notation (SAN).\n",
+              "prompt_tokens": 425,
+              "reasoning_tokens": 0,
+              "response": "The current position is `r3n1k1/2q1b1pp/pn1pN1r1/1ppPp3/8/1PP3NP/P4PP1/R1BQR1K1 b - - 5 20`. It is Black's turn to move.\n\n**Evaluation:**\nWhite has a dominant centralized knight on e6, which is cramping Black's position. The white pieces are well-coordinated, while Black's pieces are somewhat restricted. Black needs to challenge the e6 knight and improve the coordination of their pieces.\n\n**Candidate Moves:**\n1. **...Qb7**: This is the most natural move. It directly attacks the d5 pawn, which is supported by the e6 knight. If White defends the d5 pawn, the pressure on d5 might force concessions.\n2. **...Qd7**: Another way to challenge the d5 pawn and prepare to maneuver the queen.\n3. **...Rxe6**: A tactical shot to remove the annoying knight. 21. dxe6 Qxe6. Black gets a queen and bishop vs rook and knight, but the position remains complex. However, it simplifies the center and removes the outpost.\n4. **...Nf6**: Repositioning the knight to challenge the center.\n\n**Detailed Analysis:**\n*   **...Rxe6**: 21. dxe6 Qxe6. White has a solid position. The d5 pawn is a nuisance, but Black has reasonable compensation with the two bishops and central control.\n*   **...Qb7**: 21. c4 (or other defenses). This keeps the pressure on d5 and prepares to bring the knight from b6 into the game (e.g., Nc8 or Nd7).\n*   **...Nf6**: This is a solid prophylactic and regrouping move. It controls key squares and prepares to challenge the e6 knight or the d5 pawn eventually.\n\n**Engine Evaluation/Strategic Choice:**\nThe move **...Qb7** is highly standard in these structures. It places the queen on an active diagonal, targets the d5 pawn, and puts pressure on White to defend. If White plays `c4`, Black can respond with `bxc4` or `Nc8`.\n\nLet's look at `20... Qb7`. It forces White to address the tension at d5. If White plays `c4`, Black is doing well. If White plays `Nf5`, Black can respond with `Bf8` or `Rxe6`. \n\nComparing `Qb7` vs `Rxe6`:\n`Rxe6` is a concrete trade that relieves the pressure immediately. `Qb7` maintains the tension. Given the central dominance of White, removing the e6 knight is often the most principled approach to neutralize White's initiative.\n\nHowever, `Qb7` is arguably more flexible. Let's analyze `20... Qb7`. It threatens the d5 pawn. White's best response is likely `c4` or `Nf5`. \n\nActually, checking the engine perspective on this specific Ruy Lopez structure (with the early `...c5` and `...Nc4` nuances), `...Qb7` is consistently the top recommendation to challenge the white central outpost.\n\nFinal Answer: Qb7",
+              "total_tokens": 1128
+            }
+          ],
+          "status": "OK",
+          "submission": 1270,
+          "thoughts": "The current position is `r3n1k1/2q1b1pp/pn1pN1r1/1ppPp3/8/1PP3NP/P4PP1/R1BQR1K1 b - - 5 20`. It is Black's turn to move.\n\n**Evaluation:**\nWhite has a dominant centralized knight on e6, which is cramping Black's position. The white pieces are well-coordinated, while Black's pieces are somewhat restricted. Black needs to challenge the e6 knight and improve the coordination of their pieces.\n\n**Candidate Moves:**\n1. **...Qb7**: This is the most natural move. It directly attacks the d5 pawn, which is supported by the e6 knight. If White defends the d5 pawn, the pressure on d5 might force concessions.\n2. **...Qd7**: Another way to challenge the d5 pawn and prepare to maneuver the queen.\n3. **...Rxe6**: A tactical shot to remove the annoying knight. 21. dxe6 Qxe6. Black gets a queen and bishop vs rook and knight, but the position remains complex. However, it simplifies the center and removes the outpost.\n4. **...Nf6**: Repositioning the knight to challenge the center.\n\n**Detailed Analysis:**\n*   **...Rxe6**: 21. dxe6 Qxe6. White has a solid position. The d5 pawn is a nuisance, but Black has reasonable compensation with the two bishops and central control.\n*   **...Qb7**: 21. c4 (or other defenses). This keeps the pressure on d5 and prepares to bring the knight from b6 into the game (e.g., Nc8 or Nd7).\n*   **...Nf6**: This is a solid prophylactic and regrouping move. It controls key squares and prepares to challenge the e6 knight or the d5 pawn eventually.\n\n**Engine Evaluation/Strategic Choice:**\nThe move **...Qb7** is highly standard in these structures. It places the queen on an active diagonal, targets the d5 pawn, and puts pressure on White to defend. If White plays `c4`, Black can respond with `bxc4` or `Nc8`.\n\nLet's look at `20... Qb7`. It forces White to address the tension at d5. If White plays `c4`, Black is doing well. If White plays `Nf5`, Black can respond with `Bf8` or `Rxe6`. \n\nComparing `Qb7` vs `Rxe6`:\n`Rxe6` is a concrete trade that relieves the pressure immediately. `Qb7` maintains the tension. Given the central dominance of White, removing the e6 knight is often the most principled approach to neutralize White's initiative.\n\nHowever, `Qb7` is arguably more flexible. Let's analyze `20... Qb7`. It threatens the d5 pawn. White's best response is likely `c4` or `Nf5`. \n\nActually, checking the engine perspective on this specific Ruy Lopez structure (with the early `...c5` and `...Nc4` nuances), `...Qb7` is consistently the top recommendation to challenge the white central outpost.\n\nFinal Answer: Qb7"
+        },
+        "info": {
+          "actionApplied": 1270,
+          "actionSubmitted": 1270,
+          "actionSubmittedToString": "Qb7",
+          "agentSelfReportedStatus": "OK",
+          "timeTaken": 4.295
+        },
+        "observation": {
+          "currentPlayer": 1,
+          "isTerminal": false,
+          "observationString": "r3n1k1/1q2b1pp/pn1pN1r1/1ppPp3/8/1PP3NP/P4PP1/R1BQR1K1 w - - 6 21",
+          "playerId": 0,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n2426\n3572\n656\n2974\n89\n919\n3572\n4673\n2977\n2949\n674\n277\n1841\n1257\n4673\n4177\n1380\n788\n1258\n1842\n1809\n1987\n289\n673\n1527\n654\n3133\n1894\n3010\n2599\n1214\n1287\n2938\n2992\n3154\n3138\n3096\n3862\n1270\n\n",
+          "step": 41
+        },
+        "reward": null,
+        "status": "INACTIVE"
+      },
+      {
+        "action": { "submission": -1 },
+        "info": {},
+        "observation": {
+          "currentPlayer": 1,
+          "isTerminal": false,
+          "observationString": "r3n1k1/1q2b1pp/pn1pN1r1/1ppPp3/8/1PP3NP/P4PP1/R1BQR1K1 w - - 6 21",
+          "playerId": 1,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n2426\n3572\n656\n2974\n89\n919\n3572\n4673\n2977\n2949\n674\n277\n1841\n1257\n4673\n4177\n1380\n788\n1258\n1842\n1809\n1987\n289\n673\n1527\n654\n3133\n1894\n3010\n2599\n1214\n1287\n2938\n2992\n3154\n3138\n3096\n3862\n1270\n\n"
+        },
+        "reward": null,
+        "status": "ACTIVE"
+      }
+    ],
+    [
+      {
+        "action": { "submission": -1 },
+        "info": {},
+        "observation": {
+          "currentPlayer": 0,
+          "isTerminal": false,
+          "observationString": "r3n1k1/1q2b1pp/pn1pN1r1/1ppPpN2/8/1PP4P/P4PP1/R1BQR1K1 b - - 7 21",
+          "playerId": 0,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n2426\n3572\n656\n2974\n89\n919\n3572\n4673\n2977\n2949\n674\n277\n1841\n1257\n4673\n4177\n1380\n788\n1258\n1842\n1809\n1987\n289\n673\n1527\n654\n3133\n1894\n3010\n2599\n1214\n1287\n2938\n2992\n3154\n3138\n3096\n3862\n1270\n3718\n\n",
+          "step": 42
+        },
+        "reward": null,
+        "status": "ACTIVE"
+      },
+      {
+        "action": {
+          "actionString": "Nf5",
+          "call_details": [
+            {
+              "duration_secs": 2.937,
+              "finish_reason": "stop",
+              "first_token_secs": 0.645,
+              "generation_tokens": 472,
+              "model": "openai/google/gemini-3.1-flash-lite-preview",
+              "prompt": "You are a chess expert\n\nLet's play chess. The current game state in Forsyth-Edwards Notation (FEN) notation is:\nr3n1k1/1q2b1pp/pn1pN1r1/1ppPp3/8/1PP3NP/P4PP1/R1BQR1K1 w - - 6 21\nThe moves played so far are:\n1. e4 e5 2. Nf3 Nc6 3. Bb5 a6 4. Ba4 Nf6 5. O-O Be7 6. Re1 b5 7. Bb3 d6 8. c3 O-O 9. h3 Na5 10. Bc2 c5 11. d4 Qc7 12. d5 Nc4 13. b3 Nb6 14. Nbd2 Ne8 15. Nf1 f5 16. exf5 Bxf5 17. Bxf5 Rxf5 18. Ng3 Rf6 19. Ng5 Rg6 20. Ne6 Qb7 21.\nYou are playing as player White.\nIt is now your turn. Play your strongest move. The move MUST be legal. Reason step by step to come up with your move, then output your final answer in the format \"Final Answer: X\" where X is your chosen move in standard algebraic notation (SAN).\n",
+              "prompt_tokens": 311,
+              "reasoning_tokens": 0,
+              "response": "The current FEN is `r3n1k1/1q2b1pp/pn1pN1r1/1ppPp3/8/1PP3NP/P4PP1/R1BQR1K1 w - - 6 21`.\n\n**Evaluation and Analysis:**\n1. **Material:** The position is equal.\n2. **Positional Factors:**\n   * White has a very strong knight on `e6`, which is exerting significant pressure on the black position.\n   * Black's rook on `g6` is somewhat misplaced but eyes the `g2` pawn.\n   * White's d5 pawn is a thorn in Black's position, cramping their pieces.\n   * The move `Nf5` is a thematic idea here, utilizing the control of the e6 square and putting pressure on the king-side and the `g6` rook.\n3. **Candidate Moves:**\n   * **Nf5:** This is a very strong, centralizing move. It attacks the `e7` bishop and forces Black to react to the pressure on the king-side. If Black plays `Bf8`, White gains space and restricts Black further.\n   * **c4:** A standard thematic break, but given the current positioning, improving the knight position is more pressing.\n   * **Qh5:** An aggressive attempt to push on the king-side, but it might be premature.\n\n**Detailed look at Nf5:**\nIf White plays `Nf5`, the knight eyes the `g7` square and coordinates well with the other pieces. If `Bf6` or `Bf8`, White maintains a significant positional advantage. If Black captures `Rxf5` (not possible here due to the position of the pieces, but checking tactical lines), White improves the central structure. The knight on `e6` is already doing a great job, and adding another piece to the attack or central control is highly beneficial.\n\nComparing alternatives, `Nf5` seems the most principled move to capitalize on the advanced `e6` knight and the general congestion in Black's camp. It creates immediate threats and improves White's coordination.\n\nFinal Answer: Nf5",
+              "total_tokens": 783
+            }
+          ],
+          "status": "OK",
+          "submission": 3718,
+          "thoughts": "The current FEN is `r3n1k1/1q2b1pp/pn1pN1r1/1ppPp3/8/1PP3NP/P4PP1/R1BQR1K1 w - - 6 21`.\n\n**Evaluation and Analysis:**\n1. **Material:** The position is equal.\n2. **Positional Factors:**\n   * White has a very strong knight on `e6`, which is exerting significant pressure on the black position.\n   * Black's rook on `g6` is somewhat misplaced but eyes the `g2` pawn.\n   * White's d5 pawn is a thorn in Black's position, cramping their pieces.\n   * The move `Nf5` is a thematic idea here, utilizing the control of the e6 square and putting pressure on the king-side and the `g6` rook.\n3. **Candidate Moves:**\n   * **Nf5:** This is a very strong, centralizing move. It attacks the `e7` bishop and forces Black to react to the pressure on the king-side. If Black plays `Bf8`, White gains space and restricts Black further.\n   * **c4:** A standard thematic break, but given the current positioning, improving the knight position is more pressing.\n   * **Qh5:** An aggressive attempt to push on the king-side, but it might be premature.\n\n**Detailed look at Nf5:**\nIf White plays `Nf5`, the knight eyes the `g7` square and coordinates well with the other pieces. If `Bf6` or `Bf8`, White maintains a significant positional advantage. If Black captures `Rxf5` (not possible here due to the position of the pieces, but checking tactical lines), White improves the central structure. The knight on `e6` is already doing a great job, and adding another piece to the attack or central control is highly beneficial.\n\nComparing alternatives, `Nf5` seems the most principled move to capitalize on the advanced `e6` knight and the general congestion in Black's camp. It creates immediate threats and improves White's coordination.\n\nFinal Answer: Nf5"
+        },
+        "info": {
+          "actionApplied": 3718,
+          "actionSubmitted": 3718,
+          "actionSubmittedToString": "Nf5",
+          "agentSelfReportedStatus": "OK",
+          "timeTaken": 3.379
+        },
+        "observation": {
+          "currentPlayer": 0,
+          "isTerminal": false,
+          "observationString": "r3n1k1/1q2b1pp/pn1pN1r1/1ppPpN2/8/1PP4P/P4PP1/R1BQR1K1 b - - 7 21",
+          "playerId": 1,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n2426\n3572\n656\n2974\n89\n919\n3572\n4673\n2977\n2949\n674\n277\n1841\n1257\n4673\n4177\n1380\n788\n1258\n1842\n1809\n1987\n289\n673\n1527\n654\n3133\n1894\n3010\n2599\n1214\n1287\n2938\n2992\n3154\n3138\n3096\n3862\n1270\n3718\n\n"
+        },
+        "reward": null,
+        "status": "INACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "actionString": "Nxd5",
+          "call_details": [
+            {
+              "duration_secs": 3.113,
+              "finish_reason": "stop",
+              "first_token_secs": 0.756,
+              "generation_tokens": 530,
+              "model": "openai/google/gemini-3.1-flash-lite-preview",
+              "prompt": "\ud83d\udc4c\ud83d\udc40\ud83d\udc4c\ud83d\udc40\ud83d\udc4c\ud83d\udc40\ud83d\udc4c\ud83d\udc40\ud83d\udc4c\ud83d\udc40 good shit go\u0c66\u0501 sHit\ud83d\udc4c thats \u2714 some good\ud83d\udc4c\ud83d\udc4cshit right\ud83d\udc4c\ud83d\udc4cthere\ud83d\udc4c\ud83d\udc4c\ud83d\udc4c right\u2714there \u2714\u2714if i do \u01bda\u04af so my self \ud83d\udcaf i say so \ud83d\udcaf thats what im talking about right there right there (chorus: \u02b3\u1da6\u1d4d\u02b0\u1d57 \u1d57\u02b0\u1d49\u02b3\u1d49) mMMMM\u13b7\u041c\ud83d\udcaf \ud83d\udc4c\ud83d\udc4c \ud83d\udc4c\u041dO0\u041e\u0b20OOOOO\u041e\u0b20\u0b20Oooo\u1d52\u1d52\u1d52\u1d52\u1d52\u1d52\u1d52\u1d52\u1d52\ud83d\udc4c \ud83d\udc4c\ud83d\udc4c \ud83d\udc4c \ud83d\udcaf \ud83d\udc4c \ud83d\udc40 \ud83d\udc40 \ud83d\udc40 \ud83d\udc4c\ud83d\udc4c\n\nLet's play chess. The current game state in Forsyth-Edwards Notation (FEN) notation is:\nr3n1k1/1q2b1pp/pn1pN1r1/1ppPpN2/8/1PP4P/P4PP1/R1BQR1K1 b - - 7 21\nThe moves played so far are:\n1. e4 e5 2. Nf3 Nc6 3. Bb5 a6 4. Ba4 Nf6 5. O-O Be7 6. Re1 b5 7. Bb3 d6 8. c3 O-O 9. h3 Na5 10. Bc2 c5 11. d4 Qc7 12. d5 Nc4 13. b3 Nb6 14. Nbd2 Ne8 15. Nf1 f5 16. exf5 Bxf5 17. Bxf5 Rxf5 18. Ng3 Rf6 19. Ng5 Rg6 20. Ne6 Qb7 21. Nf5\nYou are playing as player Black.\nIt is now your turn. Play your strongest move. The move MUST be legal. Reason step by step to come up with your move, then output your final answer in the format \"Final Answer: X\" where X is your chosen move in standard algebraic notation (SAN).\n",
+              "prompt_tokens": 434,
+              "reasoning_tokens": 0,
+              "response": "The current FEN is `r3n1k1/1q2b1pp/pn1pN1r1/1ppPpN2/8/1PP4P/P4PP1/R1BQR1K1 b - - 7 21`.\n\n**Evaluation and Analysis:**\n1. **Material and Position:** The material is equal. White's knights are very active and aggressive, particularly the knight on e6, which is a thorn in Black's position.\n2. **Threats:** White is threatening `Nxg7` (if allowed) or potentially utilizing the strong knight on e6 and f5 to create attacking patterns against the Black king. Black's position is somewhat cramped.\n3. **Candidate Moves:**\n    *   **21... Nxd5:** This captures the central pawn and challenges the knight on e6. If White plays `Nxd5`, then `Qxd5` centralizes the queen and clears the back rank. This seems like the most principled move to challenge White's central dominance.\n    *   **21... Nc7:** This attacks the knight on e6 directly. However, after `Nxe7+`, Black loses the bishop pair and structural integrity.\n    *   **21... Rxe6:** This is a tactical shot to remove the annoying knight. `21... Rxe6 22. dxe6`. Black wins the exchange for a pawn but loses positional control. It is a playable line but perhaps unnecessary given `Nxd5`.\n\n**Detailed look at 21... Nxd5:**\n*   If `21... Nxd5`, the pawn on d5 is removed, opening the d-file.\n*   If `22. Nxd5`, then `22... Qxd5`. The queen is well-placed, and the pressure on White's f5 knight increases.\n*   If `22. Qf3`, White tries to maintain the pressure. Black can follow up with `22... Nc7` or `22... Nf6`.\n\nThe move `21... Nxd5` is the most active and centralizing move. It forces White to address the hanging pawn and the threat to the e6 knight, effectively diffusing the immediate pressure of White's pieces.\n\n**Evaluation:**\nThe position is roughly equal, but Black needs to be precise to neutralize the activity of the White knights. `Nxd5` is the most logical move to restore balance.\n\nFinal Answer: Nxd5",
+              "total_tokens": 964
+            }
+          ],
+          "status": "OK",
+          "submission": 800,
+          "thoughts": "The current FEN is `r3n1k1/1q2b1pp/pn1pN1r1/1ppPpN2/8/1PP4P/P4PP1/R1BQR1K1 b - - 7 21`.\n\n**Evaluation and Analysis:**\n1. **Material and Position:** The material is equal. White's knights are very active and aggressive, particularly the knight on e6, which is a thorn in Black's position.\n2. **Threats:** White is threatening `Nxg7` (if allowed) or potentially utilizing the strong knight on e6 and f5 to create attacking patterns against the Black king. Black's position is somewhat cramped.\n3. **Candidate Moves:**\n    *   **21... Nxd5:** This captures the central pawn and challenges the knight on e6. If White plays `Nxd5`, then `Qxd5` centralizes the queen and clears the back rank. This seems like the most principled move to challenge White's central dominance.\n    *   **21... Nc7:** This attacks the knight on e6 directly. However, after `Nxe7+`, Black loses the bishop pair and structural integrity.\n    *   **21... Rxe6:** This is a tactical shot to remove the annoying knight. `21... Rxe6 22. dxe6`. Black wins the exchange for a pawn but loses positional control. It is a playable line but perhaps unnecessary given `Nxd5`.\n\n**Detailed look at 21... Nxd5:**\n*   If `21... Nxd5`, the pawn on d5 is removed, opening the d-file.\n*   If `22. Nxd5`, then `22... Qxd5`. The queen is well-placed, and the pressure on White's f5 knight increases.\n*   If `22. Qf3`, White tries to maintain the pressure. Black can follow up with `22... Nc7` or `22... Nf6`.\n\nThe move `21... Nxd5` is the most active and centralizing move. It forces White to address the hanging pawn and the threat to the e6 knight, effectively diffusing the immediate pressure of White's pieces.\n\n**Evaluation:**\nThe position is roughly equal, but Black needs to be precise to neutralize the activity of the White knights. `Nxd5` is the most logical move to restore balance.\n\nFinal Answer: Nxd5"
+        },
+        "info": {
+          "actionApplied": 800,
+          "actionSubmitted": 800,
+          "actionSubmittedToString": "Nxd5",
+          "agentSelfReportedStatus": "OK",
+          "timeTaken": 3.618
+        },
+        "observation": {
+          "currentPlayer": 1,
+          "isTerminal": false,
+          "observationString": "r3n1k1/1q2b1pp/p2pN1r1/1ppnpN2/8/1PP4P/P4PP1/R1BQR1K1 w - - 0 22",
+          "playerId": 0,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n2426\n3572\n656\n2974\n89\n919\n3572\n4673\n2977\n2949\n674\n277\n1841\n1257\n4673\n4177\n1380\n788\n1258\n1842\n1809\n1987\n289\n673\n1527\n654\n3133\n1894\n3010\n2599\n1214\n1287\n2938\n2992\n3154\n3138\n3096\n3862\n1270\n3718\n800\n\n",
+          "step": 43
+        },
+        "reward": null,
+        "status": "INACTIVE"
+      },
+      {
+        "action": { "submission": -1 },
+        "info": {},
+        "observation": {
+          "currentPlayer": 1,
+          "isTerminal": false,
+          "observationString": "r3n1k1/1q2b1pp/p2pN1r1/1ppnpN2/8/1PP4P/P4PP1/R1BQR1K1 w - - 0 22",
+          "playerId": 1,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n2426\n3572\n656\n2974\n89\n919\n3572\n4673\n2977\n2949\n674\n277\n1841\n1257\n4673\n4177\n1380\n788\n1258\n1842\n1809\n1987\n289\n673\n1527\n654\n3133\n1894\n3010\n2599\n1214\n1287\n2938\n2992\n3154\n3138\n3096\n3862\n1270\n3718\n800\n\n"
+        },
+        "reward": null,
+        "status": "ACTIVE"
+      }
+    ],
+    [
+      {
+        "action": { "submission": -1 },
+        "info": {},
+        "observation": {
+          "currentPlayer": 0,
+          "isTerminal": false,
+          "observationString": "r3n1k1/1q2b1pp/p2pN1r1/1ppQpN2/8/1PP4P/P4PP1/R1B1R1K1 b - - 0 22",
+          "playerId": 0,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n2426\n3572\n656\n2974\n89\n919\n3572\n4673\n2977\n2949\n674\n277\n1841\n1257\n4673\n4177\n1380\n788\n1258\n1842\n1809\n1987\n289\n673\n1527\n654\n3133\n1894\n3010\n2599\n1214\n1287\n2938\n2992\n3154\n3138\n3096\n3862\n1270\n3718\n800\n1771\n\n",
+          "step": 44
+        },
+        "reward": null,
+        "status": "ACTIVE"
+      },
+      {
+        "action": {
+          "actionString": "Qxd5",
+          "call_details": [
+            {
+              "duration_secs": 3.54,
+              "finish_reason": "stop",
+              "first_token_secs": 0.765,
+              "generation_tokens": 634,
+              "model": "openai/google/gemini-3.1-flash-lite-preview",
+              "prompt": "You are a chess expert\n\nLet's play chess. The current game state in Forsyth-Edwards Notation (FEN) notation is:\nr3n1k1/1q2b1pp/p2pN1r1/1ppnpN2/8/1PP4P/P4PP1/R1BQR1K1 w - - 0 22\nThe moves played so far are:\n1. e4 e5 2. Nf3 Nc6 3. Bb5 a6 4. Ba4 Nf6 5. O-O Be7 6. Re1 b5 7. Bb3 d6 8. c3 O-O 9. h3 Na5 10. Bc2 c5 11. d4 Qc7 12. d5 Nc4 13. b3 Nb6 14. Nbd2 Ne8 15. Nf1 f5 16. exf5 Bxf5 17. Bxf5 Rxf5 18. Ng3 Rf6 19. Ng5 Rg6 20. Ne6 Qb7 21. Nf5 Nxd5 22.\nYou are playing as player White.\nIt is now your turn. Play your strongest move. The move MUST be legal. Reason step by step to come up with your move, then output your final answer in the format \"Final Answer: X\" where X is your chosen move in standard algebraic notation (SAN).\n",
+              "prompt_tokens": 320,
+              "reasoning_tokens": 0,
+              "response": "The current position is `r3n1k1/1q2b1pp/p2pN1r1/1ppnpN2/8/1PP4P/P4PP1/R1BQR1K1 w - - 0 22`. It is white's turn to move.\n\n**Evaluation:**\nWhite has a very strong initiative. The black king is slightly exposed, and the knight on e6 is a thorn in black's position. White also has a strong attacking setup with the pieces concentrated towards the kingside.\n\n**Candidate Moves:**\n1. **Qxd5**: This is a powerful tactical shot. It eliminates the knight on d5, which is currently guarding critical squares and restricting white. After 22. Qxd5 Qxd5 23. Nxe7+ Kf7 24. Nxd5, white wins the queen for a knight and a bishop.\n   - Let's verify the tactical sequence: 22. Qxd5 Qxd5 23. Nxe7+ Kf7 24. Nxd5.\n   - White gains material (Queen for Knight/Bishop) and reaches a winning endgame/middlegame.\n\n2. **Nxg7**: Attacking the rook on g6, but this allows black to simplify or counterattack. It is significantly weaker than taking the queen.\n\n3. **c4**: Trying to challenge the knight on d5, but black can simply move the knight or maintain the blockade. This is too slow.\n\n**Analysis of 22. Qxd5:**\n- If 22... Qxd5, 23. Nxe7+ Kf7 24. Nxd5. White is up a significant amount of material. Black's minor pieces are not coordinated enough to compensate for the loss of the queen.\n- Are there any traps? If 22. Qxd5, black might try to respond with something else, but there is no better defense for the queen. If 22... Rxe6, then 23. Qxe6+ Kh8, and white is winning easily.\n\nThe move 22. Qxd5 is clearly the strongest move as it wins decisive material immediately.\n\n**Step-by-step logic:**\n1. Identify the tactical opportunity: The black queen is on b7, and the white queen is on d1. The d5 square is occupied by a black knight.\n2. Calculate the forced sequence: 22. Qxd5 Qxd5 23. Nxe7+ Kf7 24. Nxd5.\n3. Assess the resulting position: White wins the queen for the knight on e6 and the queen on d1, but gains the knight on d5 as well. The material count heavily favors white (Queen vs Rook + Knight).\n4. Verify safety: The white king is safe, and there are no immediate threats from black that prevent this capture.\n\nFinal conclusion: 22. Qxd5 is the winning move.\n\nFinal Answer: Qxd5",
+              "total_tokens": 954
+            }
+          ],
+          "status": "OK",
+          "submission": 1771,
+          "thoughts": "The current position is `r3n1k1/1q2b1pp/p2pN1r1/1ppnpN2/8/1PP4P/P4PP1/R1BQR1K1 w - - 0 22`. It is white's turn to move.\n\n**Evaluation:**\nWhite has a very strong initiative. The black king is slightly exposed, and the knight on e6 is a thorn in black's position. White also has a strong attacking setup with the pieces concentrated towards the kingside.\n\n**Candidate Moves:**\n1. **Qxd5**: This is a powerful tactical shot. It eliminates the knight on d5, which is currently guarding critical squares and restricting white. After 22. Qxd5 Qxd5 23. Nxe7+ Kf7 24. Nxd5, white wins the queen for a knight and a bishop.\n   - Let's verify the tactical sequence: 22. Qxd5 Qxd5 23. Nxe7+ Kf7 24. Nxd5.\n   - White gains material (Queen for Knight/Bishop) and reaches a winning endgame/middlegame.\n\n2. **Nxg7**: Attacking the rook on g6, but this allows black to simplify or counterattack. It is significantly weaker than taking the queen.\n\n3. **c4**: Trying to challenge the knight on d5, but black can simply move the knight or maintain the blockade. This is too slow.\n\n**Analysis of 22. Qxd5:**\n- If 22... Qxd5, 23. Nxe7+ Kf7 24. Nxd5. White is up a significant amount of material. Black's minor pieces are not coordinated enough to compensate for the loss of the queen.\n- Are there any traps? If 22. Qxd5, black might try to respond with something else, but there is no better defense for the queen. If 22... Rxe6, then 23. Qxe6+ Kh8, and white is winning easily.\n\nThe move 22. Qxd5 is clearly the strongest move as it wins decisive material immediately.\n\n**Step-by-step logic:**\n1. Identify the tactical opportunity: The black queen is on b7, and the white queen is on d1. The d5 square is occupied by a black knight.\n2. Calculate the forced sequence: 22. Qxd5 Qxd5 23. Nxe7+ Kf7 24. Nxd5.\n3. Assess the resulting position: White wins the queen for the knight on e6 and the queen on d1, but gains the knight on d5 as well. The material count heavily favors white (Queen vs Rook + Knight).\n4. Verify safety: The white king is safe, and there are no immediate threats from black that prevent this capture.\n\nFinal conclusion: 22. Qxd5 is the winning move.\n\nFinal Answer: Qxd5"
+        },
+        "info": {
+          "actionApplied": 1771,
+          "actionSubmitted": 1771,
+          "actionSubmittedToString": "Qxd5",
+          "agentSelfReportedStatus": "OK",
+          "timeTaken": 4.076
+        },
+        "observation": {
+          "currentPlayer": 0,
+          "isTerminal": false,
+          "observationString": "r3n1k1/1q2b1pp/p2pN1r1/1ppQpN2/8/1PP4P/P4PP1/R1B1R1K1 b - - 0 22",
+          "playerId": 1,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n2426\n3572\n656\n2974\n89\n919\n3572\n4673\n2977\n2949\n674\n277\n1841\n1257\n4673\n4177\n1380\n788\n1258\n1842\n1809\n1987\n289\n673\n1527\n654\n3133\n1894\n3010\n2599\n1214\n1287\n2938\n2992\n3154\n3138\n3096\n3862\n1270\n3718\n800\n1771\n\n"
+        },
+        "reward": null,
+        "status": "INACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "actionString": "Qxd5",
+          "call_details": [
+            {
+              "duration_secs": 4.759,
+              "finish_reason": "stop",
+              "first_token_secs": 0.757,
+              "generation_tokens": 997,
+              "model": "openai/google/gemini-3.1-flash-lite-preview",
+              "prompt": "\ud83d\udc4c\ud83d\udc40\ud83d\udc4c\ud83d\udc40\ud83d\udc4c\ud83d\udc40\ud83d\udc4c\ud83d\udc40\ud83d\udc4c\ud83d\udc40 good shit go\u0c66\u0501 sHit\ud83d\udc4c thats \u2714 some good\ud83d\udc4c\ud83d\udc4cshit right\ud83d\udc4c\ud83d\udc4cthere\ud83d\udc4c\ud83d\udc4c\ud83d\udc4c right\u2714there \u2714\u2714if i do \u01bda\u04af so my self \ud83d\udcaf i say so \ud83d\udcaf thats what im talking about right there right there (chorus: \u02b3\u1da6\u1d4d\u02b0\u1d57 \u1d57\u02b0\u1d49\u02b3\u1d49) mMMMM\u13b7\u041c\ud83d\udcaf \ud83d\udc4c\ud83d\udc4c \ud83d\udc4c\u041dO0\u041e\u0b20OOOOO\u041e\u0b20\u0b20Oooo\u1d52\u1d52\u1d52\u1d52\u1d52\u1d52\u1d52\u1d52\u1d52\ud83d\udc4c \ud83d\udc4c\ud83d\udc4c \ud83d\udc4c \ud83d\udcaf \ud83d\udc4c \ud83d\udc40 \ud83d\udc40 \ud83d\udc40 \ud83d\udc4c\ud83d\udc4c\n\nLet's play chess. The current game state in Forsyth-Edwards Notation (FEN) notation is:\nr3n1k1/1q2b1pp/p2pN1r1/1ppQpN2/8/1PP4P/P4PP1/R1B1R1K1 b - - 0 22\nThe moves played so far are:\n1. e4 e5 2. Nf3 Nc6 3. Bb5 a6 4. Ba4 Nf6 5. O-O Be7 6. Re1 b5 7. Bb3 d6 8. c3 O-O 9. h3 Na5 10. Bc2 c5 11. d4 Qc7 12. d5 Nc4 13. b3 Nb6 14. Nbd2 Ne8 15. Nf1 f5 16. exf5 Bxf5 17. Bxf5 Rxf5 18. Ng3 Rf6 19. Ng5 Rg6 20. Ne6 Qb7 21. Nf5 Nxd5 22. Qxd5\nYou are playing as player Black.\nIt is now your turn. Play your strongest move. The move MUST be legal. Reason step by step to come up with your move, then output your final answer in the format \"Final Answer: X\" where X is your chosen move in standard algebraic notation (SAN).\n",
+              "prompt_tokens": 443,
+              "reasoning_tokens": 0,
+              "response": "The current position is `r3n1k1/1q2b1pp/p2pN1r1/1ppQpN2/8/1PP4P/P4PP1/R1B1R1K1 b - - 0 22`. It is Black's turn to move.\n\n**Evaluation:**\nWhite has just played `Qxd5`. This move puts Black's queen on `b7` under attack and simultaneously threatens the knight on `d5` (which was the piece that captured on `d5`, but wait, let me re-examine the board).\n\nLet's trace the move:\n21. Nf5 Nxd5 22. Qxd5+\nWait, if white plays 22. Qxd5, it is a check, but it also captures the knight on `d5`. Black must respond to the check.\n\n**Candidate moves:**\n1. **... Qxd5**: This is the most natural move. It removes the attacking queen, captures the piece that just captured our knight, and resolves the material imbalance.\n2. **... Kh8**: Simply moving the king out of check. This loses the knight on `d5` for free, as the queen remains on `d5` after the king moves.\n\n**Analysis of 22... Qxd5:**\nIf Black plays 22... Qxd5:\nWhite can play 23. Nxe7+. This is a fork. The knight on `e7` checks the king and attacks the rook on `g6` or `c8` (depending on the position). Let's re-verify:\nThe board is: `r3n1k1/1q2b1pp/p2pN1r1/1ppQpN2/8/1PP4P/P4PP1/R1B1R1K1 b - - 0 22`\nWait, the FEN shows `Qxd5`.\nIf `22... Qxd5`, then `23. Nxe7+`.\nAfter `23. Nxe7+ Kf7`, the knight is trapped, or white picks up the exchange.\nHowever, if Black does *not* capture the queen, Black loses the piece on `d5` for nothing and remains under heavy pressure.\n\nActually, in this position, Black is in check.\nThe FEN provided: `r3n1k1/1q2b1pp/p2pN1r1/1ppQpN2/8/1PP4P/P4PP1/R1B1R1K1 b - - 0 22`\nThe White Queen is on `d5`. Black's King is on `g8`. There is no check on the board in the FEN provided. `d5` to `g8` is not a diagonal or rank/file attack.\nWait, looking at the FEN: `r3n1k1/1q2b1pp/p2pN1r1/1ppQpN2/8/1PP4P/P4PP1/R1B1R1K1 b - - 0 22`\nThe Queen on `d5` is not checking the King on `g8`.\nMy mistake, let me re-read the FEN.\nWhite Queen at `d5`. Black King at `g8`. Correct.\nBlack's Knight at `d5` was just captured.\nBlack's Queen is at `b7`.\n\nThe move `Qxd5` by White creates a major threat: `Nxe7+` (a fork) or just simply having a strong central queen.\nIf Black plays `22... Qxd5`, then `23. Nxe7+` wins the exchange and the queen trade is favorable for White.\nHowever, `22... Qxd5` is the only way to avoid losing the piece on `d5` for free while also controlling the center.\n\nLet's look for alternatives:\n`22... Rxe6` is possible. If `22... Rxe6 23. Qxe6+ Kf8`, Black is down material but removes the threatening knight.\nComparing `22... Qxd5` vs `22... Rxe6`.\nIf `22... Qxd5 23. Nxe7+ Kf7 24. Nxd5`, White has a better endgame.\nIf `22... Rxe6 23. Qxe6+ Kf8`, White is better.\n\nActually, `22... Qxd5` is mandatory. It challenges the queen.\n\nFinal Answer: Qxd5",
+              "total_tokens": 1440
+            }
+          ],
+          "status": "OK",
+          "submission": 702,
+          "thoughts": "The current position is `r3n1k1/1q2b1pp/p2pN1r1/1ppQpN2/8/1PP4P/P4PP1/R1B1R1K1 b - - 0 22`. It is Black's turn to move.\n\n**Evaluation:**\nWhite has just played `Qxd5`. This move puts Black's queen on `b7` under attack and simultaneously threatens the knight on `d5` (which was the piece that captured on `d5`, but wait, let me re-examine the board).\n\nLet's trace the move:\n21. Nf5 Nxd5 22. Qxd5+\nWait, if white plays 22. Qxd5, it is a check, but it also captures the knight on `d5`. Black must respond to the check.\n\n**Candidate moves:**\n1. **... Qxd5**: This is the most natural move. It removes the attacking queen, captures the piece that just captured our knight, and resolves the material imbalance.\n2. **... Kh8**: Simply moving the king out of check. This loses the knight on `d5` for free, as the queen remains on `d5` after the king moves.\n\n**Analysis of 22... Qxd5:**\nIf Black plays 22... Qxd5:\nWhite can play 23. Nxe7+. This is a fork. The knight on `e7` checks the king and attacks the rook on `g6` or `c8` (depending on the position). Let's re-verify:\nThe board is: `r3n1k1/1q2b1pp/p2pN1r1/1ppQpN2/8/1PP4P/P4PP1/R1B1R1K1 b - - 0 22`\nWait, the FEN shows `Qxd5`.\nIf `22... Qxd5`, then `23. Nxe7+`.\nAfter `23. Nxe7+ Kf7`, the knight is trapped, or white picks up the exchange.\nHowever, if Black does *not* capture the queen, Black loses the piece on `d5` for nothing and remains under heavy pressure.\n\nActually, in this position, Black is in check.\nThe FEN provided: `r3n1k1/1q2b1pp/p2pN1r1/1ppQpN2/8/1PP4P/P4PP1/R1B1R1K1 b - - 0 22`\nThe White Queen is on `d5`. Black's King is on `g8`. There is no check on the board in the FEN provided. `d5` to `g8` is not a diagonal or rank/file attack.\nWait, looking at the FEN: `r3n1k1/1q2b1pp/p2pN1r1/1ppQpN2/8/1PP4P/P4PP1/R1B1R1K1 b - - 0 22`\nThe Queen on `d5` is not checking the King on `g8`.\nMy mistake, let me re-read the FEN.\nWhite Queen at `d5`. Black King at `g8`. Correct.\nBlack's Knight at `d5` was just captured.\nBlack's Queen is at `b7`.\n\nThe move `Qxd5` by White creates a major threat: `Nxe7+` (a fork) or just simply having a strong central queen.\nIf Black plays `22... Qxd5`, then `23. Nxe7+` wins the exchange and the queen trade is favorable for White.\nHowever, `22... Qxd5` is the only way to avoid losing the piece on `d5` for free while also controlling the center.\n\nLet's look for alternatives:\n`22... Rxe6` is possible. If `22... Rxe6 23. Qxe6+ Kf8`, Black is down material but removes the threatening knight.\nComparing `22... Qxd5` vs `22... Rxe6`.\nIf `22... Qxd5 23. Nxe7+ Kf7 24. Nxd5`, White has a better endgame.\nIf `22... Rxe6 23. Qxe6+ Kf8`, White is better.\n\nActually, `22... Qxd5` is mandatory. It challenges the queen.\n\nFinal Answer: Qxd5"
+        },
+        "info": {
+          "actionApplied": 702,
+          "actionSubmitted": 702,
+          "actionSubmittedToString": "Qxd5",
+          "agentSelfReportedStatus": "OK",
+          "timeTaken": 5.3
+        },
+        "observation": {
+          "currentPlayer": 1,
+          "isTerminal": false,
+          "observationString": "r3n1k1/4b1pp/p2pN1r1/1ppqpN2/8/1PP4P/P4PP1/R1B1R1K1 w - - 0 23",
+          "playerId": 0,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n2426\n3572\n656\n2974\n89\n919\n3572\n4673\n2977\n2949\n674\n277\n1841\n1257\n4673\n4177\n1380\n788\n1258\n1842\n1809\n1987\n289\n673\n1527\n654\n3133\n1894\n3010\n2599\n1214\n1287\n2938\n2992\n3154\n3138\n3096\n3862\n1270\n3718\n800\n1771\n702\n\n",
+          "step": 45
+        },
+        "reward": null,
+        "status": "INACTIVE"
+      },
+      {
+        "action": { "submission": -1 },
+        "info": {},
+        "observation": {
+          "currentPlayer": 1,
+          "isTerminal": false,
+          "observationString": "r3n1k1/4b1pp/p2pN1r1/1ppqpN2/8/1PP4P/P4PP1/R1B1R1K1 w - - 0 23",
+          "playerId": 1,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n2426\n3572\n656\n2974\n89\n919\n3572\n4673\n2977\n2949\n674\n277\n1841\n1257\n4673\n4177\n1380\n788\n1258\n1842\n1809\n1987\n289\n673\n1527\n654\n3133\n1894\n3010\n2599\n1214\n1287\n2938\n2992\n3154\n3138\n3096\n3862\n1270\n3718\n800\n1771\n702\n\n"
+        },
+        "reward": null,
+        "status": "ACTIVE"
+      }
+    ],
+    [
+      {
+        "action": { "submission": -1 },
+        "info": {},
+        "observation": {
+          "currentPlayer": 0,
+          "isTerminal": false,
+          "observationString": "r3n1k1/4N1pp/p2pN1r1/1ppqp3/8/1PP4P/P4PP1/R1B1R1K1 b - - 0 23",
+          "playerId": 0,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n2426\n3572\n656\n2974\n89\n919\n3572\n4673\n2977\n2949\n674\n277\n1841\n1257\n4673\n4177\n1380\n788\n1258\n1842\n1809\n1987\n289\n673\n1527\n654\n3133\n1894\n3010\n2599\n1214\n1287\n2938\n2992\n3154\n3138\n3096\n3862\n1270\n3718\n800\n1771\n702\n3280\n\n",
+          "step": 46
+        },
+        "reward": null,
+        "status": "ACTIVE"
+      },
+      {
+        "action": {
+          "actionString": "Nxe7+",
+          "call_details": [
+            {
+              "duration_secs": 3.662,
+              "finish_reason": "stop",
+              "first_token_secs": 0.656,
+              "generation_tokens": 645,
+              "model": "openai/google/gemini-3.1-flash-lite-preview",
+              "prompt": "You are a chess expert\n\nLet's play chess. The current game state in Forsyth-Edwards Notation (FEN) notation is:\nr3n1k1/4b1pp/p2pN1r1/1ppqpN2/8/1PP4P/P4PP1/R1B1R1K1 w - - 0 23\nThe moves played so far are:\n1. e4 e5 2. Nf3 Nc6 3. Bb5 a6 4. Ba4 Nf6 5. O-O Be7 6. Re1 b5 7. Bb3 d6 8. c3 O-O 9. h3 Na5 10. Bc2 c5 11. d4 Qc7 12. d5 Nc4 13. b3 Nb6 14. Nbd2 Ne8 15. Nf1 f5 16. exf5 Bxf5 17. Bxf5 Rxf5 18. Ng3 Rf6 19. Ng5 Rg6 20. Ne6 Qb7 21. Nf5 Nxd5 22. Qxd5 Qxd5 23.\nYou are playing as player White.\nIt is now your turn. Play your strongest move. The move MUST be legal. Reason step by step to come up with your move, then output your final answer in the format \"Final Answer: X\" where X is your chosen move in standard algebraic notation (SAN).\n",
+              "prompt_tokens": 327,
+              "reasoning_tokens": 0,
+              "response": "The current FEN is `r3n1k1/4b1pp/p2pN1r1/1ppqpN2/8/1PP4P/P4PP1/R1B1R1K1 w - - 0 23`. Wait, looking at the provided FEN and the move list, there is a discrepancy: the last move provided was `23.`, implying white is to move after the black move `22... Qxd5`. However, the board shows white's queen is gone and black has a queen on `d5`.\n\nLet's evaluate the position:\n1. **Material:** White has a knight on `e6` and `f5`. Black has a rook on `g6` and a queen on `d5`.\n2. **Threats:** Black's queen on `d5` is attacking the knight on `e6` and `f5` (indirectly). The white knight on `e6` is currently under attack by the queen.\n3. **Candidate Moves:**\n    - `Nxe7+`: This is a powerful intermezzo. By playing `Nxe7+`, White puts the Black king in check and simultaneously attacks the Black queen on `d5` if Black responds with `...Kf7` or `...Kh8`.\n    - Let's check `23. Nxe7+`:\n        - If `23... Kf7`, White can then follow up.\n        - If `23... Kh8`, White captures the queen or retreats the knight.\n\nActually, looking closely at the board:\n- The move `22... Qxd5` was played. It is now White's turn.\n- White has a knight on `e6`.\n- Black has a bishop on `e7`.\n- `23. Nxe7+` is a check. After `23... Kf7` (or `Kh8`), White has effectively removed the bishop and created a tactical complication.\n- More importantly, `23. Nxe7+` forks the King and the Queen (since the Queen is on d5 and the King is on g8). Wait, the Queen is on d5, the King is on g8. A knight on e7 attacks c8, d5, f5, g6, g8.\n- If `23. Nxe7+`, the King must move. If `23... Kf7`, White can then consider moves like `Nxd5`. If `23... Kh8`, White has `Nxd5`.\n\nThis is a winning move as it wins the Queen for a knight or forces a major positional advantage.\n\nStep-by-step reasoning:\n1. The move `Nxe7+` checks the King on g8.\n2. It simultaneously attacks the Queen on d5.\n3. Black is forced to move the King.\n4. White will then be able to capture the Queen on d5.\n\nFinal Answer: Nxe7+",
+              "total_tokens": 972
+            }
+          ],
+          "status": "OK",
+          "submission": 3280,
+          "thoughts": "The current FEN is `r3n1k1/4b1pp/p2pN1r1/1ppqpN2/8/1PP4P/P4PP1/R1B1R1K1 w - - 0 23`. Wait, looking at the provided FEN and the move list, there is a discrepancy: the last move provided was `23.`, implying white is to move after the black move `22... Qxd5`. However, the board shows white's queen is gone and black has a queen on `d5`.\n\nLet's evaluate the position:\n1. **Material:** White has a knight on `e6` and `f5`. Black has a rook on `g6` and a queen on `d5`.\n2. **Threats:** Black's queen on `d5` is attacking the knight on `e6` and `f5` (indirectly). The white knight on `e6` is currently under attack by the queen.\n3. **Candidate Moves:**\n    - `Nxe7+`: This is a powerful intermezzo. By playing `Nxe7+`, White puts the Black king in check and simultaneously attacks the Black queen on `d5` if Black responds with `...Kf7` or `...Kh8`.\n    - Let's check `23. Nxe7+`:\n        - If `23... Kf7`, White can then follow up.\n        - If `23... Kh8`, White captures the queen or retreats the knight.\n\nActually, looking closely at the board:\n- The move `22... Qxd5` was played. It is now White's turn.\n- White has a knight on `e6`.\n- Black has a bishop on `e7`.\n- `23. Nxe7+` is a check. After `23... Kf7` (or `Kh8`), White has effectively removed the bishop and created a tactical complication.\n- More importantly, `23. Nxe7+` forks the King and the Queen (since the Queen is on d5 and the King is on g8). Wait, the Queen is on d5, the King is on g8. A knight on e7 attacks c8, d5, f5, g6, g8.\n- If `23. Nxe7+`, the King must move. If `23... Kf7`, White can then consider moves like `Nxd5`. If `23... Kh8`, White has `Nxd5`.\n\nThis is a winning move as it wins the Queen for a knight or forces a major positional advantage.\n\nStep-by-step reasoning:\n1. The move `Nxe7+` checks the King on g8.\n2. It simultaneously attacks the Queen on d5.\n3. Black is forced to move the King.\n4. White will then be able to capture the Queen on d5.\n\nFinal Answer: Nxe7+"
+        },
+        "info": {
+          "actionApplied": 3280,
+          "actionSubmitted": 3280,
+          "actionSubmittedToString": "Nxe7+",
+          "agentSelfReportedStatus": "OK",
+          "timeTaken": 4.655
+        },
+        "observation": {
+          "currentPlayer": 0,
+          "isTerminal": false,
+          "observationString": "r3n1k1/4N1pp/p2pN1r1/1ppqp3/8/1PP4P/P4PP1/R1B1R1K1 b - - 0 23",
+          "playerId": 1,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n2426\n3572\n656\n2974\n89\n919\n3572\n4673\n2977\n2949\n674\n277\n1841\n1257\n4673\n4177\n1380\n788\n1258\n1842\n1809\n1987\n289\n673\n1527\n654\n3133\n1894\n3010\n2599\n1214\n1287\n2938\n2992\n3154\n3138\n3096\n3862\n1270\n3718\n800\n1771\n702\n3280\n\n"
+        },
+        "reward": null,
+        "status": "INACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "actionString": "Kf7",
+          "call_details": [
+            {
+              "duration_secs": 2.458,
+              "finish_reason": "stop",
+              "first_token_secs": 0.617,
+              "generation_tokens": 450,
+              "model": "openai/google/gemini-3.1-flash-lite-preview",
+              "prompt": "\ud83d\udc4c\ud83d\udc40\ud83d\udc4c\ud83d\udc40\ud83d\udc4c\ud83d\udc40\ud83d\udc4c\ud83d\udc40\ud83d\udc4c\ud83d\udc40 good shit go\u0c66\u0501 sHit\ud83d\udc4c thats \u2714 some good\ud83d\udc4c\ud83d\udc4cshit right\ud83d\udc4c\ud83d\udc4cthere\ud83d\udc4c\ud83d\udc4c\ud83d\udc4c right\u2714there \u2714\u2714if i do \u01bda\u04af so my self \ud83d\udcaf i say so \ud83d\udcaf thats what im talking about right there right there (chorus: \u02b3\u1da6\u1d4d\u02b0\u1d57 \u1d57\u02b0\u1d49\u02b3\u1d49) mMMMM\u13b7\u041c\ud83d\udcaf \ud83d\udc4c\ud83d\udc4c \ud83d\udc4c\u041dO0\u041e\u0b20OOOOO\u041e\u0b20\u0b20Oooo\u1d52\u1d52\u1d52\u1d52\u1d52\u1d52\u1d52\u1d52\u1d52\ud83d\udc4c \ud83d\udc4c\ud83d\udc4c \ud83d\udc4c \ud83d\udcaf \ud83d\udc4c \ud83d\udc40 \ud83d\udc40 \ud83d\udc40 \ud83d\udc4c\ud83d\udc4c\n\nLet's play chess. The current game state in Forsyth-Edwards Notation (FEN) notation is:\nr3n1k1/4N1pp/p2pN1r1/1ppqp3/8/1PP4P/P4PP1/R1B1R1K1 b - - 0 23\nThe moves played so far are:\n1. e4 e5 2. Nf3 Nc6 3. Bb5 a6 4. Ba4 Nf6 5. O-O Be7 6. Re1 b5 7. Bb3 d6 8. c3 O-O 9. h3 Na5 10. Bc2 c5 11. d4 Qc7 12. d5 Nc4 13. b3 Nb6 14. Nbd2 Ne8 15. Nf1 f5 16. exf5 Bxf5 17. Bxf5 Rxf5 18. Ng3 Rf6 19. Ng5 Rg6 20. Ne6 Qb7 21. Nf5 Nxd5 22. Qxd5 Qxd5 23. Nxe7+\nYou are playing as player Black.\nIt is now your turn. Play your strongest move. The move MUST be legal. Reason step by step to come up with your move, then output your final answer in the format \"Final Answer: X\" where X is your chosen move in standard algebraic notation (SAN).\n",
+              "prompt_tokens": 449,
+              "reasoning_tokens": 0,
+              "response": "The current position is `r3n1k1/4N1pp/p2pN1r1/1ppqp3/8/1PP4P/P4PP1/R1B1R1K1 b - - 0 23`.\n\n**Evaluation:**\nWhite has just played `23. Nxe7+`, checking the Black king and simultaneously attacking the Black queen on `d5`. Black is in check and must respond.\n\n**Candidate Moves:**\n1. **... Kf7**: Moves the king out of check. However, White then plays `24. Nxd5`, capturing the queen for free.\n2. **... Kh8**: Moves the king to the corner. White then plays `24. Nxd5`, capturing the queen for free.\n\n**Analysis:**\nBlack's queen is hanging and the king is in check. There is no way to save the queen while addressing the check.\n*   If `23... Kf7`, White plays `24. Nxd5`. Black loses the queen, but might try to fight on in an endgame.\n*   If `23... Kh8`, White plays `24. Nxd5`. Black is down a significant amount of material (the queen).\n\nSince the queen is lost regardless of the king move, Black should choose the move that keeps the king safer or prepares to consolidate. `Kf7` centralizes the king slightly more, while `Kh8` keeps it tucked away. However, both lose the queen immediately.\n\nLooking at the board:\n*   White's `Nxe7+` is a fork of the King and the Queen.\n*   Black has no way to block the check or capture the attacking piece (`Nxe7`).\n*   Black must move the king.\n*   After `23... Kf7 24. Nxd5`, Black is left with a rook and a few pawns against White's queen and minor pieces.\n\nThere is no strategic alternative to losing the queen. `Kf7` is a standard response to get the king off the back rank.\n\nFinal Answer: Kf7",
+              "total_tokens": 899
+            }
+          ],
+          "status": "OK",
+          "submission": 3561,
+          "thoughts": "The current position is `r3n1k1/4N1pp/p2pN1r1/1ppqp3/8/1PP4P/P4PP1/R1B1R1K1 b - - 0 23`.\n\n**Evaluation:**\nWhite has just played `23. Nxe7+`, checking the Black king and simultaneously attacking the Black queen on `d5`. Black is in check and must respond.\n\n**Candidate Moves:**\n1. **... Kf7**: Moves the king out of check. However, White then plays `24. Nxd5`, capturing the queen for free.\n2. **... Kh8**: Moves the king to the corner. White then plays `24. Nxd5`, capturing the queen for free.\n\n**Analysis:**\nBlack's queen is hanging and the king is in check. There is no way to save the queen while addressing the check.\n*   If `23... Kf7`, White plays `24. Nxd5`. Black loses the queen, but might try to fight on in an endgame.\n*   If `23... Kh8`, White plays `24. Nxd5`. Black is down a significant amount of material (the queen).\n\nSince the queen is lost regardless of the king move, Black should choose the move that keeps the king safer or prepares to consolidate. `Kf7` centralizes the king slightly more, while `Kh8` keeps it tucked away. However, both lose the queen immediately.\n\nLooking at the board:\n*   White's `Nxe7+` is a fork of the King and the Queen.\n*   Black has no way to block the check or capture the attacking piece (`Nxe7`).\n*   Black must move the king.\n*   After `23... Kf7 24. Nxd5`, Black is left with a rook and a few pawns against White's queen and minor pieces.\n\nThere is no strategic alternative to losing the queen. `Kf7` is a standard response to get the king off the back rank.\n\nFinal Answer: Kf7"
+        },
+        "info": {
+          "actionApplied": 3561,
+          "actionSubmitted": 3561,
+          "actionSubmittedToString": "Kf7",
+          "agentSelfReportedStatus": "OK",
+          "timeTaken": 3.164
+        },
+        "observation": {
+          "currentPlayer": 1,
+          "isTerminal": false,
+          "observationString": "r3n3/4Nkpp/p2pN1r1/1ppqp3/8/1PP4P/P4PP1/R1B1R1K1 w - - 1 24",
+          "playerId": 0,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n2426\n3572\n656\n2974\n89\n919\n3572\n4673\n2977\n2949\n674\n277\n1841\n1257\n4673\n4177\n1380\n788\n1258\n1842\n1809\n1987\n289\n673\n1527\n654\n3133\n1894\n3010\n2599\n1214\n1287\n2938\n2992\n3154\n3138\n3096\n3862\n1270\n3718\n800\n1771\n702\n3280\n3561\n\n",
+          "step": 47
+        },
+        "reward": null,
+        "status": "INACTIVE"
+      },
+      {
+        "action": { "submission": -1 },
+        "info": {},
+        "observation": {
+          "currentPlayer": 1,
+          "isTerminal": false,
+          "observationString": "r3n3/4Nkpp/p2pN1r1/1ppqp3/8/1PP4P/P4PP1/R1B1R1K1 w - - 1 24",
+          "playerId": 1,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n2426\n3572\n656\n2974\n89\n919\n3572\n4673\n2977\n2949\n674\n277\n1841\n1257\n4673\n4177\n1380\n788\n1258\n1842\n1809\n1987\n289\n673\n1527\n654\n3133\n1894\n3010\n2599\n1214\n1287\n2938\n2992\n3154\n3138\n3096\n3862\n1270\n3718\n800\n1771\n702\n3280\n3561\n\n"
+        },
+        "reward": null,
+        "status": "ACTIVE"
+      }
+    ],
+    [
+      {
+        "action": { "submission": -1 },
+        "info": {},
+        "observation": {
+          "currentPlayer": 0,
+          "isTerminal": false,
+          "observationString": "r3n3/5kpp/p2pN1r1/1ppNp3/8/1PP4P/P4PP1/R1B1R1K1 b - - 0 24",
+          "playerId": 0,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n2426\n3572\n656\n2974\n89\n919\n3572\n4673\n2977\n2949\n674\n277\n1841\n1257\n4673\n4177\n1380\n788\n1258\n1842\n1809\n1987\n289\n673\n1527\n654\n3133\n1894\n3010\n2599\n1214\n1287\n2938\n2992\n3154\n3138\n3096\n3862\n1270\n3718\n800\n1771\n702\n3280\n3561\n2841\n\n",
+          "step": 48
+        },
+        "reward": null,
+        "status": "ACTIVE"
+      },
+      {
+        "action": {
+          "actionString": "Nxd5",
+          "call_details": [
+            {
+              "duration_secs": 3.028,
+              "finish_reason": "stop",
+              "first_token_secs": 0.841,
+              "generation_tokens": 459,
+              "model": "openai/google/gemini-3.1-flash-lite-preview",
+              "prompt": "You are a chess expert\n\nLet's play chess. The current game state in Forsyth-Edwards Notation (FEN) notation is:\nr3n3/4Nkpp/p2pN1r1/1ppqp3/8/1PP4P/P4PP1/R1B1R1K1 w - - 1 24\nThe moves played so far are:\n1. e4 e5 2. Nf3 Nc6 3. Bb5 a6 4. Ba4 Nf6 5. O-O Be7 6. Re1 b5 7. Bb3 d6 8. c3 O-O 9. h3 Na5 10. Bc2 c5 11. d4 Qc7 12. d5 Nc4 13. b3 Nb6 14. Nbd2 Ne8 15. Nf1 f5 16. exf5 Bxf5 17. Bxf5 Rxf5 18. Ng3 Rf6 19. Ng5 Rg6 20. Ne6 Qb7 21. Nf5 Nxd5 22. Qxd5 Qxd5 23. Nxe7+ Kf7 24.\nYou are playing as player White.\nIt is now your turn. Play your strongest move. The move MUST be legal. Reason step by step to come up with your move, then output your final answer in the format \"Final Answer: X\" where X is your chosen move in standard algebraic notation (SAN).\n",
+              "prompt_tokens": 332,
+              "reasoning_tokens": 0,
+              "response": "The current position is `r3n3/4Nkpp/p2pN1r1/1ppqp3/8/1PP4P/P4PP1/R1B1R1K1 w - - 1 24`. It is White's turn to move.\n\n**Evaluation:**\nWhite is currently in a winning position (+8 to +9). White has a material advantage (a Knight and a Pawn for nothing, after the tactical sequence involving the dual forks). Black's King is exposed, and White's pieces are well-coordinated.\n\n**Analysis:**\n1. **The immediate threat:** The move 24. Nxd5 is the most obvious and powerful candidate.\n2. **Material count:**\n   - White: Rooks on a1, e1; Bishop on c1; Knights on e6, e7; Pawns on a2, b3, c3, f2, g2, h3.\n   - Black: Rooks on a8, g6; Knight on e8; Queen on d5; Pawns on a6, b5, c5, e5, f7, g7, h7.\n   - Wait, looking at the board: Black just played 23... Kf7. The move 24. Nxd5 captures the Queen.\n3. **Candidate moves:**\n   - **24. Nxd5**: This wins the Queen for free. After 24. Nxd5, Black has no compensation.\n   - Any other move would be a massive blunder, throwing away the material advantage gained by the sequence of Knight forks.\n\n**Detailed look at 24. Nxd5:**\n- After 24. Nxd5, Black is down a Queen for a Knight. Black will likely respond with 24... Kxe6 to regain some material, but White will be up a Queen for a Knight (or simply a massive material lead).\n- White's material advantage is overwhelming. There are no tactical traps for Black that survive the capture of the Queen.\n\n**Conclusion:**\nTaking the Queen is the only logical and winning move.\n\nFinal Answer: Nxd5",
+              "total_tokens": 791
+            }
+          ],
+          "status": "OK",
+          "submission": 2841,
+          "thoughts": "The current position is `r3n3/4Nkpp/p2pN1r1/1ppqp3/8/1PP4P/P4PP1/R1B1R1K1 w - - 1 24`. It is White's turn to move.\n\n**Evaluation:**\nWhite is currently in a winning position (+8 to +9). White has a material advantage (a Knight and a Pawn for nothing, after the tactical sequence involving the dual forks). Black's King is exposed, and White's pieces are well-coordinated.\n\n**Analysis:**\n1. **The immediate threat:** The move 24. Nxd5 is the most obvious and powerful candidate.\n2. **Material count:**\n   - White: Rooks on a1, e1; Bishop on c1; Knights on e6, e7; Pawns on a2, b3, c3, f2, g2, h3.\n   - Black: Rooks on a8, g6; Knight on e8; Queen on d5; Pawns on a6, b5, c5, e5, f7, g7, h7.\n   - Wait, looking at the board: Black just played 23... Kf7. The move 24. Nxd5 captures the Queen.\n3. **Candidate moves:**\n   - **24. Nxd5**: This wins the Queen for free. After 24. Nxd5, Black has no compensation.\n   - Any other move would be a massive blunder, throwing away the material advantage gained by the sequence of Knight forks.\n\n**Detailed look at 24. Nxd5:**\n- After 24. Nxd5, Black is down a Queen for a Knight. Black will likely respond with 24... Kxe6 to regain some material, but White will be up a Queen for a Knight (or simply a massive material lead).\n- White's material advantage is overwhelming. There are no tactical traps for Black that survive the capture of the Queen.\n\n**Conclusion:**\nTaking the Queen is the only logical and winning move.\n\nFinal Answer: Nxd5"
+        },
+        "info": {
+          "actionApplied": 2841,
+          "actionSubmitted": 2841,
+          "actionSubmittedToString": "Nxd5",
+          "agentSelfReportedStatus": "OK",
+          "timeTaken": 3.706
+        },
+        "observation": {
+          "currentPlayer": 0,
+          "isTerminal": false,
+          "observationString": "r3n3/5kpp/p2pN1r1/1ppNp3/8/1PP4P/P4PP1/R1B1R1K1 b - - 0 24",
+          "playerId": 1,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n2426\n3572\n656\n2974\n89\n919\n3572\n4673\n2977\n2949\n674\n277\n1841\n1257\n4673\n4177\n1380\n788\n1258\n1842\n1809\n1987\n289\n673\n1527\n654\n3133\n1894\n3010\n2599\n1214\n1287\n2938\n2992\n3154\n3138\n3096\n3862\n1270\n3718\n800\n1771\n702\n3280\n3561\n2841\n\n"
+        },
+        "reward": null,
+        "status": "INACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "actionString": "Kxe6",
+          "call_details": [
+            {
+              "duration_secs": 4.843,
+              "finish_reason": "stop",
+              "first_token_secs": 0.667,
+              "generation_tokens": 1024,
+              "model": "openai/google/gemini-3.1-flash-lite-preview",
+              "prompt": "\ud83d\udc4c\ud83d\udc40\ud83d\udc4c\ud83d\udc40\ud83d\udc4c\ud83d\udc40\ud83d\udc4c\ud83d\udc40\ud83d\udc4c\ud83d\udc40 good shit go\u0c66\u0501 sHit\ud83d\udc4c thats \u2714 some good\ud83d\udc4c\ud83d\udc4cshit right\ud83d\udc4c\ud83d\udc4cthere\ud83d\udc4c\ud83d\udc4c\ud83d\udc4c right\u2714there \u2714\u2714if i do \u01bda\u04af so my self \ud83d\udcaf i say so \ud83d\udcaf thats what im talking about right there right there (chorus: \u02b3\u1da6\u1d4d\u02b0\u1d57 \u1d57\u02b0\u1d49\u02b3\u1d49) mMMMM\u13b7\u041c\ud83d\udcaf \ud83d\udc4c\ud83d\udc4c \ud83d\udc4c\u041dO0\u041e\u0b20OOOOO\u041e\u0b20\u0b20Oooo\u1d52\u1d52\u1d52\u1d52\u1d52\u1d52\u1d52\u1d52\u1d52\ud83d\udc4c \ud83d\udc4c\ud83d\udc4c \ud83d\udc4c \ud83d\udcaf \ud83d\udc4c \ud83d\udc40 \ud83d\udc40 \ud83d\udc40 \ud83d\udc4c\ud83d\udc4c\n\nLet's play chess. The current game state in Forsyth-Edwards Notation (FEN) notation is:\nr3n3/5kpp/p2pN1r1/1ppNp3/8/1PP4P/P4PP1/R1B1R1K1 b - - 0 24\nThe moves played so far are:\n1. e4 e5 2. Nf3 Nc6 3. Bb5 a6 4. Ba4 Nf6 5. O-O Be7 6. Re1 b5 7. Bb3 d6 8. c3 O-O 9. h3 Na5 10. Bc2 c5 11. d4 Qc7 12. d5 Nc4 13. b3 Nb6 14. Nbd2 Ne8 15. Nf1 f5 16. exf5 Bxf5 17. Bxf5 Rxf5 18. Ng3 Rf6 19. Ng5 Rg6 20. Ne6 Qb7 21. Nf5 Nxd5 22. Qxd5 Qxd5 23. Nxe7+ Kf7 24. Nxd5\nYou are playing as player Black.\nIt is now your turn. Play your strongest move. The move MUST be legal. Reason step by step to come up with your move, then output your final answer in the format \"Final Answer: X\" where X is your chosen move in standard algebraic notation (SAN).\n",
+              "prompt_tokens": 454,
+              "reasoning_tokens": 0,
+              "response": "The current FEN is `r3n3/5kpp/p2pN1r1/1ppNp3/8/1PP4P/P4PP1/R1B1R1K1 b - - 0 24`.\n\n**Evaluation:**\nWhite has a significant advantage due to the material lead (White is up a full piece: a knight for a pawn) and a dominant knight on `e6` that restricts Black's king and coordinates well with the rest of the position.\n\n**Candidate Moves for Black:**\n1. **...Kxe6**: This is the most logical move. It eliminates the annoying knight on `e6` that is currently forking the king and the rook on `g6`.\n2. **...Rxe6**: This also removes the knight but allows White to maintain a better structure and keeps Black's king somewhat exposed.\n\n**Detailed Analysis:**\n*   **...Kxe6**: \n    *   24... Kxe6 \n    *   The position becomes `r3n3/6pp/p2p2r1/1ppNp3/8/1PP4P/P4PP1/R1B1R1K1 w - - 0 25`.\n    *   Black has removed the main threat. White will likely respond with 25. c4 or 25. Ne3. \n    *   Material is still down, but the immediate pressure is relieved.\n\n*   **...Rxe6**: \n    *   24... Rxe6 \n    *   The position becomes `r3n3/5k2/p2pR3/1ppNp3/8/1PP4P/P4PP1/R1B1R1K1 w - - 0 25` (wait, the FEN update after 24. Nxd5 is that the knight on e6 is still there).\n    *   Let's re-verify: White just played 24. Nxd5.\n    *   The board: \n        White: R on a1, R on e1, N on e6, N on d5, K on g1, Pawns on a2, b3, c3, f2, g2, h3.\n        Black: R on a8, N on e8, R on g6, K on f7, Pawns on a6, c5, e5, d6, f7 (wait, the FEN says `r3n3/5kpp/p2pN1r1/1ppNp3/8/1PP4P/P4PP1/R1B1R1K1 b - - 0 24`).\n    *   Wait, the FEN provided is `r3n3/5kpp/p2pN1r1/1ppNp3/8/1PP4P/P4PP1/R1B1R1K1 b - - 0 24`.\n    *   The piece on e6 is White's knight. The piece on d5 is White's knight.\n    *   Black's pieces: K on f7, R on g6, N on e8.\n    *   Black is indeed in check from the knight on e6? No, the knight on e6 is not checking the king on f7.\n    *   Wait, let's re-check the FEN: `r3n3/5kpp/p2pN1r1/1ppNp3/8/1PP4P/P4PP1/R1B1R1K1`.\n    *   The knight on e6 is attacking f8 and g7 and d8 and c7. It is not checking the king. \n    *   Correction: The knight on e6 is threatening the rook on g6 and the pawn on g7.\n    *   Actually, 24... Kxe6 is definitely the best move to remove the monster knight on e6, which is controlling key squares.\n\n**Engine evaluation:**\nThe position is crushing for White. Taking the knight on e6 is the only reasonable way to continue.\n\n**Step-by-step reasoning:**\n1. The knight on e6 is extremely powerful, restricting the Black king and threatening to jump to other squares or create further threats.\n2. 24... Kxe6 removes this piece immediately.\n3. 24... Rxe6 would also remove the piece, but moving the king to e6 is safer as it centralized the king in the endgame, which is generally standard practice.\n\nTherefore, `Kxe6` is the correct move.\n\nFinal Answer: Kxe6",
+              "total_tokens": 1478
+            }
+          ],
+          "status": "OK",
+          "submission": 3050,
+          "thoughts": "The current FEN is `r3n3/5kpp/p2pN1r1/1ppNp3/8/1PP4P/P4PP1/R1B1R1K1 b - - 0 24`.\n\n**Evaluation:**\nWhite has a significant advantage due to the material lead (White is up a full piece: a knight for a pawn) and a dominant knight on `e6` that restricts Black's king and coordinates well with the rest of the position.\n\n**Candidate Moves for Black:**\n1. **...Kxe6**: This is the most logical move. It eliminates the annoying knight on `e6` that is currently forking the king and the rook on `g6`.\n2. **...Rxe6**: This also removes the knight but allows White to maintain a better structure and keeps Black's king somewhat exposed.\n\n**Detailed Analysis:**\n*   **...Kxe6**: \n    *   24... Kxe6 \n    *   The position becomes `r3n3/6pp/p2p2r1/1ppNp3/8/1PP4P/P4PP1/R1B1R1K1 w - - 0 25`.\n    *   Black has removed the main threat. White will likely respond with 25. c4 or 25. Ne3. \n    *   Material is still down, but the immediate pressure is relieved.\n\n*   **...Rxe6**: \n    *   24... Rxe6 \n    *   The position becomes `r3n3/5k2/p2pR3/1ppNp3/8/1PP4P/P4PP1/R1B1R1K1 w - - 0 25` (wait, the FEN update after 24. Nxd5 is that the knight on e6 is still there).\n    *   Let's re-verify: White just played 24. Nxd5.\n    *   The board: \n        White: R on a1, R on e1, N on e6, N on d5, K on g1, Pawns on a2, b3, c3, f2, g2, h3.\n        Black: R on a8, N on e8, R on g6, K on f7, Pawns on a6, c5, e5, d6, f7 (wait, the FEN says `r3n3/5kpp/p2pN1r1/1ppNp3/8/1PP4P/P4PP1/R1B1R1K1 b - - 0 24`).\n    *   Wait, the FEN provided is `r3n3/5kpp/p2pN1r1/1ppNp3/8/1PP4P/P4PP1/R1B1R1K1 b - - 0 24`.\n    *   The piece on e6 is White's knight. The piece on d5 is White's knight.\n    *   Black's pieces: K on f7, R on g6, N on e8.\n    *   Black is indeed in check from the knight on e6? No, the knight on e6 is not checking the king on f7.\n    *   Wait, let's re-check the FEN: `r3n3/5kpp/p2pN1r1/1ppNp3/8/1PP4P/P4PP1/R1B1R1K1`.\n    *   The knight on e6 is attacking f8 and g7 and d8 and c7. It is not checking the king. \n    *   Correction: The knight on e6 is threatening the rook on g6 and the pawn on g7.\n    *   Actually, 24... Kxe6 is definitely the best move to remove the monster knight on e6, which is controlling key squares.\n\n**Engine evaluation:**\nThe position is crushing for White. Taking the knight on e6 is the only reasonable way to continue.\n\n**Step-by-step reasoning:**\n1. The knight on e6 is extremely powerful, restricting the Black king and threatening to jump to other squares or create further threats.\n2. 24... Kxe6 removes this piece immediately.\n3. 24... Rxe6 would also remove the piece, but moving the king to e6 is safer as it centralized the king in the endgame, which is generally standard practice.\n\nTherefore, `Kxe6` is the correct move.\n\nFinal Answer: Kxe6"
+        },
+        "info": {
+          "actionApplied": 3050,
+          "actionSubmitted": 3050,
+          "actionSubmittedToString": "Kxe6",
+          "agentSelfReportedStatus": "OK",
+          "timeTaken": 5.456
+        },
+        "observation": {
+          "currentPlayer": 1,
+          "isTerminal": false,
+          "observationString": "r3n3/6pp/p2pk1r1/1ppNp3/8/1PP4P/P4PP1/R1B1R1K1 w - - 0 25",
+          "playerId": 0,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n2426\n3572\n656\n2974\n89\n919\n3572\n4673\n2977\n2949\n674\n277\n1841\n1257\n4673\n4177\n1380\n788\n1258\n1842\n1809\n1987\n289\n673\n1527\n654\n3133\n1894\n3010\n2599\n1214\n1287\n2938\n2992\n3154\n3138\n3096\n3862\n1270\n3718\n800\n1771\n702\n3280\n3561\n2841\n3050\n\n",
+          "step": 49
+        },
+        "reward": null,
+        "status": "INACTIVE"
+      },
+      {
+        "action": { "submission": -1 },
+        "info": {},
+        "observation": {
+          "currentPlayer": 1,
+          "isTerminal": false,
+          "observationString": "r3n3/6pp/p2pk1r1/1ppNp3/8/1PP4P/P4PP1/R1B1R1K1 w - - 0 25",
+          "playerId": 1,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n2426\n3572\n656\n2974\n89\n919\n3572\n4673\n2977\n2949\n674\n277\n1841\n1257\n4673\n4177\n1380\n788\n1258\n1842\n1809\n1987\n289\n673\n1527\n654\n3133\n1894\n3010\n2599\n1214\n1287\n2938\n2992\n3154\n3138\n3096\n3862\n1270\n3718\n800\n1771\n702\n3280\n3561\n2841\n3050\n\n"
+        },
+        "reward": null,
+        "status": "ACTIVE"
+      }
+    ],
+    [
+      {
+        "action": { "submission": -1 },
+        "info": {},
+        "observation": {
+          "currentPlayer": 0,
+          "isTerminal": false,
+          "observationString": "r3n3/6pp/p2pk1r1/1ppNp3/2P5/1P5P/P4PP1/R1B1R1K1 b - - 0 25",
+          "playerId": 0,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n2426\n3572\n656\n2974\n89\n919\n3572\n4673\n2977\n2949\n674\n277\n1841\n1257\n4673\n4177\n1380\n788\n1258\n1842\n1809\n1987\n289\n673\n1527\n654\n3133\n1894\n3010\n2599\n1214\n1287\n2938\n2992\n3154\n3138\n3096\n3862\n1270\n3718\n800\n1771\n702\n3280\n3561\n2841\n3050\n1330\n\n",
+          "step": 50
+        },
+        "reward": null,
+        "status": "ACTIVE"
+      },
+      {
+        "action": {
+          "actionString": "c4",
+          "call_details": [
+            {
+              "duration_secs": 3.318,
+              "finish_reason": "stop",
+              "first_token_secs": 0.777,
+              "generation_tokens": 575,
+              "model": "openai/google/gemini-3.1-flash-lite-preview",
+              "prompt": "You are a chess expert\n\nLet's play chess. The current game state in Forsyth-Edwards Notation (FEN) notation is:\nr3n3/6pp/p2pk1r1/1ppNp3/8/1PP4P/P4PP1/R1B1R1K1 w - - 0 25\nThe moves played so far are:\n1. e4 e5 2. Nf3 Nc6 3. Bb5 a6 4. Ba4 Nf6 5. O-O Be7 6. Re1 b5 7. Bb3 d6 8. c3 O-O 9. h3 Na5 10. Bc2 c5 11. d4 Qc7 12. d5 Nc4 13. b3 Nb6 14. Nbd2 Ne8 15. Nf1 f5 16. exf5 Bxf5 17. Bxf5 Rxf5 18. Ng3 Rf6 19. Ng5 Rg6 20. Ne6 Qb7 21. Nf5 Nxd5 22. Qxd5 Qxd5 23. Nxe7+ Kf7 24. Nxd5 Kxe6 25.\nYou are playing as player White.\nIt is now your turn. Play your strongest move. The move MUST be legal. Reason step by step to come up with your move, then output your final answer in the format \"Final Answer: X\" where X is your chosen move in standard algebraic notation (SAN).\n",
+              "prompt_tokens": 339,
+              "reasoning_tokens": 0,
+              "response": "The current position is `r3n3/6pp/p2pk1r1/1ppNp3/8/1PP4P/P4PP1/R1B1R1K1 w - - 0 25`. It is White's turn to move.\n\n**Evaluation:**\nWhite has a material advantage (a Knight for a Pawn). Black has a centralized King on e6 and a rook on g6. White's Knight on d5 is a very strong piece, restricting Black's pieces.\n\n**Candidate Moves:**\n1. **c4:** This move controls d5, fixes the queenside, and prepares to challenge the black pawns.\n2. **Ne3:** Repositioning the knight to a square where it can challenge the e6 king or prepare f4.\n3. **Rd1:** Bringing the rook into play to support the center and potentially challenge the d-file or rank.\n\n**Analysis:**\n- **25. c4:** This is a very solid positional move. It blunts Black's potential queenside play (`...bxc4` is not immediately threatening) and maintains control of the board.\n- **25. Ne3:** This moves the knight away from the d5 outpost. While the knight on d5 is strong, moving it to e3 could be useful if Black tries to harass it, but currently, it is safe.\n- **25. Rd1:** Developing the rook is standard. The rook on e1 is already well-placed, and the a1 rook needs development. \n\nConsidering the tactical situation, White's goal is to convert the material advantage. Trading pieces usually favors the side with the material advantage. The knight on d5 is the best piece on the board for White. Maintaining it is key.\n\nLet's look at `25. c4`. If Black plays `25... bxc4 26. bxc4`, White creates a protected passed pawn structure or at least a very stable center. If Black plays passively, White can bring the rook from a1 to d1 or c1. \n\nAnother option is **25. Nc7+**. Wait, the knight is on d5. The knight on d5 is very strong. Moving it should be done carefully. `25. c4` seems the most flexible and improves White's control.\n\nLet's re-examine `25. c4`. It limits the mobility of Black's pieces further. Black's king on e6 is somewhat exposed. `c4` restricts the black rook's ability to participate on the queenside.\n\nI will proceed with **25. c4**.\n\nFinal Answer: c4",
+              "total_tokens": 914
+            }
+          ],
+          "status": "OK",
+          "submission": 1330,
+          "thoughts": "The current position is `r3n3/6pp/p2pk1r1/1ppNp3/8/1PP4P/P4PP1/R1B1R1K1 w - - 0 25`. It is White's turn to move.\n\n**Evaluation:**\nWhite has a material advantage (a Knight for a Pawn). Black has a centralized King on e6 and a rook on g6. White's Knight on d5 is a very strong piece, restricting Black's pieces.\n\n**Candidate Moves:**\n1. **c4:** This move controls d5, fixes the queenside, and prepares to challenge the black pawns.\n2. **Ne3:** Repositioning the knight to a square where it can challenge the e6 king or prepare f4.\n3. **Rd1:** Bringing the rook into play to support the center and potentially challenge the d-file or rank.\n\n**Analysis:**\n- **25. c4:** This is a very solid positional move. It blunts Black's potential queenside play (`...bxc4` is not immediately threatening) and maintains control of the board.\n- **25. Ne3:** This moves the knight away from the d5 outpost. While the knight on d5 is strong, moving it to e3 could be useful if Black tries to harass it, but currently, it is safe.\n- **25. Rd1:** Developing the rook is standard. The rook on e1 is already well-placed, and the a1 rook needs development. \n\nConsidering the tactical situation, White's goal is to convert the material advantage. Trading pieces usually favors the side with the material advantage. The knight on d5 is the best piece on the board for White. Maintaining it is key.\n\nLet's look at `25. c4`. If Black plays `25... bxc4 26. bxc4`, White creates a protected passed pawn structure or at least a very stable center. If Black plays passively, White can bring the rook from a1 to d1 or c1. \n\nAnother option is **25. Nc7+**. Wait, the knight is on d5. The knight on d5 is very strong. Moving it should be done carefully. `25. c4` seems the most flexible and improves White's control.\n\nLet's re-examine `25. c4`. It limits the mobility of Black's pieces further. Black's king on e6 is somewhat exposed. `c4` restricts the black rook's ability to participate on the queenside.\n\nI will proceed with **25. c4**.\n\nFinal Answer: c4"
+        },
+        "info": {
+          "actionApplied": 1330,
+          "actionSubmitted": 1330,
+          "actionSubmittedToString": "c4",
+          "agentSelfReportedStatus": "OK",
+          "timeTaken": 3.889
+        },
+        "observation": {
+          "currentPlayer": 0,
+          "isTerminal": false,
+          "observationString": "r3n3/6pp/p2pk1r1/1ppNp3/2P5/1P5P/P4PP1/R1B1R1K1 b - - 0 25",
+          "playerId": 1,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n2426\n3572\n656\n2974\n89\n919\n3572\n4673\n2977\n2949\n674\n277\n1841\n1257\n4673\n4177\n1380\n788\n1258\n1842\n1809\n1987\n289\n673\n1527\n654\n3133\n1894\n3010\n2599\n1214\n1287\n2938\n2992\n3154\n3138\n3096\n3862\n1270\n3718\n800\n1771\n702\n3280\n3561\n2841\n3050\n1330\n\n"
+        },
+        "reward": null,
+        "status": "INACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "actionString": "Nf6",
+          "call_details": [
+            {
+              "duration_secs": 2.9,
+              "finish_reason": "stop",
+              "first_token_secs": 0.634,
+              "generation_tokens": 517,
+              "model": "openai/google/gemini-3.1-flash-lite-preview",
+              "prompt": "\ud83d\udc4c\ud83d\udc40\ud83d\udc4c\ud83d\udc40\ud83d\udc4c\ud83d\udc40\ud83d\udc4c\ud83d\udc40\ud83d\udc4c\ud83d\udc40 good shit go\u0c66\u0501 sHit\ud83d\udc4c thats \u2714 some good\ud83d\udc4c\ud83d\udc4cshit right\ud83d\udc4c\ud83d\udc4cthere\ud83d\udc4c\ud83d\udc4c\ud83d\udc4c right\u2714there \u2714\u2714if i do \u01bda\u04af so my self \ud83d\udcaf i say so \ud83d\udcaf thats what im talking about right there right there (chorus: \u02b3\u1da6\u1d4d\u02b0\u1d57 \u1d57\u02b0\u1d49\u02b3\u1d49) mMMMM\u13b7\u041c\ud83d\udcaf \ud83d\udc4c\ud83d\udc4c \ud83d\udc4c\u041dO0\u041e\u0b20OOOOO\u041e\u0b20\u0b20Oooo\u1d52\u1d52\u1d52\u1d52\u1d52\u1d52\u1d52\u1d52\u1d52\ud83d\udc4c \ud83d\udc4c\ud83d\udc4c \ud83d\udc4c \ud83d\udcaf \ud83d\udc4c \ud83d\udc40 \ud83d\udc40 \ud83d\udc40 \ud83d\udc4c\ud83d\udc4c\n\nLet's play chess. The current game state in Forsyth-Edwards Notation (FEN) notation is:\nr3n3/6pp/p2pk1r1/1ppNp3/2P5/1P5P/P4PP1/R1B1R1K1 b - - 0 25\nThe moves played so far are:\n1. e4 e5 2. Nf3 Nc6 3. Bb5 a6 4. Ba4 Nf6 5. O-O Be7 6. Re1 b5 7. Bb3 d6 8. c3 O-O 9. h3 Na5 10. Bc2 c5 11. d4 Qc7 12. d5 Nc4 13. b3 Nb6 14. Nbd2 Ne8 15. Nf1 f5 16. exf5 Bxf5 17. Bxf5 Rxf5 18. Ng3 Rf6 19. Ng5 Rg6 20. Ne6 Qb7 21. Nf5 Nxd5 22. Qxd5 Qxd5 23. Nxe7+ Kf7 24. Nxd5 Kxe6 25. c4\nYou are playing as player Black.\nIt is now your turn. Play your strongest move. The move MUST be legal. Reason step by step to come up with your move, then output your final answer in the format \"Final Answer: X\" where X is your chosen move in standard algebraic notation (SAN).\n",
+              "prompt_tokens": 463,
+              "reasoning_tokens": 0,
+              "response": "The current position is `r3n3/6pp/p2pk1r1/1ppNp3/2P5/1P5P/P4PP1/R1B1R1K1 b - - 0 25`. It is Black's turn to move.\n\n**Evaluation:**\nBlack has a slight advantage due to the centralized position of the king and the active rook on g6. White's knight on d5 is very strong, but Black's position is solid.\n\n**Candidate Moves for Black:**\n1. **...Nf6:** Challenges the d5 knight and prepares to improve the knight's position.\n2. **...Kd7:** Moves the king to a safer square, clearing the e-file and preparing to connect rooks.\n3. **...bxc4:** Simplifies the pawn structure.\n4. **...h6:** Prophylactic move against Ng5/Bg5 ideas, though not strictly necessary.\n\n**Analysis:**\n*   **...Nf6:** This is a very natural and strong move. It directly challenges White's best piece (the knight on d5). If White plays `Nxf6`, Black recaptures with `gxf6`, gaining the open g-file and controlling key squares. If White moves the knight, Black has successfully contested the center.\n*   **...bxc4:** After `25... bxc4 26. bxc4`, the position becomes very dry and drawish.\n*   **...Kd7:** A solid developing move, but less forcing than `Nf6`.\n\n**Detailed look at ...Nf6:**\nIf `25... Nf6`:\n- If `26. Nxf6 gxf6`, Black has a very active game with the rooks and a solid structure. The e-file remains under control.\n- If `26. Nc3` (or similar), Black has successfully improved the position of the knight and can continue to play for the initiative.\n\nThe move `Nf6` seems the most principled, as it forces White to make a decision about the knight on d5, which is currently the anchor of White's position. By trading or forcing the knight away, Black neutralizes White's primary source of counterplay.\n\nI have evaluated the position and determined that challenging the centralized knight is the most effective way to maintain and press the advantage.\n\nFinal Answer: Nf6",
+              "total_tokens": 980
+            }
+          ],
+          "status": "OK",
+          "submission": 2408,
+          "thoughts": "The current position is `r3n3/6pp/p2pk1r1/1ppNp3/2P5/1P5P/P4PP1/R1B1R1K1 b - - 0 25`. It is Black's turn to move.\n\n**Evaluation:**\nBlack has a slight advantage due to the centralized position of the king and the active rook on g6. White's knight on d5 is very strong, but Black's position is solid.\n\n**Candidate Moves for Black:**\n1. **...Nf6:** Challenges the d5 knight and prepares to improve the knight's position.\n2. **...Kd7:** Moves the king to a safer square, clearing the e-file and preparing to connect rooks.\n3. **...bxc4:** Simplifies the pawn structure.\n4. **...h6:** Prophylactic move against Ng5/Bg5 ideas, though not strictly necessary.\n\n**Analysis:**\n*   **...Nf6:** This is a very natural and strong move. It directly challenges White's best piece (the knight on d5). If White plays `Nxf6`, Black recaptures with `gxf6`, gaining the open g-file and controlling key squares. If White moves the knight, Black has successfully contested the center.\n*   **...bxc4:** After `25... bxc4 26. bxc4`, the position becomes very dry and drawish.\n*   **...Kd7:** A solid developing move, but less forcing than `Nf6`.\n\n**Detailed look at ...Nf6:**\nIf `25... Nf6`:\n- If `26. Nxf6 gxf6`, Black has a very active game with the rooks and a solid structure. The e-file remains under control.\n- If `26. Nc3` (or similar), Black has successfully improved the position of the knight and can continue to play for the initiative.\n\nThe move `Nf6` seems the most principled, as it forces White to make a decision about the knight on d5, which is currently the anchor of White's position. By trading or forcing the knight away, Black neutralizes White's primary source of counterplay.\n\nI have evaluated the position and determined that challenging the centralized knight is the most effective way to maintain and press the advantage.\n\nFinal Answer: Nf6"
+        },
+        "info": {
+          "actionApplied": 2408,
+          "actionSubmitted": 2408,
+          "actionSubmittedToString": "Nf6",
+          "agentSelfReportedStatus": "OK",
+          "timeTaken": 3.408
+        },
+        "observation": {
+          "currentPlayer": 1,
+          "isTerminal": false,
+          "observationString": "r7/6pp/p2pknr1/1ppNp3/2P5/1P5P/P4PP1/R1B1R1K1 w - - 1 26",
+          "playerId": 0,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n2426\n3572\n656\n2974\n89\n919\n3572\n4673\n2977\n2949\n674\n277\n1841\n1257\n4673\n4177\n1380\n788\n1258\n1842\n1809\n1987\n289\n673\n1527\n654\n3133\n1894\n3010\n2599\n1214\n1287\n2938\n2992\n3154\n3138\n3096\n3862\n1270\n3718\n800\n1771\n702\n3280\n3561\n2841\n3050\n1330\n2408\n\n",
+          "step": 51
+        },
+        "reward": null,
+        "status": "INACTIVE"
+      },
+      {
+        "action": { "submission": -1 },
+        "info": {},
+        "observation": {
+          "currentPlayer": 1,
+          "isTerminal": false,
+          "observationString": "r7/6pp/p2pknr1/1ppNp3/2P5/1P5P/P4PP1/R1B1R1K1 w - - 1 26",
+          "playerId": 1,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n2426\n3572\n656\n2974\n89\n919\n3572\n4673\n2977\n2949\n674\n277\n1841\n1257\n4673\n4177\n1380\n788\n1258\n1842\n1809\n1987\n289\n673\n1527\n654\n3133\n1894\n3010\n2599\n1214\n1287\n2938\n2992\n3154\n3138\n3096\n3862\n1270\n3718\n800\n1771\n702\n3280\n3561\n2841\n3050\n1330\n2408\n\n"
+        },
+        "reward": null,
+        "status": "ACTIVE"
+      }
+    ],
+    [
+      {
+        "action": { "submission": -1 },
+        "info": {},
+        "observation": {
+          "currentPlayer": 0,
+          "isTerminal": false,
+          "observationString": "r7/2N3pp/p2pknr1/1pp1p3/2P5/1P5P/P4PP1/R1B1R1K1 b - - 2 26",
+          "playerId": 0,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n2426\n3572\n656\n2974\n89\n919\n3572\n4673\n2977\n2949\n674\n277\n1841\n1257\n4673\n4177\n1380\n788\n1258\n1842\n1809\n1987\n289\n673\n1527\n654\n3133\n1894\n3010\n2599\n1214\n1287\n2938\n2992\n3154\n3138\n3096\n3862\n1270\n3718\n800\n1771\n702\n3280\n3561\n2841\n3050\n1330\n2408\n2112\n\n",
+          "step": 52
+        },
+        "reward": null,
+        "status": "ACTIVE"
+      },
+      {
+        "action": {
+          "actionString": "Nc7+",
+          "call_details": [
+            {
+              "duration_secs": 3.12,
+              "finish_reason": "stop",
+              "first_token_secs": 0.798,
+              "generation_tokens": 483,
+              "model": "openai/google/gemini-3.1-flash-lite-preview",
+              "prompt": "You are a chess expert\n\nLet's play chess. The current game state in Forsyth-Edwards Notation (FEN) notation is:\nr7/6pp/p2pknr1/1ppNp3/2P5/1P5P/P4PP1/R1B1R1K1 w - - 1 26\nThe moves played so far are:\n1. e4 e5 2. Nf3 Nc6 3. Bb5 a6 4. Ba4 Nf6 5. O-O Be7 6. Re1 b5 7. Bb3 d6 8. c3 O-O 9. h3 Na5 10. Bc2 c5 11. d4 Qc7 12. d5 Nc4 13. b3 Nb6 14. Nbd2 Ne8 15. Nf1 f5 16. exf5 Bxf5 17. Bxf5 Rxf5 18. Ng3 Rf6 19. Ng5 Rg6 20. Ne6 Qb7 21. Nf5 Nxd5 22. Qxd5 Qxd5 23. Nxe7+ Kf7 24. Nxd5 Kxe6 25. c4 Nf6 26.\nYou are playing as player White.\nIt is now your turn. Play your strongest move. The move MUST be legal. Reason step by step to come up with your move, then output your final answer in the format \"Final Answer: X\" where X is your chosen move in standard algebraic notation (SAN).\n",
+              "prompt_tokens": 347,
+              "reasoning_tokens": 0,
+              "response": "The current position is `r7/6pp/p2pknr1/1ppNp3/2P5/1P5P/P4PP1/R1B1R1K1 w - - 1 26`. It is White's turn to move.\n\n**Evaluation:**\nWhite has a clear material advantage (a Knight for a Pawn). Black has centralized the King, but the position is relatively open, and White's pieces are well-coordinated.\n\n**Candidate Moves:**\n1. **Nc7+**: This is a direct tactical shot. It attacks the Rook on a8. After 26. Nc7+ Kd7 27. Nxa8, White wins the exchange and transitions into a winning endgame.\n2. **Nxf6+**: This simplifies the position further, forcing 26... gxf6. While good, it is less ambitious than winning the exchange.\n3. **Be3**: A solid developing move, improving the coordination of the minor pieces.\n\n**Analysis of 26. Nc7+:**\nIf 26. Nc7+ Kd7 27. Nxa8. Black has to play something like 27... bxc4. White is clearly winning here due to the exchange advantage. Black's king is still somewhat exposed in the center, and White's material advantage is overwhelming.\n\n**Analysis of 26. Nxf6:**\nIf 26. Nxf6 gxf6, White still holds an advantage, but it doesn't immediately capitalize on the tactical opportunity provided by the misplaced Black pieces.\n\n**Conclusion:**\nThe move 26. Nc7+ is a strong forcing move that wins material and maintains the initiative. It immediately creates a decisive advantage by trapping the Rook on a8.\n\nStep-by-step reasoning:\n1. Identify the tactical opportunity: The Black Rook on a8 is undefended and reachable by the Knight on d5 via a fork.\n2. Verify the legality: 26. Nc7+ is a legal Knight move.\n3. Calculate the follow-up: After 26. Nc7+ Kd7 27. Nxa8, White has gained a Rook for a Knight, which is a decisive material advantage.\n\nFinal Answer: Nc7+",
+              "total_tokens": 830
+            }
+          ],
+          "status": "OK",
+          "submission": 2112,
+          "thoughts": "The current position is `r7/6pp/p2pknr1/1ppNp3/2P5/1P5P/P4PP1/R1B1R1K1 w - - 1 26`. It is White's turn to move.\n\n**Evaluation:**\nWhite has a clear material advantage (a Knight for a Pawn). Black has centralized the King, but the position is relatively open, and White's pieces are well-coordinated.\n\n**Candidate Moves:**\n1. **Nc7+**: This is a direct tactical shot. It attacks the Rook on a8. After 26. Nc7+ Kd7 27. Nxa8, White wins the exchange and transitions into a winning endgame.\n2. **Nxf6+**: This simplifies the position further, forcing 26... gxf6. While good, it is less ambitious than winning the exchange.\n3. **Be3**: A solid developing move, improving the coordination of the minor pieces.\n\n**Analysis of 26. Nc7+:**\nIf 26. Nc7+ Kd7 27. Nxa8. Black has to play something like 27... bxc4. White is clearly winning here due to the exchange advantage. Black's king is still somewhat exposed in the center, and White's material advantage is overwhelming.\n\n**Analysis of 26. Nxf6:**\nIf 26. Nxf6 gxf6, White still holds an advantage, but it doesn't immediately capitalize on the tactical opportunity provided by the misplaced Black pieces.\n\n**Conclusion:**\nThe move 26. Nc7+ is a strong forcing move that wins material and maintains the initiative. It immediately creates a decisive advantage by trapping the Rook on a8.\n\nStep-by-step reasoning:\n1. Identify the tactical opportunity: The Black Rook on a8 is undefended and reachable by the Knight on d5 via a fork.\n2. Verify the legality: 26. Nc7+ is a legal Knight move.\n3. Calculate the follow-up: After 26. Nc7+ Kd7 27. Nxa8, White has gained a Rook for a Knight, which is a decisive material advantage.\n\nFinal Answer: Nc7+"
+        },
+        "info": {
+          "actionApplied": 2112,
+          "actionSubmitted": 2112,
+          "actionSubmittedToString": "Nc7+",
+          "agentSelfReportedStatus": "OK",
+          "timeTaken": 3.687
+        },
+        "observation": {
+          "currentPlayer": 0,
+          "isTerminal": false,
+          "observationString": "r7/2N3pp/p2pknr1/1pp1p3/2P5/1P5P/P4PP1/R1B1R1K1 b - - 2 26",
+          "playerId": 1,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n2426\n3572\n656\n2974\n89\n919\n3572\n4673\n2977\n2949\n674\n277\n1841\n1257\n4673\n4177\n1380\n788\n1258\n1842\n1809\n1987\n289\n673\n1527\n654\n3133\n1894\n3010\n2599\n1214\n1287\n2938\n2992\n3154\n3138\n3096\n3862\n1270\n3718\n800\n1771\n702\n3280\n3561\n2841\n3050\n1330\n2408\n2112\n\n"
+        },
+        "reward": null,
+        "status": "INACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "actionString": "Kd7",
+          "call_details": [
+            {
+              "duration_secs": 2.987,
+              "finish_reason": "stop",
+              "first_token_secs": 0.648,
+              "generation_tokens": 567,
+              "model": "openai/google/gemini-3.1-flash-lite-preview",
+              "prompt": "\ud83d\udc4c\ud83d\udc40\ud83d\udc4c\ud83d\udc40\ud83d\udc4c\ud83d\udc40\ud83d\udc4c\ud83d\udc40\ud83d\udc4c\ud83d\udc40 good shit go\u0c66\u0501 sHit\ud83d\udc4c thats \u2714 some good\ud83d\udc4c\ud83d\udc4cshit right\ud83d\udc4c\ud83d\udc4cthere\ud83d\udc4c\ud83d\udc4c\ud83d\udc4c right\u2714there \u2714\u2714if i do \u01bda\u04af so my self \ud83d\udcaf i say so \ud83d\udcaf thats what im talking about right there right there (chorus: \u02b3\u1da6\u1d4d\u02b0\u1d57 \u1d57\u02b0\u1d49\u02b3\u1d49) mMMMM\u13b7\u041c\ud83d\udcaf \ud83d\udc4c\ud83d\udc4c \ud83d\udc4c\u041dO0\u041e\u0b20OOOOO\u041e\u0b20\u0b20Oooo\u1d52\u1d52\u1d52\u1d52\u1d52\u1d52\u1d52\u1d52\u1d52\ud83d\udc4c \ud83d\udc4c\ud83d\udc4c \ud83d\udc4c \ud83d\udcaf \ud83d\udc4c \ud83d\udc40 \ud83d\udc40 \ud83d\udc40 \ud83d\udc4c\ud83d\udc4c\n\nLet's play chess. The current game state in Forsyth-Edwards Notation (FEN) notation is:\nr7/2N3pp/p2pknr1/1pp1p3/2P5/1P5P/P4PP1/R1B1R1K1 b - - 2 26\nThe moves played so far are:\n1. e4 e5 2. Nf3 Nc6 3. Bb5 a6 4. Ba4 Nf6 5. O-O Be7 6. Re1 b5 7. Bb3 d6 8. c3 O-O 9. h3 Na5 10. Bc2 c5 11. d4 Qc7 12. d5 Nc4 13. b3 Nb6 14. Nbd2 Ne8 15. Nf1 f5 16. exf5 Bxf5 17. Bxf5 Rxf5 18. Ng3 Rf6 19. Ng5 Rg6 20. Ne6 Qb7 21. Nf5 Nxd5 22. Qxd5 Qxd5 23. Nxe7+ Kf7 24. Nxd5 Kxe6 25. c4 Nf6 26. Nc7+\nYou are playing as player Black.\nIt is now your turn. Play your strongest move. The move MUST be legal. Reason step by step to come up with your move, then output your final answer in the format \"Final Answer: X\" where X is your chosen move in standard algebraic notation (SAN).\n",
+              "prompt_tokens": 473,
+              "reasoning_tokens": 0,
+              "response": "The current FEN is `r7/2N3pp/p2pknr1/1pp1p3/2P5/1P5P/P4PP1/R1B1R1K1 b - - 2 26`. It is Black's turn to move.\n\n**Evaluation and Analysis:**\n1.  **Material:** Black is currently down a piece (the knight on c7 is forking the rooks).\n2.  **Immediate Threat:** The knight on c7 is attacking both rooks (a8 and e8). Black must move the rook that is not attacked by the knight or reposition to minimize damage.\n3.  **Candidate Moves:**\n    *   **... Kd7:** This moves the king out of check (wait, the move played was `26. Nc7+`, so the king is currently in check).\n    *   **King Safety:** The king is on e6 and is currently in check from the knight on c7. Black *must* move the king.\n    *   **Available King Moves:**\n        *   `... Kd7`: Moves the king to d7, away from the check, and no longer puts the king in range of the knight's fork. However, the knight on c7 will likely capture the rook on a8 next turn (`Nxa8`).\n        *   `... Kf5`: Moves the king toward the center/kingside, but allows the knight to capture a rook.\n        *   `... Ke7`: Moves the king back, allows the knight to capture a rook.\n\n**Detailed Consideration:**\n*   The knight on c7 is attacking the rooks on a8 and e8.\n*   After any king move, White will play `Nxa8`.\n*   Black needs to play the most active king move. `... Kd7` is the most standard escape, putting the king on a square where it is not immediately under fire and preparing to contest the position despite the material disadvantage.\n\nLet's look at the alternatives. The king must move because of the check.\n*   If `26... Kd7`, White plays `27. Nxa8`.\n*   If `26... Ke7`, White plays `27. Nxa8`.\n\nSince the loss of a full rook is inevitable due to the fork, the choice of king square is largely about where the king is safest. `Kd7` is active and keeps the king near the center, though the rook on a8 is lost. There are no tactical refutations to save the rook, so we play the forced legal move to escape check.\n\nFinal Answer: Kd7",
+              "total_tokens": 1040
+            }
+          ],
+          "status": "OK",
+          "submission": 2525,
+          "thoughts": "The current FEN is `r7/2N3pp/p2pknr1/1pp1p3/2P5/1P5P/P4PP1/R1B1R1K1 b - - 2 26`. It is Black's turn to move.\n\n**Evaluation and Analysis:**\n1.  **Material:** Black is currently down a piece (the knight on c7 is forking the rooks).\n2.  **Immediate Threat:** The knight on c7 is attacking both rooks (a8 and e8). Black must move the rook that is not attacked by the knight or reposition to minimize damage.\n3.  **Candidate Moves:**\n    *   **... Kd7:** This moves the king out of check (wait, the move played was `26. Nc7+`, so the king is currently in check).\n    *   **King Safety:** The king is on e6 and is currently in check from the knight on c7. Black *must* move the king.\n    *   **Available King Moves:**\n        *   `... Kd7`: Moves the king to d7, away from the check, and no longer puts the king in range of the knight's fork. However, the knight on c7 will likely capture the rook on a8 next turn (`Nxa8`).\n        *   `... Kf5`: Moves the king toward the center/kingside, but allows the knight to capture a rook.\n        *   `... Ke7`: Moves the king back, allows the knight to capture a rook.\n\n**Detailed Consideration:**\n*   The knight on c7 is attacking the rooks on a8 and e8.\n*   After any king move, White will play `Nxa8`.\n*   Black needs to play the most active king move. `... Kd7` is the most standard escape, putting the king on a square where it is not immediately under fire and preparing to contest the position despite the material disadvantage.\n\nLet's look at the alternatives. The king must move because of the check.\n*   If `26... Kd7`, White plays `27. Nxa8`.\n*   If `26... Ke7`, White plays `27. Nxa8`.\n\nSince the loss of a full rook is inevitable due to the fork, the choice of king square is largely about where the king is safest. `Kd7` is active and keeps the king near the center, though the rook on a8 is lost. There are no tactical refutations to save the rook, so we play the forced legal move to escape check.\n\nFinal Answer: Kd7"
+        },
+        "info": {
+          "actionApplied": 2525,
+          "actionSubmitted": 2525,
+          "actionSubmittedToString": "Kd7",
+          "agentSelfReportedStatus": "OK",
+          "timeTaken": 3.416
+        },
+        "observation": {
+          "currentPlayer": 1,
+          "isTerminal": false,
+          "observationString": "r7/2Nk2pp/p2p1nr1/1pp1p3/2P5/1P5P/P4PP1/R1B1R1K1 w - - 3 27",
+          "playerId": 0,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n2426\n3572\n656\n2974\n89\n919\n3572\n4673\n2977\n2949\n674\n277\n1841\n1257\n4673\n4177\n1380\n788\n1258\n1842\n1809\n1987\n289\n673\n1527\n654\n3133\n1894\n3010\n2599\n1214\n1287\n2938\n2992\n3154\n3138\n3096\n3862\n1270\n3718\n800\n1771\n702\n3280\n3561\n2841\n3050\n1330\n2408\n2112\n2525\n\n",
+          "step": 53
+        },
+        "reward": null,
+        "status": "INACTIVE"
+      },
+      {
+        "action": { "submission": -1 },
+        "info": {},
+        "observation": {
+          "currentPlayer": 1,
+          "isTerminal": false,
+          "observationString": "r7/2Nk2pp/p2p1nr1/1pp1p3/2P5/1P5P/P4PP1/R1B1R1K1 w - - 3 27",
+          "playerId": 1,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n2426\n3572\n656\n2974\n89\n919\n3572\n4673\n2977\n2949\n674\n277\n1841\n1257\n4673\n4177\n1380\n788\n1258\n1842\n1809\n1987\n289\n673\n1527\n654\n3133\n1894\n3010\n2599\n1214\n1287\n2938\n2992\n3154\n3138\n3096\n3862\n1270\n3718\n800\n1771\n702\n3280\n3561\n2841\n3050\n1330\n2408\n2112\n2525\n\n"
+        },
+        "reward": null,
+        "status": "ACTIVE"
+      }
+    ],
+    [
+      {
+        "action": { "submission": -1 },
+        "info": {},
+        "observation": {
+          "currentPlayer": 0,
+          "isTerminal": false,
+          "observationString": "N7/3k2pp/p2p1nr1/1pp1p3/2P5/1P5P/P4PP1/R1B1R1K1 b - - 0 27",
+          "playerId": 0,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n2426\n3572\n656\n2974\n89\n919\n3572\n4673\n2977\n2949\n674\n277\n1841\n1257\n4673\n4177\n1380\n788\n1258\n1842\n1809\n1987\n289\n673\n1527\n654\n3133\n1894\n3010\n2599\n1214\n1287\n2938\n2992\n3154\n3138\n3096\n3862\n1270\n3718\n800\n1771\n702\n3280\n3561\n2841\n3050\n1330\n2408\n2112\n2525\n1672\n\n",
+          "step": 54
+        },
+        "reward": null,
+        "status": "ACTIVE"
+      },
+      {
+        "action": {
+          "actionString": "Nxa8",
+          "call_details": [
+            {
+              "duration_secs": 2.741,
+              "finish_reason": "stop",
+              "first_token_secs": 0.617,
+              "generation_tokens": 547,
+              "model": "openai/google/gemini-3.1-flash-lite-preview",
+              "prompt": "You are a chess expert\n\nLet's play chess. The current game state in Forsyth-Edwards Notation (FEN) notation is:\nr7/2Nk2pp/p2p1nr1/1pp1p3/2P5/1P5P/P4PP1/R1B1R1K1 w - - 3 27\nThe moves played so far are:\n1. e4 e5 2. Nf3 Nc6 3. Bb5 a6 4. Ba4 Nf6 5. O-O Be7 6. Re1 b5 7. Bb3 d6 8. c3 O-O 9. h3 Na5 10. Bc2 c5 11. d4 Qc7 12. d5 Nc4 13. b3 Nb6 14. Nbd2 Ne8 15. Nf1 f5 16. exf5 Bxf5 17. Bxf5 Rxf5 18. Ng3 Rf6 19. Ng5 Rg6 20. Ne6 Qb7 21. Nf5 Nxd5 22. Qxd5 Qxd5 23. Nxe7+ Kf7 24. Nxd5 Kxe6 25. c4 Nf6 26. Nc7+ Kd7 27.\nYou are playing as player White.\nIt is now your turn. Play your strongest move. The move MUST be legal. Reason step by step to come up with your move, then output your final answer in the format \"Final Answer: X\" where X is your chosen move in standard algebraic notation (SAN).\n",
+              "prompt_tokens": 359,
+              "reasoning_tokens": 0,
+              "response": "The current FEN is `r7/2Nk2pp/p2p1nr1/1pp1p3/2P5/1P5P/P4PP1/R1B1R1K1 w - - 3 27`. It is White's turn to move.\n\n**Evaluation:**\nWhite has a clear material advantage (the Rook for a Knight exchange on the queenside occurred earlier, leaving White with an extra Knight). White just played `Nc7+`, forking the King and the Rook on `a8`. Black must respond to this.\n\n**Analysis of the Position:**\n1. **The Fork:** Black's Rook on `a8` is currently hanging. If Black moves the King (e.g., `Kd7` or `Ke7`), White will capture `Nxa8`.\n2. **Material:** White has a Knight for a Pawn advantage in the endgame after the exchange. Converting this should be straightforward.\n3. **Black's Responses:**\n   - If Black moves the King, `Nxa8` is the immediate capture.\n   - There are no tactical threats from Black that prevent White from taking the Rook.\n\n**Candidate Move:**\n- **Nxa8:** This is the most logical and powerful move. It wins the exchange (a Rook for a Knight), simplifying the position significantly and increasing White's material advantage to a full Rook.\n\n**Reasoning:**\n- White is currently attacking the Rook on `a8`.\n- Black must move their King to escape the check.\n- After the King moves, the Rook on `a8` remains undefended and hanging.\n- Taking the Rook creates a decisive material advantage that should lead to a win in the endgame. There are no complications or hidden traps for Black here.\n\nStep-by-step:\n1. Current FEN: `r7/2Nk2pp/p2p1nr1/1pp1p3/2P5/1P5P/P4PP1/R1B1R1K1 w - - 3 27`\n2. Black is in check from the Knight on `c7`.\n3. Black must move the King (e.g., `Kd8` or `Ke7`).\n4. White plays `Nxa8`, removing the Rook from the board.\n5. White is then up by a Rook against Black's remaining pieces.\n\nThe move `Nxa8` is the standard and correct continuation after the fork on `c7`.\n\nFinal Answer: Nxa8",
+              "total_tokens": 906
+            }
+          ],
+          "status": "OK",
+          "submission": 1672,
+          "thoughts": "The current FEN is `r7/2Nk2pp/p2p1nr1/1pp1p3/2P5/1P5P/P4PP1/R1B1R1K1 w - - 3 27`. It is White's turn to move.\n\n**Evaluation:**\nWhite has a clear material advantage (the Rook for a Knight exchange on the queenside occurred earlier, leaving White with an extra Knight). White just played `Nc7+`, forking the King and the Rook on `a8`. Black must respond to this.\n\n**Analysis of the Position:**\n1. **The Fork:** Black's Rook on `a8` is currently hanging. If Black moves the King (e.g., `Kd7` or `Ke7`), White will capture `Nxa8`.\n2. **Material:** White has a Knight for a Pawn advantage in the endgame after the exchange. Converting this should be straightforward.\n3. **Black's Responses:**\n   - If Black moves the King, `Nxa8` is the immediate capture.\n   - There are no tactical threats from Black that prevent White from taking the Rook.\n\n**Candidate Move:**\n- **Nxa8:** This is the most logical and powerful move. It wins the exchange (a Rook for a Knight), simplifying the position significantly and increasing White's material advantage to a full Rook.\n\n**Reasoning:**\n- White is currently attacking the Rook on `a8`.\n- Black must move their King to escape the check.\n- After the King moves, the Rook on `a8` remains undefended and hanging.\n- Taking the Rook creates a decisive material advantage that should lead to a win in the endgame. There are no complications or hidden traps for Black here.\n\nStep-by-step:\n1. Current FEN: `r7/2Nk2pp/p2p1nr1/1pp1p3/2P5/1P5P/P4PP1/R1B1R1K1 w - - 3 27`\n2. Black is in check from the Knight on `c7`.\n3. Black must move the King (e.g., `Kd8` or `Ke7`).\n4. White plays `Nxa8`, removing the Rook from the board.\n5. White is then up by a Rook against Black's remaining pieces.\n\nThe move `Nxa8` is the standard and correct continuation after the fork on `c7`.\n\nFinal Answer: Nxa8"
+        },
+        "info": {
+          "actionApplied": 1672,
+          "actionSubmitted": 1672,
+          "actionSubmittedToString": "Nxa8",
+          "agentSelfReportedStatus": "OK",
+          "timeTaken": 3.249
+        },
+        "observation": {
+          "currentPlayer": 0,
+          "isTerminal": false,
+          "observationString": "N7/3k2pp/p2p1nr1/1pp1p3/2P5/1P5P/P4PP1/R1B1R1K1 b - - 0 27",
+          "playerId": 1,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n2426\n3572\n656\n2974\n89\n919\n3572\n4673\n2977\n2949\n674\n277\n1841\n1257\n4673\n4177\n1380\n788\n1258\n1842\n1809\n1987\n289\n673\n1527\n654\n3133\n1894\n3010\n2599\n1214\n1287\n2938\n2992\n3154\n3138\n3096\n3862\n1270\n3718\n800\n1771\n702\n3280\n3561\n2841\n3050\n1330\n2408\n2112\n2525\n1672\n\n"
+        },
+        "reward": null,
+        "status": "INACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "actionString": "Kc6",
+          "call_details": [
+            {
+              "duration_secs": 2.765,
+              "finish_reason": "stop",
+              "first_token_secs": 0.724,
+              "generation_tokens": 465,
+              "model": "openai/google/gemini-3.1-flash-lite-preview",
+              "prompt": "\ud83d\udc4c\ud83d\udc40\ud83d\udc4c\ud83d\udc40\ud83d\udc4c\ud83d\udc40\ud83d\udc4c\ud83d\udc40\ud83d\udc4c\ud83d\udc40 good shit go\u0c66\u0501 sHit\ud83d\udc4c thats \u2714 some good\ud83d\udc4c\ud83d\udc4cshit right\ud83d\udc4c\ud83d\udc4cthere\ud83d\udc4c\ud83d\udc4c\ud83d\udc4c right\u2714there \u2714\u2714if i do \u01bda\u04af so my self \ud83d\udcaf i say so \ud83d\udcaf thats what im talking about right there right there (chorus: \u02b3\u1da6\u1d4d\u02b0\u1d57 \u1d57\u02b0\u1d49\u02b3\u1d49) mMMMM\u13b7\u041c\ud83d\udcaf \ud83d\udc4c\ud83d\udc4c \ud83d\udc4c\u041dO0\u041e\u0b20OOOOO\u041e\u0b20\u0b20Oooo\u1d52\u1d52\u1d52\u1d52\u1d52\u1d52\u1d52\u1d52\u1d52\ud83d\udc4c \ud83d\udc4c\ud83d\udc4c \ud83d\udc4c \ud83d\udcaf \ud83d\udc4c \ud83d\udc40 \ud83d\udc40 \ud83d\udc40 \ud83d\udc4c\ud83d\udc4c\n\nLet's play chess. The current game state in Forsyth-Edwards Notation (FEN) notation is:\nN7/3k2pp/p2p1nr1/1pp1p3/2P5/1P5P/P4PP1/R1B1R1K1 b - - 0 27\nThe moves played so far are:\n1. e4 e5 2. Nf3 Nc6 3. Bb5 a6 4. Ba4 Nf6 5. O-O Be7 6. Re1 b5 7. Bb3 d6 8. c3 O-O 9. h3 Na5 10. Bc2 c5 11. d4 Qc7 12. d5 Nc4 13. b3 Nb6 14. Nbd2 Ne8 15. Nf1 f5 16. exf5 Bxf5 17. Bxf5 Rxf5 18. Ng3 Rf6 19. Ng5 Rg6 20. Ne6 Qb7 21. Nf5 Nxd5 22. Qxd5 Qxd5 23. Nxe7+ Kf7 24. Nxd5 Kxe6 25. c4 Nf6 26. Nc7+ Kd7 27. Nxa8\nYou are playing as player Black.\nIt is now your turn. Play your strongest move. The move MUST be legal. Reason step by step to come up with your move, then output your final answer in the format \"Final Answer: X\" where X is your chosen move in standard algebraic notation (SAN).\n",
+              "prompt_tokens": 481,
+              "reasoning_tokens": 0,
+              "response": "The current position is `N7/3k2pp/p2p1nr1/1pp1p3/2P5/1P5P/P4PP1/R1B1R1K1 b - - 0 27`. It is Black's turn to move.\n\n**Evaluation:**\nWhite has just captured the rook on a8 with their knight (`Nxa8`). Black is down a significant amount of material (an exchange and a pawn). The knight on a8 is somewhat trapped but still creates a material advantage for White. Black needs to generate activity or consolidate the position to avoid immediate collapse.\n\n**Candidate Moves:**\n1. **... Kc6**: Centralizes the king and prepares to challenge the knight on a8 or support the center.\n2. **... bxc4**: Opens lines and challenges the c4 pawn.\n3. **... Nh5**: Relocates the knight to a more active square, eyeing potential threats or kingside pressure.\n\n**Detailed Analysis:**\n*   **... bxc4**: This is a solid choice. If `28. bxc4`, Black simplifies the center. However, the knight on a8 remains a nuisance.\n*   **... Kc6**: This is a very natural move. It improves the king's position and prepares to attack the trapped knight on a8. After `27... Kc6`, White will likely try to extract the knight (e.g., `28. Bd2` or `28. Be3`), but Black regains some control.\n*   **... Nh5**: This aims to pressure the kingside but seems slightly premature while the knight on a8 is still a tactical factor.\n\nConsidering the engine evaluation and positional needs, `Kc6` is the most principled move. It centralizes the king and immediately puts pressure on the white knight stuck on the rim.\n\n**Strategic Plan:**\n1. Centralize the King.\n2. Neutralize the white knight on a8.\n3. Use the space on the queenside to create counterplay.\n\nMove `Kc6` places the king on a more active square and prepares to box in the white knight.\n\nFinal Answer: Kc6",
+              "total_tokens": 946
+            }
+          ],
+          "status": "OK",
+          "submission": 1882,
+          "thoughts": "The current position is `N7/3k2pp/p2p1nr1/1pp1p3/2P5/1P5P/P4PP1/R1B1R1K1 b - - 0 27`. It is Black's turn to move.\n\n**Evaluation:**\nWhite has just captured the rook on a8 with their knight (`Nxa8`). Black is down a significant amount of material (an exchange and a pawn). The knight on a8 is somewhat trapped but still creates a material advantage for White. Black needs to generate activity or consolidate the position to avoid immediate collapse.\n\n**Candidate Moves:**\n1. **... Kc6**: Centralizes the king and prepares to challenge the knight on a8 or support the center.\n2. **... bxc4**: Opens lines and challenges the c4 pawn.\n3. **... Nh5**: Relocates the knight to a more active square, eyeing potential threats or kingside pressure.\n\n**Detailed Analysis:**\n*   **... bxc4**: This is a solid choice. If `28. bxc4`, Black simplifies the center. However, the knight on a8 remains a nuisance.\n*   **... Kc6**: This is a very natural move. It improves the king's position and prepares to attack the trapped knight on a8. After `27... Kc6`, White will likely try to extract the knight (e.g., `28. Bd2` or `28. Be3`), but Black regains some control.\n*   **... Nh5**: This aims to pressure the kingside but seems slightly premature while the knight on a8 is still a tactical factor.\n\nConsidering the engine evaluation and positional needs, `Kc6` is the most principled move. It centralizes the king and immediately puts pressure on the white knight stuck on the rim.\n\n**Strategic Plan:**\n1. Centralize the King.\n2. Neutralize the white knight on a8.\n3. Use the space on the queenside to create counterplay.\n\nMove `Kc6` places the king on a more active square and prepares to box in the white knight.\n\nFinal Answer: Kc6"
+        },
+        "info": {
+          "actionApplied": 1882,
+          "actionSubmitted": 1882,
+          "actionSubmittedToString": "Kc6",
+          "agentSelfReportedStatus": "OK",
+          "timeTaken": 3.209
+        },
+        "observation": {
+          "currentPlayer": 1,
+          "isTerminal": false,
+          "observationString": "N7/6pp/p1kp1nr1/1pp1p3/2P5/1P5P/P4PP1/R1B1R1K1 w - - 1 28",
+          "playerId": 0,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n2426\n3572\n656\n2974\n89\n919\n3572\n4673\n2977\n2949\n674\n277\n1841\n1257\n4673\n4177\n1380\n788\n1258\n1842\n1809\n1987\n289\n673\n1527\n654\n3133\n1894\n3010\n2599\n1214\n1287\n2938\n2992\n3154\n3138\n3096\n3862\n1270\n3718\n800\n1771\n702\n3280\n3561\n2841\n3050\n1330\n2408\n2112\n2525\n1672\n1882\n\n",
+          "step": 55
+        },
+        "reward": null,
+        "status": "INACTIVE"
+      },
+      {
+        "action": { "submission": -1 },
+        "info": {},
+        "observation": {
+          "currentPlayer": 1,
+          "isTerminal": false,
+          "observationString": "N7/6pp/p1kp1nr1/1pp1p3/2P5/1P5P/P4PP1/R1B1R1K1 w - - 1 28",
+          "playerId": 1,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n2426\n3572\n656\n2974\n89\n919\n3572\n4673\n2977\n2949\n674\n277\n1841\n1257\n4673\n4177\n1380\n788\n1258\n1842\n1809\n1987\n289\n673\n1527\n654\n3133\n1894\n3010\n2599\n1214\n1287\n2938\n2992\n3154\n3138\n3096\n3862\n1270\n3718\n800\n1771\n702\n3280\n3561\n2841\n3050\n1330\n2408\n2112\n2525\n1672\n1882\n\n"
+        },
+        "reward": null,
+        "status": "ACTIVE"
+      }
+    ],
+    [
+      {
+        "action": { "submission": -1 },
+        "info": {},
+        "observation": {
+          "currentPlayer": 0,
+          "isTerminal": false,
+          "observationString": "N7/6pp/p1kp1nr1/1pp1p3/2P5/1P5P/P2B1PP1/R3R1K1 b - - 2 28",
+          "playerId": 0,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n2426\n3572\n656\n2974\n89\n919\n3572\n4673\n2977\n2949\n674\n277\n1841\n1257\n4673\n4177\n1380\n788\n1258\n1842\n1809\n1987\n289\n673\n1527\n654\n3133\n1894\n3010\n2599\n1214\n1287\n2938\n2992\n3154\n3138\n3096\n3862\n1270\n3718\n800\n1771\n702\n3280\n3561\n2841\n3050\n1330\n2408\n2112\n2525\n1672\n1882\n1212\n\n",
+          "step": 56
+        },
+        "reward": null,
+        "status": "ACTIVE"
+      },
+      {
+        "action": {
+          "actionString": "Bd2",
+          "call_details": [
+            {
+              "duration_secs": 3.455,
+              "finish_reason": "stop",
+              "first_token_secs": 0.661,
+              "generation_tokens": 566,
+              "model": "openai/google/gemini-3.1-flash-lite-preview",
+              "prompt": "You are a chess expert\n\nLet's play chess. The current game state in Forsyth-Edwards Notation (FEN) notation is:\nN7/6pp/p1kp1nr1/1pp1p3/2P5/1P5P/P4PP1/R1B1R1K1 w - - 1 28\nThe moves played so far are:\n1. e4 e5 2. Nf3 Nc6 3. Bb5 a6 4. Ba4 Nf6 5. O-O Be7 6. Re1 b5 7. Bb3 d6 8. c3 O-O 9. h3 Na5 10. Bc2 c5 11. d4 Qc7 12. d5 Nc4 13. b3 Nb6 14. Nbd2 Ne8 15. Nf1 f5 16. exf5 Bxf5 17. Bxf5 Rxf5 18. Ng3 Rf6 19. Ng5 Rg6 20. Ne6 Qb7 21. Nf5 Nxd5 22. Qxd5 Qxd5 23. Nxe7+ Kf7 24. Nxd5 Kxe6 25. c4 Nf6 26. Nc7+ Kd7 27. Nxa8 Kc6 28.\nYou are playing as player White.\nIt is now your turn. Play your strongest move. The move MUST be legal. Reason step by step to come up with your move, then output your final answer in the format \"Final Answer: X\" where X is your chosen move in standard algebraic notation (SAN).\n",
+              "prompt_tokens": 365,
+              "reasoning_tokens": 0,
+              "response": "The current position is `N7/6pp/p1kp1nr1/1pp1p3/2P5/1P5P/P4PP1/R1B1R1K1 w - - 1 28`. It is White's turn to move.\n\n**Evaluation:**\nWhite is significantly ahead in material (a full rook). The knight on a8 is currently trapped and will likely be lost (Black threatens ...Kb7), but even after losing the knight, White remains materially ahead and enjoys a winning position.\n\n**Candidate Moves:**\n1. **a4**: This move attempts to create counterplay or loosen Black's queenside pawn structure. It also aims to potentially defend the a8 knight or create space for the white pieces.\n2. **Bd2**: This develops the bishop, controlling important diagonals and preparing to connect the rooks or bring the bishop into the game more effectively.\n3. **Be3**: Similar to Bd2, this develops the bishop to a strong square, eyeing the center and supporting the potential advance of the kingside pawns.\n4. **f4**: Challenges Black's center immediately.\n\n**Analysis:**\n- White's primary goal is to consolidate the material advantage and neutralize Black's activity. The knight on a8 is essentially \"doomed,\" as ...Kb7 will capture it. White should focus on activating the pieces and preparing for the endgame.\n- `Bd2` looks like a solid developmental move. It puts the bishop on a more active square and prepares to bring the rook into play or bolster the center.\n- `a4` is also interesting because if Black plays ...Kb7, White needs to consider if there are ways to complicate things or create threats while the black king is busy capturing the knight.\n- Given the material advantage, simplicity is key. Improving the position of the pieces while accepting the loss of the a8 knight is the most pragmatic approach. `Bd2` or `Be3` are both excellent ways to improve the minor piece. `Bd2` allows the bishop to look at the c3-square and participate in the defense if necessary.\n\nLet's look at `Bd2`:\nIt is simple, develops the piece, and prepares for the next phase of the game where Black will capture the knight on a8.\n\nFinal check of the FEN and board: The knight on a8 has no escape squares (b6, c7, b8 are covered or occupied). It will be captured by the king. White needs to ensure that the rest of the position remains solid.\n\nI will choose `Bd2` as a solid, principled developing move.\n\nFinal Answer: Bd2",
+              "total_tokens": 931
+            }
+          ],
+          "status": "OK",
+          "submission": 1212,
+          "thoughts": "The current position is `N7/6pp/p1kp1nr1/1pp1p3/2P5/1P5P/P4PP1/R1B1R1K1 w - - 1 28`. It is White's turn to move.\n\n**Evaluation:**\nWhite is significantly ahead in material (a full rook). The knight on a8 is currently trapped and will likely be lost (Black threatens ...Kb7), but even after losing the knight, White remains materially ahead and enjoys a winning position.\n\n**Candidate Moves:**\n1. **a4**: This move attempts to create counterplay or loosen Black's queenside pawn structure. It also aims to potentially defend the a8 knight or create space for the white pieces.\n2. **Bd2**: This develops the bishop, controlling important diagonals and preparing to connect the rooks or bring the bishop into the game more effectively.\n3. **Be3**: Similar to Bd2, this develops the bishop to a strong square, eyeing the center and supporting the potential advance of the kingside pawns.\n4. **f4**: Challenges Black's center immediately.\n\n**Analysis:**\n- White's primary goal is to consolidate the material advantage and neutralize Black's activity. The knight on a8 is essentially \"doomed,\" as ...Kb7 will capture it. White should focus on activating the pieces and preparing for the endgame.\n- `Bd2` looks like a solid developmental move. It puts the bishop on a more active square and prepares to bring the rook into play or bolster the center.\n- `a4` is also interesting because if Black plays ...Kb7, White needs to consider if there are ways to complicate things or create threats while the black king is busy capturing the knight.\n- Given the material advantage, simplicity is key. Improving the position of the pieces while accepting the loss of the a8 knight is the most pragmatic approach. `Bd2` or `Be3` are both excellent ways to improve the minor piece. `Bd2` allows the bishop to look at the c3-square and participate in the defense if necessary.\n\nLet's look at `Bd2`:\nIt is simple, develops the piece, and prepares for the next phase of the game where Black will capture the knight on a8.\n\nFinal check of the FEN and board: The knight on a8 has no escape squares (b6, c7, b8 are covered or occupied). It will be captured by the king. White needs to ensure that the rest of the position remains solid.\n\nI will choose `Bd2` as a solid, principled developing move.\n\nFinal Answer: Bd2"
+        },
+        "info": {
+          "actionApplied": 1212,
+          "actionSubmitted": 1212,
+          "actionSubmittedToString": "Bd2",
+          "agentSelfReportedStatus": "OK",
+          "timeTaken": 4.001
+        },
+        "observation": {
+          "currentPlayer": 0,
+          "isTerminal": false,
+          "observationString": "N7/6pp/p1kp1nr1/1pp1p3/2P5/1P5P/P2B1PP1/R3R1K1 b - - 2 28",
+          "playerId": 1,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n2426\n3572\n656\n2974\n89\n919\n3572\n4673\n2977\n2949\n674\n277\n1841\n1257\n4673\n4177\n1380\n788\n1258\n1842\n1809\n1987\n289\n673\n1527\n654\n3133\n1894\n3010\n2599\n1214\n1287\n2938\n2992\n3154\n3138\n3096\n3862\n1270\n3718\n800\n1771\n702\n3280\n3561\n2841\n3050\n1330\n2408\n2112\n2525\n1672\n1882\n1212\n\n"
+        },
+        "reward": null,
+        "status": "INACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "actionString": "bxc4",
+          "call_details": [
+            {
+              "duration_secs": 3.253,
+              "finish_reason": "stop",
+              "first_token_secs": 0.89,
+              "generation_tokens": 529,
+              "model": "openai/google/gemini-3.1-flash-lite-preview",
+              "prompt": "\ud83d\udc4c\ud83d\udc40\ud83d\udc4c\ud83d\udc40\ud83d\udc4c\ud83d\udc40\ud83d\udc4c\ud83d\udc40\ud83d\udc4c\ud83d\udc40 good shit go\u0c66\u0501 sHit\ud83d\udc4c thats \u2714 some good\ud83d\udc4c\ud83d\udc4cshit right\ud83d\udc4c\ud83d\udc4cthere\ud83d\udc4c\ud83d\udc4c\ud83d\udc4c right\u2714there \u2714\u2714if i do \u01bda\u04af so my self \ud83d\udcaf i say so \ud83d\udcaf thats what im talking about right there right there (chorus: \u02b3\u1da6\u1d4d\u02b0\u1d57 \u1d57\u02b0\u1d49\u02b3\u1d49) mMMMM\u13b7\u041c\ud83d\udcaf \ud83d\udc4c\ud83d\udc4c \ud83d\udc4c\u041dO0\u041e\u0b20OOOOO\u041e\u0b20\u0b20Oooo\u1d52\u1d52\u1d52\u1d52\u1d52\u1d52\u1d52\u1d52\u1d52\ud83d\udc4c \ud83d\udc4c\ud83d\udc4c \ud83d\udc4c \ud83d\udcaf \ud83d\udc4c \ud83d\udc40 \ud83d\udc40 \ud83d\udc40 \ud83d\udc4c\ud83d\udc4c\n\nLet's play chess. The current game state in Forsyth-Edwards Notation (FEN) notation is:\nN7/6pp/p1kp1nr1/1pp1p3/2P5/1P5P/P2B1PP1/R3R1K1 b - - 2 28\nThe moves played so far are:\n1. e4 e5 2. Nf3 Nc6 3. Bb5 a6 4. Ba4 Nf6 5. O-O Be7 6. Re1 b5 7. Bb3 d6 8. c3 O-O 9. h3 Na5 10. Bc2 c5 11. d4 Qc7 12. d5 Nc4 13. b3 Nb6 14. Nbd2 Ne8 15. Nf1 f5 16. exf5 Bxf5 17. Bxf5 Rxf5 18. Ng3 Rf6 19. Ng5 Rg6 20. Ne6 Qb7 21. Nf5 Nxd5 22. Qxd5 Qxd5 23. Nxe7+ Kf7 24. Nxd5 Kxe6 25. c4 Nf6 26. Nc7+ Kd7 27. Nxa8 Kc6 28. Bd2\nYou are playing as player Black.\nIt is now your turn. Play your strongest move. The move MUST be legal. Reason step by step to come up with your move, then output your final answer in the format \"Final Answer: X\" where X is your chosen move in standard algebraic notation (SAN).\n",
+              "prompt_tokens": 487,
+              "reasoning_tokens": 0,
+              "response": "The current position is `N7/6pp/p1kp1nr1/1pp1p3/2P5/1P5P/P2B1PP1/R3R1K1 b - - 2 28`. It is black's turn to move.\n\n**Evaluation:**\nBlack is currently down a full Rook (the Knight on a8 is trapped and effectively lost, though White hasn't captured it yet). However, Black has a solid pawn structure and some activity. White's pieces are somewhat uncoordinated, and the Knight on a8 is a target, but it also controls key squares.\n\n**Candidate Moves for Black:**\n1. **... bxc4:** This simplifies the position slightly, clears the a-file for the Rook, and creates tension on the queenside.\n2. **... Nh5:** Relocates the Knight to a more active square, preparing to challenge the kingside or support the center.\n3. **... Kb7:** Prepares to potentially trap the Knight on a8 if White isn't careful, although it's already quite restricted.\n\n**Analysis:**\n*   If Black plays **... bxc4**, White will likely respond with `bxc4`. This leaves Black with a backward d-pawn but opens the file.\n*   If Black plays **... Nh5**, it puts pressure on the g3/f4 squares and prepares to maneuver.\n*   The knight on a8 is doomed. Black's priority should be to maintain activity and limit White's ability to capitalize on the material advantage.\n\nLooking at engine evaluations for this specific end-game structure, the move **... bxc4** is the most standard and solid choice. It forces White to resolve the tension on the queenside and prevents White from creating a passed pawn easily.\n\nDetailed look at **... bxc4**:\nIf 28... bxc4 29. bxc4, the position remains roughly equal in terms of compensation for the material deficit, as White's Knight on a8 remains out of play for the time being. Any other move allows White to maintain a tighter grip on the queenside.\n\nLet's refine the move selection:\nThe move **bxc4** directly challenges White's structure and prevents the c4 pawn from becoming a nuisance.\n\nFinal check of the move legality:\nThe pawn is on b5, there is a pawn on c4. `bxc4` is a standard capture.\n\nFinal Answer: bxc4",
+              "total_tokens": 1016
+            }
+          ],
+          "status": "OK",
+          "submission": 847,
+          "thoughts": "The current position is `N7/6pp/p1kp1nr1/1pp1p3/2P5/1P5P/P2B1PP1/R3R1K1 b - - 2 28`. It is black's turn to move.\n\n**Evaluation:**\nBlack is currently down a full Rook (the Knight on a8 is trapped and effectively lost, though White hasn't captured it yet). However, Black has a solid pawn structure and some activity. White's pieces are somewhat uncoordinated, and the Knight on a8 is a target, but it also controls key squares.\n\n**Candidate Moves for Black:**\n1. **... bxc4:** This simplifies the position slightly, clears the a-file for the Rook, and creates tension on the queenside.\n2. **... Nh5:** Relocates the Knight to a more active square, preparing to challenge the kingside or support the center.\n3. **... Kb7:** Prepares to potentially trap the Knight on a8 if White isn't careful, although it's already quite restricted.\n\n**Analysis:**\n*   If Black plays **... bxc4**, White will likely respond with `bxc4`. This leaves Black with a backward d-pawn but opens the file.\n*   If Black plays **... Nh5**, it puts pressure on the g3/f4 squares and prepares to maneuver.\n*   The knight on a8 is doomed. Black's priority should be to maintain activity and limit White's ability to capitalize on the material advantage.\n\nLooking at engine evaluations for this specific end-game structure, the move **... bxc4** is the most standard and solid choice. It forces White to resolve the tension on the queenside and prevents White from creating a passed pawn easily.\n\nDetailed look at **... bxc4**:\nIf 28... bxc4 29. bxc4, the position remains roughly equal in terms of compensation for the material deficit, as White's Knight on a8 remains out of play for the time being. Any other move allows White to maintain a tighter grip on the queenside.\n\nLet's refine the move selection:\nThe move **bxc4** directly challenges White's structure and prevents the c4 pawn from becoming a nuisance.\n\nFinal check of the move legality:\nThe pawn is on b5, there is a pawn on c4. `bxc4` is a standard capture.\n\nFinal Answer: bxc4"
+        },
+        "info": {
+          "actionApplied": 847,
+          "actionSubmitted": 847,
+          "actionSubmittedToString": "bxc4",
+          "agentSelfReportedStatus": "OK",
+          "timeTaken": 3.727
+        },
+        "observation": {
+          "currentPlayer": 1,
+          "isTerminal": false,
+          "observationString": "N7/6pp/p1kp1nr1/2p1p3/2p5/1P5P/P2B1PP1/R3R1K1 w - - 0 29",
+          "playerId": 0,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n2426\n3572\n656\n2974\n89\n919\n3572\n4673\n2977\n2949\n674\n277\n1841\n1257\n4673\n4177\n1380\n788\n1258\n1842\n1809\n1987\n289\n673\n1527\n654\n3133\n1894\n3010\n2599\n1214\n1287\n2938\n2992\n3154\n3138\n3096\n3862\n1270\n3718\n800\n1771\n702\n3280\n3561\n2841\n3050\n1330\n2408\n2112\n2525\n1672\n1882\n1212\n847\n\n",
+          "step": 57
+        },
+        "reward": null,
+        "status": "INACTIVE"
+      },
+      {
+        "action": { "submission": -1 },
+        "info": {},
+        "observation": {
+          "currentPlayer": 1,
+          "isTerminal": false,
+          "observationString": "N7/6pp/p1kp1nr1/2p1p3/2p5/1P5P/P2B1PP1/R3R1K1 w - - 0 29",
+          "playerId": 1,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n2426\n3572\n656\n2974\n89\n919\n3572\n4673\n2977\n2949\n674\n277\n1841\n1257\n4673\n4177\n1380\n788\n1258\n1842\n1809\n1987\n289\n673\n1527\n654\n3133\n1894\n3010\n2599\n1214\n1287\n2938\n2992\n3154\n3138\n3096\n3862\n1270\n3718\n800\n1771\n702\n3280\n3561\n2841\n3050\n1330\n2408\n2112\n2525\n1672\n1882\n1212\n847\n\n"
+        },
+        "reward": null,
+        "status": "ACTIVE"
+      }
+    ],
+    [
+      {
+        "action": { "submission": -1 },
+        "info": {},
+        "observation": {
+          "currentPlayer": 0,
+          "isTerminal": false,
+          "observationString": "N7/6pp/p1kp1nr1/2p1p3/2P5/7P/P2B1PP1/R3R1K1 b - - 0 29",
+          "playerId": 0,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n2426\n3572\n656\n2974\n89\n919\n3572\n4673\n2977\n2949\n674\n277\n1841\n1257\n4673\n4177\n1380\n788\n1258\n1842\n1809\n1987\n289\n673\n1527\n654\n3133\n1894\n3010\n2599\n1214\n1287\n2938\n2992\n3154\n3138\n3096\n3862\n1270\n3718\n800\n1771\n702\n3280\n3561\n2841\n3050\n1330\n2408\n2112\n2525\n1672\n1882\n1212\n847\n774\n\n",
+          "step": 58
+        },
+        "reward": null,
+        "status": "ACTIVE"
+      },
+      {
+        "action": {
+          "actionString": "bxc4",
+          "call_details": [
+            {
+              "duration_secs": 3.335,
+              "finish_reason": "stop",
+              "first_token_secs": 0.727,
+              "generation_tokens": 550,
+              "model": "openai/google/gemini-3.1-flash-lite-preview",
+              "prompt": "You are a chess expert\n\nLet's play chess. The current game state in Forsyth-Edwards Notation (FEN) notation is:\nN7/6pp/p1kp1nr1/2p1p3/2p5/1P5P/P2B1PP1/R3R1K1 w - - 0 29\nThe moves played so far are:\n1. e4 e5 2. Nf3 Nc6 3. Bb5 a6 4. Ba4 Nf6 5. O-O Be7 6. Re1 b5 7. Bb3 d6 8. c3 O-O 9. h3 Na5 10. Bc2 c5 11. d4 Qc7 12. d5 Nc4 13. b3 Nb6 14. Nbd2 Ne8 15. Nf1 f5 16. exf5 Bxf5 17. Bxf5 Rxf5 18. Ng3 Rf6 19. Ng5 Rg6 20. Ne6 Qb7 21. Nf5 Nxd5 22. Qxd5 Qxd5 23. Nxe7+ Kf7 24. Nxd5 Kxe6 25. c4 Nf6 26. Nc7+ Kd7 27. Nxa8 Kc6 28. Bd2 bxc4 29.\nYou are playing as player White.\nIt is now your turn. Play your strongest move. The move MUST be legal. Reason step by step to come up with your move, then output your final answer in the format \"Final Answer: X\" where X is your chosen move in standard algebraic notation (SAN).\n",
+              "prompt_tokens": 373,
+              "reasoning_tokens": 0,
+              "response": "The current FEN is `N7/6pp/p1kp1nr1/2p1p3/2p5/1P5P/P2B1PP1/R3R1K1 w - - 0 29`. It is white's turn to move.\n\n**Evaluation:**\nWhite is currently up a full exchange (Knight for two pawns, but effectively material is +1 for White after the tactical sequence). Black's knight on f6 is somewhat restricted, and the position is solid for White.\n\n**Candidate Moves:**\n1. **bxc4:** This is the most natural move. Black has a pawn on c4 attacking the knight on a8. Capturing `bxc4` eliminates the threat to the knight and consolidates the structure.\n2. **Re3:** A prophylactic move, but unnecessary as the immediate threat is the pawn capturing the knight.\n3. **a4:** Trying to secure the queenside, but allowing `cxb3` could be problematic.\n\n**Analysis of bxc4:**\nIf White plays `bxc4`, Black might respond with `Kb7`, trapping the knight on a8. Let's look at that:\n29. bxc4 Kb7 30. Rab1+ Kxa8. White loses the knight, but maintains material equality (or close to it) and a strong position. \nWait, let's look at the board again. After 29. bxc4, if Black plays 29... Kb7, White has 30. Rab1+ Kxa8 31. Rb6. White's rook becomes very active on the 6th rank, attacking the d6-pawn and putting pressure on the Black king.\n\nIf White does not play `bxc4`, the knight on a8 is doomed anyway (it has no escape squares), so capturing the pawn on c4 is the best way to gain structural compensation and activate the rooks.\n\n**Step-by-step reasoning:**\n- The knight on a8 is trapped and will be captured by the king or bishop eventually.\n- The pawn on c4 is a nuisance.\n- `bxc4` stabilizes the position, removes the dangerous passed pawn, and opens the b-file for the rook.\n- After 29. bxc4 Kb7 30. Rab1+ Kxa8 31. Rb6, White has excellent compensation for the knight through activity and attacking chances on the kingside/central pawns.\n\nThis is the most principled and strongest move.\n\nFinal Answer: bxc4",
+              "total_tokens": 923
+            }
+          ],
+          "status": "OK",
+          "submission": 774,
+          "thoughts": "The current FEN is `N7/6pp/p1kp1nr1/2p1p3/2p5/1P5P/P2B1PP1/R3R1K1 w - - 0 29`. It is white's turn to move.\n\n**Evaluation:**\nWhite is currently up a full exchange (Knight for two pawns, but effectively material is +1 for White after the tactical sequence). Black's knight on f6 is somewhat restricted, and the position is solid for White.\n\n**Candidate Moves:**\n1. **bxc4:** This is the most natural move. Black has a pawn on c4 attacking the knight on a8. Capturing `bxc4` eliminates the threat to the knight and consolidates the structure.\n2. **Re3:** A prophylactic move, but unnecessary as the immediate threat is the pawn capturing the knight.\n3. **a4:** Trying to secure the queenside, but allowing `cxb3` could be problematic.\n\n**Analysis of bxc4:**\nIf White plays `bxc4`, Black might respond with `Kb7`, trapping the knight on a8. Let's look at that:\n29. bxc4 Kb7 30. Rab1+ Kxa8. White loses the knight, but maintains material equality (or close to it) and a strong position. \nWait, let's look at the board again. After 29. bxc4, if Black plays 29... Kb7, White has 30. Rab1+ Kxa8 31. Rb6. White's rook becomes very active on the 6th rank, attacking the d6-pawn and putting pressure on the Black king.\n\nIf White does not play `bxc4`, the knight on a8 is doomed anyway (it has no escape squares), so capturing the pawn on c4 is the best way to gain structural compensation and activate the rooks.\n\n**Step-by-step reasoning:**\n- The knight on a8 is trapped and will be captured by the king or bishop eventually.\n- The pawn on c4 is a nuisance.\n- `bxc4` stabilizes the position, removes the dangerous passed pawn, and opens the b-file for the rook.\n- After 29. bxc4 Kb7 30. Rab1+ Kxa8 31. Rb6, White has excellent compensation for the knight through activity and attacking chances on the kingside/central pawns.\n\nThis is the most principled and strongest move.\n\nFinal Answer: bxc4"
+        },
+        "info": {
+          "actionApplied": 774,
+          "actionSubmitted": 774,
+          "actionSubmittedToString": "bxc4",
+          "agentSelfReportedStatus": "OK",
+          "timeTaken": 3.786
+        },
+        "observation": {
+          "currentPlayer": 0,
+          "isTerminal": false,
+          "observationString": "N7/6pp/p1kp1nr1/2p1p3/2P5/7P/P2B1PP1/R3R1K1 b - - 0 29",
+          "playerId": 1,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n2426\n3572\n656\n2974\n89\n919\n3572\n4673\n2977\n2949\n674\n277\n1841\n1257\n4673\n4177\n1380\n788\n1258\n1842\n1809\n1987\n289\n673\n1527\n654\n3133\n1894\n3010\n2599\n1214\n1287\n2938\n2992\n3154\n3138\n3096\n3862\n1270\n3718\n800\n1771\n702\n3280\n3561\n2841\n3050\n1330\n2408\n2112\n2525\n1672\n1882\n1212\n847\n774\n\n"
+        },
+        "reward": null,
+        "status": "INACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "actionString": "Nd7",
+          "call_details": [
+            {
+              "duration_secs": 2.907,
+              "finish_reason": "stop",
+              "first_token_secs": 0.607,
+              "generation_tokens": 500,
+              "model": "openai/google/gemini-3.1-flash-lite-preview",
+              "prompt": "\ud83d\udc4c\ud83d\udc40\ud83d\udc4c\ud83d\udc40\ud83d\udc4c\ud83d\udc40\ud83d\udc4c\ud83d\udc40\ud83d\udc4c\ud83d\udc40 good shit go\u0c66\u0501 sHit\ud83d\udc4c thats \u2714 some good\ud83d\udc4c\ud83d\udc4cshit right\ud83d\udc4c\ud83d\udc4cthere\ud83d\udc4c\ud83d\udc4c\ud83d\udc4c right\u2714there \u2714\u2714if i do \u01bda\u04af so my self \ud83d\udcaf i say so \ud83d\udcaf thats what im talking about right there right there (chorus: \u02b3\u1da6\u1d4d\u02b0\u1d57 \u1d57\u02b0\u1d49\u02b3\u1d49) mMMMM\u13b7\u041c\ud83d\udcaf \ud83d\udc4c\ud83d\udc4c \ud83d\udc4c\u041dO0\u041e\u0b20OOOOO\u041e\u0b20\u0b20Oooo\u1d52\u1d52\u1d52\u1d52\u1d52\u1d52\u1d52\u1d52\u1d52\ud83d\udc4c \ud83d\udc4c\ud83d\udc4c \ud83d\udc4c \ud83d\udcaf \ud83d\udc4c \ud83d\udc40 \ud83d\udc40 \ud83d\udc40 \ud83d\udc4c\ud83d\udc4c\n\nLet's play chess. The current game state in Forsyth-Edwards Notation (FEN) notation is:\nN7/6pp/p1kp1nr1/2p1p3/2P5/7P/P2B1PP1/R3R1K1 b - - 0 29\nThe moves played so far are:\n1. e4 e5 2. Nf3 Nc6 3. Bb5 a6 4. Ba4 Nf6 5. O-O Be7 6. Re1 b5 7. Bb3 d6 8. c3 O-O 9. h3 Na5 10. Bc2 c5 11. d4 Qc7 12. d5 Nc4 13. b3 Nb6 14. Nbd2 Ne8 15. Nf1 f5 16. exf5 Bxf5 17. Bxf5 Rxf5 18. Ng3 Rf6 19. Ng5 Rg6 20. Ne6 Qb7 21. Nf5 Nxd5 22. Qxd5 Qxd5 23. Nxe7+ Kf7 24. Nxd5 Kxe6 25. c4 Nf6 26. Nc7+ Kd7 27. Nxa8 Kc6 28. Bd2 bxc4 29. bxc4\nYou are playing as player Black.\nIt is now your turn. Play your strongest move. The move MUST be legal. Reason step by step to come up with your move, then output your final answer in the format \"Final Answer: X\" where X is your chosen move in standard algebraic notation (SAN).\n",
+              "prompt_tokens": 493,
+              "reasoning_tokens": 0,
+              "response": "The current position is `N7/6pp/p1kp1nr1/2p1p3/2P5/7P/P2B1PP1/R3R1K1 b - - 0 29`. It is black's turn to move.\n\n**Evaluation:**\nBlack is down a full rook (the Knight on a8 is captured). White has a significant material advantage. Black's goal is to activate the pieces and try to find some counterplay or simplify to minimize White's advantage.\n\n**Candidate moves for Black:**\n1. **... Nd7:** This develops the knight from f6, clears the f-file for the rook, and eyes the c5 or e5 squares.\n2. **... Kb7:** A standard prophylactic move to get the king out of the center and off the potential c-file pressure.\n3. **... h6:** Prepares to restrict White's kingside and gives the king an escape square at h7.\n\n**Analysis:**\n- White's knight on a8 is trapped and will eventually be lost, but Black is currently losing material.\n- The immediate priority for Black is piece coordination. The Knight on f6 is the only active piece besides the King.\n- `... Nd7` is a strong positional move. It challenges the control of the board, prepares to redeploy the knight to b6 or e5, and clears the path for the rook.\n- After `29... Nd7`, Black aims to solidify the position. If White plays `30. Rab1`, Black can play `30... Nb6` (attacking c4) or `30... Kc7`.\n\nConsidering the engine evaluation and positional needs, `Nd7` is the most flexible and active move for Black in this lost position. It improves the knight's position from the passive f6 square and prepares to challenge White's control.\n\nStep-by-step reasoning:\n1. Identify the material deficit (White is up a piece).\n2. The goal is to improve piece activity. The knight on f6 is doing little.\n3. Moving the knight to d7 prepares to challenge the c4 pawn (via b6) and improves defensive stability.\n4. `Nd7` is the most principled move to reorganize Black's forces.\n\nFinal Answer: Nd7",
+              "total_tokens": 993
+            }
+          ],
+          "status": "OK",
+          "submission": 3131,
+          "thoughts": "The current position is `N7/6pp/p1kp1nr1/2p1p3/2P5/7P/P2B1PP1/R3R1K1 b - - 0 29`. It is black's turn to move.\n\n**Evaluation:**\nBlack is down a full rook (the Knight on a8 is captured). White has a significant material advantage. Black's goal is to activate the pieces and try to find some counterplay or simplify to minimize White's advantage.\n\n**Candidate moves for Black:**\n1. **... Nd7:** This develops the knight from f6, clears the f-file for the rook, and eyes the c5 or e5 squares.\n2. **... Kb7:** A standard prophylactic move to get the king out of the center and off the potential c-file pressure.\n3. **... h6:** Prepares to restrict White's kingside and gives the king an escape square at h7.\n\n**Analysis:**\n- White's knight on a8 is trapped and will eventually be lost, but Black is currently losing material.\n- The immediate priority for Black is piece coordination. The Knight on f6 is the only active piece besides the King.\n- `... Nd7` is a strong positional move. It challenges the control of the board, prepares to redeploy the knight to b6 or e5, and clears the path for the rook.\n- After `29... Nd7`, Black aims to solidify the position. If White plays `30. Rab1`, Black can play `30... Nb6` (attacking c4) or `30... Kc7`.\n\nConsidering the engine evaluation and positional needs, `Nd7` is the most flexible and active move for Black in this lost position. It improves the knight's position from the passive f6 square and prepares to challenge White's control.\n\nStep-by-step reasoning:\n1. Identify the material deficit (White is up a piece).\n2. The goal is to improve piece activity. The knight on f6 is doing little.\n3. Moving the knight to d7 prepares to challenge the c4 pawn (via b6) and improves defensive stability.\n4. `Nd7` is the most principled move to reorganize Black's forces.\n\nFinal Answer: Nd7"
+        },
+        "info": {
+          "actionApplied": 3131,
+          "actionSubmitted": 3131,
+          "actionSubmittedToString": "Nd7",
+          "agentSelfReportedStatus": "OK",
+          "timeTaken": 3.371
+        },
+        "observation": {
+          "currentPlayer": 1,
+          "isTerminal": false,
+          "observationString": "N7/3n2pp/p1kp2r1/2p1p3/2P5/7P/P2B1PP1/R3R1K1 w - - 1 30",
+          "playerId": 0,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n2426\n3572\n656\n2974\n89\n919\n3572\n4673\n2977\n2949\n674\n277\n1841\n1257\n4673\n4177\n1380\n788\n1258\n1842\n1809\n1987\n289\n673\n1527\n654\n3133\n1894\n3010\n2599\n1214\n1287\n2938\n2992\n3154\n3138\n3096\n3862\n1270\n3718\n800\n1771\n702\n3280\n3561\n2841\n3050\n1330\n2408\n2112\n2525\n1672\n1882\n1212\n847\n774\n3131\n\n",
+          "step": 59
+        },
+        "reward": null,
+        "status": "INACTIVE"
+      },
+      {
+        "action": { "submission": -1 },
+        "info": {},
+        "observation": {
+          "currentPlayer": 1,
+          "isTerminal": false,
+          "observationString": "N7/3n2pp/p1kp2r1/2p1p3/2P5/7P/P2B1PP1/R3R1K1 w - - 1 30",
+          "playerId": 1,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n2426\n3572\n656\n2974\n89\n919\n3572\n4673\n2977\n2949\n674\n277\n1841\n1257\n4673\n4177\n1380\n788\n1258\n1842\n1809\n1987\n289\n673\n1527\n654\n3133\n1894\n3010\n2599\n1214\n1287\n2938\n2992\n3154\n3138\n3096\n3862\n1270\n3718\n800\n1771\n702\n3280\n3561\n2841\n3050\n1330\n2408\n2112\n2525\n1672\n1882\n1212\n847\n774\n3131\n\n"
+        },
+        "reward": null,
+        "status": "ACTIVE"
+      }
+    ],
+    [
+      {
+        "action": { "submission": -1 },
+        "info": {},
+        "observation": {
+          "currentPlayer": 0,
+          "isTerminal": false,
+          "observationString": "N7/3n2pp/p1kp2r1/2p1p3/2P5/7P/P2B1PP1/1R2R1K1 b - - 2 30",
+          "playerId": 0,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n2426\n3572\n656\n2974\n89\n919\n3572\n4673\n2977\n2949\n674\n277\n1841\n1257\n4673\n4177\n1380\n788\n1258\n1842\n1809\n1987\n289\n673\n1527\n654\n3133\n1894\n3010\n2599\n1214\n1287\n2938\n2992\n3154\n3138\n3096\n3862\n1270\n3718\n800\n1771\n702\n3280\n3561\n2841\n3050\n1330\n2408\n2112\n2525\n1672\n1882\n1212\n847\n774\n3131\n30\n\n",
+          "step": 60
+        },
+        "reward": null,
+        "status": "ACTIVE"
+      },
+      {
+        "action": {
+          "actionString": "Rab1",
+          "call_details": [
+            {
+              "duration_secs": 2.881,
+              "finish_reason": "stop",
+              "first_token_secs": 0.695,
+              "generation_tokens": 470,
+              "model": "openai/google/gemini-3.1-flash-lite-preview",
+              "prompt": "You are a chess expert\n\nLet's play chess. The current game state in Forsyth-Edwards Notation (FEN) notation is:\nN7/3n2pp/p1kp2r1/2p1p3/2P5/7P/P2B1PP1/R3R1K1 w - - 1 30\nThe moves played so far are:\n1. e4 e5 2. Nf3 Nc6 3. Bb5 a6 4. Ba4 Nf6 5. O-O Be7 6. Re1 b5 7. Bb3 d6 8. c3 O-O 9. h3 Na5 10. Bc2 c5 11. d4 Qc7 12. d5 Nc4 13. b3 Nb6 14. Nbd2 Ne8 15. Nf1 f5 16. exf5 Bxf5 17. Bxf5 Rxf5 18. Ng3 Rf6 19. Ng5 Rg6 20. Ne6 Qb7 21. Nf5 Nxd5 22. Qxd5 Qxd5 23. Nxe7+ Kf7 24. Nxd5 Kxe6 25. c4 Nf6 26. Nc7+ Kd7 27. Nxa8 Kc6 28. Bd2 bxc4 29. bxc4 Nd7 30.\nYou are playing as player White.\nIt is now your turn. Play your strongest move. The move MUST be legal. Reason step by step to come up with your move, then output your final answer in the format \"Final Answer: X\" where X is your chosen move in standard algebraic notation (SAN).\n",
+              "prompt_tokens": 381,
+              "reasoning_tokens": 0,
+              "response": "The current FEN is `N7/3n2pp/p1kp2r1/2p1p3/2P5/7P/P2B1PP1/R3R1K1 w - - 1 30`. It is White's turn to move.\n\n**Evaluation:**\nWhite has a significant material advantage (a Knight for two pawns, and Black's rook is somewhat constrained). White's knight on a8 is currently trapped and will eventually be captured by the black king or knight, but White's overall position is very solid.\n\n**Candidate Moves:**\n1. **Rab1:** This move puts immediate pressure on the b-file and eyes the b7/b5 squares. It prepares to challenge Black's control.\n2. **Reb1:** Similar to Rab1, this activates the rook on the b-file.\n3. **a4:** Prophylaxis against ...a5 and potential expansion on the queenside.\n4. **f4:** Challenging the center immediately.\n\n**Reasoning:**\n* The knight on a8 is essentially \"lost\" but serves as a distraction. It forces Black to spend time capturing it, during which White can consolidate.\n* White's goal should be to activate the heavy pieces and restrict Black's minor pieces.\n* `Rab1` is a strong, natural move. It controls the open file and prevents Black from using the b-file effectively. If Black plays `...Kxa8`, White has established a strong presence on the b-file.\n* `f4` is also tempting to break the center, but opening the game while the knight is trapped might be premature.\n* `Rab1` seems the most principled move, improving the rook's activity and preparing to dominate the queenside.\n\nLet's look at the position:\n- Black's knight on d7 is passive.\n- White's bishop on d2 is well-placed to challenge potential threats.\n- White has a clear plan: activate the rooks and play for the endgame where the extra exchange/material eventually tells.\n\n`Rab1` is the most active and constructive plan.\n\nFinal Answer: Rab1",
+              "total_tokens": 851
+            }
+          ],
+          "status": "OK",
+          "submission": 30,
+          "thoughts": "The current FEN is `N7/3n2pp/p1kp2r1/2p1p3/2P5/7P/P2B1PP1/R3R1K1 w - - 1 30`. It is White's turn to move.\n\n**Evaluation:**\nWhite has a significant material advantage (a Knight for two pawns, and Black's rook is somewhat constrained). White's knight on a8 is currently trapped and will eventually be captured by the black king or knight, but White's overall position is very solid.\n\n**Candidate Moves:**\n1. **Rab1:** This move puts immediate pressure on the b-file and eyes the b7/b5 squares. It prepares to challenge Black's control.\n2. **Reb1:** Similar to Rab1, this activates the rook on the b-file.\n3. **a4:** Prophylaxis against ...a5 and potential expansion on the queenside.\n4. **f4:** Challenging the center immediately.\n\n**Reasoning:**\n* The knight on a8 is essentially \"lost\" but serves as a distraction. It forces Black to spend time capturing it, during which White can consolidate.\n* White's goal should be to activate the heavy pieces and restrict Black's minor pieces.\n* `Rab1` is a strong, natural move. It controls the open file and prevents Black from using the b-file effectively. If Black plays `...Kxa8`, White has established a strong presence on the b-file.\n* `f4` is also tempting to break the center, but opening the game while the knight is trapped might be premature.\n* `Rab1` seems the most principled move, improving the rook's activity and preparing to dominate the queenside.\n\nLet's look at the position:\n- Black's knight on d7 is passive.\n- White's bishop on d2 is well-placed to challenge potential threats.\n- White has a clear plan: activate the rooks and play for the endgame where the extra exchange/material eventually tells.\n\n`Rab1` is the most active and constructive plan.\n\nFinal Answer: Rab1"
+        },
+        "info": {
+          "actionApplied": 30,
+          "actionSubmitted": 30,
+          "actionSubmittedToString": "Rab1",
+          "agentSelfReportedStatus": "OK",
+          "timeTaken": 3.376
+        },
+        "observation": {
+          "currentPlayer": 0,
+          "isTerminal": false,
+          "observationString": "N7/3n2pp/p1kp2r1/2p1p3/2P5/7P/P2B1PP1/1R2R1K1 b - - 2 30",
+          "playerId": 1,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n2426\n3572\n656\n2974\n89\n919\n3572\n4673\n2977\n2949\n674\n277\n1841\n1257\n4673\n4177\n1380\n788\n1258\n1842\n1809\n1987\n289\n673\n1527\n654\n3133\n1894\n3010\n2599\n1214\n1287\n2938\n2992\n3154\n3138\n3096\n3862\n1270\n3718\n800\n1771\n702\n3280\n3561\n2841\n3050\n1330\n2408\n2112\n2525\n1672\n1882\n1212\n847\n774\n3131\n30\n\n"
+        },
+        "reward": null,
+        "status": "INACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "actionString": "Nb6",
+          "call_details": [
+            {
+              "duration_secs": 3.18,
+              "finish_reason": "stop",
+              "first_token_secs": 0.593,
+              "generation_tokens": 535,
+              "model": "openai/google/gemini-3.1-flash-lite-preview",
+              "prompt": "\ud83d\udc4c\ud83d\udc40\ud83d\udc4c\ud83d\udc40\ud83d\udc4c\ud83d\udc40\ud83d\udc4c\ud83d\udc40\ud83d\udc4c\ud83d\udc40 good shit go\u0c66\u0501 sHit\ud83d\udc4c thats \u2714 some good\ud83d\udc4c\ud83d\udc4cshit right\ud83d\udc4c\ud83d\udc4cthere\ud83d\udc4c\ud83d\udc4c\ud83d\udc4c right\u2714there \u2714\u2714if i do \u01bda\u04af so my self \ud83d\udcaf i say so \ud83d\udcaf thats what im talking about right there right there (chorus: \u02b3\u1da6\u1d4d\u02b0\u1d57 \u1d57\u02b0\u1d49\u02b3\u1d49) mMMMM\u13b7\u041c\ud83d\udcaf \ud83d\udc4c\ud83d\udc4c \ud83d\udc4c\u041dO0\u041e\u0b20OOOOO\u041e\u0b20\u0b20Oooo\u1d52\u1d52\u1d52\u1d52\u1d52\u1d52\u1d52\u1d52\u1d52\ud83d\udc4c \ud83d\udc4c\ud83d\udc4c \ud83d\udc4c \ud83d\udcaf \ud83d\udc4c \ud83d\udc40 \ud83d\udc40 \ud83d\udc40 \ud83d\udc4c\ud83d\udc4c\n\nLet's play chess. The current game state in Forsyth-Edwards Notation (FEN) notation is:\nN7/3n2pp/p1kp2r1/2p1p3/2P5/7P/P2B1PP1/1R2R1K1 b - - 2 30\nThe moves played so far are:\n1. e4 e5 2. Nf3 Nc6 3. Bb5 a6 4. Ba4 Nf6 5. O-O Be7 6. Re1 b5 7. Bb3 d6 8. c3 O-O 9. h3 Na5 10. Bc2 c5 11. d4 Qc7 12. d5 Nc4 13. b3 Nb6 14. Nbd2 Ne8 15. Nf1 f5 16. exf5 Bxf5 17. Bxf5 Rxf5 18. Ng3 Rf6 19. Ng5 Rg6 20. Ne6 Qb7 21. Nf5 Nxd5 22. Qxd5 Qxd5 23. Nxe7+ Kf7 24. Nxd5 Kxe6 25. c4 Nf6 26. Nc7+ Kd7 27. Nxa8 Kc6 28. Bd2 bxc4 29. bxc4 Nd7 30. Rab1\nYou are playing as player Black.\nIt is now your turn. Play your strongest move. The move MUST be legal. Reason step by step to come up with your move, then output your final answer in the format \"Final Answer: X\" where X is your chosen move in standard algebraic notation (SAN).\n",
+              "prompt_tokens": 504,
+              "reasoning_tokens": 0,
+              "response": "The current position is `N7/3n2pp/p1kp2r1/2p1p3/2P5/7P/P2B1PP1/1R2R1K1 b - - 2 30`. It is Black's turn to move.\n\n**Evaluation:**\nWhite has a significant advantage due to the material gain (a Knight for a Pawn) and Black's uncoordinated pieces. Black's Rook on g6 is somewhat restricted, and the Knight on d7 is passive. White's pieces (Rook on b1, Bishop on d2, Knight on a8) are well-placed to squeeze Black's position.\n\n**Candidate Moves for Black:**\n1. **... Re6**: This attempts to challenge White's control of the e-file and activate the Rook.\n2. **... Nb6**: This attacks the c4 pawn and tries to relocate the Knight to a more active square.\n3. **... h6**: A prophylactic move to prevent any back-rank or g5 ideas, though not immediately urgent.\n\n**Detailed Analysis:**\n*   **... Nb6**: This seems the most principled move. It challenges White's hold on the queenside and forces a decision regarding the c4 pawn. If White plays `Rb3` or `Ba5`, Black gains time.\n*   **... Re6**: If Black plays `Re6`, White might respond with `f4`, putting pressure on the e5 pawn and further cramping Black.\n*   **... Nb6 31. Re4**: White reinforces the c4 pawn and eyes the kingside. Black can continue with `d5` or `h6`.\n\nGiven the material deficit, Black needs to trade pieces or create counterplay. `Nb6` seems the most active way to challenge White's control of the board. It forces White to defend c4 and prepares to contest the queenside.\n\nEngine analysis suggests that `Nb6` is the most resilient move in this difficult position. It forces White to address the pressure on c4 and allows the Black pieces to coordinate slightly better.\n\n1. ... Nb6\n2. Re4 (or Ba5)\nIf 2. Ba5, then 2... Nxc4. This wins back a pawn and simplifies the position, which is favorable for Black who is down material. Therefore, White will likely defend c4.\n\nBlack's best practical chance is to centralize and challenge the minor pieces.\n\nFinal Answer: Nb6",
+              "total_tokens": 1039
+            }
+          ],
+          "status": "OK",
+          "submission": 1891,
+          "thoughts": "The current position is `N7/3n2pp/p1kp2r1/2p1p3/2P5/7P/P2B1PP1/1R2R1K1 b - - 2 30`. It is Black's turn to move.\n\n**Evaluation:**\nWhite has a significant advantage due to the material gain (a Knight for a Pawn) and Black's uncoordinated pieces. Black's Rook on g6 is somewhat restricted, and the Knight on d7 is passive. White's pieces (Rook on b1, Bishop on d2, Knight on a8) are well-placed to squeeze Black's position.\n\n**Candidate Moves for Black:**\n1. **... Re6**: This attempts to challenge White's control of the e-file and activate the Rook.\n2. **... Nb6**: This attacks the c4 pawn and tries to relocate the Knight to a more active square.\n3. **... h6**: A prophylactic move to prevent any back-rank or g5 ideas, though not immediately urgent.\n\n**Detailed Analysis:**\n*   **... Nb6**: This seems the most principled move. It challenges White's hold on the queenside and forces a decision regarding the c4 pawn. If White plays `Rb3` or `Ba5`, Black gains time.\n*   **... Re6**: If Black plays `Re6`, White might respond with `f4`, putting pressure on the e5 pawn and further cramping Black.\n*   **... Nb6 31. Re4**: White reinforces the c4 pawn and eyes the kingside. Black can continue with `d5` or `h6`.\n\nGiven the material deficit, Black needs to trade pieces or create counterplay. `Nb6` seems the most active way to challenge White's control of the board. It forces White to defend c4 and prepares to contest the queenside.\n\nEngine analysis suggests that `Nb6` is the most resilient move in this difficult position. It forces White to address the pressure on c4 and allows the Black pieces to coordinate slightly better.\n\n1. ... Nb6\n2. Re4 (or Ba5)\nIf 2. Ba5, then 2... Nxc4. This wins back a pawn and simplifies the position, which is favorable for Black who is down material. Therefore, White will likely defend c4.\n\nBlack's best practical chance is to centralize and challenge the minor pieces.\n\nFinal Answer: Nb6"
+        },
+        "info": {
+          "actionApplied": 1891,
+          "actionSubmitted": 1891,
+          "actionSubmittedToString": "Nb6",
+          "agentSelfReportedStatus": "OK",
+          "timeTaken": 3.733
+        },
+        "observation": {
+          "currentPlayer": 1,
+          "isTerminal": false,
+          "observationString": "N7/6pp/pnkp2r1/2p1p3/2P5/7P/P2B1PP1/1R2R1K1 w - - 3 31",
+          "playerId": 0,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n2426\n3572\n656\n2974\n89\n919\n3572\n4673\n2977\n2949\n674\n277\n1841\n1257\n4673\n4177\n1380\n788\n1258\n1842\n1809\n1987\n289\n673\n1527\n654\n3133\n1894\n3010\n2599\n1214\n1287\n2938\n2992\n3154\n3138\n3096\n3862\n1270\n3718\n800\n1771\n702\n3280\n3561\n2841\n3050\n1330\n2408\n2112\n2525\n1672\n1882\n1212\n847\n774\n3131\n30\n1891\n\n",
+          "step": 61
+        },
+        "reward": null,
+        "status": "INACTIVE"
+      },
+      {
+        "action": { "submission": -1 },
+        "info": {},
+        "observation": {
+          "currentPlayer": 1,
+          "isTerminal": false,
+          "observationString": "N7/6pp/pnkp2r1/2p1p3/2P5/7P/P2B1PP1/1R2R1K1 w - - 3 31",
+          "playerId": 1,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n2426\n3572\n656\n2974\n89\n919\n3572\n4673\n2977\n2949\n674\n277\n1841\n1257\n4673\n4177\n1380\n788\n1258\n1842\n1809\n1987\n289\n673\n1527\n654\n3133\n1894\n3010\n2599\n1214\n1287\n2938\n2992\n3154\n3138\n3096\n3862\n1270\n3718\n800\n1771\n702\n3280\n3561\n2841\n3050\n1330\n2408\n2112\n2525\n1672\n1882\n1212\n847\n774\n3131\n30\n1891\n\n"
+        },
+        "reward": null,
+        "status": "ACTIVE"
+      }
+    ],
+    [
+      {
+        "action": { "submission": -1 },
+        "info": {},
+        "observation": {
+          "currentPlayer": 0,
+          "isTerminal": false,
+          "observationString": "8/6pp/pNkp2r1/2p1p3/2P5/7P/P2B1PP1/1R2R1K1 b - - 0 31",
+          "playerId": 0,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n2426\n3572\n656\n2974\n89\n919\n3572\n4673\n2977\n2949\n674\n277\n1841\n1257\n4673\n4177\n1380\n788\n1258\n1842\n1809\n1987\n289\n673\n1527\n654\n3133\n1894\n3010\n2599\n1214\n1287\n2938\n2992\n3154\n3138\n3096\n3862\n1270\n3718\n800\n1771\n702\n3280\n3561\n2841\n3050\n1330\n2408\n2112\n2525\n1672\n1882\n1212\n847\n774\n3131\n30\n1891\n582\n\n",
+          "step": 62
+        },
+        "reward": null,
+        "status": "ACTIVE"
+      },
+      {
+        "action": {
+          "actionString": "Nxb6",
+          "call_details": [
+            {
+              "duration_secs": 3.627,
+              "finish_reason": "stop",
+              "first_token_secs": 0.7,
+              "generation_tokens": 557,
+              "model": "openai/google/gemini-3.1-flash-lite-preview",
+              "prompt": "You are a chess expert\n\nLet's play chess. The current game state in Forsyth-Edwards Notation (FEN) notation is:\nN7/6pp/pnkp2r1/2p1p3/2P5/7P/P2B1PP1/1R2R1K1 w - - 3 31\nThe moves played so far are:\n1. e4 e5 2. Nf3 Nc6 3. Bb5 a6 4. Ba4 Nf6 5. O-O Be7 6. Re1 b5 7. Bb3 d6 8. c3 O-O 9. h3 Na5 10. Bc2 c5 11. d4 Qc7 12. d5 Nc4 13. b3 Nb6 14. Nbd2 Ne8 15. Nf1 f5 16. exf5 Bxf5 17. Bxf5 Rxf5 18. Ng3 Rf6 19. Ng5 Rg6 20. Ne6 Qb7 21. Nf5 Nxd5 22. Qxd5 Qxd5 23. Nxe7+ Kf7 24. Nxd5 Kxe6 25. c4 Nf6 26. Nc7+ Kd7 27. Nxa8 Kc6 28. Bd2 bxc4 29. bxc4 Nd7 30. Rab1 Nb6 31.\nYou are playing as player White.\nIt is now your turn. Play your strongest move. The move MUST be legal. Reason step by step to come up with your move, then output your final answer in the format \"Final Answer: X\" where X is your chosen move in standard algebraic notation (SAN).\n",
+              "prompt_tokens": 387,
+              "reasoning_tokens": 0,
+              "response": "The current position is `N7/6pp/pnkp2r1/2p1p3/2P5/7P/P2B1PP1/1R2R1K1 w - - 3 31`.\n\n**Evaluation and Analysis:**\n1. **Material:** White has a Knight for a Pawn (White is up in material, but Black has some activity).\n2. **King Safety:** Both kings are relatively safe.\n3. **Tactical Considerations:**\n    - Black's knight on b6 is attacked by my rook on b1.\n    - If I move the knight on a8, I secure the advantage. Currently, the knight on a8 is trapped in the corner but is essentially \"out of play.\" However, I must ensure I don't blunder any pieces.\n    - Black is threatening to improve their position.\n    - My immediate tactical goal should be to consolidate and challenge Black's active pieces. \n\n**Candidate Moves:**\n1. **Nxb6**: This is the most natural move. It eliminates the knight on b6, which is currently threatening to jump into d5 or c4, and simplifies the position while keeping the material advantage. After 31. Nxb6, Black will likely respond with 31... Kxb6. Then White can continue with moves like a4 to restrict Black's queenside or simply improve the position of the rooks.\n2. **Re3**: Trying to bring the rook into the action, but Nxb6 is more forcing and removes Black's counterplay.\n\n**Reasoning for Nxb6:**\n- White is currently up material (Knight vs Pawn). Trading the knight on a8 for the active knight on b6 is highly favorable because it removes Black's most active piece and forces the Black king to capture on b6, where it is slightly more exposed.\n- After 31. Nxb6 Kxb6, White can play 32. Re3 or 32. a4 to consolidate the advantage.\n- The knight on a8 is doing nothing; trading it for the knight on b6 simplifies the game to a winning endgame for White.\n\nStep-by-step:\n1. Identify that the knight on a8 is currently attacking the b6-knight.\n2. Black's knight on b6 is a key defensive and potentially aggressive piece.\n3. Capturing the knight (Nxb6) forces Black to take back, simplifying the board while maintaining a significant material advantage.\n4. This move is solid, improves the structure, and leads to a clearly winning endgame.\n\nFinal Answer: Nxb6",
+              "total_tokens": 944
+            }
+          ],
+          "status": "OK",
+          "submission": 582,
+          "thoughts": "The current position is `N7/6pp/pnkp2r1/2p1p3/2P5/7P/P2B1PP1/1R2R1K1 w - - 3 31`.\n\n**Evaluation and Analysis:**\n1. **Material:** White has a Knight for a Pawn (White is up in material, but Black has some activity).\n2. **King Safety:** Both kings are relatively safe.\n3. **Tactical Considerations:**\n    - Black's knight on b6 is attacked by my rook on b1.\n    - If I move the knight on a8, I secure the advantage. Currently, the knight on a8 is trapped in the corner but is essentially \"out of play.\" However, I must ensure I don't blunder any pieces.\n    - Black is threatening to improve their position.\n    - My immediate tactical goal should be to consolidate and challenge Black's active pieces. \n\n**Candidate Moves:**\n1. **Nxb6**: This is the most natural move. It eliminates the knight on b6, which is currently threatening to jump into d5 or c4, and simplifies the position while keeping the material advantage. After 31. Nxb6, Black will likely respond with 31... Kxb6. Then White can continue with moves like a4 to restrict Black's queenside or simply improve the position of the rooks.\n2. **Re3**: Trying to bring the rook into the action, but Nxb6 is more forcing and removes Black's counterplay.\n\n**Reasoning for Nxb6:**\n- White is currently up material (Knight vs Pawn). Trading the knight on a8 for the active knight on b6 is highly favorable because it removes Black's most active piece and forces the Black king to capture on b6, where it is slightly more exposed.\n- After 31. Nxb6 Kxb6, White can play 32. Re3 or 32. a4 to consolidate the advantage.\n- The knight on a8 is doing nothing; trading it for the knight on b6 simplifies the game to a winning endgame for White.\n\nStep-by-step:\n1. Identify that the knight on a8 is currently attacking the b6-knight.\n2. Black's knight on b6 is a key defensive and potentially aggressive piece.\n3. Capturing the knight (Nxb6) forces Black to take back, simplifying the board while maintaining a significant material advantage.\n4. This move is solid, improves the structure, and leads to a clearly winning endgame.\n\nFinal Answer: Nxb6"
+        },
+        "info": {
+          "actionApplied": 582,
+          "actionSubmitted": 582,
+          "actionSubmittedToString": "Nxb6",
+          "agentSelfReportedStatus": "OK",
+          "timeTaken": 4.08
+        },
+        "observation": {
+          "currentPlayer": 0,
+          "isTerminal": false,
+          "observationString": "8/6pp/pNkp2r1/2p1p3/2P5/7P/P2B1PP1/1R2R1K1 b - - 0 31",
+          "playerId": 1,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n2426\n3572\n656\n2974\n89\n919\n3572\n4673\n2977\n2949\n674\n277\n1841\n1257\n4673\n4177\n1380\n788\n1258\n1842\n1809\n1987\n289\n673\n1527\n654\n3133\n1894\n3010\n2599\n1214\n1287\n2938\n2992\n3154\n3138\n3096\n3862\n1270\n3718\n800\n1771\n702\n3280\n3561\n2841\n3050\n1330\n2408\n2112\n2525\n1672\n1882\n1212\n847\n774\n3131\n30\n1891\n582\n\n"
+        },
+        "reward": null,
+        "status": "INACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "actionString": "Re6",
+          "call_details": [
+            {
+              "duration_secs": 3.213,
+              "finish_reason": "stop",
+              "first_token_secs": 0.672,
+              "generation_tokens": 508,
+              "model": "openai/google/gemini-3.1-flash-lite-preview",
+              "prompt": "\ud83d\udc4c\ud83d\udc40\ud83d\udc4c\ud83d\udc40\ud83d\udc4c\ud83d\udc40\ud83d\udc4c\ud83d\udc40\ud83d\udc4c\ud83d\udc40 good shit go\u0c66\u0501 sHit\ud83d\udc4c thats \u2714 some good\ud83d\udc4c\ud83d\udc4cshit right\ud83d\udc4c\ud83d\udc4cthere\ud83d\udc4c\ud83d\udc4c\ud83d\udc4c right\u2714there \u2714\u2714if i do \u01bda\u04af so my self \ud83d\udcaf i say so \ud83d\udcaf thats what im talking about right there right there (chorus: \u02b3\u1da6\u1d4d\u02b0\u1d57 \u1d57\u02b0\u1d49\u02b3\u1d49) mMMMM\u13b7\u041c\ud83d\udcaf \ud83d\udc4c\ud83d\udc4c \ud83d\udc4c\u041dO0\u041e\u0b20OOOOO\u041e\u0b20\u0b20Oooo\u1d52\u1d52\u1d52\u1d52\u1d52\u1d52\u1d52\u1d52\u1d52\ud83d\udc4c \ud83d\udc4c\ud83d\udc4c \ud83d\udc4c \ud83d\udcaf \ud83d\udc4c \ud83d\udc40 \ud83d\udc40 \ud83d\udc40 \ud83d\udc4c\ud83d\udc4c\n\nLet's play chess. The current game state in Forsyth-Edwards Notation (FEN) notation is:\n8/6pp/pNkp2r1/2p1p3/2P5/7P/P2B1PP1/1R2R1K1 b - - 0 31\nThe moves played so far are:\n1. e4 e5 2. Nf3 Nc6 3. Bb5 a6 4. Ba4 Nf6 5. O-O Be7 6. Re1 b5 7. Bb3 d6 8. c3 O-O 9. h3 Na5 10. Bc2 c5 11. d4 Qc7 12. d5 Nc4 13. b3 Nb6 14. Nbd2 Ne8 15. Nf1 f5 16. exf5 Bxf5 17. Bxf5 Rxf5 18. Ng3 Rf6 19. Ng5 Rg6 20. Ne6 Qb7 21. Nf5 Nxd5 22. Qxd5 Qxd5 23. Nxe7+ Kf7 24. Nxd5 Kxe6 25. c4 Nf6 26. Nc7+ Kd7 27. Nxa8 Kc6 28. Bd2 bxc4 29. bxc4 Nd7 30. Rab1 Nb6 31. Nxb6\nYou are playing as player Black.\nIt is now your turn. Play your strongest move. The move MUST be legal. Reason step by step to come up with your move, then output your final answer in the format \"Final Answer: X\" where X is your chosen move in standard algebraic notation (SAN).\n",
+              "prompt_tokens": 508,
+              "reasoning_tokens": 0,
+              "response": "The current position is `8/6pp/pNkp2r1/2p1p3/2P5/7P/P2B1PP1/1R2R1K1 b - - 0 31`. It is Black's turn to move.\n\n**Evaluation:**\nWhite has a significant material advantage (a Knight for a Pawn). Black's position is cramped, and the Rook on h6 is somewhat passive. The goal for Black is to activate the pieces and try to create some counterplay or simplify into a slightly more manageable position, although the engine evaluation heavily favors White (+4.5 to +5.0).\n\n**Candidate Moves:**\n1. **... Re6**: This is the most natural move to defend the e5 pawn and centralize the rook.\n2. **... d5**: An attempt to break in the center and open lines, but it might be premature.\n3. **... h6**: Providing \"luft\" for the king and preventing any back-rank issues or immediate Ng5 ideas, though the knight is already quite far away.\n\n**Analysis:**\n- After **31... Re6**, White will likely continue with 32. Nd5 or 32. a4 to restrict the Black rook further.\n- **31... d5** fails to create real pressure because White can ignore it or consolidate easily (e.g., 32. cxd5+ Kxd5 33. Nc3+).\n- **31... Re6** seems the most principled, as it prepares to maneuver and defends the weak e-pawn, which is currently under pressure from the Nb6 and potential future threats.\n\nLet's look at the engine's top choice:\nThe position is quite lost, but the engine suggests **31... Re6**. It stabilizes the center and prepares to contest the open files.\n\nStep-by-step reasoning:\n1. Black is down a full piece.\n2. The immediate threat is the pressure on the central pawns and the mobility of the White pieces.\n3. 31... Re6 is the most solid move to consolidate. It protects the e5 pawn and allows the Rook to potentially maneuver to d6 or other squares if needed.\n4. There are no tactical shots for Black to regain material; therefore, patience and central control are the priorities.\n\nFinal Answer: Re6",
+              "total_tokens": 1016
+            }
+          ],
+          "status": "OK",
+          "submission": 3678,
+          "thoughts": "The current position is `8/6pp/pNkp2r1/2p1p3/2P5/7P/P2B1PP1/1R2R1K1 b - - 0 31`. It is Black's turn to move.\n\n**Evaluation:**\nWhite has a significant material advantage (a Knight for a Pawn). Black's position is cramped, and the Rook on h6 is somewhat passive. The goal for Black is to activate the pieces and try to create some counterplay or simplify into a slightly more manageable position, although the engine evaluation heavily favors White (+4.5 to +5.0).\n\n**Candidate Moves:**\n1. **... Re6**: This is the most natural move to defend the e5 pawn and centralize the rook.\n2. **... d5**: An attempt to break in the center and open lines, but it might be premature.\n3. **... h6**: Providing \"luft\" for the king and preventing any back-rank issues or immediate Ng5 ideas, though the knight is already quite far away.\n\n**Analysis:**\n- After **31... Re6**, White will likely continue with 32. Nd5 or 32. a4 to restrict the Black rook further.\n- **31... d5** fails to create real pressure because White can ignore it or consolidate easily (e.g., 32. cxd5+ Kxd5 33. Nc3+).\n- **31... Re6** seems the most principled, as it prepares to maneuver and defends the weak e-pawn, which is currently under pressure from the Nb6 and potential future threats.\n\nLet's look at the engine's top choice:\nThe position is quite lost, but the engine suggests **31... Re6**. It stabilizes the center and prepares to contest the open files.\n\nStep-by-step reasoning:\n1. Black is down a full piece.\n2. The immediate threat is the pressure on the central pawns and the mobility of the White pieces.\n3. 31... Re6 is the most solid move to consolidate. It protects the e5 pawn and allows the Rook to potentially maneuver to d6 or other squares if needed.\n4. There are no tactical shots for Black to regain material; therefore, patience and central control are the priorities.\n\nFinal Answer: Re6"
+        },
+        "info": {
+          "actionApplied": 3678,
+          "actionSubmitted": 3678,
+          "actionSubmittedToString": "Re6",
+          "agentSelfReportedStatus": "OK",
+          "timeTaken": 3.838
+        },
+        "observation": {
+          "currentPlayer": 1,
+          "isTerminal": false,
+          "observationString": "8/6pp/pNkpr3/2p1p3/2P5/7P/P2B1PP1/1R2R1K1 w - - 1 32",
+          "playerId": 0,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n2426\n3572\n656\n2974\n89\n919\n3572\n4673\n2977\n2949\n674\n277\n1841\n1257\n4673\n4177\n1380\n788\n1258\n1842\n1809\n1987\n289\n673\n1527\n654\n3133\n1894\n3010\n2599\n1214\n1287\n2938\n2992\n3154\n3138\n3096\n3862\n1270\n3718\n800\n1771\n702\n3280\n3561\n2841\n3050\n1330\n2408\n2112\n2525\n1672\n1882\n1212\n847\n774\n3131\n30\n1891\n582\n3678\n\n",
+          "step": 63
+        },
+        "reward": null,
+        "status": "INACTIVE"
+      },
+      {
+        "action": { "submission": -1 },
+        "info": {},
+        "observation": {
+          "currentPlayer": 1,
+          "isTerminal": false,
+          "observationString": "8/6pp/pNkpr3/2p1p3/2P5/7P/P2B1PP1/1R2R1K1 w - - 1 32",
+          "playerId": 1,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n2426\n3572\n656\n2974\n89\n919\n3572\n4673\n2977\n2949\n674\n277\n1841\n1257\n4673\n4177\n1380\n788\n1258\n1842\n1809\n1987\n289\n673\n1527\n654\n3133\n1894\n3010\n2599\n1214\n1287\n2938\n2992\n3154\n3138\n3096\n3862\n1270\n3718\n800\n1771\n702\n3280\n3561\n2841\n3050\n1330\n2408\n2112\n2525\n1672\n1882\n1212\n847\n774\n3131\n30\n1891\n582\n3678\n\n"
+        },
+        "reward": null,
+        "status": "ACTIVE"
+      }
+    ],
+    [
+      {
+        "action": { "submission": -1 },
+        "info": {},
+        "observation": {
+          "currentPlayer": 0,
+          "isTerminal": false,
+          "observationString": "8/6pp/p1kpr3/2pNp3/2P5/7P/P2B1PP1/1R2R1K1 b - - 2 32",
+          "playerId": 0,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n2426\n3572\n656\n2974\n89\n919\n3572\n4673\n2977\n2949\n674\n277\n1841\n1257\n4673\n4177\n1380\n788\n1258\n1842\n1809\n1987\n289\n673\n1527\n654\n3133\n1894\n3010\n2599\n1214\n1287\n2938\n2992\n3154\n3138\n3096\n3862\n1270\n3718\n800\n1771\n702\n3280\n3561\n2841\n3050\n1330\n2408\n2112\n2525\n1672\n1882\n1212\n847\n774\n3131\n30\n1891\n582\n3678\n1018\n\n",
+          "step": 64
+        },
+        "reward": null,
+        "status": "ACTIVE"
+      },
+      {
+        "action": {
+          "actionString": "Nd5",
+          "call_details": [
+            {
+              "duration_secs": 2.617,
+              "finish_reason": "stop",
+              "first_token_secs": 0.655,
+              "generation_tokens": 395,
+              "model": "openai/google/gemini-3.1-flash-lite-preview",
+              "prompt": "You are a chess expert\n\nLet's play chess. The current game state in Forsyth-Edwards Notation (FEN) notation is:\n8/6pp/pNkpr3/2p1p3/2P5/7P/P2B1PP1/1R2R1K1 w - - 1 32\nThe moves played so far are:\n1. e4 e5 2. Nf3 Nc6 3. Bb5 a6 4. Ba4 Nf6 5. O-O Be7 6. Re1 b5 7. Bb3 d6 8. c3 O-O 9. h3 Na5 10. Bc2 c5 11. d4 Qc7 12. d5 Nc4 13. b3 Nb6 14. Nbd2 Ne8 15. Nf1 f5 16. exf5 Bxf5 17. Bxf5 Rxf5 18. Ng3 Rf6 19. Ng5 Rg6 20. Ne6 Qb7 21. Nf5 Nxd5 22. Qxd5 Qxd5 23. Nxe7+ Kf7 24. Nxd5 Kxe6 25. c4 Nf6 26. Nc7+ Kd7 27. Nxa8 Kc6 28. Bd2 bxc4 29. bxc4 Nd7 30. Rab1 Nb6 31. Nxb6 Re6 32.\nYou are playing as player White.\nIt is now your turn. Play your strongest move. The move MUST be legal. Reason step by step to come up with your move, then output your final answer in the format \"Final Answer: X\" where X is your chosen move in standard algebraic notation (SAN).\n",
+              "prompt_tokens": 393,
+              "reasoning_tokens": 0,
+              "response": "The current position is: `8/6pp/pNkpr3/2p1p3/2P5/7P/P2B1PP1/1R2R1K1 w - - 1 32`.\n\n**Evaluation:**\nWhite is significantly ahead in material (a full rook). The knight on b6 is a powerhouse, pinning the black king and rook complex against the black king's mobility. Black's position is cramped, and White\u2019s pieces are well-coordinated to maintain the advantage.\n\n**Candidate Moves:**\n1. **Nd5:** Improves the position of the knight further. It centralizes the piece, eyes the f6 and c7 squares, and prevents any counterplay.\n2. **Ba5:** Targets the c7 square and prepares to box in the king/rook further.\n3. **a4:** Solidifies the queenside and prepares to push pawns if necessary.\n\n**Reasoning:**\n*   **Nd5:** This move is very strong. It centralizes the knight, which currently is a bit peripheral on b6. From d5, it eyes e7, f6, c7, and b6, and it directly coordinates with the rooks to restrict Black's movement. It also prevents any tactical tricks involving the knight being pinned or traded off too easily.\n*   **Ba5:** Also strong, but Black can play ...Kd7 or similar. Nd5 feels more restrictive and dominating.\n*   **Tactical overview:** White has a winning material advantage. The key is to simplify or restrict Black's counterplay. Nd5 restricts the black king and rook effectively. If Black tries to trade the rooks, White maintains a winning endgame easily.\n\nConsidering the positional dominance, Nd5 is the most principled move to solidify the win and push toward a quick resolution.\n\nFinal Answer: Nd5",
+              "total_tokens": 788
+            }
+          ],
+          "status": "OK",
+          "submission": 1018,
+          "thoughts": "The current position is: `8/6pp/pNkpr3/2p1p3/2P5/7P/P2B1PP1/1R2R1K1 w - - 1 32`.\n\n**Evaluation:**\nWhite is significantly ahead in material (a full rook). The knight on b6 is a powerhouse, pinning the black king and rook complex against the black king's mobility. Black's position is cramped, and White\u2019s pieces are well-coordinated to maintain the advantage.\n\n**Candidate Moves:**\n1. **Nd5:** Improves the position of the knight further. It centralizes the piece, eyes the f6 and c7 squares, and prevents any counterplay.\n2. **Ba5:** Targets the c7 square and prepares to box in the king/rook further.\n3. **a4:** Solidifies the queenside and prepares to push pawns if necessary.\n\n**Reasoning:**\n*   **Nd5:** This move is very strong. It centralizes the knight, which currently is a bit peripheral on b6. From d5, it eyes e7, f6, c7, and b6, and it directly coordinates with the rooks to restrict Black's movement. It also prevents any tactical tricks involving the knight being pinned or traded off too easily.\n*   **Ba5:** Also strong, but Black can play ...Kd7 or similar. Nd5 feels more restrictive and dominating.\n*   **Tactical overview:** White has a winning material advantage. The key is to simplify or restrict Black's counterplay. Nd5 restricts the black king and rook effectively. If Black tries to trade the rooks, White maintains a winning endgame easily.\n\nConsidering the positional dominance, Nd5 is the most principled move to solidify the win and push toward a quick resolution.\n\nFinal Answer: Nd5"
+        },
+        "info": {
+          "actionApplied": 1018,
+          "actionSubmitted": 1018,
+          "actionSubmittedToString": "Nd5",
+          "agentSelfReportedStatus": "OK",
+          "timeTaken": 3.143
+        },
+        "observation": {
+          "currentPlayer": 0,
+          "isTerminal": false,
+          "observationString": "8/6pp/p1kpr3/2pNp3/2P5/7P/P2B1PP1/1R2R1K1 b - - 2 32",
+          "playerId": 1,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n2426\n3572\n656\n2974\n89\n919\n3572\n4673\n2977\n2949\n674\n277\n1841\n1257\n4673\n4177\n1380\n788\n1258\n1842\n1809\n1987\n289\n673\n1527\n654\n3133\n1894\n3010\n2599\n1214\n1287\n2938\n2992\n3154\n3138\n3096\n3862\n1270\n3718\n800\n1771\n702\n3280\n3561\n2841\n3050\n1330\n2408\n2112\n2525\n1672\n1882\n1212\n847\n774\n3131\n30\n1891\n582\n3678\n1018\n\n"
+        },
+        "reward": null,
+        "status": "INACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "actionString": "Kd7",
+          "call_details": [
+            {
+              "duration_secs": 3.422,
+              "finish_reason": "stop",
+              "first_token_secs": 1.574,
+              "generation_tokens": 496,
+              "model": "openai/google/gemini-3.1-flash-lite-preview",
+              "prompt": "\ud83d\udc4c\ud83d\udc40\ud83d\udc4c\ud83d\udc40\ud83d\udc4c\ud83d\udc40\ud83d\udc4c\ud83d\udc40\ud83d\udc4c\ud83d\udc40 good shit go\u0c66\u0501 sHit\ud83d\udc4c thats \u2714 some good\ud83d\udc4c\ud83d\udc4cshit right\ud83d\udc4c\ud83d\udc4cthere\ud83d\udc4c\ud83d\udc4c\ud83d\udc4c right\u2714there \u2714\u2714if i do \u01bda\u04af so my self \ud83d\udcaf i say so \ud83d\udcaf thats what im talking about right there right there (chorus: \u02b3\u1da6\u1d4d\u02b0\u1d57 \u1d57\u02b0\u1d49\u02b3\u1d49) mMMMM\u13b7\u041c\ud83d\udcaf \ud83d\udc4c\ud83d\udc4c \ud83d\udc4c\u041dO0\u041e\u0b20OOOOO\u041e\u0b20\u0b20Oooo\u1d52\u1d52\u1d52\u1d52\u1d52\u1d52\u1d52\u1d52\u1d52\ud83d\udc4c \ud83d\udc4c\ud83d\udc4c \ud83d\udc4c \ud83d\udcaf \ud83d\udc4c \ud83d\udc40 \ud83d\udc40 \ud83d\udc40 \ud83d\udc4c\ud83d\udc4c\n\nLet's play chess. The current game state in Forsyth-Edwards Notation (FEN) notation is:\n8/6pp/p1kpr3/2pNp3/2P5/7P/P2B1PP1/1R2R1K1 b - - 2 32\nThe moves played so far are:\n1. e4 e5 2. Nf3 Nc6 3. Bb5 a6 4. Ba4 Nf6 5. O-O Be7 6. Re1 b5 7. Bb3 d6 8. c3 O-O 9. h3 Na5 10. Bc2 c5 11. d4 Qc7 12. d5 Nc4 13. b3 Nb6 14. Nbd2 Ne8 15. Nf1 f5 16. exf5 Bxf5 17. Bxf5 Rxf5 18. Ng3 Rf6 19. Ng5 Rg6 20. Ne6 Qb7 21. Nf5 Nxd5 22. Qxd5 Qxd5 23. Nxe7+ Kf7 24. Nxd5 Kxe6 25. c4 Nf6 26. Nc7+ Kd7 27. Nxa8 Kc6 28. Bd2 bxc4 29. bxc4 Nd7 30. Rab1 Nb6 31. Nxb6 Re6 32. Nd5\nYou are playing as player Black.\nIt is now your turn. Play your strongest move. The move MUST be legal. Reason step by step to come up with your move, then output your final answer in the format \"Final Answer: X\" where X is your chosen move in standard algebraic notation (SAN).\n",
+              "prompt_tokens": 515,
+              "reasoning_tokens": 0,
+              "response": "The current position is `8/6pp/p1kpr3/2pNp3/2P5/7P/P2B1PP1/1R2R1K1 b - - 2 32`. It is Black's turn to move.\n\n**Evaluation:**\nWhite has a significant material advantage (a Knight for a Pawn, and a very active Knight on d5). Black's position is cramped, and the Rook on e6 is restricted. White's pieces are well-coordinated, and the Knight on d5 is a powerful outpost.\n\n**Candidate Moves for Black:**\n1. **...Kd7**: Attempts to improve the King's position, but it remains passive.\n2. **...h6**: A prophylactic move to prevent Ng5 or other potential issues, but it doesn't solve the long-term material disadvantage.\n3. **...Re8**: Attempts to challenge the open file and prepare to contest the board, but White is dominating the center.\n4. **...g5**: Attempts to gain space on the kingside, but it's very slow.\n\n**Analysis:**\nThe position is objectively lost for Black due to the material deficit (White is up a piece) and the strong centralization of White's pieces. Black's goal is to attempt to survive or make White work for the win.\n\n- If **32... Kd7**: White continues with 33. Rb7+ or 33. Rb6, increasing pressure. \n- The move **32... h6** is a waiting move that doesn't significantly weaken the position but does little to improve it.\n- **32... Re8** is a logical attempt to activate the Rook, but White simply controls the board.\n\nGiven the depth of the position and the evaluation (Stockfish suggests a massive advantage for White), the game is essentially decided. There are no tactical shots to win back material or force a draw. I will choose a move that develops the King toward a slightly safer square while attempting to consolidate the position.\n\n**Reasoning:**\nMoving the King to d7 is a standard defensive measure in such endgames to get the King out of the file that might become relevant if the Rook maneuvers. It does not improve the situation, but it is a legal and solid move.\n\nFinal Answer: Kd7",
+              "total_tokens": 1011
+            }
+          ],
+          "status": "OK",
+          "submission": 1372,
+          "thoughts": "The current position is `8/6pp/p1kpr3/2pNp3/2P5/7P/P2B1PP1/1R2R1K1 b - - 2 32`. It is Black's turn to move.\n\n**Evaluation:**\nWhite has a significant material advantage (a Knight for a Pawn, and a very active Knight on d5). Black's position is cramped, and the Rook on e6 is restricted. White's pieces are well-coordinated, and the Knight on d5 is a powerful outpost.\n\n**Candidate Moves for Black:**\n1. **...Kd7**: Attempts to improve the King's position, but it remains passive.\n2. **...h6**: A prophylactic move to prevent Ng5 or other potential issues, but it doesn't solve the long-term material disadvantage.\n3. **...Re8**: Attempts to challenge the open file and prepare to contest the board, but White is dominating the center.\n4. **...g5**: Attempts to gain space on the kingside, but it's very slow.\n\n**Analysis:**\nThe position is objectively lost for Black due to the material deficit (White is up a piece) and the strong centralization of White's pieces. Black's goal is to attempt to survive or make White work for the win.\n\n- If **32... Kd7**: White continues with 33. Rb7+ or 33. Rb6, increasing pressure. \n- The move **32... h6** is a waiting move that doesn't significantly weaken the position but does little to improve it.\n- **32... Re8** is a logical attempt to activate the Rook, but White simply controls the board.\n\nGiven the depth of the position and the evaluation (Stockfish suggests a massive advantage for White), the game is essentially decided. There are no tactical shots to win back material or force a draw. I will choose a move that develops the King toward a slightly safer square while attempting to consolidate the position.\n\n**Reasoning:**\nMoving the King to d7 is a standard defensive measure in such endgames to get the King out of the file that might become relevant if the Rook maneuvers. It does not improve the situation, but it is a legal and solid move.\n\nFinal Answer: Kd7"
+        },
+        "info": {
+          "actionApplied": 1372,
+          "actionSubmitted": 1372,
+          "actionSubmittedToString": "Kd7",
+          "agentSelfReportedStatus": "OK",
+          "timeTaken": 3.924
+        },
+        "observation": {
+          "currentPlayer": 1,
+          "isTerminal": false,
+          "observationString": "8/3k2pp/p2pr3/2pNp3/2P5/7P/P2B1PP1/1R2R1K1 w - - 3 33",
+          "playerId": 0,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n2426\n3572\n656\n2974\n89\n919\n3572\n4673\n2977\n2949\n674\n277\n1841\n1257\n4673\n4177\n1380\n788\n1258\n1842\n1809\n1987\n289\n673\n1527\n654\n3133\n1894\n3010\n2599\n1214\n1287\n2938\n2992\n3154\n3138\n3096\n3862\n1270\n3718\n800\n1771\n702\n3280\n3561\n2841\n3050\n1330\n2408\n2112\n2525\n1672\n1882\n1212\n847\n774\n3131\n30\n1891\n582\n3678\n1018\n1372\n\n",
+          "step": 65
+        },
+        "reward": null,
+        "status": "INACTIVE"
+      },
+      {
+        "action": { "submission": -1 },
+        "info": {},
+        "observation": {
+          "currentPlayer": 1,
+          "isTerminal": false,
+          "observationString": "8/3k2pp/p2pr3/2pNp3/2P5/7P/P2B1PP1/1R2R1K1 w - - 3 33",
+          "playerId": 1,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n2426\n3572\n656\n2974\n89\n919\n3572\n4673\n2977\n2949\n674\n277\n1841\n1257\n4673\n4177\n1380\n788\n1258\n1842\n1809\n1987\n289\n673\n1527\n654\n3133\n1894\n3010\n2599\n1214\n1287\n2938\n2992\n3154\n3138\n3096\n3862\n1270\n3718\n800\n1771\n702\n3280\n3561\n2841\n3050\n1330\n2408\n2112\n2525\n1672\n1882\n1212\n847\n774\n3131\n30\n1891\n582\n3678\n1018\n1372\n\n"
+        },
+        "reward": null,
+        "status": "ACTIVE"
+      }
+    ],
+    [
+      {
+        "action": { "submission": -1 },
+        "info": {},
+        "observation": {
+          "currentPlayer": 0,
+          "isTerminal": false,
+          "observationString": "8/1R1k2pp/p2pr3/2pNp3/2P5/7P/P2B1PP1/4R1K1 b - - 4 33",
+          "playerId": 0,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n2426\n3572\n656\n2974\n89\n919\n3572\n4673\n2977\n2949\n674\n277\n1841\n1257\n4673\n4177\n1380\n788\n1258\n1842\n1809\n1987\n289\n673\n1527\n654\n3133\n1894\n3010\n2599\n1214\n1287\n2938\n2992\n3154\n3138\n3096\n3862\n1270\n3718\n800\n1771\n702\n3280\n3561\n2841\n3050\n1330\n2408\n2112\n2525\n1672\n1882\n1212\n847\n774\n3131\n30\n1891\n582\n3678\n1018\n1372\n605\n\n",
+          "step": 66
+        },
+        "reward": null,
+        "status": "ACTIVE"
+      },
+      {
+        "action": {
+          "actionString": "Rb7+",
+          "call_details": [
+            {
+              "duration_secs": 2.733,
+              "finish_reason": "stop",
+              "first_token_secs": 0.787,
+              "generation_tokens": 416,
+              "model": "openai/google/gemini-3.1-flash-lite-preview",
+              "prompt": "You are a chess expert\n\nLet's play chess. The current game state in Forsyth-Edwards Notation (FEN) notation is:\n8/3k2pp/p2pr3/2pNp3/2P5/7P/P2B1PP1/1R2R1K1 w - - 3 33\nThe moves played so far are:\n1. e4 e5 2. Nf3 Nc6 3. Bb5 a6 4. Ba4 Nf6 5. O-O Be7 6. Re1 b5 7. Bb3 d6 8. c3 O-O 9. h3 Na5 10. Bc2 c5 11. d4 Qc7 12. d5 Nc4 13. b3 Nb6 14. Nbd2 Ne8 15. Nf1 f5 16. exf5 Bxf5 17. Bxf5 Rxf5 18. Ng3 Rf6 19. Ng5 Rg6 20. Ne6 Qb7 21. Nf5 Nxd5 22. Qxd5 Qxd5 23. Nxe7+ Kf7 24. Nxd5 Kxe6 25. c4 Nf6 26. Nc7+ Kd7 27. Nxa8 Kc6 28. Bd2 bxc4 29. bxc4 Nd7 30. Rab1 Nb6 31. Nxb6 Re6 32. Nd5 Kd7 33.\nYou are playing as player White.\nIt is now your turn. Play your strongest move. The move MUST be legal. Reason step by step to come up with your move, then output your final answer in the format \"Final Answer: X\" where X is your chosen move in standard algebraic notation (SAN).\n",
+              "prompt_tokens": 402,
+              "reasoning_tokens": 0,
+              "response": "The current position is `8/3k2pp/p2pr3/2pNp3/2P5/7P/P2B1PP1/1R2R1K1 w - - 3 33`. White has a decisive material advantage (a full rook) and a very strong position. The black king is somewhat exposed, and White's pieces are well-coordinated.\n\n**Evaluation:**\n* **Material:** White is up a rook.\n* **King Safety:** Black's king is on d7, constrained by White's pieces.\n* **Piece Activity:** White's knight on d5 is a dominant piece. The rooks on b1 and e1 control the open files.\n* **Strategy:** White should look to simplify the position or apply direct pressure to the Black king to force a collapse. Moves like Rb7+ are very strong, driving the king further into discomfort or forcing a trade of pieces that leads to an easy endgame.\n\n**Candidate Moves:**\n1. **Rb7+**: This is the most forceful move. It puts the king in check, forces it to move (likely to c8 or e8), and dominates the 7th rank.\n2. **Rb6**: A solid move that continues to cramp Black's position, but less active than Rb7+.\n3. **f4**: A thematic move to challenge Black's center, but there is no rush as White is already winning easily.\n\n**Analysis of Rb7+:**\nIf 33. Rb7+, Kc8 (or Ke8).\nIf 33... Kc8, then 34. Reb1 (threatening mate on b8) or 34. Rxg7.\nIf 33... Ke8, then 34. Nc7+ wins more material.\n\nRb7+ is the most aggressive and decisive move, cutting off the king and preparing further infiltration.\n\nFinal Answer: Rb7+",
+              "total_tokens": 818
+            }
+          ],
+          "status": "OK",
+          "submission": 605,
+          "thoughts": "The current position is `8/3k2pp/p2pr3/2pNp3/2P5/7P/P2B1PP1/1R2R1K1 w - - 3 33`. White has a decisive material advantage (a full rook) and a very strong position. The black king is somewhat exposed, and White's pieces are well-coordinated.\n\n**Evaluation:**\n* **Material:** White is up a rook.\n* **King Safety:** Black's king is on d7, constrained by White's pieces.\n* **Piece Activity:** White's knight on d5 is a dominant piece. The rooks on b1 and e1 control the open files.\n* **Strategy:** White should look to simplify the position or apply direct pressure to the Black king to force a collapse. Moves like Rb7+ are very strong, driving the king further into discomfort or forcing a trade of pieces that leads to an easy endgame.\n\n**Candidate Moves:**\n1. **Rb7+**: This is the most forceful move. It puts the king in check, forces it to move (likely to c8 or e8), and dominates the 7th rank.\n2. **Rb6**: A solid move that continues to cramp Black's position, but less active than Rb7+.\n3. **f4**: A thematic move to challenge Black's center, but there is no rush as White is already winning easily.\n\n**Analysis of Rb7+:**\nIf 33. Rb7+, Kc8 (or Ke8).\nIf 33... Kc8, then 34. Reb1 (threatening mate on b8) or 34. Rxg7.\nIf 33... Ke8, then 34. Nc7+ wins more material.\n\nRb7+ is the most aggressive and decisive move, cutting off the king and preparing further infiltration.\n\nFinal Answer: Rb7+"
+        },
+        "info": {
+          "actionApplied": 605,
+          "actionSubmitted": 605,
+          "actionSubmittedToString": "Rb7+",
+          "agentSelfReportedStatus": "OK",
+          "timeTaken": 3.314
+        },
+        "observation": {
+          "currentPlayer": 0,
+          "isTerminal": false,
+          "observationString": "8/1R1k2pp/p2pr3/2pNp3/2P5/7P/P2B1PP1/4R1K1 b - - 4 33",
+          "playerId": 1,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n2426\n3572\n656\n2974\n89\n919\n3572\n4673\n2977\n2949\n674\n277\n1841\n1257\n4673\n4177\n1380\n788\n1258\n1842\n1809\n1987\n289\n673\n1527\n654\n3133\n1894\n3010\n2599\n1214\n1287\n2938\n2992\n3154\n3138\n3096\n3862\n1270\n3718\n800\n1771\n702\n3280\n3561\n2841\n3050\n1330\n2408\n2112\n2525\n1672\n1882\n1212\n847\n774\n3131\n30\n1891\n582\n3678\n1018\n1372\n605\n\n"
+        },
+        "reward": null,
+        "status": "INACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "actionString": "Ke8",
+          "call_details": [
+            {
+              "duration_secs": 3.565,
+              "finish_reason": "stop",
+              "first_token_secs": 0.768,
+              "generation_tokens": 674,
+              "model": "openai/google/gemini-3.1-flash-lite-preview",
+              "prompt": "\ud83d\udc4c\ud83d\udc40\ud83d\udc4c\ud83d\udc40\ud83d\udc4c\ud83d\udc40\ud83d\udc4c\ud83d\udc40\ud83d\udc4c\ud83d\udc40 good shit go\u0c66\u0501 sHit\ud83d\udc4c thats \u2714 some good\ud83d\udc4c\ud83d\udc4cshit right\ud83d\udc4c\ud83d\udc4cthere\ud83d\udc4c\ud83d\udc4c\ud83d\udc4c right\u2714there \u2714\u2714if i do \u01bda\u04af so my self \ud83d\udcaf i say so \ud83d\udcaf thats what im talking about right there right there (chorus: \u02b3\u1da6\u1d4d\u02b0\u1d57 \u1d57\u02b0\u1d49\u02b3\u1d49) mMMMM\u13b7\u041c\ud83d\udcaf \ud83d\udc4c\ud83d\udc4c \ud83d\udc4c\u041dO0\u041e\u0b20OOOOO\u041e\u0b20\u0b20Oooo\u1d52\u1d52\u1d52\u1d52\u1d52\u1d52\u1d52\u1d52\u1d52\ud83d\udc4c \ud83d\udc4c\ud83d\udc4c \ud83d\udc4c \ud83d\udcaf \ud83d\udc4c \ud83d\udc40 \ud83d\udc40 \ud83d\udc40 \ud83d\udc4c\ud83d\udc4c\n\nLet's play chess. The current game state in Forsyth-Edwards Notation (FEN) notation is:\n8/1R1k2pp/p2pr3/2pNp3/2P5/7P/P2B1PP1/4R1K1 b - - 4 33\nThe moves played so far are:\n1. e4 e5 2. Nf3 Nc6 3. Bb5 a6 4. Ba4 Nf6 5. O-O Be7 6. Re1 b5 7. Bb3 d6 8. c3 O-O 9. h3 Na5 10. Bc2 c5 11. d4 Qc7 12. d5 Nc4 13. b3 Nb6 14. Nbd2 Ne8 15. Nf1 f5 16. exf5 Bxf5 17. Bxf5 Rxf5 18. Ng3 Rf6 19. Ng5 Rg6 20. Ne6 Qb7 21. Nf5 Nxd5 22. Qxd5 Qxd5 23. Nxe7+ Kf7 24. Nxd5 Kxe6 25. c4 Nf6 26. Nc7+ Kd7 27. Nxa8 Kc6 28. Bd2 bxc4 29. bxc4 Nd7 30. Rab1 Nb6 31. Nxb6 Re6 32. Nd5 Kd7 33. Rb7+\nYou are playing as player Black.\nIt is now your turn. Play your strongest move. The move MUST be legal. Reason step by step to come up with your move, then output your final answer in the format \"Final Answer: X\" where X is your chosen move in standard algebraic notation (SAN).\n",
+              "prompt_tokens": 525,
+              "reasoning_tokens": 0,
+              "response": "The current position is `8/1R1k2pp/p2pr3/2pNp3/2P5/7P/P2B1PP1/4R1K1 b - - 4 33`. It is Black's turn to move.\n\n**Evaluation:**\nWhite is significantly ahead in material (a Rook and a Knight versus nothing for Black's sacrificed material). White's pieces are highly active. Black's King is under immediate attack by the Rook on b7.\n\n**Analysis of candidate moves for Black:**\nBlack must deal with the check from the Rook on b7. The King has two legal squares:\n1. **...Kc6**: This square is attacked by the Knight on d5. If `33... Kc6`, White can respond with `34. Rb6+` or even `34. Rc7#`.\n2. **...Ke8**: Moving the King back to the back rank.\n\nLet's evaluate `33... Ke8`:\n- If `33... Ke8`, White can continue the attack with `34. Nc7+`. If `34... Kd7`, White continues with `35. Nxe6+`. This leads to a further loss of material.\n- If `33... Ke8 34. Reb1`, White prepares to swing the other rook or further infiltrate.\n- Black is in a completely lost position regardless of the move, but `Ke8` is the only move that doesn't immediately lose the King or lead to a forced mate in one or two.\n\nGiven the desperate nature of the position:\n- `33... Kc6` is illegal or leads to mate because the d5 Knight covers c6.\n- `33... Ke8` is the only legal move.\n\nWait, looking closely at the board:\n- The King is at d7. The Rook is at b7 (giving check).\n- The Knight is at d5.\n- The King cannot move to c6 because it is protected by the Knight on d5.\n- The King cannot move to e8? No, e8 is empty.\n- Are there any other squares? No, c8, d8, e8 are the only ones. c8 is covered by the Rook on b7 (indirectly if the rook moves) or the Knight? No, just checking the King's mobility.\n- After `33. Rb7+`, the King at d7 is attacked.\n- Can the King move to c8? No, the Rook on b7 controls the 7th rank.\n- Can the King move to d8? No, the Rook on b7 controls d7, but does it control d8? No, but the Knight on d5 controls c7, e7, b6, f6, etc.\n- The King is currently on d7. The move `33... Kc8` would be illegal because the Rook on b7 controls the 7th rank. `33... Ke8` is the only move.\n\nFinal check: 33... Ke8.\n\nFinal Answer: Ke8",
+              "total_tokens": 1199
+            }
+          ],
+          "status": "OK",
+          "submission": 1883,
+          "thoughts": "The current position is `8/1R1k2pp/p2pr3/2pNp3/2P5/7P/P2B1PP1/4R1K1 b - - 4 33`. It is Black's turn to move.\n\n**Evaluation:**\nWhite is significantly ahead in material (a Rook and a Knight versus nothing for Black's sacrificed material). White's pieces are highly active. Black's King is under immediate attack by the Rook on b7.\n\n**Analysis of candidate moves for Black:**\nBlack must deal with the check from the Rook on b7. The King has two legal squares:\n1. **...Kc6**: This square is attacked by the Knight on d5. If `33... Kc6`, White can respond with `34. Rb6+` or even `34. Rc7#`.\n2. **...Ke8**: Moving the King back to the back rank.\n\nLet's evaluate `33... Ke8`:\n- If `33... Ke8`, White can continue the attack with `34. Nc7+`. If `34... Kd7`, White continues with `35. Nxe6+`. This leads to a further loss of material.\n- If `33... Ke8 34. Reb1`, White prepares to swing the other rook or further infiltrate.\n- Black is in a completely lost position regardless of the move, but `Ke8` is the only move that doesn't immediately lose the King or lead to a forced mate in one or two.\n\nGiven the desperate nature of the position:\n- `33... Kc6` is illegal or leads to mate because the d5 Knight covers c6.\n- `33... Ke8` is the only legal move.\n\nWait, looking closely at the board:\n- The King is at d7. The Rook is at b7 (giving check).\n- The Knight is at d5.\n- The King cannot move to c6 because it is protected by the Knight on d5.\n- The King cannot move to e8? No, e8 is empty.\n- Are there any other squares? No, c8, d8, e8 are the only ones. c8 is covered by the Rook on b7 (indirectly if the rook moves) or the Knight? No, just checking the King's mobility.\n- After `33. Rb7+`, the King at d7 is attacked.\n- Can the King move to c8? No, the Rook on b7 controls the 7th rank.\n- Can the King move to d8? No, the Rook on b7 controls d7, but does it control d8? No, but the Knight on d5 controls c7, e7, b6, f6, etc.\n- The King is currently on d7. The move `33... Kc8` would be illegal because the Rook on b7 controls the 7th rank. `33... Ke8` is the only move.\n\nFinal check: 33... Ke8.\n\nFinal Answer: Ke8"
+        },
+        "info": {
+          "actionApplied": 1883,
+          "actionSubmitted": 1883,
+          "actionSubmittedToString": "Ke8",
+          "agentSelfReportedStatus": "OK",
+          "timeTaken": 4.015
+        },
+        "observation": {
+          "currentPlayer": 1,
+          "isTerminal": false,
+          "observationString": "4k3/1R4pp/p2pr3/2pNp3/2P5/7P/P2B1PP1/4R1K1 w - - 5 34",
+          "playerId": 0,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n2426\n3572\n656\n2974\n89\n919\n3572\n4673\n2977\n2949\n674\n277\n1841\n1257\n4673\n4177\n1380\n788\n1258\n1842\n1809\n1987\n289\n673\n1527\n654\n3133\n1894\n3010\n2599\n1214\n1287\n2938\n2992\n3154\n3138\n3096\n3862\n1270\n3718\n800\n1771\n702\n3280\n3561\n2841\n3050\n1330\n2408\n2112\n2525\n1672\n1882\n1212\n847\n774\n3131\n30\n1891\n582\n3678\n1018\n1372\n605\n1883\n\n",
+          "step": 67
+        },
+        "reward": null,
+        "status": "INACTIVE"
+      },
+      {
+        "action": { "submission": -1 },
+        "info": {},
+        "observation": {
+          "currentPlayer": 1,
+          "isTerminal": false,
+          "observationString": "4k3/1R4pp/p2pr3/2pNp3/2P5/7P/P2B1PP1/4R1K1 w - - 5 34",
+          "playerId": 1,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n2426\n3572\n656\n2974\n89\n919\n3572\n4673\n2977\n2949\n674\n277\n1841\n1257\n4673\n4177\n1380\n788\n1258\n1842\n1809\n1987\n289\n673\n1527\n654\n3133\n1894\n3010\n2599\n1214\n1287\n2938\n2992\n3154\n3138\n3096\n3862\n1270\n3718\n800\n1771\n702\n3280\n3561\n2841\n3050\n1330\n2408\n2112\n2525\n1672\n1882\n1212\n847\n774\n3131\n30\n1891\n582\n3678\n1018\n1372\n605\n1883\n\n"
+        },
+        "reward": null,
+        "status": "ACTIVE"
+      }
+    ],
+    [
+      {
+        "action": { "submission": -1 },
+        "info": {},
+        "observation": {
+          "currentPlayer": 0,
+          "isTerminal": false,
+          "observationString": "4k3/1RN3pp/p2pr3/2p1p3/2P5/7P/P2B1PP1/4R1K1 b - - 6 34",
+          "playerId": 0,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n2426\n3572\n656\n2974\n89\n919\n3572\n4673\n2977\n2949\n674\n277\n1841\n1257\n4673\n4177\n1380\n788\n1258\n1842\n1809\n1987\n289\n673\n1527\n654\n3133\n1894\n3010\n2599\n1214\n1287\n2938\n2992\n3154\n3138\n3096\n3862\n1270\n3718\n800\n1771\n702\n3280\n3561\n2841\n3050\n1330\n2408\n2112\n2525\n1672\n1882\n1212\n847\n774\n3131\n30\n1891\n582\n3678\n1018\n1372\n605\n1883\n2112\n\n",
+          "step": 68
+        },
+        "reward": null,
+        "status": "ACTIVE"
+      },
+      {
+        "action": {
+          "actionString": "Nc7+",
+          "call_details": [
+            {
+              "duration_secs": 3.24,
+              "finish_reason": "stop",
+              "first_token_secs": 0.838,
+              "generation_tokens": 479,
+              "model": "openai/google/gemini-3.1-flash-lite-preview",
+              "prompt": "You are a chess expert\n\nLet's play chess. The current game state in Forsyth-Edwards Notation (FEN) notation is:\n4k3/1R4pp/p2pr3/2pNp3/2P5/7P/P2B1PP1/4R1K1 w - - 5 34\nThe moves played so far are:\n1. e4 e5 2. Nf3 Nc6 3. Bb5 a6 4. Ba4 Nf6 5. O-O Be7 6. Re1 b5 7. Bb3 d6 8. c3 O-O 9. h3 Na5 10. Bc2 c5 11. d4 Qc7 12. d5 Nc4 13. b3 Nb6 14. Nbd2 Ne8 15. Nf1 f5 16. exf5 Bxf5 17. Bxf5 Rxf5 18. Ng3 Rf6 19. Ng5 Rg6 20. Ne6 Qb7 21. Nf5 Nxd5 22. Qxd5 Qxd5 23. Nxe7+ Kf7 24. Nxd5 Kxe6 25. c4 Nf6 26. Nc7+ Kd7 27. Nxa8 Kc6 28. Bd2 bxc4 29. bxc4 Nd7 30. Rab1 Nb6 31. Nxb6 Re6 32. Nd5 Kd7 33. Rb7+ Ke8 34.\nYou are playing as player White.\nIt is now your turn. Play your strongest move. The move MUST be legal. Reason step by step to come up with your move, then output your final answer in the format \"Final Answer: X\" where X is your chosen move in standard algebraic notation (SAN).\n",
+              "prompt_tokens": 411,
+              "reasoning_tokens": 0,
+              "response": "The current position is `4k3/1R4pp/p2pr3/2pNp3/2P5/7P/P2B1PP1/4R1K1 w - - 5 34`. It is White's turn to move.\n\n**Evaluation:**\nWhite has a significant advantage (+4.5 to +5.0). The black king is trapped on the back rank, and White's pieces (Rook on b7, Knight on d5) are paralyzing Black's position. Black's minor pieces are completely inactive, and their King is cut off by the Rook on b7.\n\n**Candidate Moves:**\n1. **Nc7+**: This is a direct check. If Black plays `...Kf7`, the knight can then move back or support the attack. However, `Nc7+` is a forced sequence that leads to the win of the exchange or further material.\n2. **Reb1**: Brings the other rook into play, adding pressure on the b-file, but it is not as immediate as the tactical blow.\n3. **Bg5**: Developing the bishop to restrict Black further, but again, tactical lines are usually superior when the opponent is pinned down.\n\n**Analysis of Nc7+:**\n34. Nc7+\nIf 34... Kd8, then 35. Nxe6+ Kc8 36. Rxg7. This wins the rook and leaves White with a crushing material advantage.\nIf 34... Kf7, White continues to apply pressure. The king is still stuck. 35. Nxe6 Kxe6. This simplifies the position into a winning endgame where White is up significant material.\n\nGiven that Black is already in a losing position, taking the material advantage immediately via the knight check is the most clinical and strongest way to convert.\n\nStep-by-step calculation:\n1. 34. Nc7+ Kd8 (or Kf7)\n2. 35. Nxe6+ (winning the rook)\n3. 35... Kc8\n4. 36. Rxg7\nWhite remains with a Rook, Bishop, and pawns against very little. The game is essentially decided.\n\nFinal Answer: Nc7+",
+              "total_tokens": 890
+            }
+          ],
+          "status": "OK",
+          "submission": 2112,
+          "thoughts": "The current position is `4k3/1R4pp/p2pr3/2pNp3/2P5/7P/P2B1PP1/4R1K1 w - - 5 34`. It is White's turn to move.\n\n**Evaluation:**\nWhite has a significant advantage (+4.5 to +5.0). The black king is trapped on the back rank, and White's pieces (Rook on b7, Knight on d5) are paralyzing Black's position. Black's minor pieces are completely inactive, and their King is cut off by the Rook on b7.\n\n**Candidate Moves:**\n1. **Nc7+**: This is a direct check. If Black plays `...Kf7`, the knight can then move back or support the attack. However, `Nc7+` is a forced sequence that leads to the win of the exchange or further material.\n2. **Reb1**: Brings the other rook into play, adding pressure on the b-file, but it is not as immediate as the tactical blow.\n3. **Bg5**: Developing the bishop to restrict Black further, but again, tactical lines are usually superior when the opponent is pinned down.\n\n**Analysis of Nc7+:**\n34. Nc7+\nIf 34... Kd8, then 35. Nxe6+ Kc8 36. Rxg7. This wins the rook and leaves White with a crushing material advantage.\nIf 34... Kf7, White continues to apply pressure. The king is still stuck. 35. Nxe6 Kxe6. This simplifies the position into a winning endgame where White is up significant material.\n\nGiven that Black is already in a losing position, taking the material advantage immediately via the knight check is the most clinical and strongest way to convert.\n\nStep-by-step calculation:\n1. 34. Nc7+ Kd8 (or Kf7)\n2. 35. Nxe6+ (winning the rook)\n3. 35... Kc8\n4. 36. Rxg7\nWhite remains with a Rook, Bishop, and pawns against very little. The game is essentially decided.\n\nFinal Answer: Nc7+"
+        },
+        "info": {
+          "actionApplied": 2112,
+          "actionSubmitted": 2112,
+          "actionSubmittedToString": "Nc7+",
+          "agentSelfReportedStatus": "OK",
+          "timeTaken": 3.761
+        },
+        "observation": {
+          "currentPlayer": 0,
+          "isTerminal": false,
+          "observationString": "4k3/1RN3pp/p2pr3/2p1p3/2P5/7P/P2B1PP1/4R1K1 b - - 6 34",
+          "playerId": 1,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n2426\n3572\n656\n2974\n89\n919\n3572\n4673\n2977\n2949\n674\n277\n1841\n1257\n4673\n4177\n1380\n788\n1258\n1842\n1809\n1987\n289\n673\n1527\n654\n3133\n1894\n3010\n2599\n1214\n1287\n2938\n2992\n3154\n3138\n3096\n3862\n1270\n3718\n800\n1771\n702\n3280\n3561\n2841\n3050\n1330\n2408\n2112\n2525\n1672\n1882\n1212\n847\n774\n3131\n30\n1891\n582\n3678\n1018\n1372\n605\n1883\n2112\n\n"
+        },
+        "reward": null,
+        "status": "INACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "actionString": "Kd7",
+          "call_details": [
+            {
+              "duration_secs": 3.83,
+              "finish_reason": "stop",
+              "first_token_secs": 0.657,
+              "generation_tokens": 688,
+              "model": "openai/google/gemini-3.1-flash-lite-preview",
+              "prompt": "\ud83d\udc4c\ud83d\udc40\ud83d\udc4c\ud83d\udc40\ud83d\udc4c\ud83d\udc40\ud83d\udc4c\ud83d\udc40\ud83d\udc4c\ud83d\udc40 good shit go\u0c66\u0501 sHit\ud83d\udc4c thats \u2714 some good\ud83d\udc4c\ud83d\udc4cshit right\ud83d\udc4c\ud83d\udc4cthere\ud83d\udc4c\ud83d\udc4c\ud83d\udc4c right\u2714there \u2714\u2714if i do \u01bda\u04af so my self \ud83d\udcaf i say so \ud83d\udcaf thats what im talking about right there right there (chorus: \u02b3\u1da6\u1d4d\u02b0\u1d57 \u1d57\u02b0\u1d49\u02b3\u1d49) mMMMM\u13b7\u041c\ud83d\udcaf \ud83d\udc4c\ud83d\udc4c \ud83d\udc4c\u041dO0\u041e\u0b20OOOOO\u041e\u0b20\u0b20Oooo\u1d52\u1d52\u1d52\u1d52\u1d52\u1d52\u1d52\u1d52\u1d52\ud83d\udc4c \ud83d\udc4c\ud83d\udc4c \ud83d\udc4c \ud83d\udcaf \ud83d\udc4c \ud83d\udc40 \ud83d\udc40 \ud83d\udc40 \ud83d\udc4c\ud83d\udc4c\n\nLet's play chess. The current game state in Forsyth-Edwards Notation (FEN) notation is:\n4k3/1RN3pp/p2pr3/2p1p3/2P5/7P/P2B1PP1/4R1K1 b - - 6 34\nThe moves played so far are:\n1. e4 e5 2. Nf3 Nc6 3. Bb5 a6 4. Ba4 Nf6 5. O-O Be7 6. Re1 b5 7. Bb3 d6 8. c3 O-O 9. h3 Na5 10. Bc2 c5 11. d4 Qc7 12. d5 Nc4 13. b3 Nb6 14. Nbd2 Ne8 15. Nf1 f5 16. exf5 Bxf5 17. Bxf5 Rxf5 18. Ng3 Rf6 19. Ng5 Rg6 20. Ne6 Qb7 21. Nf5 Nxd5 22. Qxd5 Qxd5 23. Nxe7+ Kf7 24. Nxd5 Kxe6 25. c4 Nf6 26. Nc7+ Kd7 27. Nxa8 Kc6 28. Bd2 bxc4 29. bxc4 Nd7 30. Rab1 Nb6 31. Nxb6 Re6 32. Nd5 Kd7 33. Rb7+ Ke8 34. Nc7+\nYou are playing as player Black.\nIt is now your turn. Play your strongest move. The move MUST be legal. Reason step by step to come up with your move, then output your final answer in the format \"Final Answer: X\" where X is your chosen move in standard algebraic notation (SAN).\n",
+              "prompt_tokens": 535,
+              "reasoning_tokens": 0,
+              "response": "The current position is `4k3/1RN3pp/p2pr3/2p1p3/2P5/7P/P2B1PP1/4R1K1 b - - 6 34`. It is black's turn to move.\n\n**Evaluation:**\nWhite has a overwhelming material advantage (a full rook up, plus the knight on c7 is attacking the rook on e6). Black's position is completely lost. The only move that does not immediately result in the loss of further material (like simply moving the king) is to move the rook, but the rook is under attack and essentially trapped or destined to fall.\n\n**Analysis:**\n1. **... Ke7:** This moves the king out of check. White will then play `Nxe6` or simply continue building the attack.\n2. **... Kd7:** This is also a legal move, moving the king to a safer square (though nowhere is safe).\n3. **... Kf7:** This is the most logical attempt to defend or shuffle, but the position is lost regardless.\n\nLet's look at the immediate threats:\n- The knight on c7 is currently attacking the rook on e6.\n- The rook on b7 is extremely active.\n\nIf I play `34... Kf7`, White will simply play `35. Nxe6`.\nIf I play `34... Kd7`, White will simply play `35. Nxe6`.\n\nThere is no way to save the rook on e6. The game is essentially over. I will play the most standard king move to continue the game.\n\n**Decision:**\n`34... Kd7` is a standard response to getting out of check when the position is already resigned.\n\nWait, let me double-check the board state.\nThe move `34. Nc7+` puts the black king in check. Black *must* get out of check.\nThe king is on e8.\nLegal moves for the King:\n- `Kd7`\n- `Kf7`\n\nBoth lead to the same result: `35. Nxe6`. I will choose `Kd7`.The current position is `4k3/1RN3pp/p2pr3/2p1p3/2P5/7P/P2B1PP1/4R1K1 b - - 6 34`. It is black's turn to move.\n\n**Evaluation:**\nBlack is in check from the knight on c7. The king must move. Regardless of whether the king moves to d7 or f7, white will respond with `35. Nxe6`, capturing the rook and further increasing their material and positional advantage. The game is effectively decided.\n\n**Analysis:**\n1. **... Kd7:** The king moves to d7, out of check. White will subsequently play `35. Nxe6`.\n2. **... Kf7:** The king moves to f7, out of check. White will subsequently play `35. Nxe6`.\n\nSince both moves lead to the same material loss and the position is hopeless, `Kd7` is as good as any other legal move to continue play.\n\nFinal Answer: Kd7",
+              "total_tokens": 1223
+            }
+          ],
+          "status": "OK",
+          "submission": 2393,
+          "thoughts": "The current position is `4k3/1RN3pp/p2pr3/2p1p3/2P5/7P/P2B1PP1/4R1K1 b - - 6 34`. It is black's turn to move.\n\n**Evaluation:**\nWhite has a overwhelming material advantage (a full rook up, plus the knight on c7 is attacking the rook on e6). Black's position is completely lost. The only move that does not immediately result in the loss of further material (like simply moving the king) is to move the rook, but the rook is under attack and essentially trapped or destined to fall.\n\n**Analysis:**\n1. **... Ke7:** This moves the king out of check. White will then play `Nxe6` or simply continue building the attack.\n2. **... Kd7:** This is also a legal move, moving the king to a safer square (though nowhere is safe).\n3. **... Kf7:** This is the most logical attempt to defend or shuffle, but the position is lost regardless.\n\nLet's look at the immediate threats:\n- The knight on c7 is currently attacking the rook on e6.\n- The rook on b7 is extremely active.\n\nIf I play `34... Kf7`, White will simply play `35. Nxe6`.\nIf I play `34... Kd7`, White will simply play `35. Nxe6`.\n\nThere is no way to save the rook on e6. The game is essentially over. I will play the most standard king move to continue the game.\n\n**Decision:**\n`34... Kd7` is a standard response to getting out of check when the position is already resigned.\n\nWait, let me double-check the board state.\nThe move `34. Nc7+` puts the black king in check. Black *must* get out of check.\nThe king is on e8.\nLegal moves for the King:\n- `Kd7`\n- `Kf7`\n\nBoth lead to the same result: `35. Nxe6`. I will choose `Kd7`.The current position is `4k3/1RN3pp/p2pr3/2p1p3/2P5/7P/P2B1PP1/4R1K1 b - - 6 34`. It is black's turn to move.\n\n**Evaluation:**\nBlack is in check from the knight on c7. The king must move. Regardless of whether the king moves to d7 or f7, white will respond with `35. Nxe6`, capturing the rook and further increasing their material and positional advantage. The game is effectively decided.\n\n**Analysis:**\n1. **... Kd7:** The king moves to d7, out of check. White will subsequently play `35. Nxe6`.\n2. **... Kf7:** The king moves to f7, out of check. White will subsequently play `35. Nxe6`.\n\nSince both moves lead to the same material loss and the position is hopeless, `Kd7` is as good as any other legal move to continue play.\n\nFinal Answer: Kd7"
+        },
+        "info": {
+          "actionApplied": 2393,
+          "actionSubmitted": 2393,
+          "actionSubmittedToString": "Kd7",
+          "agentSelfReportedStatus": "OK",
+          "timeTaken": 4.358
+        },
+        "observation": {
+          "currentPlayer": 1,
+          "isTerminal": false,
+          "observationString": "8/1RNk2pp/p2pr3/2p1p3/2P5/7P/P2B1PP1/4R1K1 w - - 7 35",
+          "playerId": 0,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n2426\n3572\n656\n2974\n89\n919\n3572\n4673\n2977\n2949\n674\n277\n1841\n1257\n4673\n4177\n1380\n788\n1258\n1842\n1809\n1987\n289\n673\n1527\n654\n3133\n1894\n3010\n2599\n1214\n1287\n2938\n2992\n3154\n3138\n3096\n3862\n1270\n3718\n800\n1771\n702\n3280\n3561\n2841\n3050\n1330\n2408\n2112\n2525\n1672\n1882\n1212\n847\n774\n3131\n30\n1891\n582\n3678\n1018\n1372\n605\n1883\n2112\n2393\n\n",
+          "step": 69
+        },
+        "reward": null,
+        "status": "INACTIVE"
+      },
+      {
+        "action": { "submission": -1 },
+        "info": {},
+        "observation": {
+          "currentPlayer": 1,
+          "isTerminal": false,
+          "observationString": "8/1RNk2pp/p2pr3/2p1p3/2P5/7P/P2B1PP1/4R1K1 w - - 7 35",
+          "playerId": 1,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n2426\n3572\n656\n2974\n89\n919\n3572\n4673\n2977\n2949\n674\n277\n1841\n1257\n4673\n4177\n1380\n788\n1258\n1842\n1809\n1987\n289\n673\n1527\n654\n3133\n1894\n3010\n2599\n1214\n1287\n2938\n2992\n3154\n3138\n3096\n3862\n1270\n3718\n800\n1771\n702\n3280\n3561\n2841\n3050\n1330\n2408\n2112\n2525\n1672\n1882\n1212\n847\n774\n3131\n30\n1891\n582\n3678\n1018\n1372\n605\n1883\n2112\n2393\n\n"
+        },
+        "reward": null,
+        "status": "ACTIVE"
+      }
+    ],
+    [
+      {
+        "action": { "submission": -1 },
+        "info": {},
+        "observation": {
+          "currentPlayer": 0,
+          "isTerminal": false,
+          "observationString": "8/1R1k2pp/p2pN3/2p1p3/2P5/7P/P2B1PP1/4R1K1 b - - 0 35",
+          "playerId": 0,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n2426\n3572\n656\n2974\n89\n919\n3572\n4673\n2977\n2949\n674\n277\n1841\n1257\n4673\n4177\n1380\n788\n1258\n1842\n1809\n1987\n289\n673\n1527\n654\n3133\n1894\n3010\n2599\n1214\n1287\n2938\n2992\n3154\n3138\n3096\n3862\n1270\n3718\n800\n1771\n702\n3280\n3561\n2841\n3050\n1330\n2408\n2112\n2525\n1672\n1882\n1212\n847\n774\n3131\n30\n1891\n582\n3678\n1018\n1372\n605\n1883\n2112\n2393\n1675\n\n",
+          "step": 70
+        },
+        "reward": null,
+        "status": "ACTIVE"
+      },
+      {
+        "action": {
+          "actionString": "Nxe6+",
+          "call_details": [
+            {
+              "duration_secs": 2.976,
+              "finish_reason": "stop",
+              "first_token_secs": 0.64,
+              "generation_tokens": 466,
+              "model": "openai/google/gemini-3.1-flash-lite-preview",
+              "prompt": "You are a chess expert\n\nLet's play chess. The current game state in Forsyth-Edwards Notation (FEN) notation is:\n8/1RNk2pp/p2pr3/2p1p3/2P5/7P/P2B1PP1/4R1K1 w - - 7 35\nThe moves played so far are:\n1. e4 e5 2. Nf3 Nc6 3. Bb5 a6 4. Ba4 Nf6 5. O-O Be7 6. Re1 b5 7. Bb3 d6 8. c3 O-O 9. h3 Na5 10. Bc2 c5 11. d4 Qc7 12. d5 Nc4 13. b3 Nb6 14. Nbd2 Ne8 15. Nf1 f5 16. exf5 Bxf5 17. Bxf5 Rxf5 18. Ng3 Rf6 19. Ng5 Rg6 20. Ne6 Qb7 21. Nf5 Nxd5 22. Qxd5 Qxd5 23. Nxe7+ Kf7 24. Nxd5 Kxe6 25. c4 Nf6 26. Nc7+ Kd7 27. Nxa8 Kc6 28. Bd2 bxc4 29. bxc4 Nd7 30. Rab1 Nb6 31. Nxb6 Re6 32. Nd5 Kd7 33. Rb7+ Ke8 34. Nc7+ Kd7 35.\nYou are playing as player White.\nIt is now your turn. Play your strongest move. The move MUST be legal. Reason step by step to come up with your move, then output your final answer in the format \"Final Answer: X\" where X is your chosen move in standard algebraic notation (SAN).\n",
+              "prompt_tokens": 420,
+              "reasoning_tokens": 0,
+              "response": "The current FEN is `8/1RNk2pp/p2pr3/2p1p3/2P5/7P/P2B1PP1/4R1K1 w - - 7 35`. It is White's turn to move.\n\n**Evaluation:**\nWhite is significantly ahead in material (an exchange up) and the position is winning. Black's king is restricted, and White's pieces are well-coordinated.\n\n**Candidate Moves:**\n1. **Nxe6**: This is the most direct and crushing move. It captures the rook on e6, leaving White with a decisive material advantage (a full rook up). After 35. Nxe6 Kxe6, White is up a rook in an endgame that is technically won.\n2. **Nd5+**: This is also a strong move, forcing the king to move or allowing further consolidation, but it allows Black's rook on e6 to remain on the board for one more move.\n3. **Ba5**: A prophylactic move, but unnecessary given the immediate tactical win available.\n\n**Analysis of 35. Nxe6:**\n* 35. Nxe6 Kxe6\n* The position becomes a simple endgame: White has a rook and bishop against Black's bishop and pawns.\n* White's king is safe, and Black has no counterplay.\n* White will easily win by centralizing the king and advancing the kingside pawns or using the rook to target Black's weak pawns.\n\n**Conclusion:**\nCapturing the rook on e6 is the most clinical way to finish the game. It simplifies the position, eliminates Black's only active piece, and secures the win.\n\nStep-by-step reasoning:\n1. Identify the material imbalance: White is currently winning.\n2. Identify hanging pieces: The black rook on e6 is currently undefended after the sequence leading to this position.\n3. Calculate: 35. Nxe6 Kxe6. White remains with a decisive material advantage. No threats from Black exist.\n4. Selection: 35. Nxe6 is the best move as it guarantees a winning endgame.\n\nFinal Answer: Nxe6",
+              "total_tokens": 886
+            }
+          ],
+          "status": "OK",
+          "submission": 1675,
+          "thoughts": "The current FEN is `8/1RNk2pp/p2pr3/2p1p3/2P5/7P/P2B1PP1/4R1K1 w - - 7 35`. It is White's turn to move.\n\n**Evaluation:**\nWhite is significantly ahead in material (an exchange up) and the position is winning. Black's king is restricted, and White's pieces are well-coordinated.\n\n**Candidate Moves:**\n1. **Nxe6**: This is the most direct and crushing move. It captures the rook on e6, leaving White with a decisive material advantage (a full rook up). After 35. Nxe6 Kxe6, White is up a rook in an endgame that is technically won.\n2. **Nd5+**: This is also a strong move, forcing the king to move or allowing further consolidation, but it allows Black's rook on e6 to remain on the board for one more move.\n3. **Ba5**: A prophylactic move, but unnecessary given the immediate tactical win available.\n\n**Analysis of 35. Nxe6:**\n* 35. Nxe6 Kxe6\n* The position becomes a simple endgame: White has a rook and bishop against Black's bishop and pawns.\n* White's king is safe, and Black has no counterplay.\n* White will easily win by centralizing the king and advancing the kingside pawns or using the rook to target Black's weak pawns.\n\n**Conclusion:**\nCapturing the rook on e6 is the most clinical way to finish the game. It simplifies the position, eliminates Black's only active piece, and secures the win.\n\nStep-by-step reasoning:\n1. Identify the material imbalance: White is currently winning.\n2. Identify hanging pieces: The black rook on e6 is currently undefended after the sequence leading to this position.\n3. Calculate: 35. Nxe6 Kxe6. White remains with a decisive material advantage. No threats from Black exist.\n4. Selection: 35. Nxe6 is the best move as it guarantees a winning endgame.\n\nFinal Answer: Nxe6"
+        },
+        "info": {
+          "actionApplied": 1675,
+          "actionSubmitted": 1675,
+          "actionSubmittedToString": "Nxe6+",
+          "agentSelfReportedStatus": "OK",
+          "timeTaken": 3.429
+        },
+        "observation": {
+          "currentPlayer": 0,
+          "isTerminal": false,
+          "observationString": "8/1R1k2pp/p2pN3/2p1p3/2P5/7P/P2B1PP1/4R1K1 b - - 0 35",
+          "playerId": 1,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n2426\n3572\n656\n2974\n89\n919\n3572\n4673\n2977\n2949\n674\n277\n1841\n1257\n4673\n4177\n1380\n788\n1258\n1842\n1809\n1987\n289\n673\n1527\n654\n3133\n1894\n3010\n2599\n1214\n1287\n2938\n2992\n3154\n3138\n3096\n3862\n1270\n3718\n800\n1771\n702\n3280\n3561\n2841\n3050\n1330\n2408\n2112\n2525\n1672\n1882\n1212\n847\n774\n3131\n30\n1891\n582\n3678\n1018\n1372\n605\n1883\n2112\n2393\n1675\n\n"
+        },
+        "reward": null,
+        "status": "INACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "actionString": "Kxe6",
+          "call_details": [
+            {
+              "duration_secs": 1.874,
+              "finish_reason": "stop",
+              "first_token_secs": 0.691,
+              "generation_tokens": 281,
+              "model": "openai/google/gemini-3.1-flash-lite-preview",
+              "prompt": "\ud83d\udc4c\ud83d\udc40\ud83d\udc4c\ud83d\udc40\ud83d\udc4c\ud83d\udc40\ud83d\udc4c\ud83d\udc40\ud83d\udc4c\ud83d\udc40 good shit go\u0c66\u0501 sHit\ud83d\udc4c thats \u2714 some good\ud83d\udc4c\ud83d\udc4cshit right\ud83d\udc4c\ud83d\udc4cthere\ud83d\udc4c\ud83d\udc4c\ud83d\udc4c right\u2714there \u2714\u2714if i do \u01bda\u04af so my self \ud83d\udcaf i say so \ud83d\udcaf thats what im talking about right there right there (chorus: \u02b3\u1da6\u1d4d\u02b0\u1d57 \u1d57\u02b0\u1d49\u02b3\u1d49) mMMMM\u13b7\u041c\ud83d\udcaf \ud83d\udc4c\ud83d\udc4c \ud83d\udc4c\u041dO0\u041e\u0b20OOOOO\u041e\u0b20\u0b20Oooo\u1d52\u1d52\u1d52\u1d52\u1d52\u1d52\u1d52\u1d52\u1d52\ud83d\udc4c \ud83d\udc4c\ud83d\udc4c \ud83d\udc4c \ud83d\udcaf \ud83d\udc4c \ud83d\udc40 \ud83d\udc40 \ud83d\udc40 \ud83d\udc4c\ud83d\udc4c\n\nLet's play chess. The current game state in Forsyth-Edwards Notation (FEN) notation is:\n8/1R1k2pp/p2pN3/2p1p3/2P5/7P/P2B1PP1/4R1K1 b - - 0 35\nThe moves played so far are:\n1. e4 e5 2. Nf3 Nc6 3. Bb5 a6 4. Ba4 Nf6 5. O-O Be7 6. Re1 b5 7. Bb3 d6 8. c3 O-O 9. h3 Na5 10. Bc2 c5 11. d4 Qc7 12. d5 Nc4 13. b3 Nb6 14. Nbd2 Ne8 15. Nf1 f5 16. exf5 Bxf5 17. Bxf5 Rxf5 18. Ng3 Rf6 19. Ng5 Rg6 20. Ne6 Qb7 21. Nf5 Nxd5 22. Qxd5 Qxd5 23. Nxe7+ Kf7 24. Nxd5 Kxe6 25. c4 Nf6 26. Nc7+ Kd7 27. Nxa8 Kc6 28. Bd2 bxc4 29. bxc4 Nd7 30. Rab1 Nb6 31. Nxb6 Re6 32. Nd5 Kd7 33. Rb7+ Ke8 34. Nc7+ Kd7 35. Nxe6+\nYou are playing as player Black.\nIt is now your turn. Play your strongest move. The move MUST be legal. Reason step by step to come up with your move, then output your final answer in the format \"Final Answer: X\" where X is your chosen move in standard algebraic notation (SAN).\n",
+              "prompt_tokens": 544,
+              "reasoning_tokens": 0,
+              "response": "The current position is `8/1R1k2pp/p2pN3/2p1p3/2P5/7P/P2B1PP1/4R1K1 b - - 0 35`.\n\n**Evaluation:**\nWhite has a decisive material advantage (a Rook and a Knight against Black's remaining pieces). Black is in check from the Knight on e6.\n\n**Analysis:**\n1. **Legal Moves:** Black is currently in check from the Knight at e6. The only way to move out of check is to capture the knight or move the King.\n    *   `...Kxe6`: The King captures the Knight on e6. This is the only legal move.\n\n2. **Consequences:**\n    *   After `35... Kxe6`, the position becomes `8/1R6/p2pk3/2p1p3/2P5/7P/P2B1PP1/4R1K1 w - - 0 36`.\n    *   White remains with a Rook advantage. The game is lost for Black, but capturing the knight is mandatory to stay in the game.\n\n**Conclusion:**\nThere is only one legal move available to Black to escape the check from the Knight.\n\nFinal Answer: Kxe6",
+              "total_tokens": 825
+            }
+          ],
+          "status": "OK",
+          "submission": 1869,
+          "thoughts": "The current position is `8/1R1k2pp/p2pN3/2p1p3/2P5/7P/P2B1PP1/4R1K1 b - - 0 35`.\n\n**Evaluation:**\nWhite has a decisive material advantage (a Rook and a Knight against Black's remaining pieces). Black is in check from the Knight on e6.\n\n**Analysis:**\n1. **Legal Moves:** Black is currently in check from the Knight at e6. The only way to move out of check is to capture the knight or move the King.\n    *   `...Kxe6`: The King captures the Knight on e6. This is the only legal move.\n\n2. **Consequences:**\n    *   After `35... Kxe6`, the position becomes `8/1R6/p2pk3/2p1p3/2P5/7P/P2B1PP1/4R1K1 w - - 0 36`.\n    *   White remains with a Rook advantage. The game is lost for Black, but capturing the knight is mandatory to stay in the game.\n\n**Conclusion:**\nThere is only one legal move available to Black to escape the check from the Knight.\n\nFinal Answer: Kxe6"
+        },
+        "info": {
+          "actionApplied": 1869,
+          "actionSubmitted": 1869,
+          "actionSubmittedToString": "Kxe6",
+          "agentSelfReportedStatus": "OK",
+          "timeTaken": 2.458
+        },
+        "observation": {
+          "currentPlayer": 1,
+          "isTerminal": false,
+          "observationString": "8/1R4pp/p2pk3/2p1p3/2P5/7P/P2B1PP1/4R1K1 w - - 0 36",
+          "playerId": 0,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n2426\n3572\n656\n2974\n89\n919\n3572\n4673\n2977\n2949\n674\n277\n1841\n1257\n4673\n4177\n1380\n788\n1258\n1842\n1809\n1987\n289\n673\n1527\n654\n3133\n1894\n3010\n2599\n1214\n1287\n2938\n2992\n3154\n3138\n3096\n3862\n1270\n3718\n800\n1771\n702\n3280\n3561\n2841\n3050\n1330\n2408\n2112\n2525\n1672\n1882\n1212\n847\n774\n3131\n30\n1891\n582\n3678\n1018\n1372\n605\n1883\n2112\n2393\n1675\n1869\n\n",
+          "step": 71
+        },
+        "reward": null,
+        "status": "INACTIVE"
+      },
+      {
+        "action": { "submission": -1 },
+        "info": {},
+        "observation": {
+          "currentPlayer": 1,
+          "isTerminal": false,
+          "observationString": "8/1R4pp/p2pk3/2p1p3/2P5/7P/P2B1PP1/4R1K1 w - - 0 36",
+          "playerId": 1,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n2426\n3572\n656\n2974\n89\n919\n3572\n4673\n2977\n2949\n674\n277\n1841\n1257\n4673\n4177\n1380\n788\n1258\n1842\n1809\n1987\n289\n673\n1527\n654\n3133\n1894\n3010\n2599\n1214\n1287\n2938\n2992\n3154\n3138\n3096\n3862\n1270\n3718\n800\n1771\n702\n3280\n3561\n2841\n3050\n1330\n2408\n2112\n2525\n1672\n1882\n1212\n847\n774\n3131\n30\n1891\n582\n3678\n1018\n1372\n605\n1883\n2112\n2393\n1675\n1869\n\n"
+        },
+        "reward": null,
+        "status": "ACTIVE"
+      }
+    ],
+    [
+      {
+        "action": { "submission": -1 },
+        "info": {},
+        "observation": {
+          "currentPlayer": 0,
+          "isTerminal": false,
+          "observationString": "8/6Rp/p2pk3/2p1p3/2P5/7P/P2B1PP1/4R1K1 b - - 0 36",
+          "playerId": 0,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n2426\n3572\n656\n2974\n89\n919\n3572\n4673\n2977\n2949\n674\n277\n1841\n1257\n4673\n4177\n1380\n788\n1258\n1842\n1809\n1987\n289\n673\n1527\n654\n3133\n1894\n3010\n2599\n1214\n1287\n2938\n2992\n3154\n3138\n3096\n3862\n1270\n3718\n800\n1771\n702\n3280\n3561\n2841\n3050\n1330\n2408\n2112\n2525\n1672\n1882\n1212\n847\n774\n3131\n30\n1891\n582\n3678\n1018\n1372\n605\n1883\n2112\n2393\n1675\n1869\n1056\n\n",
+          "step": 72
+        },
+        "reward": null,
+        "status": "ACTIVE"
+      },
+      {
+        "action": {
+          "actionString": "Rxg7",
+          "call_details": [
+            {
+              "duration_secs": 2.435,
+              "finish_reason": "stop",
+              "first_token_secs": 0.759,
+              "generation_tokens": 361,
+              "model": "openai/google/gemini-3.1-flash-lite-preview",
+              "prompt": "You are a chess expert\n\nLet's play chess. The current game state in Forsyth-Edwards Notation (FEN) notation is:\n8/1R4pp/p2pk3/2p1p3/2P5/7P/P2B1PP1/4R1K1 w - - 0 36\nThe moves played so far are:\n1. e4 e5 2. Nf3 Nc6 3. Bb5 a6 4. Ba4 Nf6 5. O-O Be7 6. Re1 b5 7. Bb3 d6 8. c3 O-O 9. h3 Na5 10. Bc2 c5 11. d4 Qc7 12. d5 Nc4 13. b3 Nb6 14. Nbd2 Ne8 15. Nf1 f5 16. exf5 Bxf5 17. Bxf5 Rxf5 18. Ng3 Rf6 19. Ng5 Rg6 20. Ne6 Qb7 21. Nf5 Nxd5 22. Qxd5 Qxd5 23. Nxe7+ Kf7 24. Nxd5 Kxe6 25. c4 Nf6 26. Nc7+ Kd7 27. Nxa8 Kc6 28. Bd2 bxc4 29. bxc4 Nd7 30. Rab1 Nb6 31. Nxb6 Re6 32. Nd5 Kd7 33. Rb7+ Ke8 34. Nc7+ Kd7 35. Nxe6+ Kxe6 36.\nYou are playing as player White.\nIt is now your turn. Play your strongest move. The move MUST be legal. Reason step by step to come up with your move, then output your final answer in the format \"Final Answer: X\" where X is your chosen move in standard algebraic notation (SAN).\n",
+              "prompt_tokens": 428,
+              "reasoning_tokens": 0,
+              "response": "The current position is `8/1R4pp/p2pk3/2p1p3/2P5/7P/P2B1PP1/4R1K1 w - - 0 36`. \n\n**Evaluation:**\nWhite is winning decisively. White has a Rook and a Bishop against Black's army, and Black's King is relatively exposed. The material advantage (Rook + Bishop vs nothing extra on the board) is insurmountable.\n\n**Candidate moves:**\n1. **Rxg7:** This is the most natural move. It captures the g7-pawn, creating a passed h-pawn for White and further weakening Black's structure.\n2. **Reb1:** This prepares to double rooks or support the bishop/pawns, but capturing the pawn is more forcing.\n3. **Bc3:** Developing/repositioning the bishop to a more active square.\n\n**Analysis:**\n- `Rxg7` is clearly the best move. It removes the last active pawn on the kingside for Black, gives White a passed h-pawn, and continues the process of simplification towards a technically won endgame.\n- Black has no immediate threats. After `Rxg7`, the pawn on g7 is gone, and Black's structure is compromised. The transition to a won endgame is straightforward.\n\n**Step-by-step logic:**\n1. White has a significant material advantage.\n2. The g7 pawn is hanging and serves no defensive purpose for Black; it is a free asset.\n3. Capturing it facilitates the conversion of the advantage.\n4. There are no tactical traps for Black to exploit.\n\nFinal Answer: Rxg7",
+              "total_tokens": 789
+            }
+          ],
+          "status": "OK",
+          "submission": 1056,
+          "thoughts": "The current position is `8/1R4pp/p2pk3/2p1p3/2P5/7P/P2B1PP1/4R1K1 w - - 0 36`. \n\n**Evaluation:**\nWhite is winning decisively. White has a Rook and a Bishop against Black's army, and Black's King is relatively exposed. The material advantage (Rook + Bishop vs nothing extra on the board) is insurmountable.\n\n**Candidate moves:**\n1. **Rxg7:** This is the most natural move. It captures the g7-pawn, creating a passed h-pawn for White and further weakening Black's structure.\n2. **Reb1:** This prepares to double rooks or support the bishop/pawns, but capturing the pawn is more forcing.\n3. **Bc3:** Developing/repositioning the bishop to a more active square.\n\n**Analysis:**\n- `Rxg7` is clearly the best move. It removes the last active pawn on the kingside for Black, gives White a passed h-pawn, and continues the process of simplification towards a technically won endgame.\n- Black has no immediate threats. After `Rxg7`, the pawn on g7 is gone, and Black's structure is compromised. The transition to a won endgame is straightforward.\n\n**Step-by-step logic:**\n1. White has a significant material advantage.\n2. The g7 pawn is hanging and serves no defensive purpose for Black; it is a free asset.\n3. Capturing it facilitates the conversion of the advantage.\n4. There are no tactical traps for Black to exploit.\n\nFinal Answer: Rxg7"
+        },
+        "info": {
+          "actionApplied": 1056,
+          "actionSubmitted": 1056,
+          "actionSubmittedToString": "Rxg7",
+          "agentSelfReportedStatus": "OK",
+          "timeTaken": 2.917
+        },
+        "observation": {
+          "currentPlayer": 0,
+          "isTerminal": false,
+          "observationString": "8/6Rp/p2pk3/2p1p3/2P5/7P/P2B1PP1/4R1K1 b - - 0 36",
+          "playerId": 1,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n2426\n3572\n656\n2974\n89\n919\n3572\n4673\n2977\n2949\n674\n277\n1841\n1257\n4673\n4177\n1380\n788\n1258\n1842\n1809\n1987\n289\n673\n1527\n654\n3133\n1894\n3010\n2599\n1214\n1287\n2938\n2992\n3154\n3138\n3096\n3862\n1270\n3718\n800\n1771\n702\n3280\n3561\n2841\n3050\n1330\n2408\n2112\n2525\n1672\n1882\n1212\n847\n774\n3131\n30\n1891\n582\n3678\n1018\n1372\n605\n1883\n2112\n2393\n1675\n1869\n1056\n\n"
+        },
+        "reward": null,
+        "status": "INACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "actionString": "d5",
+          "call_details": [
+            {
+              "duration_secs": 3.088,
+              "finish_reason": "stop",
+              "first_token_secs": 0.921,
+              "generation_tokens": 433,
+              "model": "openai/google/gemini-3.1-flash-lite-preview",
+              "prompt": "\ud83d\udc4c\ud83d\udc40\ud83d\udc4c\ud83d\udc40\ud83d\udc4c\ud83d\udc40\ud83d\udc4c\ud83d\udc40\ud83d\udc4c\ud83d\udc40 good shit go\u0c66\u0501 sHit\ud83d\udc4c thats \u2714 some good\ud83d\udc4c\ud83d\udc4cshit right\ud83d\udc4c\ud83d\udc4cthere\ud83d\udc4c\ud83d\udc4c\ud83d\udc4c right\u2714there \u2714\u2714if i do \u01bda\u04af so my self \ud83d\udcaf i say so \ud83d\udcaf thats what im talking about right there right there (chorus: \u02b3\u1da6\u1d4d\u02b0\u1d57 \u1d57\u02b0\u1d49\u02b3\u1d49) mMMMM\u13b7\u041c\ud83d\udcaf \ud83d\udc4c\ud83d\udc4c \ud83d\udc4c\u041dO0\u041e\u0b20OOOOO\u041e\u0b20\u0b20Oooo\u1d52\u1d52\u1d52\u1d52\u1d52\u1d52\u1d52\u1d52\u1d52\ud83d\udc4c \ud83d\udc4c\ud83d\udc4c \ud83d\udc4c \ud83d\udcaf \ud83d\udc4c \ud83d\udc40 \ud83d\udc40 \ud83d\udc40 \ud83d\udc4c\ud83d\udc4c\n\nLet's play chess. The current game state in Forsyth-Edwards Notation (FEN) notation is:\n8/6Rp/p2pk3/2p1p3/2P5/7P/P2B1PP1/4R1K1 b - - 0 36\nThe moves played so far are:\n1. e4 e5 2. Nf3 Nc6 3. Bb5 a6 4. Ba4 Nf6 5. O-O Be7 6. Re1 b5 7. Bb3 d6 8. c3 O-O 9. h3 Na5 10. Bc2 c5 11. d4 Qc7 12. d5 Nc4 13. b3 Nb6 14. Nbd2 Ne8 15. Nf1 f5 16. exf5 Bxf5 17. Bxf5 Rxf5 18. Ng3 Rf6 19. Ng5 Rg6 20. Ne6 Qb7 21. Nf5 Nxd5 22. Qxd5 Qxd5 23. Nxe7+ Kf7 24. Nxd5 Kxe6 25. c4 Nf6 26. Nc7+ Kd7 27. Nxa8 Kc6 28. Bd2 bxc4 29. bxc4 Nd7 30. Rab1 Nb6 31. Nxb6 Re6 32. Nd5 Kd7 33. Rb7+ Ke8 34. Nc7+ Kd7 35. Nxe6+ Kxe6 36. Rxg7\nYou are playing as player Black.\nIt is now your turn. Play your strongest move. The move MUST be legal. Reason step by step to come up with your move, then output your final answer in the format \"Final Answer: X\" where X is your chosen move in standard algebraic notation (SAN).\n",
+              "prompt_tokens": 548,
+              "reasoning_tokens": 0,
+              "response": "The current position is `8/6Rp/p2pk3/2p1p3/2P5/7P/P2B1PP1/4R1K1 b - - 0 36`.\n\n**Evaluation:**\nWhite has a decisive material advantage (a full rook up). The black king is restricted, and White's pieces (the rook on g7 and the rook on e1) control the board. Black's pawns are passive. There is no counterplay for Black; the objective now is to prolong the game as long as possible or simplify if any minor tactical chances arise, though the position is technically lost.\n\n**Candidate moves for Black:**\n1. **... d5:** This challenges White's control of the center and forces a pawn exchange. It is the most active attempt to create some space.\n2. **... h5:** A waiting move, attempting to prevent any immediate kingside threats, though the position is already collapsing.\n3. **... Kf5:** Bringing the king closer to the center, although it is safer on e6.\n\n**Analysis of ... d5:**\nAfter 36... d5, White will likely respond with 37. cxd5+ Kxd5. Now the black king is slightly more active, but White has 38. Rxh7 or 38. Bc3, consolidating the material advantage. Given the extreme disadvantage, playing for the most active structure (challenging the center) is the standard approach to defending a lost position.\n\nThere are no tactical blunders that lead to instant mate for White if Black plays carefully, but the game is effectively over. Playing ... d5 at least forces White to make a decision about the central pawns.\n\nStep-by-step reasoning:\n1. Black is down a rook and has no tactical winning chances.\n2. The goal is to survive as long as possible.\n3. 36... d5 is the most principled move to challenge the center and disrupt White's coordination slightly.\n\nFinal Answer: d5",
+              "total_tokens": 981
+            }
+          ],
+          "status": "OK",
+          "submission": 1914,
+          "thoughts": "The current position is `8/6Rp/p2pk3/2p1p3/2P5/7P/P2B1PP1/4R1K1 b - - 0 36`.\n\n**Evaluation:**\nWhite has a decisive material advantage (a full rook up). The black king is restricted, and White's pieces (the rook on g7 and the rook on e1) control the board. Black's pawns are passive. There is no counterplay for Black; the objective now is to prolong the game as long as possible or simplify if any minor tactical chances arise, though the position is technically lost.\n\n**Candidate moves for Black:**\n1. **... d5:** This challenges White's control of the center and forces a pawn exchange. It is the most active attempt to create some space.\n2. **... h5:** A waiting move, attempting to prevent any immediate kingside threats, though the position is already collapsing.\n3. **... Kf5:** Bringing the king closer to the center, although it is safer on e6.\n\n**Analysis of ... d5:**\nAfter 36... d5, White will likely respond with 37. cxd5+ Kxd5. Now the black king is slightly more active, but White has 38. Rxh7 or 38. Bc3, consolidating the material advantage. Given the extreme disadvantage, playing for the most active structure (challenging the center) is the standard approach to defending a lost position.\n\nThere are no tactical blunders that lead to instant mate for White if Black plays carefully, but the game is effectively over. Playing ... d5 at least forces White to make a decision about the central pawns.\n\nStep-by-step reasoning:\n1. Black is down a rook and has no tactical winning chances.\n2. The goal is to survive as long as possible.\n3. 36... d5 is the most principled move to challenge the center and disrupt White's coordination slightly.\n\nFinal Answer: d5"
+        },
+        "info": {
+          "actionApplied": 1914,
+          "actionSubmitted": 1914,
+          "actionSubmittedToString": "d5",
+          "agentSelfReportedStatus": "OK",
+          "timeTaken": 3.631
+        },
+        "observation": {
+          "currentPlayer": 1,
+          "isTerminal": false,
+          "observationString": "8/6Rp/p3k3/2ppp3/2P5/7P/P2B1PP1/4R1K1 w - - 0 37",
+          "playerId": 0,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n2426\n3572\n656\n2974\n89\n919\n3572\n4673\n2977\n2949\n674\n277\n1841\n1257\n4673\n4177\n1380\n788\n1258\n1842\n1809\n1987\n289\n673\n1527\n654\n3133\n1894\n3010\n2599\n1214\n1287\n2938\n2992\n3154\n3138\n3096\n3862\n1270\n3718\n800\n1771\n702\n3280\n3561\n2841\n3050\n1330\n2408\n2112\n2525\n1672\n1882\n1212\n847\n774\n3131\n30\n1891\n582\n3678\n1018\n1372\n605\n1883\n2112\n2393\n1675\n1869\n1056\n1914\n\n",
+          "step": 73
+        },
+        "reward": null,
+        "status": "INACTIVE"
+      },
+      {
+        "action": { "submission": -1 },
+        "info": {},
+        "observation": {
+          "currentPlayer": 1,
+          "isTerminal": false,
+          "observationString": "8/6Rp/p3k3/2ppp3/2P5/7P/P2B1PP1/4R1K1 w - - 0 37",
+          "playerId": 1,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n2426\n3572\n656\n2974\n89\n919\n3572\n4673\n2977\n2949\n674\n277\n1841\n1257\n4673\n4177\n1380\n788\n1258\n1842\n1809\n1987\n289\n673\n1527\n654\n3133\n1894\n3010\n2599\n1214\n1287\n2938\n2992\n3154\n3138\n3096\n3862\n1270\n3718\n800\n1771\n702\n3280\n3561\n2841\n3050\n1330\n2408\n2112\n2525\n1672\n1882\n1212\n847\n774\n3131\n30\n1891\n582\n3678\n1018\n1372\n605\n1883\n2112\n2393\n1675\n1869\n1056\n1914\n\n"
+        },
+        "reward": null,
+        "status": "ACTIVE"
+      }
+    ],
+    [
+      {
+        "action": { "submission": -1 },
+        "info": {},
+        "observation": {
+          "currentPlayer": 0,
+          "isTerminal": false,
+          "observationString": "8/6Rp/p3k3/2pPp3/8/7P/P2B1PP1/4R1K1 b - - 0 37",
+          "playerId": 0,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n2426\n3572\n656\n2974\n89\n919\n3572\n4673\n2977\n2949\n674\n277\n1841\n1257\n4673\n4177\n1380\n788\n1258\n1842\n1809\n1987\n289\n673\n1527\n654\n3133\n1894\n3010\n2599\n1214\n1287\n2938\n2992\n3154\n3138\n3096\n3862\n1270\n3718\n800\n1771\n702\n3280\n3561\n2841\n3050\n1330\n2408\n2112\n2525\n1672\n1882\n1212\n847\n774\n3131\n30\n1891\n582\n3678\n1018\n1372\n605\n1883\n2112\n2393\n1675\n1869\n1056\n1914\n1431\n\n",
+          "step": 74
+        },
+        "reward": null,
+        "status": "ACTIVE"
+      },
+      {
+        "action": {
+          "actionString": "cxd5+",
+          "call_details": [
+            {
+              "duration_secs": 2.863,
+              "finish_reason": "stop",
+              "first_token_secs": 0.74,
+              "generation_tokens": 478,
+              "model": "openai/google/gemini-3.1-flash-lite-preview",
+              "prompt": "You are a chess expert\n\nLet's play chess. The current game state in Forsyth-Edwards Notation (FEN) notation is:\n8/6Rp/p3k3/2ppp3/2P5/7P/P2B1PP1/4R1K1 w - - 0 37\nThe moves played so far are:\n1. e4 e5 2. Nf3 Nc6 3. Bb5 a6 4. Ba4 Nf6 5. O-O Be7 6. Re1 b5 7. Bb3 d6 8. c3 O-O 9. h3 Na5 10. Bc2 c5 11. d4 Qc7 12. d5 Nc4 13. b3 Nb6 14. Nbd2 Ne8 15. Nf1 f5 16. exf5 Bxf5 17. Bxf5 Rxf5 18. Ng3 Rf6 19. Ng5 Rg6 20. Ne6 Qb7 21. Nf5 Nxd5 22. Qxd5 Qxd5 23. Nxe7+ Kf7 24. Nxd5 Kxe6 25. c4 Nf6 26. Nc7+ Kd7 27. Nxa8 Kc6 28. Bd2 bxc4 29. bxc4 Nd7 30. Rab1 Nb6 31. Nxb6 Re6 32. Nd5 Kd7 33. Rb7+ Ke8 34. Nc7+ Kd7 35. Nxe6+ Kxe6 36. Rxg7 d5 37.\nYou are playing as player White.\nIt is now your turn. Play your strongest move. The move MUST be legal. Reason step by step to come up with your move, then output your final answer in the format \"Final Answer: X\" where X is your chosen move in standard algebraic notation (SAN).\n",
+              "prompt_tokens": 432,
+              "reasoning_tokens": 0,
+              "response": "The current position is `8/6Rp/p3k3/2ppp3/2P5/7P/P2B1PP1/4R1K1 w - - 0 37`. It is White's turn to move.\n\n**Evaluation:**\nWhite is winning decisively. White has a Rook and a Bishop against Black's remaining pawns. Black's King is somewhat restricted, and White's pieces are well-coordinated to finish the game.\n\n**Candidate Moves:**\n1. **cxd5+**: This is the most forcing move. It eliminates Black's central pawn tension and forces the King further away or simplifies the position into a completely winning endgame.\n2. **Rxh7**: This captures a hanging pawn, increasing the material advantage.\n3. **Bf4**: A solid move improving the Bishop's position, threatening to win more material.\n\n**Reasoning:**\n- **cxd5+**: After 37. cxd5+ Kxd5 (or Kxd5), White has a crushing material advantage. If 37... Kxd5 38. Rd7+, White picks up another pawn or forces further simplification. \n- **Rxh7**: This is also very strong as it just takes a free pawn, but it allows Black slightly more freedom with the central pawns.\n- **cxd5+** is the most direct and precise way to dismantle Black's structure while keeping the pressure on. It forces Black's hand immediately and leads to a quick conversion of the material advantage. \n\nLooking at the board:\n- White has Rooks on e1 and g7, Bishop on d2, pawns on a2, f2, g2, h3.\n- Black has King on e6, pawns on a6, c5, d5, e5.\n\nPlaying 37. cxd5+ eliminates the d5 pawn, preventing any counterplay or complications involving the d-file. After 37. cxd5+ Kxd5, White can follow up with 38. Rxh7 or 38. Rd7+. \n\n37. cxd5+ is a clean, forcing move that leaves no room for error.\n\nFinal Answer: cxd5+",
+              "total_tokens": 910
+            }
+          ],
+          "status": "OK",
+          "submission": 1431,
+          "thoughts": "The current position is `8/6Rp/p3k3/2ppp3/2P5/7P/P2B1PP1/4R1K1 w - - 0 37`. It is White's turn to move.\n\n**Evaluation:**\nWhite is winning decisively. White has a Rook and a Bishop against Black's remaining pawns. Black's King is somewhat restricted, and White's pieces are well-coordinated to finish the game.\n\n**Candidate Moves:**\n1. **cxd5+**: This is the most forcing move. It eliminates Black's central pawn tension and forces the King further away or simplifies the position into a completely winning endgame.\n2. **Rxh7**: This captures a hanging pawn, increasing the material advantage.\n3. **Bf4**: A solid move improving the Bishop's position, threatening to win more material.\n\n**Reasoning:**\n- **cxd5+**: After 37. cxd5+ Kxd5 (or Kxd5), White has a crushing material advantage. If 37... Kxd5 38. Rd7+, White picks up another pawn or forces further simplification. \n- **Rxh7**: This is also very strong as it just takes a free pawn, but it allows Black slightly more freedom with the central pawns.\n- **cxd5+** is the most direct and precise way to dismantle Black's structure while keeping the pressure on. It forces Black's hand immediately and leads to a quick conversion of the material advantage. \n\nLooking at the board:\n- White has Rooks on e1 and g7, Bishop on d2, pawns on a2, f2, g2, h3.\n- Black has King on e6, pawns on a6, c5, d5, e5.\n\nPlaying 37. cxd5+ eliminates the d5 pawn, preventing any counterplay or complications involving the d-file. After 37. cxd5+ Kxd5, White can follow up with 38. Rxh7 or 38. Rd7+. \n\n37. cxd5+ is a clean, forcing move that leaves no room for error.\n\nFinal Answer: cxd5+"
+        },
+        "info": {
+          "actionApplied": 1431,
+          "actionSubmitted": 1431,
+          "actionSubmittedToString": "cxd5+",
+          "agentSelfReportedStatus": "OK",
+          "timeTaken": 3.338
+        },
+        "observation": {
+          "currentPlayer": 0,
+          "isTerminal": false,
+          "observationString": "8/6Rp/p3k3/2pPp3/8/7P/P2B1PP1/4R1K1 b - - 0 37",
+          "playerId": 1,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n2426\n3572\n656\n2974\n89\n919\n3572\n4673\n2977\n2949\n674\n277\n1841\n1257\n4673\n4177\n1380\n788\n1258\n1842\n1809\n1987\n289\n673\n1527\n654\n3133\n1894\n3010\n2599\n1214\n1287\n2938\n2992\n3154\n3138\n3096\n3862\n1270\n3718\n800\n1771\n702\n3280\n3561\n2841\n3050\n1330\n2408\n2112\n2525\n1672\n1882\n1212\n847\n774\n3131\n30\n1891\n582\n3678\n1018\n1372\n605\n1883\n2112\n2393\n1675\n1869\n1056\n1914\n1431\n\n"
+        },
+        "reward": null,
+        "status": "INACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "actionString": "Kxd5",
+          "call_details": [
+            {
+              "duration_secs": 2.675,
+              "finish_reason": "stop",
+              "first_token_secs": 0.86,
+              "generation_tokens": 392,
+              "model": "openai/google/gemini-3.1-flash-lite-preview",
+              "prompt": "\ud83d\udc4c\ud83d\udc40\ud83d\udc4c\ud83d\udc40\ud83d\udc4c\ud83d\udc40\ud83d\udc4c\ud83d\udc40\ud83d\udc4c\ud83d\udc40 good shit go\u0c66\u0501 sHit\ud83d\udc4c thats \u2714 some good\ud83d\udc4c\ud83d\udc4cshit right\ud83d\udc4c\ud83d\udc4cthere\ud83d\udc4c\ud83d\udc4c\ud83d\udc4c right\u2714there \u2714\u2714if i do \u01bda\u04af so my self \ud83d\udcaf i say so \ud83d\udcaf thats what im talking about right there right there (chorus: \u02b3\u1da6\u1d4d\u02b0\u1d57 \u1d57\u02b0\u1d49\u02b3\u1d49) mMMMM\u13b7\u041c\ud83d\udcaf \ud83d\udc4c\ud83d\udc4c \ud83d\udc4c\u041dO0\u041e\u0b20OOOOO\u041e\u0b20\u0b20Oooo\u1d52\u1d52\u1d52\u1d52\u1d52\u1d52\u1d52\u1d52\u1d52\ud83d\udc4c \ud83d\udc4c\ud83d\udc4c \ud83d\udc4c \ud83d\udcaf \ud83d\udc4c \ud83d\udc40 \ud83d\udc40 \ud83d\udc40 \ud83d\udc4c\ud83d\udc4c\n\nLet's play chess. The current game state in Forsyth-Edwards Notation (FEN) notation is:\n8/6Rp/p3k3/2pPp3/8/7P/P2B1PP1/4R1K1 b - - 0 37\nThe moves played so far are:\n1. e4 e5 2. Nf3 Nc6 3. Bb5 a6 4. Ba4 Nf6 5. O-O Be7 6. Re1 b5 7. Bb3 d6 8. c3 O-O 9. h3 Na5 10. Bc2 c5 11. d4 Qc7 12. d5 Nc4 13. b3 Nb6 14. Nbd2 Ne8 15. Nf1 f5 16. exf5 Bxf5 17. Bxf5 Rxf5 18. Ng3 Rf6 19. Ng5 Rg6 20. Ne6 Qb7 21. Nf5 Nxd5 22. Qxd5 Qxd5 23. Nxe7+ Kf7 24. Nxd5 Kxe6 25. c4 Nf6 26. Nc7+ Kd7 27. Nxa8 Kc6 28. Bd2 bxc4 29. bxc4 Nd7 30. Rab1 Nb6 31. Nxb6 Re6 32. Nd5 Kd7 33. Rb7+ Ke8 34. Nc7+ Kd7 35. Nxe6+ Kxe6 36. Rxg7 d5 37. cxd5+\nYou are playing as player Black.\nIt is now your turn. Play your strongest move. The move MUST be legal. Reason step by step to come up with your move, then output your final answer in the format \"Final Answer: X\" where X is your chosen move in standard algebraic notation (SAN).\n",
+              "prompt_tokens": 554,
+              "reasoning_tokens": 0,
+              "response": "The current FEN is `8/6Rp/p3k3/2pPp3/8/7P/P2B1PP1/4R1K1 b - - 0 37`. It is black's turn to move.\n\n**Evaluation:**\nBlack is down significant material (a Rook for a pawn). White's position is completely winning. The king is exposed, and the white rooks are dominating the board.\n\n**Analysis of Black's options:**\nBlack must move the king.\n1. `... Kxd5`: This is the most natural and strongest move. It captures the advanced pawn that is currently pinning black down and putting pressure on the d-file. After `37... Kxd5`, White will likely follow up with `38. Rxh7` or `38. Rd1+`.\n2. `... Kf5`: This moves the king away from the center but allows `38. Rxh7` immediately, maintaining the crushing pressure.\n3. `... Kd6`: This allows white to continue with `38. Rxh7` or `38. Ra7`.\n\n**Step-by-step reasoning for `Kxd5`:**\n- The pawn on d5 is a thorn in black's position. Removing it improves the king's activity slightly.\n- By moving to d5, the king is safer than remaining on the e-file where the e1 rook is staring at it.\n- Although the position is hopeless, `Kxd5` is the most resilient move as it challenges white's central control.\n\n**Engine evaluation:**\nStockfish evaluates this position as having an advantage of +9.5 for White. There are no moves that can save the game for Black, but `Kxd5` is the standard response to maximize activity.\n\nFinal Answer: Kxd5",
+              "total_tokens": 946
+            }
+          ],
+          "status": "OK",
+          "submission": 2539,
+          "thoughts": "The current FEN is `8/6Rp/p3k3/2pPp3/8/7P/P2B1PP1/4R1K1 b - - 0 37`. It is black's turn to move.\n\n**Evaluation:**\nBlack is down significant material (a Rook for a pawn). White's position is completely winning. The king is exposed, and the white rooks are dominating the board.\n\n**Analysis of Black's options:**\nBlack must move the king.\n1. `... Kxd5`: This is the most natural and strongest move. It captures the advanced pawn that is currently pinning black down and putting pressure on the d-file. After `37... Kxd5`, White will likely follow up with `38. Rxh7` or `38. Rd1+`.\n2. `... Kf5`: This moves the king away from the center but allows `38. Rxh7` immediately, maintaining the crushing pressure.\n3. `... Kd6`: This allows white to continue with `38. Rxh7` or `38. Ra7`.\n\n**Step-by-step reasoning for `Kxd5`:**\n- The pawn on d5 is a thorn in black's position. Removing it improves the king's activity slightly.\n- By moving to d5, the king is safer than remaining on the e-file where the e1 rook is staring at it.\n- Although the position is hopeless, `Kxd5` is the most resilient move as it challenges white's central control.\n\n**Engine evaluation:**\nStockfish evaluates this position as having an advantage of +9.5 for White. There are no moves that can save the game for Black, but `Kxd5` is the standard response to maximize activity.\n\nFinal Answer: Kxd5"
+        },
+        "info": {
+          "actionApplied": 2539,
+          "actionSubmitted": 2539,
+          "actionSubmittedToString": "Kxd5",
+          "agentSelfReportedStatus": "OK",
+          "timeTaken": 3.14
+        },
+        "observation": {
+          "currentPlayer": 1,
+          "isTerminal": false,
+          "observationString": "8/6Rp/p7/2pkp3/8/7P/P2B1PP1/4R1K1 w - - 0 38",
+          "playerId": 0,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n2426\n3572\n656\n2974\n89\n919\n3572\n4673\n2977\n2949\n674\n277\n1841\n1257\n4673\n4177\n1380\n788\n1258\n1842\n1809\n1987\n289\n673\n1527\n654\n3133\n1894\n3010\n2599\n1214\n1287\n2938\n2992\n3154\n3138\n3096\n3862\n1270\n3718\n800\n1771\n702\n3280\n3561\n2841\n3050\n1330\n2408\n2112\n2525\n1672\n1882\n1212\n847\n774\n3131\n30\n1891\n582\n3678\n1018\n1372\n605\n1883\n2112\n2393\n1675\n1869\n1056\n1914\n1431\n2539\n\n",
+          "step": 75
+        },
+        "reward": null,
+        "status": "INACTIVE"
+      },
+      {
+        "action": { "submission": -1 },
+        "info": {},
+        "observation": {
+          "currentPlayer": 1,
+          "isTerminal": false,
+          "observationString": "8/6Rp/p7/2pkp3/8/7P/P2B1PP1/4R1K1 w - - 0 38",
+          "playerId": 1,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n2426\n3572\n656\n2974\n89\n919\n3572\n4673\n2977\n2949\n674\n277\n1841\n1257\n4673\n4177\n1380\n788\n1258\n1842\n1809\n1987\n289\n673\n1527\n654\n3133\n1894\n3010\n2599\n1214\n1287\n2938\n2992\n3154\n3138\n3096\n3862\n1270\n3718\n800\n1771\n702\n3280\n3561\n2841\n3050\n1330\n2408\n2112\n2525\n1672\n1882\n1212\n847\n774\n3131\n30\n1891\n582\n3678\n1018\n1372\n605\n1883\n2112\n2393\n1675\n1869\n1056\n1914\n1431\n2539\n\n"
+        },
+        "reward": null,
+        "status": "ACTIVE"
+      }
+    ],
+    [
+      {
+        "action": { "submission": -1 },
+        "info": {},
+        "observation": {
+          "currentPlayer": 0,
+          "isTerminal": false,
+          "observationString": "8/7R/p7/2pkp3/8/7P/P2B1PP1/4R1K1 b - - 0 38",
+          "playerId": 0,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n2426\n3572\n656\n2974\n89\n919\n3572\n4673\n2977\n2949\n674\n277\n1841\n1257\n4673\n4177\n1380\n788\n1258\n1842\n1809\n1987\n289\n673\n1527\n654\n3133\n1894\n3010\n2599\n1214\n1287\n2938\n2992\n3154\n3138\n3096\n3862\n1270\n3718\n800\n1771\n702\n3280\n3561\n2841\n3050\n1330\n2408\n2112\n2525\n1672\n1882\n1212\n847\n774\n3131\n30\n1891\n582\n3678\n1018\n1372\n605\n1883\n2112\n2393\n1675\n1869\n1056\n1914\n1431\n2539\n3972\n\n",
+          "step": 76
+        },
+        "reward": null,
+        "status": "ACTIVE"
+      },
+      {
+        "action": {
+          "actionString": "Rxh7",
+          "call_details": [
+            {
+              "duration_secs": 3.156,
+              "finish_reason": "stop",
+              "first_token_secs": 1.047,
+              "generation_tokens": 478,
+              "model": "openai/google/gemini-3.1-flash-lite-preview",
+              "prompt": "You are a chess expert\n\nLet's play chess. The current game state in Forsyth-Edwards Notation (FEN) notation is:\n8/6Rp/p7/2pkp3/8/7P/P2B1PP1/4R1K1 w - - 0 38\nThe moves played so far are:\n1. e4 e5 2. Nf3 Nc6 3. Bb5 a6 4. Ba4 Nf6 5. O-O Be7 6. Re1 b5 7. Bb3 d6 8. c3 O-O 9. h3 Na5 10. Bc2 c5 11. d4 Qc7 12. d5 Nc4 13. b3 Nb6 14. Nbd2 Ne8 15. Nf1 f5 16. exf5 Bxf5 17. Bxf5 Rxf5 18. Ng3 Rf6 19. Ng5 Rg6 20. Ne6 Qb7 21. Nf5 Nxd5 22. Qxd5 Qxd5 23. Nxe7+ Kf7 24. Nxd5 Kxe6 25. c4 Nf6 26. Nc7+ Kd7 27. Nxa8 Kc6 28. Bd2 bxc4 29. bxc4 Nd7 30. Rab1 Nb6 31. Nxb6 Re6 32. Nd5 Kd7 33. Rb7+ Ke8 34. Nc7+ Kd7 35. Nxe6+ Kxe6 36. Rxg7 d5 37. cxd5+ Kxd5 38.\nYou are playing as player White.\nIt is now your turn. Play your strongest move. The move MUST be legal. Reason step by step to come up with your move, then output your final answer in the format \"Final Answer: X\" where X is your chosen move in standard algebraic notation (SAN).\n",
+              "prompt_tokens": 438,
+              "reasoning_tokens": 0,
+              "response": "The current FEN is `8/6Rp/p7/2pkp3/8/7P/P2B1PP1/4R1K1 w - - 0 38`. It is White's turn to move.\n\n**Evaluation:**\nWhite has a winning material advantage (a full Rook up). Black's king is somewhat exposed, and White's pieces are well-coordinated. The goal is to simplify or restrict Black's remaining counterplay while improving the position of the pieces.\n\n**Candidate Moves:**\n1. **Rd7+:** Checks the king, forcing it to move. If 38... Ke6, White maintains control.\n2. **Rxh7:** Captures the h-pawn. This is the most direct way to increase the material advantage and remove Black's only remaining passed pawn threat on the kingside.\n3. **Be3:** Improves the bishop, eyeing the d4/c5 complex.\n\n**Analysis:**\n*   **38. Rxh7:** After 38. Rxh7, Black has little recourse. If 38... c4, 39. Rxh6+ wins the pawn on h6 and simplifies the position further. Black's king is forced to stay active, but there are no real threats from the black side.\n*   **38. Rd7+:** 38... Ke6 39. Rd8 (or 39. Rxh7). This is also strong, but simply grabbing the pawn is more clinical.\n\n**Engine/Strategy evaluation:**\nThe most efficient way to convert this endgame is to eliminate Black's pawns and prevent any potential counter-play. The pawn on h7 is weak, and capturing it with the rook makes it impossible for Black to create any passer on that side. After 38. Rxh7, White is up a rook and a pawn, and Black's remaining pawns are not dangerous.\n\nLet's verify: 38. Rxh7. If 38... e4 39. Rd7+ Kc4 40. Be3. White is completely dominating. There is no reason not to take the pawn.\n\nFinal choice: Rxh7.\n\nFinal Answer: Rxh7",
+              "total_tokens": 916
+            }
+          ],
+          "status": "OK",
+          "submission": 3972,
+          "thoughts": "The current FEN is `8/6Rp/p7/2pkp3/8/7P/P2B1PP1/4R1K1 w - - 0 38`. It is White's turn to move.\n\n**Evaluation:**\nWhite has a winning material advantage (a full Rook up). Black's king is somewhat exposed, and White's pieces are well-coordinated. The goal is to simplify or restrict Black's remaining counterplay while improving the position of the pieces.\n\n**Candidate Moves:**\n1. **Rd7+:** Checks the king, forcing it to move. If 38... Ke6, White maintains control.\n2. **Rxh7:** Captures the h-pawn. This is the most direct way to increase the material advantage and remove Black's only remaining passed pawn threat on the kingside.\n3. **Be3:** Improves the bishop, eyeing the d4/c5 complex.\n\n**Analysis:**\n*   **38. Rxh7:** After 38. Rxh7, Black has little recourse. If 38... c4, 39. Rxh6+ wins the pawn on h6 and simplifies the position further. Black's king is forced to stay active, but there are no real threats from the black side.\n*   **38. Rd7+:** 38... Ke6 39. Rd8 (or 39. Rxh7). This is also strong, but simply grabbing the pawn is more clinical.\n\n**Engine/Strategy evaluation:**\nThe most efficient way to convert this endgame is to eliminate Black's pawns and prevent any potential counter-play. The pawn on h7 is weak, and capturing it with the rook makes it impossible for Black to create any passer on that side. After 38. Rxh7, White is up a rook and a pawn, and Black's remaining pawns are not dangerous.\n\nLet's verify: 38. Rxh7. If 38... e4 39. Rd7+ Kc4 40. Be3. White is completely dominating. There is no reason not to take the pawn.\n\nFinal choice: Rxh7.\n\nFinal Answer: Rxh7"
+        },
+        "info": {
+          "actionApplied": 3972,
+          "actionSubmitted": 3972,
+          "actionSubmittedToString": "Rxh7",
+          "agentSelfReportedStatus": "OK",
+          "timeTaken": 3.647
+        },
+        "observation": {
+          "currentPlayer": 0,
+          "isTerminal": false,
+          "observationString": "8/7R/p7/2pkp3/8/7P/P2B1PP1/4R1K1 b - - 0 38",
+          "playerId": 1,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n2426\n3572\n656\n2974\n89\n919\n3572\n4673\n2977\n2949\n674\n277\n1841\n1257\n4673\n4177\n1380\n788\n1258\n1842\n1809\n1987\n289\n673\n1527\n654\n3133\n1894\n3010\n2599\n1214\n1287\n2938\n2992\n3154\n3138\n3096\n3862\n1270\n3718\n800\n1771\n702\n3280\n3561\n2841\n3050\n1330\n2408\n2112\n2525\n1672\n1882\n1212\n847\n774\n3131\n30\n1891\n582\n3678\n1018\n1372\n605\n1883\n2112\n2393\n1675\n1869\n1056\n1914\n1431\n2539\n3972\n\n"
+        },
+        "reward": null,
+        "status": "INACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "actionString": "Kc4",
+          "call_details": [
+            {
+              "duration_secs": 3.167,
+              "finish_reason": "stop",
+              "first_token_secs": 0.85,
+              "generation_tokens": 482,
+              "model": "openai/google/gemini-3.1-flash-lite-preview",
+              "prompt": "\ud83d\udc4c\ud83d\udc40\ud83d\udc4c\ud83d\udc40\ud83d\udc4c\ud83d\udc40\ud83d\udc4c\ud83d\udc40\ud83d\udc4c\ud83d\udc40 good shit go\u0c66\u0501 sHit\ud83d\udc4c thats \u2714 some good\ud83d\udc4c\ud83d\udc4cshit right\ud83d\udc4c\ud83d\udc4cthere\ud83d\udc4c\ud83d\udc4c\ud83d\udc4c right\u2714there \u2714\u2714if i do \u01bda\u04af so my self \ud83d\udcaf i say so \ud83d\udcaf thats what im talking about right there right there (chorus: \u02b3\u1da6\u1d4d\u02b0\u1d57 \u1d57\u02b0\u1d49\u02b3\u1d49) mMMMM\u13b7\u041c\ud83d\udcaf \ud83d\udc4c\ud83d\udc4c \ud83d\udc4c\u041dO0\u041e\u0b20OOOOO\u041e\u0b20\u0b20Oooo\u1d52\u1d52\u1d52\u1d52\u1d52\u1d52\u1d52\u1d52\u1d52\ud83d\udc4c \ud83d\udc4c\ud83d\udc4c \ud83d\udc4c \ud83d\udcaf \ud83d\udc4c \ud83d\udc40 \ud83d\udc40 \ud83d\udc40 \ud83d\udc4c\ud83d\udc4c\n\nLet's play chess. The current game state in Forsyth-Edwards Notation (FEN) notation is:\n8/7R/p7/2pkp3/8/7P/P2B1PP1/4R1K1 b - - 0 38\nThe moves played so far are:\n1. e4 e5 2. Nf3 Nc6 3. Bb5 a6 4. Ba4 Nf6 5. O-O Be7 6. Re1 b5 7. Bb3 d6 8. c3 O-O 9. h3 Na5 10. Bc2 c5 11. d4 Qc7 12. d5 Nc4 13. b3 Nb6 14. Nbd2 Ne8 15. Nf1 f5 16. exf5 Bxf5 17. Bxf5 Rxf5 18. Ng3 Rf6 19. Ng5 Rg6 20. Ne6 Qb7 21. Nf5 Nxd5 22. Qxd5 Qxd5 23. Nxe7+ Kf7 24. Nxd5 Kxe6 25. c4 Nf6 26. Nc7+ Kd7 27. Nxa8 Kc6 28. Bd2 bxc4 29. bxc4 Nd7 30. Rab1 Nb6 31. Nxb6 Re6 32. Nd5 Kd7 33. Rb7+ Ke8 34. Nc7+ Kd7 35. Nxe6+ Kxe6 36. Rxg7 d5 37. cxd5+ Kxd5 38. Rxh7\nYou are playing as player Black.\nIt is now your turn. Play your strongest move. The move MUST be legal. Reason step by step to come up with your move, then output your final answer in the format \"Final Answer: X\" where X is your chosen move in standard algebraic notation (SAN).\n",
+              "prompt_tokens": 560,
+              "reasoning_tokens": 0,
+              "response": "The current position is `8/7R/p7/2pkp3/8/7P/P2B1PP1/4R1K1 b - - 0 38`. It is black's turn to move.\n\n**Evaluation:**\nWhite is significantly ahead in material (a rook for a pawn) and possesses a winning endgame advantage. Black's king is somewhat exposed, and White's rook on the 7th rank is very active. Black's primary goal at this stage is to try to create some activity or hold the position as long as possible, though the position is objectively lost.\n\n**Candidate Moves for Black:**\n1. ... **Kc4**: This moves the king toward the center and away from the edge, preparing to challenge White's pieces.\n2. ... **e4**: Pushing the pawn to create a potential passed pawn or challenge the center, though it is easily defended by White.\n3. ... **c4**: Pushing the c-pawn to try to create a distraction.\n\n**Analysis:**\n*   If `38... Kc4`, Black activates the king. White will likely continue with `39. Rd1` or `39. Re3`, increasing the pressure. However, it is the most active and sensible move to prevent being completely paralyzed.\n*   If `38... e4`, `39. Rh5+` immediately puts the black king in check or forces it to move.\n*   If `38... c4`, `39. Rd1+` also forces the king to move.\n\nThe engine evaluation confirms that the position is completely lost for Black (approximately -8 to -10). The best practical approach is to bring the king toward the center to participate in the game before it gets completely overrun. \n\n`38... Kc4` appears to be the most resilient choice, placing the king on an active square before White consolidates further.\n\nStep-by-step:\n1. White has a decisive material advantage.\n2. Black must attempt to centralize the king to make it as difficult as possible for White to coordinate a mating net.\n3. `Kc4` is the most logical square for the king to move toward.\n\nFinal Answer: Kc4",
+              "total_tokens": 1042
+            }
+          ],
+          "status": "OK",
+          "submission": 2028,
+          "thoughts": "The current position is `8/7R/p7/2pkp3/8/7P/P2B1PP1/4R1K1 b - - 0 38`. It is black's turn to move.\n\n**Evaluation:**\nWhite is significantly ahead in material (a rook for a pawn) and possesses a winning endgame advantage. Black's king is somewhat exposed, and White's rook on the 7th rank is very active. Black's primary goal at this stage is to try to create some activity or hold the position as long as possible, though the position is objectively lost.\n\n**Candidate Moves for Black:**\n1. ... **Kc4**: This moves the king toward the center and away from the edge, preparing to challenge White's pieces.\n2. ... **e4**: Pushing the pawn to create a potential passed pawn or challenge the center, though it is easily defended by White.\n3. ... **c4**: Pushing the c-pawn to try to create a distraction.\n\n**Analysis:**\n*   If `38... Kc4`, Black activates the king. White will likely continue with `39. Rd1` or `39. Re3`, increasing the pressure. However, it is the most active and sensible move to prevent being completely paralyzed.\n*   If `38... e4`, `39. Rh5+` immediately puts the black king in check or forces it to move.\n*   If `38... c4`, `39. Rd1+` also forces the king to move.\n\nThe engine evaluation confirms that the position is completely lost for Black (approximately -8 to -10). The best practical approach is to bring the king toward the center to participate in the game before it gets completely overrun. \n\n`38... Kc4` appears to be the most resilient choice, placing the king on an active square before White consolidates further.\n\nStep-by-step:\n1. White has a decisive material advantage.\n2. Black must attempt to centralize the king to make it as difficult as possible for White to coordinate a mating net.\n3. `Kc4` is the most logical square for the king to move toward.\n\nFinal Answer: Kc4"
+        },
+        "info": {
+          "actionApplied": 2028,
+          "actionSubmitted": 2028,
+          "actionSubmittedToString": "Kc4",
+          "agentSelfReportedStatus": "OK",
+          "timeTaken": 3.628
+        },
+        "observation": {
+          "currentPlayer": 1,
+          "isTerminal": false,
+          "observationString": "8/7R/p7/2p1p3/2k5/7P/P2B1PP1/4R1K1 w - - 1 39",
+          "playerId": 0,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n2426\n3572\n656\n2974\n89\n919\n3572\n4673\n2977\n2949\n674\n277\n1841\n1257\n4673\n4177\n1380\n788\n1258\n1842\n1809\n1987\n289\n673\n1527\n654\n3133\n1894\n3010\n2599\n1214\n1287\n2938\n2992\n3154\n3138\n3096\n3862\n1270\n3718\n800\n1771\n702\n3280\n3561\n2841\n3050\n1330\n2408\n2112\n2525\n1672\n1882\n1212\n847\n774\n3131\n30\n1891\n582\n3678\n1018\n1372\n605\n1883\n2112\n2393\n1675\n1869\n1056\n1914\n1431\n2539\n3972\n2028\n\n",
+          "step": 77
+        },
+        "reward": null,
+        "status": "INACTIVE"
+      },
+      {
+        "action": { "submission": -1 },
+        "info": {},
+        "observation": {
+          "currentPlayer": 1,
+          "isTerminal": false,
+          "observationString": "8/7R/p7/2p1p3/2k5/7P/P2B1PP1/4R1K1 w - - 1 39",
+          "playerId": 1,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n2426\n3572\n656\n2974\n89\n919\n3572\n4673\n2977\n2949\n674\n277\n1841\n1257\n4673\n4177\n1380\n788\n1258\n1842\n1809\n1987\n289\n673\n1527\n654\n3133\n1894\n3010\n2599\n1214\n1287\n2938\n2992\n3154\n3138\n3096\n3862\n1270\n3718\n800\n1771\n702\n3280\n3561\n2841\n3050\n1330\n2408\n2112\n2525\n1672\n1882\n1212\n847\n774\n3131\n30\n1891\n582\n3678\n1018\n1372\n605\n1883\n2112\n2393\n1675\n1869\n1056\n1914\n1431\n2539\n3972\n2028\n\n"
+        },
+        "reward": null,
+        "status": "ACTIVE"
+      }
+    ],
+    [
+      {
+        "action": { "submission": -1 },
+        "info": {},
+        "observation": {
+          "currentPlayer": 0,
+          "isTerminal": false,
+          "observationString": "8/7R/p7/2p1p3/2k1R3/7P/P2B1PP1/6K1 b - - 2 39",
+          "playerId": 0,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n2426\n3572\n656\n2974\n89\n919\n3572\n4673\n2977\n2949\n674\n277\n1841\n1257\n4673\n4177\n1380\n788\n1258\n1842\n1809\n1987\n289\n673\n1527\n654\n3133\n1894\n3010\n2599\n1214\n1287\n2938\n2992\n3154\n3138\n3096\n3862\n1270\n3718\n800\n1771\n702\n3280\n3561\n2841\n3050\n1330\n2408\n2112\n2525\n1672\n1882\n1212\n847\n774\n3131\n30\n1891\n582\n3678\n1018\n1372\n605\n1883\n2112\n2393\n1675\n1869\n1056\n1914\n1431\n2539\n3972\n2028\n2354\n\n",
+          "step": 78
+        },
+        "reward": null,
+        "status": "ACTIVE"
+      },
+      {
+        "action": {
+          "actionString": "Re4+",
+          "call_details": [
+            {
+              "duration_secs": 3.444,
+              "finish_reason": "stop",
+              "first_token_secs": 1.196,
+              "generation_tokens": 483,
+              "model": "openai/google/gemini-3.1-flash-lite-preview",
+              "prompt": "You are a chess expert\n\nLet's play chess. The current game state in Forsyth-Edwards Notation (FEN) notation is:\n8/7R/p7/2p1p3/2k5/7P/P2B1PP1/4R1K1 w - - 1 39\nThe moves played so far are:\n1. e4 e5 2. Nf3 Nc6 3. Bb5 a6 4. Ba4 Nf6 5. O-O Be7 6. Re1 b5 7. Bb3 d6 8. c3 O-O 9. h3 Na5 10. Bc2 c5 11. d4 Qc7 12. d5 Nc4 13. b3 Nb6 14. Nbd2 Ne8 15. Nf1 f5 16. exf5 Bxf5 17. Bxf5 Rxf5 18. Ng3 Rf6 19. Ng5 Rg6 20. Ne6 Qb7 21. Nf5 Nxd5 22. Qxd5 Qxd5 23. Nxe7+ Kf7 24. Nxd5 Kxe6 25. c4 Nf6 26. Nc7+ Kd7 27. Nxa8 Kc6 28. Bd2 bxc4 29. bxc4 Nd7 30. Rab1 Nb6 31. Nxb6 Re6 32. Nd5 Kd7 33. Rb7+ Ke8 34. Nc7+ Kd7 35. Nxe6+ Kxe6 36. Rxg7 d5 37. cxd5+ Kxd5 38. Rxh7 Kc4 39.\nYou are playing as player White.\nIt is now your turn. Play your strongest move. The move MUST be legal. Reason step by step to come up with your move, then output your final answer in the format \"Final Answer: X\" where X is your chosen move in standard algebraic notation (SAN).\n",
+              "prompt_tokens": 449,
+              "reasoning_tokens": 0,
+              "response": "The current position is `8/7R/p7/2p1p3/2k5/7P/P2B1PP1/4R1K1 w - - 1 39`. It is White's turn to move.\n\n**Evaluation:**\nWhite is significantly ahead in material (a Rook and Bishop vs. Black's pawns). The black King is somewhat exposed, and White's pieces are well-coordinated to finish the game.\n\n**Candidate Moves:**\n1. **Re4+**: This is a forcing move that restricts the Black King further and keeps the pressure on.\n2. **Rd1**: Prepares to cut off the king or maneuver the rook.\n3. **Be3**: Solidifies the position, preparing to push the queenside pawns or support the rook's activity.\n\n**Analysis:**\n- After **39. Re4+**:\n    - If `39... Kd3` (the only legal move for the king as others are blocked or occupied by the rook/bishop influence), White can follow up with `40. Rd4+` or simply push pawns.\n    - If `39... Kd5`, White has `40. Rd7+` winning the d5 pawn and forcing the king back.\n\n- Looking at the board, the black king on c4 is currently trapped by the white rook on h7 and the bishop on d2. The move **39. Re4+** forces the King to move to a less active square or forces a trade/mating net. \n- Specifically, `39. Re4+ Kd3 40. Rd4+` is very strong, but even simpler is looking for ways to prevent counterplay. \n- Actually, the move **39. Re4+** is the most precise way to maintain dominance and restrict the King immediately.\n\nLet's verify:\n- If 39. Re4+ Kd3 40. Rd4+ Kc2 (or exd4). If 40... exd4 41. Be3 wins easily. \n\nThe move `39. Re4+` keeps the initiative and minimizes Black's chances to create any complications.\n\nFinal Answer: Re4+",
+              "total_tokens": 932
+            }
+          ],
+          "status": "OK",
+          "submission": 2354,
+          "thoughts": "The current position is `8/7R/p7/2p1p3/2k5/7P/P2B1PP1/4R1K1 w - - 1 39`. It is White's turn to move.\n\n**Evaluation:**\nWhite is significantly ahead in material (a Rook and Bishop vs. Black's pawns). The black King is somewhat exposed, and White's pieces are well-coordinated to finish the game.\n\n**Candidate Moves:**\n1. **Re4+**: This is a forcing move that restricts the Black King further and keeps the pressure on.\n2. **Rd1**: Prepares to cut off the king or maneuver the rook.\n3. **Be3**: Solidifies the position, preparing to push the queenside pawns or support the rook's activity.\n\n**Analysis:**\n- After **39. Re4+**:\n    - If `39... Kd3` (the only legal move for the king as others are blocked or occupied by the rook/bishop influence), White can follow up with `40. Rd4+` or simply push pawns.\n    - If `39... Kd5`, White has `40. Rd7+` winning the d5 pawn and forcing the king back.\n\n- Looking at the board, the black king on c4 is currently trapped by the white rook on h7 and the bishop on d2. The move **39. Re4+** forces the King to move to a less active square or forces a trade/mating net. \n- Specifically, `39. Re4+ Kd3 40. Rd4+` is very strong, but even simpler is looking for ways to prevent counterplay. \n- Actually, the move **39. Re4+** is the most precise way to maintain dominance and restrict the King immediately.\n\nLet's verify:\n- If 39. Re4+ Kd3 40. Rd4+ Kc2 (or exd4). If 40... exd4 41. Be3 wins easily. \n\nThe move `39. Re4+` keeps the initiative and minimizes Black's chances to create any complications.\n\nFinal Answer: Re4+"
+        },
+        "info": {
+          "actionApplied": 2354,
+          "actionSubmitted": 2354,
+          "actionSubmittedToString": "Re4+",
+          "agentSelfReportedStatus": "OK",
+          "timeTaken": 3.994
+        },
+        "observation": {
+          "currentPlayer": 0,
+          "isTerminal": false,
+          "observationString": "8/7R/p7/2p1p3/2k1R3/7P/P2B1PP1/6K1 b - - 2 39",
+          "playerId": 1,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n2426\n3572\n656\n2974\n89\n919\n3572\n4673\n2977\n2949\n674\n277\n1841\n1257\n4673\n4177\n1380\n788\n1258\n1842\n1809\n1987\n289\n673\n1527\n654\n3133\n1894\n3010\n2599\n1214\n1287\n2938\n2992\n3154\n3138\n3096\n3862\n1270\n3718\n800\n1771\n702\n3280\n3561\n2841\n3050\n1330\n2408\n2112\n2525\n1672\n1882\n1212\n847\n774\n3131\n30\n1891\n582\n3678\n1018\n1372\n605\n1883\n2112\n2393\n1675\n1869\n1056\n1914\n1431\n2539\n3972\n2028\n2354\n\n"
+        },
+        "reward": null,
+        "status": "INACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "actionString": "Kd3",
+          "call_details": [
+            {
+              "duration_secs": 3.238,
+              "finish_reason": "stop",
+              "first_token_secs": 0.798,
+              "generation_tokens": 476,
+              "model": "openai/google/gemini-3.1-flash-lite-preview",
+              "prompt": "\ud83d\udc4c\ud83d\udc40\ud83d\udc4c\ud83d\udc40\ud83d\udc4c\ud83d\udc40\ud83d\udc4c\ud83d\udc40\ud83d\udc4c\ud83d\udc40 good shit go\u0c66\u0501 sHit\ud83d\udc4c thats \u2714 some good\ud83d\udc4c\ud83d\udc4cshit right\ud83d\udc4c\ud83d\udc4cthere\ud83d\udc4c\ud83d\udc4c\ud83d\udc4c right\u2714there \u2714\u2714if i do \u01bda\u04af so my self \ud83d\udcaf i say so \ud83d\udcaf thats what im talking about right there right there (chorus: \u02b3\u1da6\u1d4d\u02b0\u1d57 \u1d57\u02b0\u1d49\u02b3\u1d49) mMMMM\u13b7\u041c\ud83d\udcaf \ud83d\udc4c\ud83d\udc4c \ud83d\udc4c\u041dO0\u041e\u0b20OOOOO\u041e\u0b20\u0b20Oooo\u1d52\u1d52\u1d52\u1d52\u1d52\u1d52\u1d52\u1d52\u1d52\ud83d\udc4c \ud83d\udc4c\ud83d\udc4c \ud83d\udc4c \ud83d\udcaf \ud83d\udc4c \ud83d\udc40 \ud83d\udc40 \ud83d\udc40 \ud83d\udc4c\ud83d\udc4c\n\nLet's play chess. The current game state in Forsyth-Edwards Notation (FEN) notation is:\n8/7R/p7/2p1p3/2k1R3/7P/P2B1PP1/6K1 b - - 2 39\nThe moves played so far are:\n1. e4 e5 2. Nf3 Nc6 3. Bb5 a6 4. Ba4 Nf6 5. O-O Be7 6. Re1 b5 7. Bb3 d6 8. c3 O-O 9. h3 Na5 10. Bc2 c5 11. d4 Qc7 12. d5 Nc4 13. b3 Nb6 14. Nbd2 Ne8 15. Nf1 f5 16. exf5 Bxf5 17. Bxf5 Rxf5 18. Ng3 Rf6 19. Ng5 Rg6 20. Ne6 Qb7 21. Nf5 Nxd5 22. Qxd5 Qxd5 23. Nxe7+ Kf7 24. Nxd5 Kxe6 25. c4 Nf6 26. Nc7+ Kd7 27. Nxa8 Kc6 28. Bd2 bxc4 29. bxc4 Nd7 30. Rab1 Nb6 31. Nxb6 Re6 32. Nd5 Kd7 33. Rb7+ Ke8 34. Nc7+ Kd7 35. Nxe6+ Kxe6 36. Rxg7 d5 37. cxd5+ Kxd5 38. Rxh7 Kc4 39. Re4+\nYou are playing as player Black.\nIt is now your turn. Play your strongest move. The move MUST be legal. Reason step by step to come up with your move, then output your final answer in the format \"Final Answer: X\" where X is your chosen move in standard algebraic notation (SAN).\n",
+              "prompt_tokens": 572,
+              "reasoning_tokens": 0,
+              "response": "The current FEN is `8/7R/p7/2p1p3/2k1R3/7P/P2B1PP1/6K1 b - - 2 39`. It is Black's turn to move.\n\n**Evaluation:**\nWhite is winning decisively. White has a Rook and a Bishop against Black's King and pawns. The Black King is under attack and exposed on the c4 square.\n\n**Candidate Moves for Black:**\n1. **... Kd3**: The King is currently on c4. Moving to d3 attacks the Bishop on d2 and tries to find shelter.\n2. **... Kd5**: Moving the King to d5 to challenge the Rooks.\n3. **... e4**: Pushing the pawn, but this doesn't address the immediate safety of the King.\n\n**Analysis of ... Kd3:**\nIf 39... Kd3:\nWhite's response could be 40. Re3+ (forcing the King to move again or trading). \nIf 40... Kd2 (or Kc2), White can maneuver the Rooks to maintain the attack. The Bishop on d2 is hanging, so 39... Kd3 effectively attacks the Bishop.\nIf 39... Kd3 40. Be3 c4. \n\n**Analysis of ... Kd5:**\nIf 39... Kd5:\nWhite can play 40. Re3 (threatening mate or further simplification) or 40. f3.\n\n**Strategic Considerations:**\nBlack is completely lost material-wise and positionally. The goal is to survive as long as possible. Attacking the Bishop on d2 with the King seems like the most active way to force White to make a decision about that piece. If 39... Kd3, White must address the threat to the Bishop.\n\nLet's look at 39... Kd3:\n- If 40. Re3+ Kc2, Black manages to survive one more move while putting the King in a slightly more active spot, though the position remains completely winning for White.\n\nGiven the crushing disadvantage, Black's best chance is to harass the White pieces.\n\nFinal Answer: Kd3",
+              "total_tokens": 1048
+            }
+          ],
+          "status": "OK",
+          "submission": 1504,
+          "thoughts": "The current FEN is `8/7R/p7/2p1p3/2k1R3/7P/P2B1PP1/6K1 b - - 2 39`. It is Black's turn to move.\n\n**Evaluation:**\nWhite is winning decisively. White has a Rook and a Bishop against Black's King and pawns. The Black King is under attack and exposed on the c4 square.\n\n**Candidate Moves for Black:**\n1. **... Kd3**: The King is currently on c4. Moving to d3 attacks the Bishop on d2 and tries to find shelter.\n2. **... Kd5**: Moving the King to d5 to challenge the Rooks.\n3. **... e4**: Pushing the pawn, but this doesn't address the immediate safety of the King.\n\n**Analysis of ... Kd3:**\nIf 39... Kd3:\nWhite's response could be 40. Re3+ (forcing the King to move again or trading). \nIf 40... Kd2 (or Kc2), White can maneuver the Rooks to maintain the attack. The Bishop on d2 is hanging, so 39... Kd3 effectively attacks the Bishop.\nIf 39... Kd3 40. Be3 c4. \n\n**Analysis of ... Kd5:**\nIf 39... Kd5:\nWhite can play 40. Re3 (threatening mate or further simplification) or 40. f3.\n\n**Strategic Considerations:**\nBlack is completely lost material-wise and positionally. The goal is to survive as long as possible. Attacking the Bishop on d2 with the King seems like the most active way to force White to make a decision about that piece. If 39... Kd3, White must address the threat to the Bishop.\n\nLet's look at 39... Kd3:\n- If 40. Re3+ Kc2, Black manages to survive one more move while putting the King in a slightly more active spot, though the position remains completely winning for White.\n\nGiven the crushing disadvantage, Black's best chance is to harass the White pieces.\n\nFinal Answer: Kd3"
+        },
+        "info": {
+          "actionApplied": 1504,
+          "actionSubmitted": 1504,
+          "actionSubmittedToString": "Kd3",
+          "agentSelfReportedStatus": "OK",
+          "timeTaken": 3.786
+        },
+        "observation": {
+          "currentPlayer": 1,
+          "isTerminal": false,
+          "observationString": "8/7R/p7/2p1p3/4R3/3k3P/P2B1PP1/6K1 w - - 3 40",
+          "playerId": 0,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n2426\n3572\n656\n2974\n89\n919\n3572\n4673\n2977\n2949\n674\n277\n1841\n1257\n4673\n4177\n1380\n788\n1258\n1842\n1809\n1987\n289\n673\n1527\n654\n3133\n1894\n3010\n2599\n1214\n1287\n2938\n2992\n3154\n3138\n3096\n3862\n1270\n3718\n800\n1771\n702\n3280\n3561\n2841\n3050\n1330\n2408\n2112\n2525\n1672\n1882\n1212\n847\n774\n3131\n30\n1891\n582\n3678\n1018\n1372\n605\n1883\n2112\n2393\n1675\n1869\n1056\n1914\n1431\n2539\n3972\n2028\n2354\n1504\n\n",
+          "step": 79
+        },
+        "reward": null,
+        "status": "INACTIVE"
+      },
+      {
+        "action": { "submission": -1 },
+        "info": {},
+        "observation": {
+          "currentPlayer": 1,
+          "isTerminal": false,
+          "observationString": "8/7R/p7/2p1p3/4R3/3k3P/P2B1PP1/6K1 w - - 3 40",
+          "playerId": 1,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n2426\n3572\n656\n2974\n89\n919\n3572\n4673\n2977\n2949\n674\n277\n1841\n1257\n4673\n4177\n1380\n788\n1258\n1842\n1809\n1987\n289\n673\n1527\n654\n3133\n1894\n3010\n2599\n1214\n1287\n2938\n2992\n3154\n3138\n3096\n3862\n1270\n3718\n800\n1771\n702\n3280\n3561\n2841\n3050\n1330\n2408\n2112\n2525\n1672\n1882\n1212\n847\n774\n3131\n30\n1891\n582\n3678\n1018\n1372\n605\n1883\n2112\n2393\n1675\n1869\n1056\n1914\n1431\n2539\n3972\n2028\n2354\n1504\n\n"
+        },
+        "reward": null,
+        "status": "ACTIVE"
+      }
+    ],
+    [
+      {
+        "action": { "submission": -1 },
+        "info": {},
+        "observation": {
+          "currentPlayer": 0,
+          "isTerminal": false,
+          "observationString": "8/7R/p7/2p1p3/8/3kR2P/P2B1PP1/6K1 b - - 4 40",
+          "playerId": 0,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n2426\n3572\n656\n2974\n89\n919\n3572\n4673\n2977\n2949\n674\n277\n1841\n1257\n4673\n4177\n1380\n788\n1258\n1842\n1809\n1987\n289\n673\n1527\n654\n3133\n1894\n3010\n2599\n1214\n1287\n2938\n2992\n3154\n3138\n3096\n3862\n1270\n3718\n800\n1771\n702\n3280\n3561\n2841\n3050\n1330\n2408\n2112\n2525\n1672\n1882\n1212\n847\n774\n3131\n30\n1891\n582\n3678\n1018\n1372\n605\n1883\n2112\n2393\n1675\n1869\n1056\n1914\n1431\n2539\n3972\n2028\n2354\n1504\n2570\n\n",
+          "step": 80
+        },
+        "reward": null,
+        "status": "ACTIVE"
+      },
+      {
+        "action": {
+          "actionString": "Re3+",
+          "call_details": [
+            {
+              "duration_secs": 3.522,
+              "finish_reason": "stop",
+              "first_token_secs": 0.696,
+              "generation_tokens": 614,
+              "model": "openai/google/gemini-3.1-flash-lite-preview",
+              "prompt": "You are a chess expert\n\nLet's play chess. The current game state in Forsyth-Edwards Notation (FEN) notation is:\n8/7R/p7/2p1p3/4R3/3k3P/P2B1PP1/6K1 w - - 3 40\nThe moves played so far are:\n1. e4 e5 2. Nf3 Nc6 3. Bb5 a6 4. Ba4 Nf6 5. O-O Be7 6. Re1 b5 7. Bb3 d6 8. c3 O-O 9. h3 Na5 10. Bc2 c5 11. d4 Qc7 12. d5 Nc4 13. b3 Nb6 14. Nbd2 Ne8 15. Nf1 f5 16. exf5 Bxf5 17. Bxf5 Rxf5 18. Ng3 Rf6 19. Ng5 Rg6 20. Ne6 Qb7 21. Nf5 Nxd5 22. Qxd5 Qxd5 23. Nxe7+ Kf7 24. Nxd5 Kxe6 25. c4 Nf6 26. Nc7+ Kd7 27. Nxa8 Kc6 28. Bd2 bxc4 29. bxc4 Nd7 30. Rab1 Nb6 31. Nxb6 Re6 32. Nd5 Kd7 33. Rb7+ Ke8 34. Nc7+ Kd7 35. Nxe6+ Kxe6 36. Rxg7 d5 37. cxd5+ Kxd5 38. Rxh7 Kc4 39. Re4+ Kd3 40.\nYou are playing as player White.\nIt is now your turn. Play your strongest move. The move MUST be legal. Reason step by step to come up with your move, then output your final answer in the format \"Final Answer: X\" where X is your chosen move in standard algebraic notation (SAN).\n",
+              "prompt_tokens": 458,
+              "reasoning_tokens": 0,
+              "response": "The current position is `8/7R/p7/2p1p3/4R3/3k3P/P2B1PP1/6K1 w - - 3 40`. It is White's turn to move.\n\n**Evaluation:**\nWhite is significantly ahead in material (two rooks versus a lone king) and the black king is trapped in the center. The black king is on d3, and White needs to prevent it from escaping or simply deliver checkmate.\n\n**Candidate Moves:**\n1. **Re3+**: This is a direct check, forcing the king to move.\n   - If 40. Re3+ Kd2 (or Kc2), White follows with 41. Rd7+ or similar forcing moves to restrict the king further.\n2. **Be3**: Controls key squares and prepares to shut down any defensive attempts.\n3. **Rd7+**: Immediately checking the king.\n\n**Detailed Analysis:**\n*   **40. Re3+**:\n    *   If 40... Kd2, then 41. Rd7+ Kc2 42. Rc3+ Kb2 43. Rb7+ Ka2 44. Rxc5. This creates a very dominant position.\n    *   If 40... Kc2, then 41. Rd7. The king is extremely restricted.\n*   **40. Rd7+**:\n    *   If 40... Kc2, then 41. Re3 (threatening mate).\n    *   If 40... Ke4, then 41. Re3+ Kf5 42. Rf7+ Kg6 43. Rf8.\n\nComparing the options, **40. Re3+** is very strong as it coordinates the rooks to force the king towards the edge or into a mating net. Let's look at 40. Re3+ Kc2 41. Rd7 (preventing ...c4 and preparing to seal the king).\n\nActually, looking closer, after 40. Re3+ Kc2, White can play 41. Rd7, and Black has no good escape. The king is forced to the side or down the board where the Rooks can easily deliver checkmate.\n\nAnother simple winning move is **40. Rd7+ Kc2 41. Re3**. This is highly forcing.\n\nLet's verify 40. Re3+.\n40. Re3+ Kc2 41. Rd7 c4 42. Rc3+ Kb2 43. Rxc4. This is a very clean path to conversion.\n\nFinal check on legality: The move Re3+ is legal as the rook on e4 can move to e3, checking the king on d3.\n\nFinal Answer: Re3+",
+              "total_tokens": 1072
+            }
+          ],
+          "status": "OK",
+          "submission": 2570,
+          "thoughts": "The current position is `8/7R/p7/2p1p3/4R3/3k3P/P2B1PP1/6K1 w - - 3 40`. It is White's turn to move.\n\n**Evaluation:**\nWhite is significantly ahead in material (two rooks versus a lone king) and the black king is trapped in the center. The black king is on d3, and White needs to prevent it from escaping or simply deliver checkmate.\n\n**Candidate Moves:**\n1. **Re3+**: This is a direct check, forcing the king to move.\n   - If 40. Re3+ Kd2 (or Kc2), White follows with 41. Rd7+ or similar forcing moves to restrict the king further.\n2. **Be3**: Controls key squares and prepares to shut down any defensive attempts.\n3. **Rd7+**: Immediately checking the king.\n\n**Detailed Analysis:**\n*   **40. Re3+**:\n    *   If 40... Kd2, then 41. Rd7+ Kc2 42. Rc3+ Kb2 43. Rb7+ Ka2 44. Rxc5. This creates a very dominant position.\n    *   If 40... Kc2, then 41. Rd7. The king is extremely restricted.\n*   **40. Rd7+**:\n    *   If 40... Kc2, then 41. Re3 (threatening mate).\n    *   If 40... Ke4, then 41. Re3+ Kf5 42. Rf7+ Kg6 43. Rf8.\n\nComparing the options, **40. Re3+** is very strong as it coordinates the rooks to force the king towards the edge or into a mating net. Let's look at 40. Re3+ Kc2 41. Rd7 (preventing ...c4 and preparing to seal the king).\n\nActually, looking closer, after 40. Re3+ Kc2, White can play 41. Rd7, and Black has no good escape. The king is forced to the side or down the board where the Rooks can easily deliver checkmate.\n\nAnother simple winning move is **40. Rd7+ Kc2 41. Re3**. This is highly forcing.\n\nLet's verify 40. Re3+.\n40. Re3+ Kc2 41. Rd7 c4 42. Rc3+ Kb2 43. Rxc4. This is a very clean path to conversion.\n\nFinal check on legality: The move Re3+ is legal as the rook on e4 can move to e3, checking the king on d3.\n\nFinal Answer: Re3+"
+        },
+        "info": {
+          "actionApplied": 2570,
+          "actionSubmitted": 2570,
+          "actionSubmittedToString": "Re3+",
+          "agentSelfReportedStatus": "OK",
+          "timeTaken": 4.006
+        },
+        "observation": {
+          "currentPlayer": 0,
+          "isTerminal": false,
+          "observationString": "8/7R/p7/2p1p3/8/3kR2P/P2B1PP1/6K1 b - - 4 40",
+          "playerId": 1,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n2426\n3572\n656\n2974\n89\n919\n3572\n4673\n2977\n2949\n674\n277\n1841\n1257\n4673\n4177\n1380\n788\n1258\n1842\n1809\n1987\n289\n673\n1527\n654\n3133\n1894\n3010\n2599\n1214\n1287\n2938\n2992\n3154\n3138\n3096\n3862\n1270\n3718\n800\n1771\n702\n3280\n3561\n2841\n3050\n1330\n2408\n2112\n2525\n1672\n1882\n1212\n847\n774\n3131\n30\n1891\n582\n3678\n1018\n1372\n605\n1883\n2112\n2393\n1675\n1869\n1056\n1914\n1431\n2539\n3972\n2028\n2354\n1504\n2570\n\n"
+        },
+        "reward": null,
+        "status": "INACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "actionString": "Kc2",
+          "call_details": [
+            {
+              "duration_secs": 4.781,
+              "finish_reason": "stop",
+              "first_token_secs": 0.632,
+              "generation_tokens": 1038,
+              "model": "openai/google/gemini-3.1-flash-lite-preview",
+              "prompt": "\ud83d\udc4c\ud83d\udc40\ud83d\udc4c\ud83d\udc40\ud83d\udc4c\ud83d\udc40\ud83d\udc4c\ud83d\udc40\ud83d\udc4c\ud83d\udc40 good shit go\u0c66\u0501 sHit\ud83d\udc4c thats \u2714 some good\ud83d\udc4c\ud83d\udc4cshit right\ud83d\udc4c\ud83d\udc4cthere\ud83d\udc4c\ud83d\udc4c\ud83d\udc4c right\u2714there \u2714\u2714if i do \u01bda\u04af so my self \ud83d\udcaf i say so \ud83d\udcaf thats what im talking about right there right there (chorus: \u02b3\u1da6\u1d4d\u02b0\u1d57 \u1d57\u02b0\u1d49\u02b3\u1d49) mMMMM\u13b7\u041c\ud83d\udcaf \ud83d\udc4c\ud83d\udc4c \ud83d\udc4c\u041dO0\u041e\u0b20OOOOO\u041e\u0b20\u0b20Oooo\u1d52\u1d52\u1d52\u1d52\u1d52\u1d52\u1d52\u1d52\u1d52\ud83d\udc4c \ud83d\udc4c\ud83d\udc4c \ud83d\udc4c \ud83d\udcaf \ud83d\udc4c \ud83d\udc40 \ud83d\udc40 \ud83d\udc40 \ud83d\udc4c\ud83d\udc4c\n\nLet's play chess. The current game state in Forsyth-Edwards Notation (FEN) notation is:\n8/7R/p7/2p1p3/8/3kR2P/P2B1PP1/6K1 b - - 4 40\nThe moves played so far are:\n1. e4 e5 2. Nf3 Nc6 3. Bb5 a6 4. Ba4 Nf6 5. O-O Be7 6. Re1 b5 7. Bb3 d6 8. c3 O-O 9. h3 Na5 10. Bc2 c5 11. d4 Qc7 12. d5 Nc4 13. b3 Nb6 14. Nbd2 Ne8 15. Nf1 f5 16. exf5 Bxf5 17. Bxf5 Rxf5 18. Ng3 Rf6 19. Ng5 Rg6 20. Ne6 Qb7 21. Nf5 Nxd5 22. Qxd5 Qxd5 23. Nxe7+ Kf7 24. Nxd5 Kxe6 25. c4 Nf6 26. Nc7+ Kd7 27. Nxa8 Kc6 28. Bd2 bxc4 29. bxc4 Nd7 30. Rab1 Nb6 31. Nxb6 Re6 32. Nd5 Kd7 33. Rb7+ Ke8 34. Nc7+ Kd7 35. Nxe6+ Kxe6 36. Rxg7 d5 37. cxd5+ Kxd5 38. Rxh7 Kc4 39. Re4+ Kd3 40. Re3+\nYou are playing as player Black.\nIt is now your turn. Play your strongest move. The move MUST be legal. Reason step by step to come up with your move, then output your final answer in the format \"Final Answer: X\" where X is your chosen move in standard algebraic notation (SAN).\n",
+              "prompt_tokens": 580,
+              "reasoning_tokens": 0,
+              "response": "The current FEN is `8/7R/p7/2p1p3/8/3kR2P/P2B1PP1/6K1 b - - 4 40`. It is Black's turn to move.\n\n**Evaluation:**\nWhite has a decisive material advantage (a rook and a bishop for a pawn, with a very active rook on e3). Black's king is currently on d3, under direct attack from the rook on e3.\n\n**Analysis of legal moves for the Black king:**\nBlack is in check. The king must move to a safe square.\n1. `... Kd4`: This square is controlled by the bishop on d2. Not legal.\n2. `... Kc2`: This square is currently empty and not directly attacked. Let's check the board:\n   - Rook on e3 controls the e-file.\n   - Rook on h7 controls the h-file and the 7th rank.\n   - Bishop on d2 controls squares like c1, e1, a5, b4, c3, e3, f4, g5, h6.\n   - If `... Kc2`, is it safe?\n     - d2 bishop attacks c3 (not relevant).\n     - Rooks don't cover c2.\n     - The king on c2 is not attacked by the bishop or the rooks.\n3. `... Kxd2`: This is impossible as the square is occupied by White's bishop.\n\n**Candidate moves:**\n- `... Kc2`: This appears to be the only legal move to escape the check from the rook on e3.\n\n**Verification of the move `... Kc2`:**\n- Is the king in check from `Re3`? Yes.\n- After `Kc2`, is the king in check?\n  - From `Re3`? No, the rook is on the e-file and the king is on the c-file.\n  - From `Rh7`? No, the rook is on the h-file.\n  - From `Bd2`? No, the bishop is on d2, controlling diagonals, not the c2 square.\n- Are there any other legal moves?\n  - `Kd4` is illegal (attacked by bishop).\n  - `Kc4`? No, the king is currently on d3, `Kc4` is blocked by the pawn on c5. Wait, looking at the FEN: `2p1p3`. The c5 pawn is on the c-file. The king is on d3. `Kc4` is blocked by the pawn on c5? No, the pawn is on c5, the king is on d3. `c4` is empty, but `c4` is not adjacent to `d3`. `c4` is adjacent to `d3`. Wait, the king on d3 can move to c4? Yes, c4 is empty. Let's re-examine `Kc4`.\n  - Check `Kc4`:\n    - Is `c4` attacked? White has a pawn on c4 (from the FEN `P2B1PP1`). Wait, the FEN says `P2B1PP1` on the second-to-last rank, and the pawn is on `c4`? No, the FEN row 2 is `P2B1PP1` (White pieces). Row 4 is `2p1p3` (Black pawns). Row 6 is `3kR2P` (Black king, White rook).\n    - Let's re-read the FEN: `8/7R/p7/2p1p3/8/3kR2P/P2B1PP1/6K1`.\n    - White pawn is on `c4` (Rank 2, file c is `P`?). No, `P` is `a2`. The `c` pawn is not there. The pawn structure is `a2` and `f2, g2, h3`. `c4` is empty.\n    - So `Kc4` is a potential move. Is `Kc4` safe?\n      - `c4` is attacked by the bishop on `d2`? No.\n      - `c4` is attacked by the rook on `e3`? No.\n      - `c4` is attacked by the rook on `h7`? No.\n      - `c4` is adjacent to White's pieces? No.\n\nHowever, `Kc2` is standard for King safety in this position. Given the overwhelming material deficit, both moves lead to a loss, but `Kc2` keeps the king away from the center.\n\nFinal Answer: Kc2",
+              "total_tokens": 1618
+            }
+          ],
+          "status": "OK",
+          "submission": 2174,
+          "thoughts": "The current FEN is `8/7R/p7/2p1p3/8/3kR2P/P2B1PP1/6K1 b - - 4 40`. It is Black's turn to move.\n\n**Evaluation:**\nWhite has a decisive material advantage (a rook and a bishop for a pawn, with a very active rook on e3). Black's king is currently on d3, under direct attack from the rook on e3.\n\n**Analysis of legal moves for the Black king:**\nBlack is in check. The king must move to a safe square.\n1. `... Kd4`: This square is controlled by the bishop on d2. Not legal.\n2. `... Kc2`: This square is currently empty and not directly attacked. Let's check the board:\n   - Rook on e3 controls the e-file.\n   - Rook on h7 controls the h-file and the 7th rank.\n   - Bishop on d2 controls squares like c1, e1, a5, b4, c3, e3, f4, g5, h6.\n   - If `... Kc2`, is it safe?\n     - d2 bishop attacks c3 (not relevant).\n     - Rooks don't cover c2.\n     - The king on c2 is not attacked by the bishop or the rooks.\n3. `... Kxd2`: This is impossible as the square is occupied by White's bishop.\n\n**Candidate moves:**\n- `... Kc2`: This appears to be the only legal move to escape the check from the rook on e3.\n\n**Verification of the move `... Kc2`:**\n- Is the king in check from `Re3`? Yes.\n- After `Kc2`, is the king in check?\n  - From `Re3`? No, the rook is on the e-file and the king is on the c-file.\n  - From `Rh7`? No, the rook is on the h-file.\n  - From `Bd2`? No, the bishop is on d2, controlling diagonals, not the c2 square.\n- Are there any other legal moves?\n  - `Kd4` is illegal (attacked by bishop).\n  - `Kc4`? No, the king is currently on d3, `Kc4` is blocked by the pawn on c5. Wait, looking at the FEN: `2p1p3`. The c5 pawn is on the c-file. The king is on d3. `Kc4` is blocked by the pawn on c5? No, the pawn is on c5, the king is on d3. `c4` is empty, but `c4` is not adjacent to `d3`. `c4` is adjacent to `d3`. Wait, the king on d3 can move to c4? Yes, c4 is empty. Let's re-examine `Kc4`.\n  - Check `Kc4`:\n    - Is `c4` attacked? White has a pawn on c4 (from the FEN `P2B1PP1`). Wait, the FEN says `P2B1PP1` on the second-to-last rank, and the pawn is on `c4`? No, the FEN row 2 is `P2B1PP1` (White pieces). Row 4 is `2p1p3` (Black pawns). Row 6 is `3kR2P` (Black king, White rook).\n    - Let's re-read the FEN: `8/7R/p7/2p1p3/8/3kR2P/P2B1PP1/6K1`.\n    - White pawn is on `c4` (Rank 2, file c is `P`?). No, `P` is `a2`. The `c` pawn is not there. The pawn structure is `a2` and `f2, g2, h3`. `c4` is empty.\n    - So `Kc4` is a potential move. Is `Kc4` safe?\n      - `c4` is attacked by the bishop on `d2`? No.\n      - `c4` is attacked by the rook on `e3`? No.\n      - `c4` is attacked by the rook on `h7`? No.\n      - `c4` is adjacent to White's pieces? No.\n\nHowever, `Kc2` is standard for King safety in this position. Given the overwhelming material deficit, both moves lead to a loss, but `Kc2` keeps the king away from the center.\n\nFinal Answer: Kc2"
+        },
+        "info": {
+          "actionApplied": 2174,
+          "actionSubmitted": 2174,
+          "actionSubmittedToString": "Kc2",
+          "agentSelfReportedStatus": "OK",
+          "timeTaken": 5.302
+        },
+        "observation": {
+          "currentPlayer": 1,
+          "isTerminal": false,
+          "observationString": "8/7R/p7/2p1p3/8/4R2P/P1kB1PP1/6K1 w - - 5 41",
+          "playerId": 0,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n2426\n3572\n656\n2974\n89\n919\n3572\n4673\n2977\n2949\n674\n277\n1841\n1257\n4673\n4177\n1380\n788\n1258\n1842\n1809\n1987\n289\n673\n1527\n654\n3133\n1894\n3010\n2599\n1214\n1287\n2938\n2992\n3154\n3138\n3096\n3862\n1270\n3718\n800\n1771\n702\n3280\n3561\n2841\n3050\n1330\n2408\n2112\n2525\n1672\n1882\n1212\n847\n774\n3131\n30\n1891\n582\n3678\n1018\n1372\n605\n1883\n2112\n2393\n1675\n1869\n1056\n1914\n1431\n2539\n3972\n2028\n2354\n1504\n2570\n2174\n\n",
+          "step": 81
+        },
+        "reward": null,
+        "status": "INACTIVE"
+      },
+      {
+        "action": { "submission": -1 },
+        "info": {},
+        "observation": {
+          "currentPlayer": 1,
+          "isTerminal": false,
+          "observationString": "8/7R/p7/2p1p3/8/4R2P/P1kB1PP1/6K1 w - - 5 41",
+          "playerId": 1,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n2426\n3572\n656\n2974\n89\n919\n3572\n4673\n2977\n2949\n674\n277\n1841\n1257\n4673\n4177\n1380\n788\n1258\n1842\n1809\n1987\n289\n673\n1527\n654\n3133\n1894\n3010\n2599\n1214\n1287\n2938\n2992\n3154\n3138\n3096\n3862\n1270\n3718\n800\n1771\n702\n3280\n3561\n2841\n3050\n1330\n2408\n2112\n2525\n1672\n1882\n1212\n847\n774\n3131\n30\n1891\n582\n3678\n1018\n1372\n605\n1883\n2112\n2393\n1675\n1869\n1056\n1914\n1431\n2539\n3972\n2028\n2354\n1504\n2570\n2174\n\n"
+        },
+        "reward": null,
+        "status": "ACTIVE"
+      }
+    ],
+    [
+      {
+        "action": { "submission": -1 },
+        "info": {},
+        "observation": {
+          "currentPlayer": 0,
+          "isTerminal": false,
+          "observationString": "8/3R4/p7/2p1p3/8/4R2P/P1kB1PP1/6K1 b - - 6 41",
+          "playerId": 0,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n2426\n3572\n656\n2974\n89\n919\n3572\n4673\n2977\n2949\n674\n277\n1841\n1257\n4673\n4177\n1380\n788\n1258\n1842\n1809\n1987\n289\n673\n1527\n654\n3133\n1894\n3010\n2599\n1214\n1287\n2938\n2992\n3154\n3138\n3096\n3862\n1270\n3718\n800\n1771\n702\n3280\n3561\n2841\n3050\n1330\n2408\n2112\n2525\n1672\n1882\n1212\n847\n774\n3131\n30\n1891\n582\n3678\n1018\n1372\n605\n1883\n2112\n2393\n1675\n1869\n1056\n1914\n1431\n2539\n3972\n2028\n2354\n1504\n2570\n2174\n4552\n\n",
+          "step": 82
+        },
+        "reward": null,
+        "status": "ACTIVE"
+      },
+      {
+        "action": {
+          "actionString": "Rd7",
+          "call_details": [
+            {
+              "duration_secs": 3.254,
+              "finish_reason": "stop",
+              "first_token_secs": 0.987,
+              "generation_tokens": 480,
+              "model": "openai/google/gemini-3.1-flash-lite-preview",
+              "prompt": "You are a chess expert\n\nLet's play chess. The current game state in Forsyth-Edwards Notation (FEN) notation is:\n8/7R/p7/2p1p3/8/4R2P/P1kB1PP1/6K1 w - - 5 41\nThe moves played so far are:\n1. e4 e5 2. Nf3 Nc6 3. Bb5 a6 4. Ba4 Nf6 5. O-O Be7 6. Re1 b5 7. Bb3 d6 8. c3 O-O 9. h3 Na5 10. Bc2 c5 11. d4 Qc7 12. d5 Nc4 13. b3 Nb6 14. Nbd2 Ne8 15. Nf1 f5 16. exf5 Bxf5 17. Bxf5 Rxf5 18. Ng3 Rf6 19. Ng5 Rg6 20. Ne6 Qb7 21. Nf5 Nxd5 22. Qxd5 Qxd5 23. Nxe7+ Kf7 24. Nxd5 Kxe6 25. c4 Nf6 26. Nc7+ Kd7 27. Nxa8 Kc6 28. Bd2 bxc4 29. bxc4 Nd7 30. Rab1 Nb6 31. Nxb6 Re6 32. Nd5 Kd7 33. Rb7+ Ke8 34. Nc7+ Kd7 35. Nxe6+ Kxe6 36. Rxg7 d5 37. cxd5+ Kxd5 38. Rxh7 Kc4 39. Re4+ Kd3 40. Re3+ Kc2 41.\nYou are playing as player White.\nIt is now your turn. Play your strongest move. The move MUST be legal. Reason step by step to come up with your move, then output your final answer in the format \"Final Answer: X\" where X is your chosen move in standard algebraic notation (SAN).\n",
+              "prompt_tokens": 465,
+              "reasoning_tokens": 0,
+              "response": "The current position is `8/7R/p7/2p1p3/8/4R2P/P1kB1PP1/6K1 w - - 5 41`. It is white's turn to move.\n\n**Evaluation:**\nWhite has a decisive material advantage (a Rook against the Black King). Black's King is restricted to the c-file and the area around c2. White's goal is to coordinate the rooks to deliver checkmate quickly.\n\n**Candidate Moves:**\n1. **Rd7**: This move cuts off the King from moving along the rank, while preparing to attack the pawn structure or force the king into a corner.\n2. **Bc3**: This move forces the king to move, potentially leading to faster mating patterns.\n3. **Re2**: This move puts pressure on the king while controlling the second rank.\n\n**Analysis:**\n- If White plays `Rd7`, Black has limited moves. The king is effectively trapped.\n- If White plays `Bc3`, Black has `Kb1`.\n- If White plays `Re2`, Black can try `Kd1`.\n\nLooking at the position, the rook on h7 is cutting off the 7th rank, and the rook on e3 is eyeing the 3rd rank. The bishop on d2 is well-placed to assist. \nA very strong continuation is to play `Rd7` or `Be1`. Let's look at `Rd7`. If `41. Rd7`, Black's king is restricted to the c-file. If Black plays `c4`, then `Rc7+` follows. \n\nActually, the move `Rd7` is very forcing. It prepares to bring the bishop into the attack or simply restricts the king further. Another very simple and effective move is `Be1`. It covers c3 and prepares the final blow. However, `Rd7` is more active in restricting the king immediately.\n\nLet's re-examine `Rd7`:\n41. Rd7 c4 42. Rc7 Kb2 43. Rxc4 Ka2 44. Ra4# (or similar).\n\nThis seems like a straightforward path to checkmate.\n\nFinal Answer: Rd7",
+              "total_tokens": 945
+            }
+          ],
+          "status": "OK",
+          "submission": 4552,
+          "thoughts": "The current position is `8/7R/p7/2p1p3/8/4R2P/P1kB1PP1/6K1 w - - 5 41`. It is white's turn to move.\n\n**Evaluation:**\nWhite has a decisive material advantage (a Rook against the Black King). Black's King is restricted to the c-file and the area around c2. White's goal is to coordinate the rooks to deliver checkmate quickly.\n\n**Candidate Moves:**\n1. **Rd7**: This move cuts off the King from moving along the rank, while preparing to attack the pawn structure or force the king into a corner.\n2. **Bc3**: This move forces the king to move, potentially leading to faster mating patterns.\n3. **Re2**: This move puts pressure on the king while controlling the second rank.\n\n**Analysis:**\n- If White plays `Rd7`, Black has limited moves. The king is effectively trapped.\n- If White plays `Bc3`, Black has `Kb1`.\n- If White plays `Re2`, Black can try `Kd1`.\n\nLooking at the position, the rook on h7 is cutting off the 7th rank, and the rook on e3 is eyeing the 3rd rank. The bishop on d2 is well-placed to assist. \nA very strong continuation is to play `Rd7` or `Be1`. Let's look at `Rd7`. If `41. Rd7`, Black's king is restricted to the c-file. If Black plays `c4`, then `Rc7+` follows. \n\nActually, the move `Rd7` is very forcing. It prepares to bring the bishop into the attack or simply restricts the king further. Another very simple and effective move is `Be1`. It covers c3 and prepares the final blow. However, `Rd7` is more active in restricting the king immediately.\n\nLet's re-examine `Rd7`:\n41. Rd7 c4 42. Rc7 Kb2 43. Rxc4 Ka2 44. Ra4# (or similar).\n\nThis seems like a straightforward path to checkmate.\n\nFinal Answer: Rd7"
+        },
+        "info": {
+          "actionApplied": 4552,
+          "actionSubmitted": 4552,
+          "actionSubmittedToString": "Rd7",
+          "agentSelfReportedStatus": "OK",
+          "timeTaken": 3.748
+        },
+        "observation": {
+          "currentPlayer": 0,
+          "isTerminal": false,
+          "observationString": "8/3R4/p7/2p1p3/8/4R2P/P1kB1PP1/6K1 b - - 6 41",
+          "playerId": 1,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n2426\n3572\n656\n2974\n89\n919\n3572\n4673\n2977\n2949\n674\n277\n1841\n1257\n4673\n4177\n1380\n788\n1258\n1842\n1809\n1987\n289\n673\n1527\n654\n3133\n1894\n3010\n2599\n1214\n1287\n2938\n2992\n3154\n3138\n3096\n3862\n1270\n3718\n800\n1771\n702\n3280\n3561\n2841\n3050\n1330\n2408\n2112\n2525\n1672\n1882\n1212\n847\n774\n3131\n30\n1891\n582\n3678\n1018\n1372\n605\n1883\n2112\n2393\n1675\n1869\n1056\n1914\n1431\n2539\n3972\n2028\n2354\n1504\n2570\n2174\n4552\n\n"
+        },
+        "reward": null,
+        "status": "INACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "actionString": "c4",
+          "call_details": [
+            {
+              "duration_secs": 3.003,
+              "finish_reason": "stop",
+              "first_token_secs": 0.741,
+              "generation_tokens": 483,
+              "model": "openai/google/gemini-3.1-flash-lite-preview",
+              "prompt": "\ud83d\udc4c\ud83d\udc40\ud83d\udc4c\ud83d\udc40\ud83d\udc4c\ud83d\udc40\ud83d\udc4c\ud83d\udc40\ud83d\udc4c\ud83d\udc40 good shit go\u0c66\u0501 sHit\ud83d\udc4c thats \u2714 some good\ud83d\udc4c\ud83d\udc4cshit right\ud83d\udc4c\ud83d\udc4cthere\ud83d\udc4c\ud83d\udc4c\ud83d\udc4c right\u2714there \u2714\u2714if i do \u01bda\u04af so my self \ud83d\udcaf i say so \ud83d\udcaf thats what im talking about right there right there (chorus: \u02b3\u1da6\u1d4d\u02b0\u1d57 \u1d57\u02b0\u1d49\u02b3\u1d49) mMMMM\u13b7\u041c\ud83d\udcaf \ud83d\udc4c\ud83d\udc4c \ud83d\udc4c\u041dO0\u041e\u0b20OOOOO\u041e\u0b20\u0b20Oooo\u1d52\u1d52\u1d52\u1d52\u1d52\u1d52\u1d52\u1d52\u1d52\ud83d\udc4c \ud83d\udc4c\ud83d\udc4c \ud83d\udc4c \ud83d\udcaf \ud83d\udc4c \ud83d\udc40 \ud83d\udc40 \ud83d\udc40 \ud83d\udc4c\ud83d\udc4c\n\nLet's play chess. The current game state in Forsyth-Edwards Notation (FEN) notation is:\n8/3R4/p7/2p1p3/8/4R2P/P1kB1PP1/6K1 b - - 6 41\nThe moves played so far are:\n1. e4 e5 2. Nf3 Nc6 3. Bb5 a6 4. Ba4 Nf6 5. O-O Be7 6. Re1 b5 7. Bb3 d6 8. c3 O-O 9. h3 Na5 10. Bc2 c5 11. d4 Qc7 12. d5 Nc4 13. b3 Nb6 14. Nbd2 Ne8 15. Nf1 f5 16. exf5 Bxf5 17. Bxf5 Rxf5 18. Ng3 Rf6 19. Ng5 Rg6 20. Ne6 Qb7 21. Nf5 Nxd5 22. Qxd5 Qxd5 23. Nxe7+ Kf7 24. Nxd5 Kxe6 25. c4 Nf6 26. Nc7+ Kd7 27. Nxa8 Kc6 28. Bd2 bxc4 29. bxc4 Nd7 30. Rab1 Nb6 31. Nxb6 Re6 32. Nd5 Kd7 33. Rb7+ Ke8 34. Nc7+ Kd7 35. Nxe6+ Kxe6 36. Rxg7 d5 37. cxd5+ Kxd5 38. Rxh7 Kc4 39. Re4+ Kd3 40. Re3+ Kc2 41. Rd7\nYou are playing as player Black.\nIt is now your turn. Play your strongest move. The move MUST be legal. Reason step by step to come up with your move, then output your final answer in the format \"Final Answer: X\" where X is your chosen move in standard algebraic notation (SAN).\n",
+              "prompt_tokens": 588,
+              "reasoning_tokens": 0,
+              "response": "The current FEN is `8/3R4/p7/2p1p3/8/4R2P/P1kB1PP1/6K1 b - - 6 41`. It is Black's turn to move.\n\n**Evaluation:**\nWhite has a decisive material advantage (two Rooks for a Knight) and a dominating position. The Black King is trapped on the c-file and is currently under pressure. White's Rook on d7 is attacking the d-file, and the other Rook on e3 is eyeing the remaining pawns and the king.\n\n**Candidate Moves for Black:**\nBlack is in a lost position, so the goal is to prolong the game or find the most resilient defense.\n1. **... c4**: This pushes the passed pawn and creates some space, but it does not address the immediate threats.\n2. **... Kb1**: Tries to move the King away from the c-file, but it is met by `Bc3` or similar maneuvers.\n3. **... Kb2**: Similar to Kb1, but the King remains somewhat confined.\n\n**Analysis:**\n- The move `... c4` is the most active attempt to create counterplay, although it is likely insufficient.\n- The move `... Kb2` is a standard attempt to wiggle out, but `Bc3+` immediately forces the King back or to a different square.\n- Let's look at `... c4`. After `42. Rc3`, White maintains total control.\n- Let's look at `... Kb1`. After `42. Bc3`, Black is still completely stifled.\n\nGiven the desperate state of the game, Black must try to push the pawn to create any potential for activity or simply delay the inevitable checkmate.\n\nEngine evaluation confirms that there is no saving this position, and Black is effectively in a forced loss. Among the options, `... c4` is the most logical attempt to move forward.\n\nStep-by-step:\n1. Identify the material deficit (White is up a full Rook).\n2. Recognize that the Black King is paralyzed on the queenside.\n3. Choose the most active move to prevent immediate total stagnation: `c4`.\n\nFinal Answer: c4",
+              "total_tokens": 1071
+            }
+          ],
+          "status": "OK",
+          "submission": 1403,
+          "thoughts": "The current FEN is `8/3R4/p7/2p1p3/8/4R2P/P1kB1PP1/6K1 b - - 6 41`. It is Black's turn to move.\n\n**Evaluation:**\nWhite has a decisive material advantage (two Rooks for a Knight) and a dominating position. The Black King is trapped on the c-file and is currently under pressure. White's Rook on d7 is attacking the d-file, and the other Rook on e3 is eyeing the remaining pawns and the king.\n\n**Candidate Moves for Black:**\nBlack is in a lost position, so the goal is to prolong the game or find the most resilient defense.\n1. **... c4**: This pushes the passed pawn and creates some space, but it does not address the immediate threats.\n2. **... Kb1**: Tries to move the King away from the c-file, but it is met by `Bc3` or similar maneuvers.\n3. **... Kb2**: Similar to Kb1, but the King remains somewhat confined.\n\n**Analysis:**\n- The move `... c4` is the most active attempt to create counterplay, although it is likely insufficient.\n- The move `... Kb2` is a standard attempt to wiggle out, but `Bc3+` immediately forces the King back or to a different square.\n- Let's look at `... c4`. After `42. Rc3`, White maintains total control.\n- Let's look at `... Kb1`. After `42. Bc3`, Black is still completely stifled.\n\nGiven the desperate state of the game, Black must try to push the pawn to create any potential for activity or simply delay the inevitable checkmate.\n\nEngine evaluation confirms that there is no saving this position, and Black is effectively in a forced loss. Among the options, `... c4` is the most logical attempt to move forward.\n\nStep-by-step:\n1. Identify the material deficit (White is up a full Rook).\n2. Recognize that the Black King is paralyzed on the queenside.\n3. Choose the most active move to prevent immediate total stagnation: `c4`.\n\nFinal Answer: c4"
+        },
+        "info": {
+          "actionApplied": 1403,
+          "actionSubmitted": 1403,
+          "actionSubmittedToString": "c4",
+          "agentSelfReportedStatus": "OK",
+          "timeTaken": 3.516
+        },
+        "observation": {
+          "currentPlayer": 1,
+          "isTerminal": false,
+          "observationString": "8/3R4/p7/4p3/2p5/4R2P/P1kB1PP1/6K1 w - - 0 42",
+          "playerId": 0,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n2426\n3572\n656\n2974\n89\n919\n3572\n4673\n2977\n2949\n674\n277\n1841\n1257\n4673\n4177\n1380\n788\n1258\n1842\n1809\n1987\n289\n673\n1527\n654\n3133\n1894\n3010\n2599\n1214\n1287\n2938\n2992\n3154\n3138\n3096\n3862\n1270\n3718\n800\n1771\n702\n3280\n3561\n2841\n3050\n1330\n2408\n2112\n2525\n1672\n1882\n1212\n847\n774\n3131\n30\n1891\n582\n3678\n1018\n1372\n605\n1883\n2112\n2393\n1675\n1869\n1056\n1914\n1431\n2539\n3972\n2028\n2354\n1504\n2570\n2174\n4552\n1403\n\n",
+          "step": 83
+        },
+        "reward": null,
+        "status": "INACTIVE"
+      },
+      {
+        "action": { "submission": -1 },
+        "info": {},
+        "observation": {
+          "currentPlayer": 1,
+          "isTerminal": false,
+          "observationString": "8/3R4/p7/4p3/2p5/4R2P/P1kB1PP1/6K1 w - - 0 42",
+          "playerId": 1,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n2426\n3572\n656\n2974\n89\n919\n3572\n4673\n2977\n2949\n674\n277\n1841\n1257\n4673\n4177\n1380\n788\n1258\n1842\n1809\n1987\n289\n673\n1527\n654\n3133\n1894\n3010\n2599\n1214\n1287\n2938\n2992\n3154\n3138\n3096\n3862\n1270\n3718\n800\n1771\n702\n3280\n3561\n2841\n3050\n1330\n2408\n2112\n2525\n1672\n1882\n1212\n847\n774\n3131\n30\n1891\n582\n3678\n1018\n1372\n605\n1883\n2112\n2393\n1675\n1869\n1056\n1914\n1431\n2539\n3972\n2028\n2354\n1504\n2570\n2174\n4552\n1403\n\n"
+        },
+        "reward": null,
+        "status": "ACTIVE"
+      }
+    ],
+    [
+      {
+        "action": { "submission": -1 },
+        "info": {},
+        "observation": {
+          "currentPlayer": 0,
+          "isTerminal": false,
+          "observationString": "8/3R4/p7/4p3/2p5/2R4P/P1kB1PP1/6K1 b - - 1 42",
+          "playerId": 0,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n2426\n3572\n656\n2974\n89\n919\n3572\n4673\n2977\n2949\n674\n277\n1841\n1257\n4673\n4177\n1380\n788\n1258\n1842\n1809\n1987\n289\n673\n1527\n654\n3133\n1894\n3010\n2599\n1214\n1287\n2938\n2992\n3154\n3138\n3096\n3862\n1270\n3718\n800\n1771\n702\n3280\n3561\n2841\n3050\n1330\n2408\n2112\n2525\n1672\n1882\n1212\n847\n774\n3131\n30\n1891\n582\n3678\n1018\n1372\n605\n1883\n2112\n2393\n1675\n1869\n1056\n1914\n1431\n2539\n3972\n2028\n2354\n1504\n2570\n2174\n4552\n1403\n2510\n\n",
+          "step": 84
+        },
+        "reward": null,
+        "status": "ACTIVE"
+      },
+      {
+        "action": {
+          "actionString": "Rc3+",
+          "call_details": [
+            {
+              "duration_secs": 3.288,
+              "finish_reason": "stop",
+              "first_token_secs": 0.599,
+              "generation_tokens": 591,
+              "model": "openai/google/gemini-3.1-flash-lite-preview",
+              "prompt": "You are a chess expert\n\nLet's play chess. The current game state in Forsyth-Edwards Notation (FEN) notation is:\n8/3R4/p7/4p3/2p5/4R2P/P1kB1PP1/6K1 w - - 0 42\nThe moves played so far are:\n1. e4 e5 2. Nf3 Nc6 3. Bb5 a6 4. Ba4 Nf6 5. O-O Be7 6. Re1 b5 7. Bb3 d6 8. c3 O-O 9. h3 Na5 10. Bc2 c5 11. d4 Qc7 12. d5 Nc4 13. b3 Nb6 14. Nbd2 Ne8 15. Nf1 f5 16. exf5 Bxf5 17. Bxf5 Rxf5 18. Ng3 Rf6 19. Ng5 Rg6 20. Ne6 Qb7 21. Nf5 Nxd5 22. Qxd5 Qxd5 23. Nxe7+ Kf7 24. Nxd5 Kxe6 25. c4 Nf6 26. Nc7+ Kd7 27. Nxa8 Kc6 28. Bd2 bxc4 29. bxc4 Nd7 30. Rab1 Nb6 31. Nxb6 Re6 32. Nd5 Kd7 33. Rb7+ Ke8 34. Nc7+ Kd7 35. Nxe6+ Kxe6 36. Rxg7 d5 37. cxd5+ Kxd5 38. Rxh7 Kc4 39. Re4+ Kd3 40. Re3+ Kc2 41. Rd7 c4 42.\nYou are playing as player White.\nIt is now your turn. Play your strongest move. The move MUST be legal. Reason step by step to come up with your move, then output your final answer in the format \"Final Answer: X\" where X is your chosen move in standard algebraic notation (SAN).\n",
+              "prompt_tokens": 474,
+              "reasoning_tokens": 0,
+              "response": "The current position is `8/3R4/p7/4p3/2p5/4R2P/P1kB1PP1/6K1 w - - 0 42`. It is White's turn to move.\n\n**Evaluation:**\nWhite is winning decisively. Black's king is cut off, and White has a overwhelming material advantage (Rook and Bishop versus no pieces for Black). The goal is to finish the game as efficiently as possible.\n\n**Candidate Moves:**\n1. **Rc3+**: This forces the King to move and restricts its movement further.\n2. **Ba5**: Cutting off the King even more effectively.\n3. **Re2+**: Another forcing move to restrict the King.\n\n**Analysis:**\n- If **42. Rc3+**:\n    - If 42... Kb2, then 43. Rxc4+ and the pawns will fall rapidly.\n    - If 42... Kd1, then 43. Ba5 (threatening Bc3#). If 43... e4, 44. Bc3+ Ke2 45. Re7# or similar mates.\n- If **42. Ba5**:\n    - This is a very strong prophylactic and attacking move. It sets up the threat of Rc7# or similar. Black has no meaningful counterplay. For example, if 42... e4 43. Rc3+ Kb2 44. Rxc4+ Kb3 45. Rxe4, and the game is clearly over.\n\n**Refinement:**\nThe move **Rc3+** is very forcing and coordinates the pieces to close the net around the King. However, looking at the board, the most direct way to restrict the King further while preparing for mate is to remove the escape squares or force the King into a mating net.\n\nLet's look at 42. Rc3+. If 42... Kd1, 43. Ba5. If 43... e4 44. Kf1 (preparing to bring the King into play if needed, but not necessary) or simply 44. Bc3+ Ke2 45. Re7#.\n\nAlternatively, 42. Ba5 first: 42... e4 43. Rc3+ Kb2 44. Rxc4+ Kb3. This also wins easily.\n\nGiven the position, **Rc3+** is a very active and forcing move that limits the King immediately.\n\nFinal check of the move:\n42. Rc3+ Kb2 (the only other option is Kd1) 43. Rxc4+ Kb3 44. Rxe4. This is completely winning.\n\nFinal Answer: Rc3+",
+              "total_tokens": 1065
+            }
+          ],
+          "status": "OK",
+          "submission": 2510,
+          "thoughts": "The current position is `8/3R4/p7/4p3/2p5/4R2P/P1kB1PP1/6K1 w - - 0 42`. It is White's turn to move.\n\n**Evaluation:**\nWhite is winning decisively. Black's king is cut off, and White has a overwhelming material advantage (Rook and Bishop versus no pieces for Black). The goal is to finish the game as efficiently as possible.\n\n**Candidate Moves:**\n1. **Rc3+**: This forces the King to move and restricts its movement further.\n2. **Ba5**: Cutting off the King even more effectively.\n3. **Re2+**: Another forcing move to restrict the King.\n\n**Analysis:**\n- If **42. Rc3+**:\n    - If 42... Kb2, then 43. Rxc4+ and the pawns will fall rapidly.\n    - If 42... Kd1, then 43. Ba5 (threatening Bc3#). If 43... e4, 44. Bc3+ Ke2 45. Re7# or similar mates.\n- If **42. Ba5**:\n    - This is a very strong prophylactic and attacking move. It sets up the threat of Rc7# or similar. Black has no meaningful counterplay. For example, if 42... e4 43. Rc3+ Kb2 44. Rxc4+ Kb3 45. Rxe4, and the game is clearly over.\n\n**Refinement:**\nThe move **Rc3+** is very forcing and coordinates the pieces to close the net around the King. However, looking at the board, the most direct way to restrict the King further while preparing for mate is to remove the escape squares or force the King into a mating net.\n\nLet's look at 42. Rc3+. If 42... Kd1, 43. Ba5. If 43... e4 44. Kf1 (preparing to bring the King into play if needed, but not necessary) or simply 44. Bc3+ Ke2 45. Re7#.\n\nAlternatively, 42. Ba5 first: 42... e4 43. Rc3+ Kb2 44. Rxc4+ Kb3. This also wins easily.\n\nGiven the position, **Rc3+** is a very active and forcing move that limits the King immediately.\n\nFinal check of the move:\n42. Rc3+ Kb2 (the only other option is Kd1) 43. Rxc4+ Kb3 44. Rxe4. This is completely winning.\n\nFinal Answer: Rc3+"
+        },
+        "info": {
+          "actionApplied": 2510,
+          "actionSubmitted": 2510,
+          "actionSubmittedToString": "Rc3+",
+          "agentSelfReportedStatus": "OK",
+          "timeTaken": 3.782
+        },
+        "observation": {
+          "currentPlayer": 0,
+          "isTerminal": false,
+          "observationString": "8/3R4/p7/4p3/2p5/2R4P/P1kB1PP1/6K1 b - - 1 42",
+          "playerId": 1,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n2426\n3572\n656\n2974\n89\n919\n3572\n4673\n2977\n2949\n674\n277\n1841\n1257\n4673\n4177\n1380\n788\n1258\n1842\n1809\n1987\n289\n673\n1527\n654\n3133\n1894\n3010\n2599\n1214\n1287\n2938\n2992\n3154\n3138\n3096\n3862\n1270\n3718\n800\n1771\n702\n3280\n3561\n2841\n3050\n1330\n2408\n2112\n2525\n1672\n1882\n1212\n847\n774\n3131\n30\n1891\n582\n3678\n1018\n1372\n605\n1883\n2112\n2393\n1675\n1869\n1056\n1914\n1431\n2539\n3972\n2028\n2354\n1504\n2570\n2174\n4552\n1403\n2510\n\n"
+        },
+        "reward": null,
+        "status": "INACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "actionString": "Kb1",
+          "call_details": [
+            {
+              "duration_secs": 4.871,
+              "finish_reason": "stop",
+              "first_token_secs": 0.81,
+              "generation_tokens": 892,
+              "model": "openai/google/gemini-3.1-flash-lite-preview",
+              "prompt": "\ud83d\udc4c\ud83d\udc40\ud83d\udc4c\ud83d\udc40\ud83d\udc4c\ud83d\udc40\ud83d\udc4c\ud83d\udc40\ud83d\udc4c\ud83d\udc40 good shit go\u0c66\u0501 sHit\ud83d\udc4c thats \u2714 some good\ud83d\udc4c\ud83d\udc4cshit right\ud83d\udc4c\ud83d\udc4cthere\ud83d\udc4c\ud83d\udc4c\ud83d\udc4c right\u2714there \u2714\u2714if i do \u01bda\u04af so my self \ud83d\udcaf i say so \ud83d\udcaf thats what im talking about right there right there (chorus: \u02b3\u1da6\u1d4d\u02b0\u1d57 \u1d57\u02b0\u1d49\u02b3\u1d49) mMMMM\u13b7\u041c\ud83d\udcaf \ud83d\udc4c\ud83d\udc4c \ud83d\udc4c\u041dO0\u041e\u0b20OOOOO\u041e\u0b20\u0b20Oooo\u1d52\u1d52\u1d52\u1d52\u1d52\u1d52\u1d52\u1d52\u1d52\ud83d\udc4c \ud83d\udc4c\ud83d\udc4c \ud83d\udc4c \ud83d\udcaf \ud83d\udc4c \ud83d\udc40 \ud83d\udc40 \ud83d\udc40 \ud83d\udc4c\ud83d\udc4c\n\nLet's play chess. The current game state in Forsyth-Edwards Notation (FEN) notation is:\n8/3R4/p7/4p3/2p5/2R4P/P1kB1PP1/6K1 b - - 1 42\nThe moves played so far are:\n1. e4 e5 2. Nf3 Nc6 3. Bb5 a6 4. Ba4 Nf6 5. O-O Be7 6. Re1 b5 7. Bb3 d6 8. c3 O-O 9. h3 Na5 10. Bc2 c5 11. d4 Qc7 12. d5 Nc4 13. b3 Nb6 14. Nbd2 Ne8 15. Nf1 f5 16. exf5 Bxf5 17. Bxf5 Rxf5 18. Ng3 Rf6 19. Ng5 Rg6 20. Ne6 Qb7 21. Nf5 Nxd5 22. Qxd5 Qxd5 23. Nxe7+ Kf7 24. Nxd5 Kxe6 25. c4 Nf6 26. Nc7+ Kd7 27. Nxa8 Kc6 28. Bd2 bxc4 29. bxc4 Nd7 30. Rab1 Nb6 31. Nxb6 Re6 32. Nd5 Kd7 33. Rb7+ Ke8 34. Nc7+ Kd7 35. Nxe6+ Kxe6 36. Rxg7 d5 37. cxd5+ Kxd5 38. Rxh7 Kc4 39. Re4+ Kd3 40. Re3+ Kc2 41. Rd7 c4 42. Rc3+\nYou are playing as player Black.\nIt is now your turn. Play your strongest move. The move MUST be legal. Reason step by step to come up with your move, then output your final answer in the format \"Final Answer: X\" where X is your chosen move in standard algebraic notation (SAN).\n",
+              "prompt_tokens": 597,
+              "reasoning_tokens": 0,
+              "response": "The current position is `8/3R4/p7/4p3/2p5/2R4P/P1kB1PP1/6K1 b - - 1 42`. It is Black's turn to move.\n\n**Analysis:**\n1. **Threat Assessment:** White has just played `Rc3+`, putting the Black king in check. The king is currently on `c2`.\n2. **Available Moves:** Black's king is being checked by the rook on `c3`. The king must move to a safe square.\n    *   `Kb2`: The square `b2` is controlled by the rook on `d2` and the pawn on `a2`. This is an illegal move.\n    *   `Kb1`: The square `b1` is vacant.\n    *   `Kd1`: The square `d1` is covered by the rook on `d2`. This is an illegal move.\n3. **Evaluating `Kb1`:**\n    *   If `... Kb1`, White can play `Rdc3` or look for other attacking lines. However, Black is already in a lost position material-wise (White has two rooks vs Black's pawns). The goal is to prolong the game or find the most resilient move.\n    *   Actually, let's re-examine `Kb1`. Are there any other legal moves?\n    *   The King is on `c2`. The checks are from `c3`. The squares `b2`, `c1`, `d1` are all occupied or attacked.\n    *   Wait, let's check the board:\n        *   `c2` is the king.\n        *   `c3` is White's rook (checking).\n        *   `c1` is empty. Is it safe?\n        *   `d2` is a white bishop. It controls `c1`, `c3`, `e1`, `e3`, etc.\n        *   So `Kc1` is illegal because of the bishop on `d2`.\n        *   `Kb2` is illegal because of the rook on `d2` and the pawn on `a2`.\n        *   `Kd1` is illegal because of the rook on `d2`.\n        *   `Kb1` is the only safe square? Let's check `b1`.\n        *   White's rook on `d7` does not control `b1`.\n        *   White's rook on `c3` controls the c-file.\n        *   White's bishop on `d2` does not control `b1`.\n        *   White's pawn on `a2` does not control `b1`.\n        *   White's king on `g1` does not control `b1`.\n        *   So `Kb1` is the only legal move.\n\nLet's confirm `Kb1` is the only legal move.\n- `c2` is under attack by `Rc3`.\n- `Kc1` is attacked by the Bishop on `d2`.\n- `Kb2` is attacked by the Rook on `d2` and the Pawn on `a2`.\n- `Kd1` is attacked by the Rook on `d2`.\n- `Kb3` is occupied/attacked? No, but it's not adjacent to `c2`.\n- `Kd3` is occupied? No, `d3` is empty. Let's recheck the board: `8/3R4/p7/4p3/2p5/2R4P/P1kB1PP1/6K1 b - - 1 42`.\nWait, `d3` is empty. Can the King go to `d3`?\n`d3` is currently empty. Is `d3` attacked?\nWhite's rook on `d7` attacks `d3`. So `Kd3` is illegal.\n\nSo, `Kb1` is indeed the only legal move.\n\nFinal Answer: Kb1",
+              "total_tokens": 1489
+            }
+          ],
+          "status": "OK",
+          "submission": 1663,
+          "thoughts": "The current position is `8/3R4/p7/4p3/2p5/2R4P/P1kB1PP1/6K1 b - - 1 42`. It is Black's turn to move.\n\n**Analysis:**\n1. **Threat Assessment:** White has just played `Rc3+`, putting the Black king in check. The king is currently on `c2`.\n2. **Available Moves:** Black's king is being checked by the rook on `c3`. The king must move to a safe square.\n    *   `Kb2`: The square `b2` is controlled by the rook on `d2` and the pawn on `a2`. This is an illegal move.\n    *   `Kb1`: The square `b1` is vacant.\n    *   `Kd1`: The square `d1` is covered by the rook on `d2`. This is an illegal move.\n3. **Evaluating `Kb1`:**\n    *   If `... Kb1`, White can play `Rdc3` or look for other attacking lines. However, Black is already in a lost position material-wise (White has two rooks vs Black's pawns). The goal is to prolong the game or find the most resilient move.\n    *   Actually, let's re-examine `Kb1`. Are there any other legal moves?\n    *   The King is on `c2`. The checks are from `c3`. The squares `b2`, `c1`, `d1` are all occupied or attacked.\n    *   Wait, let's check the board:\n        *   `c2` is the king.\n        *   `c3` is White's rook (checking).\n        *   `c1` is empty. Is it safe?\n        *   `d2` is a white bishop. It controls `c1`, `c3`, `e1`, `e3`, etc.\n        *   So `Kc1` is illegal because of the bishop on `d2`.\n        *   `Kb2` is illegal because of the rook on `d2` and the pawn on `a2`.\n        *   `Kd1` is illegal because of the rook on `d2`.\n        *   `Kb1` is the only safe square? Let's check `b1`.\n        *   White's rook on `d7` does not control `b1`.\n        *   White's rook on `c3` controls the c-file.\n        *   White's bishop on `d2` does not control `b1`.\n        *   White's pawn on `a2` does not control `b1`.\n        *   White's king on `g1` does not control `b1`.\n        *   So `Kb1` is the only legal move.\n\nLet's confirm `Kb1` is the only legal move.\n- `c2` is under attack by `Rc3`.\n- `Kc1` is attacked by the Bishop on `d2`.\n- `Kb2` is attacked by the Rook on `d2` and the Pawn on `a2`.\n- `Kd1` is attacked by the Rook on `d2`.\n- `Kb3` is occupied/attacked? No, but it's not adjacent to `c2`.\n- `Kd3` is occupied? No, `d3` is empty. Let's recheck the board: `8/3R4/p7/4p3/2p5/2R4P/P1kB1PP1/6K1 b - - 1 42`.\nWait, `d3` is empty. Can the King go to `d3`?\n`d3` is currently empty. Is `d3` attacked?\nWhite's rook on `d7` attacks `d3`. So `Kd3` is illegal.\n\nSo, `Kb1` is indeed the only legal move.\n\nFinal Answer: Kb1"
+        },
+        "info": {
+          "actionApplied": 1663,
+          "actionSubmitted": 1663,
+          "actionSubmittedToString": "Kb1",
+          "agentSelfReportedStatus": "OK",
+          "timeTaken": 5.383
+        },
+        "observation": {
+          "currentPlayer": 1,
+          "isTerminal": false,
+          "observationString": "8/3R4/p7/4p3/2p5/2R4P/P2B1PP1/1k4K1 w - - 2 43",
+          "playerId": 0,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n2426\n3572\n656\n2974\n89\n919\n3572\n4673\n2977\n2949\n674\n277\n1841\n1257\n4673\n4177\n1380\n788\n1258\n1842\n1809\n1987\n289\n673\n1527\n654\n3133\n1894\n3010\n2599\n1214\n1287\n2938\n2992\n3154\n3138\n3096\n3862\n1270\n3718\n800\n1771\n702\n3280\n3561\n2841\n3050\n1330\n2408\n2112\n2525\n1672\n1882\n1212\n847\n774\n3131\n30\n1891\n582\n3678\n1018\n1372\n605\n1883\n2112\n2393\n1675\n1869\n1056\n1914\n1431\n2539\n3972\n2028\n2354\n1504\n2570\n2174\n4552\n1403\n2510\n1663\n\n",
+          "step": 85
+        },
+        "reward": null,
+        "status": "INACTIVE"
+      },
+      {
+        "action": { "submission": -1 },
+        "info": {},
+        "observation": {
+          "currentPlayer": 1,
+          "isTerminal": false,
+          "observationString": "8/3R4/p7/4p3/2p5/2R4P/P2B1PP1/1k4K1 w - - 2 43",
+          "playerId": 1,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n2426\n3572\n656\n2974\n89\n919\n3572\n4673\n2977\n2949\n674\n277\n1841\n1257\n4673\n4177\n1380\n788\n1258\n1842\n1809\n1987\n289\n673\n1527\n654\n3133\n1894\n3010\n2599\n1214\n1287\n2938\n2992\n3154\n3138\n3096\n3862\n1270\n3718\n800\n1771\n702\n3280\n3561\n2841\n3050\n1330\n2408\n2112\n2525\n1672\n1882\n1212\n847\n774\n3131\n30\n1891\n582\n3678\n1018\n1372\n605\n1883\n2112\n2393\n1675\n1869\n1056\n1914\n1431\n2539\n3972\n2028\n2354\n1504\n2570\n2174\n4552\n1403\n2510\n1663\n\n"
+        },
+        "reward": null,
+        "status": "ACTIVE"
+      }
+    ],
+    [
+      {
+        "action": { "submission": -1 },
+        "info": {},
+        "observation": {
+          "currentPlayer": 0,
+          "isTerminal": false,
+          "observationString": "8/3R4/p7/4p3/2R5/7P/P2B1PP1/1k4K1 b - - 0 43",
+          "playerId": 0,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n2426\n3572\n656\n2974\n89\n919\n3572\n4673\n2977\n2949\n674\n277\n1841\n1257\n4673\n4177\n1380\n788\n1258\n1842\n1809\n1987\n289\n673\n1527\n654\n3133\n1894\n3010\n2599\n1214\n1287\n2938\n2992\n3154\n3138\n3096\n3862\n1270\n3718\n800\n1771\n702\n3280\n3561\n2841\n3050\n1330\n2408\n2112\n2525\n1672\n1882\n1212\n847\n774\n3131\n30\n1891\n582\n3678\n1018\n1372\n605\n1883\n2112\n2393\n1675\n1869\n1056\n1914\n1431\n2539\n3972\n2028\n2354\n1504\n2570\n2174\n4552\n1403\n2510\n1663\n1330\n\n",
+          "step": 86
+        },
+        "reward": null,
+        "status": "ACTIVE"
+      },
+      {
+        "action": {
+          "actionString": "Rxc4",
+          "call_details": [
+            {
+              "duration_secs": 3.143,
+              "finish_reason": "stop",
+              "first_token_secs": 0.655,
+              "generation_tokens": 553,
+              "model": "openai/google/gemini-3.1-flash-lite-preview",
+              "prompt": "You are a chess expert\n\nLet's play chess. The current game state in Forsyth-Edwards Notation (FEN) notation is:\n8/3R4/p7/4p3/2p5/2R4P/P2B1PP1/1k4K1 w - - 2 43\nThe moves played so far are:\n1. e4 e5 2. Nf3 Nc6 3. Bb5 a6 4. Ba4 Nf6 5. O-O Be7 6. Re1 b5 7. Bb3 d6 8. c3 O-O 9. h3 Na5 10. Bc2 c5 11. d4 Qc7 12. d5 Nc4 13. b3 Nb6 14. Nbd2 Ne8 15. Nf1 f5 16. exf5 Bxf5 17. Bxf5 Rxf5 18. Ng3 Rf6 19. Ng5 Rg6 20. Ne6 Qb7 21. Nf5 Nxd5 22. Qxd5 Qxd5 23. Nxe7+ Kf7 24. Nxd5 Kxe6 25. c4 Nf6 26. Nc7+ Kd7 27. Nxa8 Kc6 28. Bd2 bxc4 29. bxc4 Nd7 30. Rab1 Nb6 31. Nxb6 Re6 32. Nd5 Kd7 33. Rb7+ Ke8 34. Nc7+ Kd7 35. Nxe6+ Kxe6 36. Rxg7 d5 37. cxd5+ Kxd5 38. Rxh7 Kc4 39. Re4+ Kd3 40. Re3+ Kc2 41. Rd7 c4 42. Rc3+ Kb1 43.\nYou are playing as player White.\nIt is now your turn. Play your strongest move. The move MUST be legal. Reason step by step to come up with your move, then output your final answer in the format \"Final Answer: X\" where X is your chosen move in standard algebraic notation (SAN).\n",
+              "prompt_tokens": 485,
+              "reasoning_tokens": 0,
+              "response": "The current FEN is `8/3R4/p7/4p3/2p5/2R4P/P2B1PP1/1k4K1 w - - 2 43`. It is White's turn to move.\n\n**Evaluation:**\nWhite is winning decisively. White has a significant material advantage (two Rooks versus Black's empty board, though Black has some pawns). Black's King is trapped on the b1 square.\n\n**Candidate Moves:**\n1. **Rxc4**: This removes Black's dangerous c-pawn, which is currently advanced and could potentially cause minor annoyances, although it's not a threat to promotion.\n2. **Rd1+**: This forces the King to move or puts the King in check. However, the King is already trapped on b1. 43. Rd1+ Kxa2 is possible.\n3. **Rc1+**: This forces the King to move if it weren't already on b1, but the King is on b1. 43. Rc1+ Ka2 (Wait, the King is on b1, so 43. Rc1+ is not possible as it would be check). 43. Rxc4 is safe and straightforward.\n\n**Analysis:**\nThe goal is to deliver checkmate as efficiently as possible.\n- If 43. Rxc4: Black plays something like ...a5. White continues to restrict the King.\n- Actually, looking at the board: The black King is on b1. The white Rook on c3 controls the c-file and the 3rd rank. The white Rook on d7 controls the 7th rank.\n- 43. Rxc4 is safe. Let's look for a mate. \n- Is there a forced mate? 43. Rd1+ Kxa2 44. Rxc4.\n- 43. Rxc4 is very strong, clearing the board of Black's remaining assets.\n\nLet's re-verify the King's position. Black King is on b1. White has Rooks on d7 and c3.\nIf 43. Rxc4:\n- The c4 pawn is removed.\n- Black's options are very limited (only ...a5 or ...e4).\n- The game is clearly won.\n\nFinal verification of the move:\n43. Rxc4 is a legal move. It captures the pawn and improves White's position by removing any potential counterplay from the passed c-pawn.\n\nFinal Answer: Rxc4",
+              "total_tokens": 1038
+            }
+          ],
+          "status": "OK",
+          "submission": 1330,
+          "thoughts": "The current FEN is `8/3R4/p7/4p3/2p5/2R4P/P2B1PP1/1k4K1 w - - 2 43`. It is White's turn to move.\n\n**Evaluation:**\nWhite is winning decisively. White has a significant material advantage (two Rooks versus Black's empty board, though Black has some pawns). Black's King is trapped on the b1 square.\n\n**Candidate Moves:**\n1. **Rxc4**: This removes Black's dangerous c-pawn, which is currently advanced and could potentially cause minor annoyances, although it's not a threat to promotion.\n2. **Rd1+**: This forces the King to move or puts the King in check. However, the King is already trapped on b1. 43. Rd1+ Kxa2 is possible.\n3. **Rc1+**: This forces the King to move if it weren't already on b1, but the King is on b1. 43. Rc1+ Ka2 (Wait, the King is on b1, so 43. Rc1+ is not possible as it would be check). 43. Rxc4 is safe and straightforward.\n\n**Analysis:**\nThe goal is to deliver checkmate as efficiently as possible.\n- If 43. Rxc4: Black plays something like ...a5. White continues to restrict the King.\n- Actually, looking at the board: The black King is on b1. The white Rook on c3 controls the c-file and the 3rd rank. The white Rook on d7 controls the 7th rank.\n- 43. Rxc4 is safe. Let's look for a mate. \n- Is there a forced mate? 43. Rd1+ Kxa2 44. Rxc4.\n- 43. Rxc4 is very strong, clearing the board of Black's remaining assets.\n\nLet's re-verify the King's position. Black King is on b1. White has Rooks on d7 and c3.\nIf 43. Rxc4:\n- The c4 pawn is removed.\n- Black's options are very limited (only ...a5 or ...e4).\n- The game is clearly won.\n\nFinal verification of the move:\n43. Rxc4 is a legal move. It captures the pawn and improves White's position by removing any potential counterplay from the passed c-pawn.\n\nFinal Answer: Rxc4"
+        },
+        "info": {
+          "actionApplied": 1330,
+          "actionSubmitted": 1330,
+          "actionSubmittedToString": "Rxc4",
+          "agentSelfReportedStatus": "OK",
+          "timeTaken": 3.575
+        },
+        "observation": {
+          "currentPlayer": 0,
+          "isTerminal": false,
+          "observationString": "8/3R4/p7/4p3/2R5/7P/P2B1PP1/1k4K1 b - - 0 43",
+          "playerId": 1,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n2426\n3572\n656\n2974\n89\n919\n3572\n4673\n2977\n2949\n674\n277\n1841\n1257\n4673\n4177\n1380\n788\n1258\n1842\n1809\n1987\n289\n673\n1527\n654\n3133\n1894\n3010\n2599\n1214\n1287\n2938\n2992\n3154\n3138\n3096\n3862\n1270\n3718\n800\n1771\n702\n3280\n3561\n2841\n3050\n1330\n2408\n2112\n2525\n1672\n1882\n1212\n847\n774\n3131\n30\n1891\n582\n3678\n1018\n1372\n605\n1883\n2112\n2393\n1675\n1869\n1056\n1914\n1431\n2539\n3972\n2028\n2354\n1504\n2570\n2174\n4552\n1403\n2510\n1663\n1330\n\n"
+        },
+        "reward": null,
+        "status": "INACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "actionString": "Kxa2",
+          "call_details": [
+            {
+              "duration_secs": 2.726,
+              "finish_reason": "stop",
+              "first_token_secs": 0.698,
+              "generation_tokens": 383,
+              "model": "openai/google/gemini-3.1-flash-lite-preview",
+              "prompt": "\ud83d\udc4c\ud83d\udc40\ud83d\udc4c\ud83d\udc40\ud83d\udc4c\ud83d\udc40\ud83d\udc4c\ud83d\udc40\ud83d\udc4c\ud83d\udc40 good shit go\u0c66\u0501 sHit\ud83d\udc4c thats \u2714 some good\ud83d\udc4c\ud83d\udc4cshit right\ud83d\udc4c\ud83d\udc4cthere\ud83d\udc4c\ud83d\udc4c\ud83d\udc4c right\u2714there \u2714\u2714if i do \u01bda\u04af so my self \ud83d\udcaf i say so \ud83d\udcaf thats what im talking about right there right there (chorus: \u02b3\u1da6\u1d4d\u02b0\u1d57 \u1d57\u02b0\u1d49\u02b3\u1d49) mMMMM\u13b7\u041c\ud83d\udcaf \ud83d\udc4c\ud83d\udc4c \ud83d\udc4c\u041dO0\u041e\u0b20OOOOO\u041e\u0b20\u0b20Oooo\u1d52\u1d52\u1d52\u1d52\u1d52\u1d52\u1d52\u1d52\u1d52\ud83d\udc4c \ud83d\udc4c\ud83d\udc4c \ud83d\udc4c \ud83d\udcaf \ud83d\udc4c \ud83d\udc40 \ud83d\udc40 \ud83d\udc40 \ud83d\udc4c\ud83d\udc4c\n\nLet's play chess. The current game state in Forsyth-Edwards Notation (FEN) notation is:\n8/3R4/p7/4p3/2R5/7P/P2B1PP1/1k4K1 b - - 0 43\nThe moves played so far are:\n1. e4 e5 2. Nf3 Nc6 3. Bb5 a6 4. Ba4 Nf6 5. O-O Be7 6. Re1 b5 7. Bb3 d6 8. c3 O-O 9. h3 Na5 10. Bc2 c5 11. d4 Qc7 12. d5 Nc4 13. b3 Nb6 14. Nbd2 Ne8 15. Nf1 f5 16. exf5 Bxf5 17. Bxf5 Rxf5 18. Ng3 Rf6 19. Ng5 Rg6 20. Ne6 Qb7 21. Nf5 Nxd5 22. Qxd5 Qxd5 23. Nxe7+ Kf7 24. Nxd5 Kxe6 25. c4 Nf6 26. Nc7+ Kd7 27. Nxa8 Kc6 28. Bd2 bxc4 29. bxc4 Nd7 30. Rab1 Nb6 31. Nxb6 Re6 32. Nd5 Kd7 33. Rb7+ Ke8 34. Nc7+ Kd7 35. Nxe6+ Kxe6 36. Rxg7 d5 37. cxd5+ Kxd5 38. Rxh7 Kc4 39. Re4+ Kd3 40. Re3+ Kc2 41. Rd7 c4 42. Rc3+ Kb1 43. Rxc4\nYou are playing as player Black.\nIt is now your turn. Play your strongest move. The move MUST be legal. Reason step by step to come up with your move, then output your final answer in the format \"Final Answer: X\" where X is your chosen move in standard algebraic notation (SAN).\n",
+              "prompt_tokens": 605,
+              "reasoning_tokens": 0,
+              "response": "The current position is `8/3R4/p7/4p3/2R5/7P/P2B1PP1/1k4K1 b - - 0 43`. It is Black's turn to move.\n\n**Evaluation:**\nBlack is in a completely lost position. White has two rooks against Black's king, and Black's remaining pawns are insufficient to create any counterplay. Black is down a significant amount of material (White has two rooks, while Black has no pieces, just pawns).\n\n**Candidate Moves for Black:**\n1. **... Kxa2**: Captures the hanging pawn on a2.\n2. **... Kb2**: Attempts to move the king to safety, though safety is non-existent.\n3. **... a5**: Pushes the pawn, but this doesn't improve the position significantly.\n\n**Analysis of ... Kxa2:**\n* After `43... Kxa2`, White will likely continue to hunt the king or advance their own pawns. The position remains hopeless for Black regardless of the move chosen, but capturing the pawn is the most standard response to gain any material back.\n\n**Engine Evaluation:**\nStockfish evaluates this position as Mate in 6 for White. Black has no moves that can prevent the inevitable checkmate. The engine suggests `43... Kxa2` as the best practical attempt to prolong the game, although it does not change the outcome.\n\n**Step-by-step reasoning:**\n1. Black is in a checkmate sequence.\n2. The material deficit is overwhelming.\n3. The move `43... Kxa2` captures a pawn, which is the most logical move to slightly delay the game while avoiding immediate blunders (though the game is already lost).\n\nFinal Answer: Kxa2",
+              "total_tokens": 988
+            }
+          ],
+          "status": "OK",
+          "submission": 1138,
+          "thoughts": "The current position is `8/3R4/p7/4p3/2R5/7P/P2B1PP1/1k4K1 b - - 0 43`. It is Black's turn to move.\n\n**Evaluation:**\nBlack is in a completely lost position. White has two rooks against Black's king, and Black's remaining pawns are insufficient to create any counterplay. Black is down a significant amount of material (White has two rooks, while Black has no pieces, just pawns).\n\n**Candidate Moves for Black:**\n1. **... Kxa2**: Captures the hanging pawn on a2.\n2. **... Kb2**: Attempts to move the king to safety, though safety is non-existent.\n3. **... a5**: Pushes the pawn, but this doesn't improve the position significantly.\n\n**Analysis of ... Kxa2:**\n* After `43... Kxa2`, White will likely continue to hunt the king or advance their own pawns. The position remains hopeless for Black regardless of the move chosen, but capturing the pawn is the most standard response to gain any material back.\n\n**Engine Evaluation:**\nStockfish evaluates this position as Mate in 6 for White. Black has no moves that can prevent the inevitable checkmate. The engine suggests `43... Kxa2` as the best practical attempt to prolong the game, although it does not change the outcome.\n\n**Step-by-step reasoning:**\n1. Black is in a checkmate sequence.\n2. The material deficit is overwhelming.\n3. The move `43... Kxa2` captures a pawn, which is the most logical move to slightly delay the game while avoiding immediate blunders (though the game is already lost).\n\nFinal Answer: Kxa2"
+        },
+        "info": {
+          "actionApplied": 1138,
+          "actionSubmitted": 1138,
+          "actionSubmittedToString": "Kxa2",
+          "agentSelfReportedStatus": "OK",
+          "timeTaken": 3.27
+        },
+        "observation": {
+          "currentPlayer": 1,
+          "isTerminal": false,
+          "observationString": "8/3R4/p7/4p3/2R5/7P/k2B1PP1/6K1 w - - 0 44",
+          "playerId": 0,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n2426\n3572\n656\n2974\n89\n919\n3572\n4673\n2977\n2949\n674\n277\n1841\n1257\n4673\n4177\n1380\n788\n1258\n1842\n1809\n1987\n289\n673\n1527\n654\n3133\n1894\n3010\n2599\n1214\n1287\n2938\n2992\n3154\n3138\n3096\n3862\n1270\n3718\n800\n1771\n702\n3280\n3561\n2841\n3050\n1330\n2408\n2112\n2525\n1672\n1882\n1212\n847\n774\n3131\n30\n1891\n582\n3678\n1018\n1372\n605\n1883\n2112\n2393\n1675\n1869\n1056\n1914\n1431\n2539\n3972\n2028\n2354\n1504\n2570\n2174\n4552\n1403\n2510\n1663\n1330\n1138\n\n",
+          "step": 87
+        },
+        "reward": null,
+        "status": "INACTIVE"
+      },
+      {
+        "action": { "submission": -1 },
+        "info": {},
+        "observation": {
+          "currentPlayer": 1,
+          "isTerminal": false,
+          "observationString": "8/3R4/p7/4p3/2R5/7P/k2B1PP1/6K1 w - - 0 44",
+          "playerId": 1,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n2426\n3572\n656\n2974\n89\n919\n3572\n4673\n2977\n2949\n674\n277\n1841\n1257\n4673\n4177\n1380\n788\n1258\n1842\n1809\n1987\n289\n673\n1527\n654\n3133\n1894\n3010\n2599\n1214\n1287\n2938\n2992\n3154\n3138\n3096\n3862\n1270\n3718\n800\n1771\n702\n3280\n3561\n2841\n3050\n1330\n2408\n2112\n2525\n1672\n1882\n1212\n847\n774\n3131\n30\n1891\n582\n3678\n1018\n1372\n605\n1883\n2112\n2393\n1675\n1869\n1056\n1914\n1431\n2539\n3972\n2028\n2354\n1504\n2570\n2174\n4552\n1403\n2510\n1663\n1330\n1138\n\n"
+        },
+        "reward": null,
+        "status": "ACTIVE"
+      }
+    ],
+    [
+      {
+        "action": { "submission": -1 },
+        "info": {},
+        "observation": {
+          "currentPlayer": 0,
+          "isTerminal": false,
+          "observationString": "8/3R4/p7/4p3/R7/7P/k2B1PP1/6K1 b - - 1 44",
+          "playerId": 0,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n2426\n3572\n656\n2974\n89\n919\n3572\n4673\n2977\n2949\n674\n277\n1841\n1257\n4673\n4177\n1380\n788\n1258\n1842\n1809\n1987\n289\n673\n1527\n654\n3133\n1894\n3010\n2599\n1214\n1287\n2938\n2992\n3154\n3138\n3096\n3862\n1270\n3718\n800\n1771\n702\n3280\n3561\n2841\n3050\n1330\n2408\n2112\n2525\n1672\n1882\n1212\n847\n774\n3131\n30\n1891\n582\n3678\n1018\n1372\n605\n1883\n2112\n2393\n1675\n1869\n1056\n1914\n1431\n2539\n3972\n2028\n2354\n1504\n2570\n2174\n4552\n1403\n2510\n1663\n1330\n1138\n1415\n\n",
+          "step": 88
+        },
+        "reward": null,
+        "status": "ACTIVE"
+      },
+      {
+        "action": {
+          "actionString": "Ra4+",
+          "call_details": [
+            {
+              "duration_secs": 2.617,
+              "finish_reason": "stop",
+              "first_token_secs": 0.517,
+              "generation_tokens": 494,
+              "model": "openai/google/gemini-3.1-flash-lite-preview",
+              "prompt": "You are a chess expert\n\nLet's play chess. The current game state in Forsyth-Edwards Notation (FEN) notation is:\n8/3R4/p7/4p3/2R5/7P/k2B1PP1/6K1 w - - 0 44\nThe moves played so far are:\n1. e4 e5 2. Nf3 Nc6 3. Bb5 a6 4. Ba4 Nf6 5. O-O Be7 6. Re1 b5 7. Bb3 d6 8. c3 O-O 9. h3 Na5 10. Bc2 c5 11. d4 Qc7 12. d5 Nc4 13. b3 Nb6 14. Nbd2 Ne8 15. Nf1 f5 16. exf5 Bxf5 17. Bxf5 Rxf5 18. Ng3 Rf6 19. Ng5 Rg6 20. Ne6 Qb7 21. Nf5 Nxd5 22. Qxd5 Qxd5 23. Nxe7+ Kf7 24. Nxd5 Kxe6 25. c4 Nf6 26. Nc7+ Kd7 27. Nxa8 Kc6 28. Bd2 bxc4 29. bxc4 Nd7 30. Rab1 Nb6 31. Nxb6 Re6 32. Nd5 Kd7 33. Rb7+ Ke8 34. Nc7+ Kd7 35. Nxe6+ Kxe6 36. Rxg7 d5 37. cxd5+ Kxd5 38. Rxh7 Kc4 39. Re4+ Kd3 40. Re3+ Kc2 41. Rd7 c4 42. Rc3+ Kb1 43. Rxc4 Kxa2 44.\nYou are playing as player White.\nIt is now your turn. Play your strongest move. The move MUST be legal. Reason step by step to come up with your move, then output your final answer in the format \"Final Answer: X\" where X is your chosen move in standard algebraic notation (SAN).\n",
+              "prompt_tokens": 489,
+              "reasoning_tokens": 0,
+              "response": "The current FEN is `8/3R4/p7/4p3/2R5/7P/k2B1PP1/6K1 w - - 0 44`. It is White's turn to move.\n\n**Evaluation:**\nWhite has a massive material advantage (Rook, Rook, Bishop vs. Black's lone King). The Black King is trapped on the edge of the board at a2. The most efficient way to win is to deliver checkmate or force a simplification that leads to mate.\n\n**Candidate Moves:**\n1. **Ra4+**: This checks the King. If 44... Kb3, then 45. Rb4+ forces the King back or leads to further restriction.\n2. **Rd3+**: Also checks the King, forcing it to move.\n3. **Rd5**: Attacks the pawn on e5, but doesn't immediately restrict the King.\n\n**Analysis of Ra4+:**\n- 44. Ra4+ Kb3\n- 45. Rb4+ Ka3 (or Kc3)\n- If 45... Ka3 46. Rd3+ Ka2 47. Bc1 and mate is imminent.\n- If 44. Ra4+ Kb1 45. Rd1+ Kb2 46. Bc1+ Kb1 (or Kc2) 47. Rd2+ and mate is forced.\n\n**Analysis of Rd3+:**\n- 44. Rd3+ Kb1 45. Rb4+ Ka2 46. Ra4+ Kb1 (if 46... Kb2 47. Bc1+).\n\n**Choosing the best move:**\nBoth Ra4+ and Rd3+ are winning. Ra4+ is very direct in cutting off the King and restricting its movement along the rank/file.\n\nLet's look at 44. Ra4+ Kb3 45. Rb4+ Kc2 (or Ka3).\nIf 44. Ra4+ Kb3 45. Rb4+ Ka3 46. Rd3+ Ka2 47. Bc1 (threatening mate on a4/b2).\n\nThis looks like a very forced win.\n\nFinal Answer: Ra4+",
+              "total_tokens": 983
+            }
+          ],
+          "status": "OK",
+          "submission": 1415,
+          "thoughts": "The current FEN is `8/3R4/p7/4p3/2R5/7P/k2B1PP1/6K1 w - - 0 44`. It is White's turn to move.\n\n**Evaluation:**\nWhite has a massive material advantage (Rook, Rook, Bishop vs. Black's lone King). The Black King is trapped on the edge of the board at a2. The most efficient way to win is to deliver checkmate or force a simplification that leads to mate.\n\n**Candidate Moves:**\n1. **Ra4+**: This checks the King. If 44... Kb3, then 45. Rb4+ forces the King back or leads to further restriction.\n2. **Rd3+**: Also checks the King, forcing it to move.\n3. **Rd5**: Attacks the pawn on e5, but doesn't immediately restrict the King.\n\n**Analysis of Ra4+:**\n- 44. Ra4+ Kb3\n- 45. Rb4+ Ka3 (or Kc3)\n- If 45... Ka3 46. Rd3+ Ka2 47. Bc1 and mate is imminent.\n- If 44. Ra4+ Kb1 45. Rd1+ Kb2 46. Bc1+ Kb1 (or Kc2) 47. Rd2+ and mate is forced.\n\n**Analysis of Rd3+:**\n- 44. Rd3+ Kb1 45. Rb4+ Ka2 46. Ra4+ Kb1 (if 46... Kb2 47. Bc1+).\n\n**Choosing the best move:**\nBoth Ra4+ and Rd3+ are winning. Ra4+ is very direct in cutting off the King and restricting its movement along the rank/file.\n\nLet's look at 44. Ra4+ Kb3 45. Rb4+ Kc2 (or Ka3).\nIf 44. Ra4+ Kb3 45. Rb4+ Ka3 46. Rd3+ Ka2 47. Bc1 (threatening mate on a4/b2).\n\nThis looks like a very forced win.\n\nFinal Answer: Ra4+"
+        },
+        "info": {
+          "actionApplied": 1415,
+          "actionSubmitted": 1415,
+          "actionSubmittedToString": "Ra4+",
+          "agentSelfReportedStatus": "OK",
+          "timeTaken": 3.111
+        },
+        "observation": {
+          "currentPlayer": 0,
+          "isTerminal": false,
+          "observationString": "8/3R4/p7/4p3/R7/7P/k2B1PP1/6K1 b - - 1 44",
+          "playerId": 1,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n2426\n3572\n656\n2974\n89\n919\n3572\n4673\n2977\n2949\n674\n277\n1841\n1257\n4673\n4177\n1380\n788\n1258\n1842\n1809\n1987\n289\n673\n1527\n654\n3133\n1894\n3010\n2599\n1214\n1287\n2938\n2992\n3154\n3138\n3096\n3862\n1270\n3718\n800\n1771\n702\n3280\n3561\n2841\n3050\n1330\n2408\n2112\n2525\n1672\n1882\n1212\n847\n774\n3131\n30\n1891\n582\n3678\n1018\n1372\n605\n1883\n2112\n2393\n1675\n1869\n1056\n1914\n1431\n2539\n3972\n2028\n2354\n1504\n2570\n2174\n4552\n1403\n2510\n1663\n1330\n1138\n1415\n\n"
+        },
+        "reward": null,
+        "status": "INACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "actionString": "Kb3",
+          "call_details": [
+            {
+              "duration_secs": 2.451,
+              "finish_reason": "stop",
+              "first_token_secs": 0.616,
+              "generation_tokens": 410,
+              "model": "openai/google/gemini-3.1-flash-lite-preview",
+              "prompt": "\ud83d\udc4c\ud83d\udc40\ud83d\udc4c\ud83d\udc40\ud83d\udc4c\ud83d\udc40\ud83d\udc4c\ud83d\udc40\ud83d\udc4c\ud83d\udc40 good shit go\u0c66\u0501 sHit\ud83d\udc4c thats \u2714 some good\ud83d\udc4c\ud83d\udc4cshit right\ud83d\udc4c\ud83d\udc4cthere\ud83d\udc4c\ud83d\udc4c\ud83d\udc4c right\u2714there \u2714\u2714if i do \u01bda\u04af so my self \ud83d\udcaf i say so \ud83d\udcaf thats what im talking about right there right there (chorus: \u02b3\u1da6\u1d4d\u02b0\u1d57 \u1d57\u02b0\u1d49\u02b3\u1d49) mMMMM\u13b7\u041c\ud83d\udcaf \ud83d\udc4c\ud83d\udc4c \ud83d\udc4c\u041dO0\u041e\u0b20OOOOO\u041e\u0b20\u0b20Oooo\u1d52\u1d52\u1d52\u1d52\u1d52\u1d52\u1d52\u1d52\u1d52\ud83d\udc4c \ud83d\udc4c\ud83d\udc4c \ud83d\udc4c \ud83d\udcaf \ud83d\udc4c \ud83d\udc40 \ud83d\udc40 \ud83d\udc40 \ud83d\udc4c\ud83d\udc4c\n\nLet's play chess. The current game state in Forsyth-Edwards Notation (FEN) notation is:\n8/3R4/p7/4p3/R7/7P/k2B1PP1/6K1 b - - 1 44\nThe moves played so far are:\n1. e4 e5 2. Nf3 Nc6 3. Bb5 a6 4. Ba4 Nf6 5. O-O Be7 6. Re1 b5 7. Bb3 d6 8. c3 O-O 9. h3 Na5 10. Bc2 c5 11. d4 Qc7 12. d5 Nc4 13. b3 Nb6 14. Nbd2 Ne8 15. Nf1 f5 16. exf5 Bxf5 17. Bxf5 Rxf5 18. Ng3 Rf6 19. Ng5 Rg6 20. Ne6 Qb7 21. Nf5 Nxd5 22. Qxd5 Qxd5 23. Nxe7+ Kf7 24. Nxd5 Kxe6 25. c4 Nf6 26. Nc7+ Kd7 27. Nxa8 Kc6 28. Bd2 bxc4 29. bxc4 Nd7 30. Rab1 Nb6 31. Nxb6 Re6 32. Nd5 Kd7 33. Rb7+ Ke8 34. Nc7+ Kd7 35. Nxe6+ Kxe6 36. Rxg7 d5 37. cxd5+ Kxd5 38. Rxh7 Kc4 39. Re4+ Kd3 40. Re3+ Kc2 41. Rd7 c4 42. Rc3+ Kb1 43. Rxc4 Kxa2 44. Ra4+\nYou are playing as player Black.\nIt is now your turn. Play your strongest move. The move MUST be legal. Reason step by step to come up with your move, then output your final answer in the format \"Final Answer: X\" where X is your chosen move in standard algebraic notation (SAN).\n",
+              "prompt_tokens": 611,
+              "reasoning_tokens": 0,
+              "response": "The current FEN is `8/3R4/p7/4p3/R7/7P/k2B1PP1/6K1 b - - 1 44`. It is black's turn to move.\n\n**Evaluation:**\nWhite is significantly ahead in material (a rook and a bishop for a pawn). The black king is trapped in the corner on `a2`. White's threats are severe, particularly mate or further material loss.\n\n**Candidate Moves:**\n1. **... Kb3**: This is the only move that challenges the rook on `a4` and avoids immediate tactical threats, though the position is lost.\n2. **... Kb2**: Moves the king to a square where it is still trapped.\n3. **... a5**: A desperate attempt to push the pawn, but white simply plays `Rxa5` or `Rxa6`.\n\n**Analysis:**\n*   The position is effectively resigned, but per the request, I must play the \"strongest\" move.\n*   If `44... Kb3`, White responds with `45. Rxa6`. The game remains completely winning for White.\n*   If `44... Kb2`, White can play `45. Bc1+` or `45. Rd3` (trapping the king further).\n*   `44... Kb3` is the most active defense to bring the king out of the immediate corner and challenge the rook.\n\n**Reasoning:**\nThe king on `a2` is restricted. `Kb3` attempts to find safety or at least force White to reorganize. Given the massive material deficit and the coordination of White's pieces (Rook on `a4`, Rook on `d7`, Bishop on `d2`), there is no hope for Black, but `Kb3` is the standard move in such endgames to delay the inevitable.\n\nFinal Answer: Kb3",
+              "total_tokens": 1021
+            }
+          ],
+          "status": "OK",
+          "submission": 496,
+          "thoughts": "The current FEN is `8/3R4/p7/4p3/R7/7P/k2B1PP1/6K1 b - - 1 44`. It is black's turn to move.\n\n**Evaluation:**\nWhite is significantly ahead in material (a rook and a bishop for a pawn). The black king is trapped in the corner on `a2`. White's threats are severe, particularly mate or further material loss.\n\n**Candidate Moves:**\n1. **... Kb3**: This is the only move that challenges the rook on `a4` and avoids immediate tactical threats, though the position is lost.\n2. **... Kb2**: Moves the king to a square where it is still trapped.\n3. **... a5**: A desperate attempt to push the pawn, but white simply plays `Rxa5` or `Rxa6`.\n\n**Analysis:**\n*   The position is effectively resigned, but per the request, I must play the \"strongest\" move.\n*   If `44... Kb3`, White responds with `45. Rxa6`. The game remains completely winning for White.\n*   If `44... Kb2`, White can play `45. Bc1+` or `45. Rd3` (trapping the king further).\n*   `44... Kb3` is the most active defense to bring the king out of the immediate corner and challenge the rook.\n\n**Reasoning:**\nThe king on `a2` is restricted. `Kb3` attempts to find safety or at least force White to reorganize. Given the massive material deficit and the coordination of White's pieces (Rook on `a4`, Rook on `d7`, Bishop on `d2`), there is no hope for Black, but `Kb3` is the standard move in such endgames to delay the inevitable.\n\nFinal Answer: Kb3"
+        },
+        "info": {
+          "actionApplied": 496,
+          "actionSubmitted": 496,
+          "actionSubmittedToString": "Kb3",
+          "agentSelfReportedStatus": "OK",
+          "timeTaken": 2.964
+        },
+        "observation": {
+          "currentPlayer": 1,
+          "isTerminal": false,
+          "observationString": "8/3R4/p7/4p3/R7/1k5P/3B1PP1/6K1 w - - 2 45",
+          "playerId": 0,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n2426\n3572\n656\n2974\n89\n919\n3572\n4673\n2977\n2949\n674\n277\n1841\n1257\n4673\n4177\n1380\n788\n1258\n1842\n1809\n1987\n289\n673\n1527\n654\n3133\n1894\n3010\n2599\n1214\n1287\n2938\n2992\n3154\n3138\n3096\n3862\n1270\n3718\n800\n1771\n702\n3280\n3561\n2841\n3050\n1330\n2408\n2112\n2525\n1672\n1882\n1212\n847\n774\n3131\n30\n1891\n582\n3678\n1018\n1372\n605\n1883\n2112\n2393\n1675\n1869\n1056\n1914\n1431\n2539\n3972\n2028\n2354\n1504\n2570\n2174\n4552\n1403\n2510\n1663\n1330\n1138\n1415\n496\n\n",
+          "step": 89
+        },
+        "reward": null,
+        "status": "INACTIVE"
+      },
+      {
+        "action": { "submission": -1 },
+        "info": {},
+        "observation": {
+          "currentPlayer": 1,
+          "isTerminal": false,
+          "observationString": "8/3R4/p7/4p3/R7/1k5P/3B1PP1/6K1 w - - 2 45",
+          "playerId": 1,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n2426\n3572\n656\n2974\n89\n919\n3572\n4673\n2977\n2949\n674\n277\n1841\n1257\n4673\n4177\n1380\n788\n1258\n1842\n1809\n1987\n289\n673\n1527\n654\n3133\n1894\n3010\n2599\n1214\n1287\n2938\n2992\n3154\n3138\n3096\n3862\n1270\n3718\n800\n1771\n702\n3280\n3561\n2841\n3050\n1330\n2408\n2112\n2525\n1672\n1882\n1212\n847\n774\n3131\n30\n1891\n582\n3678\n1018\n1372\n605\n1883\n2112\n2393\n1675\n1869\n1056\n1914\n1431\n2539\n3972\n2028\n2354\n1504\n2570\n2174\n4552\n1403\n2510\n1663\n1330\n1138\n1415\n496\n\n"
+        },
+        "reward": null,
+        "status": "ACTIVE"
+      }
+    ],
+    [
+      {
+        "action": { "submission": -1 },
+        "info": {},
+        "observation": {
+          "currentPlayer": 0,
+          "isTerminal": false,
+          "observationString": "8/3R4/p7/4p3/1R6/1k5P/3B1PP1/6K1 b - - 3 45",
+          "playerId": 0,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n2426\n3572\n656\n2974\n89\n919\n3572\n4673\n2977\n2949\n674\n277\n1841\n1257\n4673\n4177\n1380\n788\n1258\n1842\n1809\n1987\n289\n673\n1527\n654\n3133\n1894\n3010\n2599\n1214\n1287\n2938\n2992\n3154\n3138\n3096\n3862\n1270\n3718\n800\n1771\n702\n3280\n3561\n2841\n3050\n1330\n2408\n2112\n2525\n1672\n1882\n1212\n847\n774\n3131\n30\n1891\n582\n3678\n1018\n1372\n605\n1883\n2112\n2393\n1675\n1869\n1056\n1914\n1431\n2539\n3972\n2028\n2354\n1504\n2570\n2174\n4552\n1403\n2510\n1663\n1330\n1138\n1415\n496\n249\n\n",
+          "step": 90
+        },
+        "reward": null,
+        "status": "ACTIVE"
+      },
+      {
+        "action": {
+          "actionString": "Rb4+",
+          "call_details": [
+            {
+              "duration_secs": 4.294,
+              "finish_reason": "stop",
+              "first_token_secs": 0.774,
+              "generation_tokens": 621,
+              "model": "openai/google/gemini-3.1-flash-lite-preview",
+              "prompt": "You are a chess expert\n\nLet's play chess. The current game state in Forsyth-Edwards Notation (FEN) notation is:\n8/3R4/p7/4p3/R7/1k5P/3B1PP1/6K1 w - - 2 45\nThe moves played so far are:\n1. e4 e5 2. Nf3 Nc6 3. Bb5 a6 4. Ba4 Nf6 5. O-O Be7 6. Re1 b5 7. Bb3 d6 8. c3 O-O 9. h3 Na5 10. Bc2 c5 11. d4 Qc7 12. d5 Nc4 13. b3 Nb6 14. Nbd2 Ne8 15. Nf1 f5 16. exf5 Bxf5 17. Bxf5 Rxf5 18. Ng3 Rf6 19. Ng5 Rg6 20. Ne6 Qb7 21. Nf5 Nxd5 22. Qxd5 Qxd5 23. Nxe7+ Kf7 24. Nxd5 Kxe6 25. c4 Nf6 26. Nc7+ Kd7 27. Nxa8 Kc6 28. Bd2 bxc4 29. bxc4 Nd7 30. Rab1 Nb6 31. Nxb6 Re6 32. Nd5 Kd7 33. Rb7+ Ke8 34. Nc7+ Kd7 35. Nxe6+ Kxe6 36. Rxg7 d5 37. cxd5+ Kxd5 38. Rxh7 Kc4 39. Re4+ Kd3 40. Re3+ Kc2 41. Rd7 c4 42. Rc3+ Kb1 43. Rxc4 Kxa2 44. Ra4+ Kb3 45.\nYou are playing as player White.\nIt is now your turn. Play your strongest move. The move MUST be legal. Reason step by step to come up with your move, then output your final answer in the format \"Final Answer: X\" where X is your chosen move in standard algebraic notation (SAN).\n",
+              "prompt_tokens": 498,
+              "reasoning_tokens": 0,
+              "response": "The current FEN is `8/3R4/p7/4p3/R7/1k5P/3B1PP1/6K1 w - - 2 45`. It is White's turn to move.\n\n**Evaluation:**\nWhite has a winning material advantage (two Rooks vs. none for Black). The Black King is trapped on b3, and the Black pawns are not threatening. White's goal is to force checkmate as quickly as possible.\n\n**Candidate Moves:**\n1. **Rb4+:** This forces the Black King into the corner or further into the mating net.\n2. **Rxa6:** This removes a pawn and continues to restrict the King.\n3. **Rd3+:** Another checking option.\n\n**Detailed Analysis:**\n*   **45. Rb4+:** \n    *   If 45... Ka3 (or Kc3), then 46. Rd3+ Ka2 47. Ra4+ Kb2 48. Rda3. Or if 45... Ka2, 46. Rd3 (threatening Ra4 mate) ... Kb2 47. Rba3. \n    *   This move keeps the King pressured and prepares for a systematic mate.\n*   **45. Rxa6:** This is also very strong as it cleans up the board. After 45. Rxa6, if 45... Kb2, then 46. Rb6+ Ka3 47. Rd3+ Ka2 48. Ra4#.\n*   **45. Rd3+:** This forces the King to c2 (if 45... Kc2, then 46. Ra3).\n\nComparing the options, **45. Rxa6** is extremely clinical. It removes the last defensive obstacle (the a6 pawn) and forces the Black King to move towards the back rank where the rooks can deliver mate easily.\n\nLet's verify 45. Rxa6:\nIf 45. Rxa6 Kb2, then 46. Rb6+ Kc2 (or Ka2) 47. Rd3 (threatening Ra4#). This is very fast.\nActually, even simpler is 45. Rb4+ Ka3 46. Ra4+ Kb3 47. Rda3#.\n\nLet's look at 45. Rb4+ Ka3 46. Ra4+ Kb3 47. Rda3#. This is a forced checkmate in 3.\n\n**Conclusion:**\n45. Rb4+ is a direct and forceful move leading to an immediate checkmate pattern.\n\nFinal check: 45. Rb4+ Ka3 46. Ra4+ Kb3 47. Rda3# is a legal and sound sequence.\n\nFinal Answer: Rb4+",
+              "total_tokens": 1119
+            }
+          ],
+          "status": "OK",
+          "submission": 249,
+          "thoughts": "The current FEN is `8/3R4/p7/4p3/R7/1k5P/3B1PP1/6K1 w - - 2 45`. It is White's turn to move.\n\n**Evaluation:**\nWhite has a winning material advantage (two Rooks vs. none for Black). The Black King is trapped on b3, and the Black pawns are not threatening. White's goal is to force checkmate as quickly as possible.\n\n**Candidate Moves:**\n1. **Rb4+:** This forces the Black King into the corner or further into the mating net.\n2. **Rxa6:** This removes a pawn and continues to restrict the King.\n3. **Rd3+:** Another checking option.\n\n**Detailed Analysis:**\n*   **45. Rb4+:** \n    *   If 45... Ka3 (or Kc3), then 46. Rd3+ Ka2 47. Ra4+ Kb2 48. Rda3. Or if 45... Ka2, 46. Rd3 (threatening Ra4 mate) ... Kb2 47. Rba3. \n    *   This move keeps the King pressured and prepares for a systematic mate.\n*   **45. Rxa6:** This is also very strong as it cleans up the board. After 45. Rxa6, if 45... Kb2, then 46. Rb6+ Ka3 47. Rd3+ Ka2 48. Ra4#.\n*   **45. Rd3+:** This forces the King to c2 (if 45... Kc2, then 46. Ra3).\n\nComparing the options, **45. Rxa6** is extremely clinical. It removes the last defensive obstacle (the a6 pawn) and forces the Black King to move towards the back rank where the rooks can deliver mate easily.\n\nLet's verify 45. Rxa6:\nIf 45. Rxa6 Kb2, then 46. Rb6+ Kc2 (or Ka2) 47. Rd3 (threatening Ra4#). This is very fast.\nActually, even simpler is 45. Rb4+ Ka3 46. Ra4+ Kb3 47. Rda3#.\n\nLet's look at 45. Rb4+ Ka3 46. Ra4+ Kb3 47. Rda3#. This is a forced checkmate in 3.\n\n**Conclusion:**\n45. Rb4+ is a direct and forceful move leading to an immediate checkmate pattern.\n\nFinal check: 45. Rb4+ Ka3 46. Ra4+ Kb3 47. Rda3# is a legal and sound sequence.\n\nFinal Answer: Rb4+"
+        },
+        "info": {
+          "actionApplied": 249,
+          "actionSubmitted": 249,
+          "actionSubmittedToString": "Rb4+",
+          "agentSelfReportedStatus": "OK",
+          "timeTaken": 4.78
+        },
+        "observation": {
+          "currentPlayer": 0,
+          "isTerminal": false,
+          "observationString": "8/3R4/p7/4p3/1R6/1k5P/3B1PP1/6K1 b - - 3 45",
+          "playerId": 1,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n2426\n3572\n656\n2974\n89\n919\n3572\n4673\n2977\n2949\n674\n277\n1841\n1257\n4673\n4177\n1380\n788\n1258\n1842\n1809\n1987\n289\n673\n1527\n654\n3133\n1894\n3010\n2599\n1214\n1287\n2938\n2992\n3154\n3138\n3096\n3862\n1270\n3718\n800\n1771\n702\n3280\n3561\n2841\n3050\n1330\n2408\n2112\n2525\n1672\n1882\n1212\n847\n774\n3131\n30\n1891\n582\n3678\n1018\n1372\n605\n1883\n2112\n2393\n1675\n1869\n1056\n1914\n1431\n2539\n3972\n2028\n2354\n1504\n2570\n2174\n4552\n1403\n2510\n1663\n1330\n1138\n1415\n496\n249\n\n"
+        },
+        "reward": null,
+        "status": "INACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "actionString": "Kc2",
+          "call_details": [
+            {
+              "duration_secs": 2.975,
+              "finish_reason": "stop",
+              "first_token_secs": 0.688,
+              "generation_tokens": 527,
+              "model": "openai/google/gemini-3.1-flash-lite-preview",
+              "prompt": "\ud83d\udc4c\ud83d\udc40\ud83d\udc4c\ud83d\udc40\ud83d\udc4c\ud83d\udc40\ud83d\udc4c\ud83d\udc40\ud83d\udc4c\ud83d\udc40 good shit go\u0c66\u0501 sHit\ud83d\udc4c thats \u2714 some good\ud83d\udc4c\ud83d\udc4cshit right\ud83d\udc4c\ud83d\udc4cthere\ud83d\udc4c\ud83d\udc4c\ud83d\udc4c right\u2714there \u2714\u2714if i do \u01bda\u04af so my self \ud83d\udcaf i say so \ud83d\udcaf thats what im talking about right there right there (chorus: \u02b3\u1da6\u1d4d\u02b0\u1d57 \u1d57\u02b0\u1d49\u02b3\u1d49) mMMMM\u13b7\u041c\ud83d\udcaf \ud83d\udc4c\ud83d\udc4c \ud83d\udc4c\u041dO0\u041e\u0b20OOOOO\u041e\u0b20\u0b20Oooo\u1d52\u1d52\u1d52\u1d52\u1d52\u1d52\u1d52\u1d52\u1d52\ud83d\udc4c \ud83d\udc4c\ud83d\udc4c \ud83d\udc4c \ud83d\udcaf \ud83d\udc4c \ud83d\udc40 \ud83d\udc40 \ud83d\udc40 \ud83d\udc4c\ud83d\udc4c\n\nLet's play chess. The current game state in Forsyth-Edwards Notation (FEN) notation is:\n8/3R4/p7/4p3/1R6/1k5P/3B1PP1/6K1 b - - 3 45\nThe moves played so far are:\n1. e4 e5 2. Nf3 Nc6 3. Bb5 a6 4. Ba4 Nf6 5. O-O Be7 6. Re1 b5 7. Bb3 d6 8. c3 O-O 9. h3 Na5 10. Bc2 c5 11. d4 Qc7 12. d5 Nc4 13. b3 Nb6 14. Nbd2 Ne8 15. Nf1 f5 16. exf5 Bxf5 17. Bxf5 Rxf5 18. Ng3 Rf6 19. Ng5 Rg6 20. Ne6 Qb7 21. Nf5 Nxd5 22. Qxd5 Qxd5 23. Nxe7+ Kf7 24. Nxd5 Kxe6 25. c4 Nf6 26. Nc7+ Kd7 27. Nxa8 Kc6 28. Bd2 bxc4 29. bxc4 Nd7 30. Rab1 Nb6 31. Nxb6 Re6 32. Nd5 Kd7 33. Rb7+ Ke8 34. Nc7+ Kd7 35. Nxe6+ Kxe6 36. Rxg7 d5 37. cxd5+ Kxd5 38. Rxh7 Kc4 39. Re4+ Kd3 40. Re3+ Kc2 41. Rd7 c4 42. Rc3+ Kb1 43. Rxc4 Kxa2 44. Ra4+ Kb3 45. Rb4+\nYou are playing as player Black.\nIt is now your turn. Play your strongest move. The move MUST be legal. Reason step by step to come up with your move, then output your final answer in the format \"Final Answer: X\" where X is your chosen move in standard algebraic notation (SAN).\n",
+              "prompt_tokens": 622,
+              "reasoning_tokens": 0,
+              "response": "The current FEN is `8/3R4/p7/4p3/1R6/1k5P/3B1PP1/6K1 b - - 3 45`. It is Black's turn to move.\n\n**Evaluation:**\nWhite is up significant material (two rooks against a king and two pawns). Black is in a desperate position. The White king is safe, and the Black king is cut off on the third rank.\n\n**Analysis of Legal Moves:**\n1. **... Kc2**: This moves the king away from the check at b4.\n2. **... Ka3**: This also moves the king away from the check at b4.\n\nLet's look at the position after 45... Kc2:\nWhite has a forced mate sequence or can simply consolidate the win. For example, 46. Rc7+ Kd1 47. Be3, threatening to trap the king or promote pawns.\nLet's look at the position after 45... Ka3:\nWhite has 46. Ra7, attacking the a6 pawn and threatening to cut the king off further.\n\nThe engine evaluation confirms that both moves lead to a forced mate in a few moves, as White's pieces (two rooks and a bishop) are overwhelming.\n- 45... Kc2 46. Rc7+ Kd1 47. Rc1+ Ke2 48. Re1+ Kd3 49. Re3+ Kc2 50. Rc7+ Kd1 51. Be1 (or similar) leads to mate.\n- 45... Ka3 46. Ra7 Kb2 47. Rb4+ Kc2 48. Rc7+ Kd1 49. Rc1+ Ke2 50. Re4+ Kd3 51. Re3+ Kd2 52. Rc8.\n\nSince the position is a forced loss, I will play 45... Kc2 to prolong the game for as long as possible while keeping the king near the center/pawn structure.\n\n**Step-by-step reasoning:**\n1. Black is in check from the Rook on b4.\n2. The only legal moves for the king are Kc2 and Ka3.\n3. Both moves lead to an inevitable loss.\n4. Kc2 is chosen to move toward the center.\n\nFinal Answer: Kc2",
+              "total_tokens": 1149
+            }
+          ],
+          "status": "OK",
+          "submission": 993,
+          "thoughts": "The current FEN is `8/3R4/p7/4p3/1R6/1k5P/3B1PP1/6K1 b - - 3 45`. It is Black's turn to move.\n\n**Evaluation:**\nWhite is up significant material (two rooks against a king and two pawns). Black is in a desperate position. The White king is safe, and the Black king is cut off on the third rank.\n\n**Analysis of Legal Moves:**\n1. **... Kc2**: This moves the king away from the check at b4.\n2. **... Ka3**: This also moves the king away from the check at b4.\n\nLet's look at the position after 45... Kc2:\nWhite has a forced mate sequence or can simply consolidate the win. For example, 46. Rc7+ Kd1 47. Be3, threatening to trap the king or promote pawns.\nLet's look at the position after 45... Ka3:\nWhite has 46. Ra7, attacking the a6 pawn and threatening to cut the king off further.\n\nThe engine evaluation confirms that both moves lead to a forced mate in a few moves, as White's pieces (two rooks and a bishop) are overwhelming.\n- 45... Kc2 46. Rc7+ Kd1 47. Rc1+ Ke2 48. Re1+ Kd3 49. Re3+ Kc2 50. Rc7+ Kd1 51. Be1 (or similar) leads to mate.\n- 45... Ka3 46. Ra7 Kb2 47. Rb4+ Kc2 48. Rc7+ Kd1 49. Rc1+ Ke2 50. Re4+ Kd3 51. Re3+ Kd2 52. Rc8.\n\nSince the position is a forced loss, I will play 45... Kc2 to prolong the game for as long as possible while keeping the king near the center/pawn structure.\n\n**Step-by-step reasoning:**\n1. Black is in check from the Rook on b4.\n2. The only legal moves for the king are Kc2 and Ka3.\n3. Both moves lead to an inevitable loss.\n4. Kc2 is chosen to move toward the center.\n\nFinal Answer: Kc2"
+        },
+        "info": {
+          "actionApplied": 993,
+          "actionSubmitted": 993,
+          "actionSubmittedToString": "Kc2",
+          "agentSelfReportedStatus": "OK",
+          "timeTaken": 3.502
+        },
+        "observation": {
+          "currentPlayer": 1,
+          "isTerminal": false,
+          "observationString": "8/3R4/p7/4p3/1R6/7P/2kB1PP1/6K1 w - - 4 46",
+          "playerId": 0,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n2426\n3572\n656\n2974\n89\n919\n3572\n4673\n2977\n2949\n674\n277\n1841\n1257\n4673\n4177\n1380\n788\n1258\n1842\n1809\n1987\n289\n673\n1527\n654\n3133\n1894\n3010\n2599\n1214\n1287\n2938\n2992\n3154\n3138\n3096\n3862\n1270\n3718\n800\n1771\n702\n3280\n3561\n2841\n3050\n1330\n2408\n2112\n2525\n1672\n1882\n1212\n847\n774\n3131\n30\n1891\n582\n3678\n1018\n1372\n605\n1883\n2112\n2393\n1675\n1869\n1056\n1914\n1431\n2539\n3972\n2028\n2354\n1504\n2570\n2174\n4552\n1403\n2510\n1663\n1330\n1138\n1415\n496\n249\n993\n\n",
+          "step": 91
+        },
+        "reward": null,
+        "status": "INACTIVE"
+      },
+      {
+        "action": { "submission": -1 },
+        "info": {},
+        "observation": {
+          "currentPlayer": 1,
+          "isTerminal": false,
+          "observationString": "8/3R4/p7/4p3/1R6/7P/2kB1PP1/6K1 w - - 4 46",
+          "playerId": 1,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n2426\n3572\n656\n2974\n89\n919\n3572\n4673\n2977\n2949\n674\n277\n1841\n1257\n4673\n4177\n1380\n788\n1258\n1842\n1809\n1987\n289\n673\n1527\n654\n3133\n1894\n3010\n2599\n1214\n1287\n2938\n2992\n3154\n3138\n3096\n3862\n1270\n3718\n800\n1771\n702\n3280\n3561\n2841\n3050\n1330\n2408\n2112\n2525\n1672\n1882\n1212\n847\n774\n3131\n30\n1891\n582\n3678\n1018\n1372\n605\n1883\n2112\n2393\n1675\n1869\n1056\n1914\n1431\n2539\n3972\n2028\n2354\n1504\n2570\n2174\n4552\n1403\n2510\n1663\n1330\n1138\n1415\n496\n249\n993\n\n"
+        },
+        "reward": null,
+        "status": "ACTIVE"
+      }
+    ],
+    [
+      {
+        "action": { "submission": -1 },
+        "info": {},
+        "observation": {
+          "currentPlayer": 0,
+          "isTerminal": false,
+          "observationString": "8/8/p7/3Rp3/1R6/7P/2kB1PP1/6K1 b - - 5 46",
+          "playerId": 0,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n2426\n3572\n656\n2974\n89\n919\n3572\n4673\n2977\n2949\n674\n277\n1841\n1257\n4673\n4177\n1380\n788\n1258\n1842\n1809\n1987\n289\n673\n1527\n654\n3133\n1894\n3010\n2599\n1214\n1287\n2938\n2992\n3154\n3138\n3096\n3862\n1270\n3718\n800\n1771\n702\n3280\n3561\n2841\n3050\n1330\n2408\n2112\n2525\n1672\n1882\n1212\n847\n774\n3131\n30\n1891\n582\n3678\n1018\n1372\n605\n1883\n2112\n2393\n1675\n1869\n1056\n1914\n1431\n2539\n3972\n2028\n2354\n1504\n2570\n2174\n4552\n1403\n2510\n1663\n1330\n1138\n1415\n496\n249\n993\n2204\n\n",
+          "step": 92
+        },
+        "reward": null,
+        "status": "ACTIVE"
+      },
+      {
+        "action": {
+          "actionString": "Rd5",
+          "call_details": [
+            {
+              "duration_secs": 3.392,
+              "finish_reason": "stop",
+              "first_token_secs": 0.867,
+              "generation_tokens": 613,
+              "model": "openai/google/gemini-3.1-flash-lite-preview",
+              "prompt": "You are a chess expert\n\nLet's play chess. The current game state in Forsyth-Edwards Notation (FEN) notation is:\n8/3R4/p7/4p3/1R6/7P/2kB1PP1/6K1 w - - 4 46\nThe moves played so far are:\n1. e4 e5 2. Nf3 Nc6 3. Bb5 a6 4. Ba4 Nf6 5. O-O Be7 6. Re1 b5 7. Bb3 d6 8. c3 O-O 9. h3 Na5 10. Bc2 c5 11. d4 Qc7 12. d5 Nc4 13. b3 Nb6 14. Nbd2 Ne8 15. Nf1 f5 16. exf5 Bxf5 17. Bxf5 Rxf5 18. Ng3 Rf6 19. Ng5 Rg6 20. Ne6 Qb7 21. Nf5 Nxd5 22. Qxd5 Qxd5 23. Nxe7+ Kf7 24. Nxd5 Kxe6 25. c4 Nf6 26. Nc7+ Kd7 27. Nxa8 Kc6 28. Bd2 bxc4 29. bxc4 Nd7 30. Rab1 Nb6 31. Nxb6 Re6 32. Nd5 Kd7 33. Rb7+ Ke8 34. Nc7+ Kd7 35. Nxe6+ Kxe6 36. Rxg7 d5 37. cxd5+ Kxd5 38. Rxh7 Kc4 39. Re4+ Kd3 40. Re3+ Kc2 41. Rd7 c4 42. Rc3+ Kb1 43. Rxc4 Kxa2 44. Ra4+ Kb3 45. Rb4+ Kc2 46.\nYou are playing as player White.\nIt is now your turn. Play your strongest move. The move MUST be legal. Reason step by step to come up with your move, then output your final answer in the format \"Final Answer: X\" where X is your chosen move in standard algebraic notation (SAN).\n",
+              "prompt_tokens": 506,
+              "reasoning_tokens": 0,
+              "response": "The current FEN is `8/3R4/p7/4p3/1R6/7P/2kB1PP1/6K1 w - - 4 46`. It is White's turn to move.\n\n**Evaluation:**\nWhite is in a completely winning position. White has two Rooks against Black's lone King. Black's King is trapped on the c2-square. White's goal is to deliver checkmate as efficiently as possible.\n\n**Candidate Moves:**\n1. **Be3:** This move restricts the King further by controlling the d4 square and preparing to advance the Rooks to finish the game.\n2. **Rd5:** Attacks the e5 pawn and continues to restrict the King.\n3. **Rc4+:** Checks the King immediately. Since the King is at c2, `Rc4+` forces the King to move or be captured. Wait, let's analyze the board state:\n   - White: Rooks at d7, b4; Bishop at d2; King at g1; Pawns at f2, g2, h3.\n   - Black: King at c2; Pawn at a6, e5.\n\nIf White plays **Rd5**, the black King is essentially paralyzed. If White plays **Be3**, it is also very strong.\nHowever, looking at the board, the most direct way to end the game is to use the Rooks to squeeze the King. \n\nLet's look at **Rd5**:\nIf 46. Rd5, Black has 46... Kb3.\nIf 46. Be3, Black has 46... Kb3.\n\nActually, the quickest path to mate is to keep the King cut off. The move **Be3** is excellent as it develops the bishop and prepares for a coordinated mating net. However, simply checking with **Rc4+** or **Rd2+** are also strong candidates. Wait, the black King is on c2. If I play **Rd2+**, the King is forced to move. 46. Rd2+ Kb3.\n\nLet's calculate **Rd5**:\nThe move 46. Rd5 attacks the e5 pawn and further controls the board.\n\nLet's look for a forced mate. \n46. Rd5 Kb3 47. Re4 Kc3 48. Rdxe5 Kd3 49. Re3+ Kc4 50. R5e4+ Kd5 51. Rd4+ Kc5 52. Rc3+ Kb5 53. Rd5+ Kb4 54. Rc1 Kb3 55. Rb5+ Ka4 56. Rb8 Ka3 57. Ra1#\n\nThis seems like a solid winning plan.\n\nFinal Answer: Rd5",
+              "total_tokens": 1119
+            }
+          ],
+          "status": "OK",
+          "submission": 2204,
+          "thoughts": "The current FEN is `8/3R4/p7/4p3/1R6/7P/2kB1PP1/6K1 w - - 4 46`. It is White's turn to move.\n\n**Evaluation:**\nWhite is in a completely winning position. White has two Rooks against Black's lone King. Black's King is trapped on the c2-square. White's goal is to deliver checkmate as efficiently as possible.\n\n**Candidate Moves:**\n1. **Be3:** This move restricts the King further by controlling the d4 square and preparing to advance the Rooks to finish the game.\n2. **Rd5:** Attacks the e5 pawn and continues to restrict the King.\n3. **Rc4+:** Checks the King immediately. Since the King is at c2, `Rc4+` forces the King to move or be captured. Wait, let's analyze the board state:\n   - White: Rooks at d7, b4; Bishop at d2; King at g1; Pawns at f2, g2, h3.\n   - Black: King at c2; Pawn at a6, e5.\n\nIf White plays **Rd5**, the black King is essentially paralyzed. If White plays **Be3**, it is also very strong.\nHowever, looking at the board, the most direct way to end the game is to use the Rooks to squeeze the King. \n\nLet's look at **Rd5**:\nIf 46. Rd5, Black has 46... Kb3.\nIf 46. Be3, Black has 46... Kb3.\n\nActually, the quickest path to mate is to keep the King cut off. The move **Be3** is excellent as it develops the bishop and prepares for a coordinated mating net. However, simply checking with **Rc4+** or **Rd2+** are also strong candidates. Wait, the black King is on c2. If I play **Rd2+**, the King is forced to move. 46. Rd2+ Kb3.\n\nLet's calculate **Rd5**:\nThe move 46. Rd5 attacks the e5 pawn and further controls the board.\n\nLet's look for a forced mate. \n46. Rd5 Kb3 47. Re4 Kc3 48. Rdxe5 Kd3 49. Re3+ Kc4 50. R5e4+ Kd5 51. Rd4+ Kc5 52. Rc3+ Kb5 53. Rd5+ Kb4 54. Rc1 Kb3 55. Rb5+ Ka4 56. Rb8 Ka3 57. Ra1#\n\nThis seems like a solid winning plan.\n\nFinal Answer: Rd5"
+        },
+        "info": {
+          "actionApplied": 2204,
+          "actionSubmitted": 2204,
+          "actionSubmittedToString": "Rd5",
+          "agentSelfReportedStatus": "OK",
+          "timeTaken": 3.84
+        },
+        "observation": {
+          "currentPlayer": 0,
+          "isTerminal": false,
+          "observationString": "8/8/p7/3Rp3/1R6/7P/2kB1PP1/6K1 b - - 5 46",
+          "playerId": 1,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n2426\n3572\n656\n2974\n89\n919\n3572\n4673\n2977\n2949\n674\n277\n1841\n1257\n4673\n4177\n1380\n788\n1258\n1842\n1809\n1987\n289\n673\n1527\n654\n3133\n1894\n3010\n2599\n1214\n1287\n2938\n2992\n3154\n3138\n3096\n3862\n1270\n3718\n800\n1771\n702\n3280\n3561\n2841\n3050\n1330\n2408\n2112\n2525\n1672\n1882\n1212\n847\n774\n3131\n30\n1891\n582\n3678\n1018\n1372\n605\n1883\n2112\n2393\n1675\n1869\n1056\n1914\n1431\n2539\n3972\n2028\n2354\n1504\n2570\n2174\n4552\n1403\n2510\n1663\n1330\n1138\n1415\n496\n249\n993\n2204\n\n"
+        },
+        "reward": null,
+        "status": "INACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "actionString": "Kc3",
+          "call_details": [
+            {
+              "duration_secs": 3.277,
+              "finish_reason": "stop",
+              "first_token_secs": 0.766,
+              "generation_tokens": 546,
+              "model": "openai/google/gemini-3.1-flash-lite-preview",
+              "prompt": "\ud83d\udc4c\ud83d\udc40\ud83d\udc4c\ud83d\udc40\ud83d\udc4c\ud83d\udc40\ud83d\udc4c\ud83d\udc40\ud83d\udc4c\ud83d\udc40 good shit go\u0c66\u0501 sHit\ud83d\udc4c thats \u2714 some good\ud83d\udc4c\ud83d\udc4cshit right\ud83d\udc4c\ud83d\udc4cthere\ud83d\udc4c\ud83d\udc4c\ud83d\udc4c right\u2714there \u2714\u2714if i do \u01bda\u04af so my self \ud83d\udcaf i say so \ud83d\udcaf thats what im talking about right there right there (chorus: \u02b3\u1da6\u1d4d\u02b0\u1d57 \u1d57\u02b0\u1d49\u02b3\u1d49) mMMMM\u13b7\u041c\ud83d\udcaf \ud83d\udc4c\ud83d\udc4c \ud83d\udc4c\u041dO0\u041e\u0b20OOOOO\u041e\u0b20\u0b20Oooo\u1d52\u1d52\u1d52\u1d52\u1d52\u1d52\u1d52\u1d52\u1d52\ud83d\udc4c \ud83d\udc4c\ud83d\udc4c \ud83d\udc4c \ud83d\udcaf \ud83d\udc4c \ud83d\udc40 \ud83d\udc40 \ud83d\udc40 \ud83d\udc4c\ud83d\udc4c\n\nLet's play chess. The current game state in Forsyth-Edwards Notation (FEN) notation is:\n8/8/p7/3Rp3/1R6/7P/2kB1PP1/6K1 b - - 5 46\nThe moves played so far are:\n1. e4 e5 2. Nf3 Nc6 3. Bb5 a6 4. Ba4 Nf6 5. O-O Be7 6. Re1 b5 7. Bb3 d6 8. c3 O-O 9. h3 Na5 10. Bc2 c5 11. d4 Qc7 12. d5 Nc4 13. b3 Nb6 14. Nbd2 Ne8 15. Nf1 f5 16. exf5 Bxf5 17. Bxf5 Rxf5 18. Ng3 Rf6 19. Ng5 Rg6 20. Ne6 Qb7 21. Nf5 Nxd5 22. Qxd5 Qxd5 23. Nxe7+ Kf7 24. Nxd5 Kxe6 25. c4 Nf6 26. Nc7+ Kd7 27. Nxa8 Kc6 28. Bd2 bxc4 29. bxc4 Nd7 30. Rab1 Nb6 31. Nxb6 Re6 32. Nd5 Kd7 33. Rb7+ Ke8 34. Nc7+ Kd7 35. Nxe6+ Kxe6 36. Rxg7 d5 37. cxd5+ Kxd5 38. Rxh7 Kc4 39. Re4+ Kd3 40. Re3+ Kc2 41. Rd7 c4 42. Rc3+ Kb1 43. Rxc4 Kxa2 44. Ra4+ Kb3 45. Rb4+ Kc2 46. Rd5\nYou are playing as player Black.\nIt is now your turn. Play your strongest move. The move MUST be legal. Reason step by step to come up with your move, then output your final answer in the format \"Final Answer: X\" where X is your chosen move in standard algebraic notation (SAN).\n",
+              "prompt_tokens": 626,
+              "reasoning_tokens": 0,
+              "response": "The current position is `8/8/p7/3Rp3/1R6/7P/2kB1PP1/6K1 b - - 5 46`. It is Black's turn to move.\n\n**Evaluation:**\nWhite has a decisive material advantage (a Rook and a Bishop against a lone King and a couple of pawns). Black's king is restricted on c2, and the pieces are poorly coordinated. The White pieces on d5 and b4 are controlling the board. Black's goal is to prolong the game, though the position is lost.\n\n**Candidate Moves for Black:**\n1. **... Kb1**: The King is currently on c2. Moving it is necessary.\n2. **... a5**: Attempting to create some space or challenge the rook on b4, but it is too slow.\n\n**Detailed Analysis:**\n*   **The position is technically lost for Black (-M5 or similar engine evaluation).**\n*   If **46... Kb1**: The King remains in the corner. White has several winning plans, such as moving the King towards the center or maneuvering the pieces to deliver checkmate.\n*   If **46... a5**: White simply responds with `47. Rxa5` or maintains the pressure.\n\nGiven the desperate nature of the position, Black's moves are largely forced or irrelevant to the outcome. The move **46... Kb1** keeps the King active to the extent possible, though the Rook on d5 and the Bishop on d2 completely paralyze Black.\n\nLet's look at the legal moves:\n*   King moves: Kb3 (illegal due to R on b4/d5 check or coverage), Kb1, Kd1 (illegal, d1 is occupied by the Bishop).\n*   Pawn moves: a5.\n\nIf Black plays **46... Kb1**, White continues to squeeze. There is no escape. I will select the King move as it is the most standard response in a lost endgame.\n\nStep-by-step evaluation:\n1. Black's King is on c2.\n2. White's Rook is on d5, White's Bishop is on d2.\n3. The square c1 is covered by the Bishop.\n4. The square b2 is covered by the Rook (indirectly) and the King.\n5. The square d1 is occupied by the Bishop.\n6. The square b1 is the only legal square for the King.\n\nTherefore, the move is forced.\n\nFinal Answer: Kb1",
+              "total_tokens": 1172
+            },
+            {
+              "duration_secs": 3.896,
+              "finish_reason": "stop",
+              "first_token_secs": 0.792,
+              "generation_tokens": 675,
+              "model": "openai/google/gemini-3.1-flash-lite-preview",
+              "prompt": "\ud83d\udc4c\ud83d\udc40\ud83d\udc4c\ud83d\udc40\ud83d\udc4c\ud83d\udc40\ud83d\udc4c\ud83d\udc40\ud83d\udc4c\ud83d\udc40 good shit go\u0c66\u0501 sHit\ud83d\udc4c thats \u2714 some good\ud83d\udc4c\ud83d\udc4cshit right\ud83d\udc4c\ud83d\udc4cthere\ud83d\udc4c\ud83d\udc4c\ud83d\udc4c right\u2714there \u2714\u2714if i do \u01bda\u04af so my self \ud83d\udcaf i say so \ud83d\udcaf thats what im talking about right there right there (chorus: \u02b3\u1da6\u1d4d\u02b0\u1d57 \u1d57\u02b0\u1d49\u02b3\u1d49) mMMMM\u13b7\u041c\ud83d\udcaf \ud83d\udc4c\ud83d\udc4c \ud83d\udc4c\u041dO0\u041e\u0b20OOOOO\u041e\u0b20\u0b20Oooo\u1d52\u1d52\u1d52\u1d52\u1d52\u1d52\u1d52\u1d52\u1d52\ud83d\udc4c \ud83d\udc4c\ud83d\udc4c \ud83d\udc4c \ud83d\udcaf \ud83d\udc4c \ud83d\udc40 \ud83d\udc40 \ud83d\udc40 \ud83d\udc4c\ud83d\udc4c\n\nLet's play chess. The current game state in Forsyth-Edwards Notation (FEN) notation is:\n8/8/p7/3Rp3/1R6/7P/2kB1PP1/6K1 b - - 5 46\nThe moves played so far are:\n1. e4 e5 2. Nf3 Nc6 3. Bb5 a6 4. Ba4 Nf6 5. O-O Be7 6. Re1 b5 7. Bb3 d6 8. c3 O-O 9. h3 Na5 10. Bc2 c5 11. d4 Qc7 12. d5 Nc4 13. b3 Nb6 14. Nbd2 Ne8 15. Nf1 f5 16. exf5 Bxf5 17. Bxf5 Rxf5 18. Ng3 Rf6 19. Ng5 Rg6 20. Ne6 Qb7 21. Nf5 Nxd5 22. Qxd5 Qxd5 23. Nxe7+ Kf7 24. Nxd5 Kxe6 25. c4 Nf6 26. Nc7+ Kd7 27. Nxa8 Kc6 28. Bd2 bxc4 29. bxc4 Nd7 30. Rab1 Nb6 31. Nxb6 Re6 32. Nd5 Kd7 33. Rb7+ Ke8 34. Nc7+ Kd7 35. Nxe6+ Kxe6 36. Rxg7 d5 37. cxd5+ Kxd5 38. Rxh7 Kc4 39. Re4+ Kd3 40. Re3+ Kc2 41. Rd7 c4 42. Rc3+ Kb1 43. Rxc4 Kxa2 44. Ra4+ Kb3 45. Rb4+ Kc2 46. Rd5\nYou are playing as player Black.\nIt is now your turn. Play your strongest move. The move MUST be legal. Reason step by step to come up with your move, then output your final answer in the format \"Final Answer: X\" where X is your chosen move in standard algebraic notation (SAN).\nYour previous move \"Kb1\" is NOT legal in the current position.\n\n\u26a0 This is your FINAL attempt. If your next move is also illegal or unparseable, you will FORFEIT this game and lose by default.\n\nBefore answering, verify:\n  - The piece you want to move is actually on the square you think it is     (re-read the FEN above).\n  - The destination is reachable for that piece, given the other pieces on     the board.\n  - The move does not leave your own king in check.\n  - You are using the same standard algebraic notation as the move history.\n\nReason step by step, then end with \"Final Answer: X\" where X is a legal SAN move.\n",
+              "prompt_tokens": 781,
+              "reasoning_tokens": 0,
+              "response": "The current FEN is `8/8/p7/3Rp3/1R6/7P/2kB1PP1/6K1 b - - 5 46`. It is Black's turn to move.\n\n**Position Analysis:**\n*   **White:** King on g1, Rooks on d5 and b4, Bishop on d2, Pawns on f2, g2, h3.\n*   **Black:** King on c2, Pawn on a6, e5.\n\nBlack is in a losing position, being down significant material (two rooks and a bishop against a lone king). Black's king is currently on c2. The white rook on d5 is attacking the pawn on e5. White's pieces are highly active.\n\n**Legal Moves for Black:**\n1.  **King moves:**\n    *   Kb3 (The king moves to b3, escaping the check or pressure from the white rook on b4, but the rook on d5 covers much of the board).\n    *   Kb2 (Moves the king back to b2).\n    *   Kc3 (Moves the king to c3).\n    *   Kd1 (Moves the king to d1).\n    *   Kc1 (Moves the king to c1).\n\nLooking at the board:\n*   The White rook on b4 is attacking the c-file (c2 square).\n*   The White rook on d5 is covering the d-file and rank 5.\n*   The White Bishop on d2 covers the a5-d8 diagonal.\n\nIf Black plays `Kb3`, the king is moving to a square where it is not immediately in check, though it remains in a desperate position. Let's evaluate the legality:\n*   Is the king currently in check? No, the FEN indicates `b - -`, so Black is not in check.\n*   Is `Kb3` legal? The king moves from c2 to b3. The destination b3 is not attacked by any white piece (the rook is on b4, so it controls the b-file, but the king is moving to b3. Wait, the rook is on b4. If the king moves to b3, is it safe? Yes, the rook on b4 attacks squares on the b-file, but a piece cannot be on the same square as an enemy king. The king moves *to* b3, which is adjacent to the rook on b4. This is illegal as the king cannot move into check). \n\nWait, the rook is on b4. The king is on c2. The rook controls b1, b2, b3, b5, b6, etc. Therefore, the king cannot move to b3 or b2.\n*   Let's check other moves:\n    *   `Kc3`: Legal.\n    *   `Kd1`: Legal.\n    *   `Kc1`: Legal.\n\nGiven the desperate nature of the position, moving to a square that avoids immediate threats is key. `Kc3` seems the most logical attempt to survive longer.\n\nFinal Answer: Kc3",
+              "total_tokens": 1456
+            }
+          ],
+          "status": "Failed to parse a legal move after 2 attempts; forfeiting.",
+          "submission": -1,
+          "thoughts": "The current FEN is `8/8/p7/3Rp3/1R6/7P/2kB1PP1/6K1 b - - 5 46`. It is Black's turn to move.\n\n**Position Analysis:**\n*   **White:** King on g1, Rooks on d5 and b4, Bishop on d2, Pawns on f2, g2, h3.\n*   **Black:** King on c2, Pawn on a6, e5.\n\nBlack is in a losing position, being down significant material (two rooks and a bishop against a lone king). Black's king is currently on c2. The white rook on d5 is attacking the pawn on e5. White's pieces are highly active.\n\n**Legal Moves for Black:**\n1.  **King moves:**\n    *   Kb3 (The king moves to b3, escaping the check or pressure from the white rook on b4, but the rook on d5 covers much of the board).\n    *   Kb2 (Moves the king back to b2).\n    *   Kc3 (Moves the king to c3).\n    *   Kd1 (Moves the king to d1).\n    *   Kc1 (Moves the king to c1).\n\nLooking at the board:\n*   The White rook on b4 is attacking the c-file (c2 square).\n*   The White rook on d5 is covering the d-file and rank 5.\n*   The White Bishop on d2 covers the a5-d8 diagonal.\n\nIf Black plays `Kb3`, the king is moving to a square where it is not immediately in check, though it remains in a desperate position. Let's evaluate the legality:\n*   Is the king currently in check? No, the FEN indicates `b - -`, so Black is not in check.\n*   Is `Kb3` legal? The king moves from c2 to b3. The destination b3 is not attacked by any white piece (the rook is on b4, so it controls the b-file, but the king is moving to b3. Wait, the rook is on b4. If the king moves to b3, is it safe? Yes, the rook on b4 attacks squares on the b-file, but a piece cannot be on the same square as an enemy king. The king moves *to* b3, which is adjacent to the rook on b4. This is illegal as the king cannot move into check). \n\nWait, the rook is on b4. The king is on c2. The rook controls b1, b2, b3, b5, b6, etc. Therefore, the king cannot move to b3 or b2.\n*   Let's check other moves:\n    *   `Kc3`: Legal.\n    *   `Kd1`: Legal.\n    *   `Kc1`: Legal.\n\nGiven the desperate nature of the position, moving to a square that avoids immediate threats is key. `Kc3` seems the most logical attempt to survive longer.\n\nFinal Answer: Kc3"
+        },
+        "info": {
+          "actionApplied": null,
+          "actionSubmitted": -1,
+          "actionSubmittedToString": null,
+          "agentSelfReportedStatus": "Failed to parse a legal move after 2 attempts; forfeiting.",
+          "timeTaken": 8.27
+        },
+        "observation": {
+          "currentPlayer": 0,
+          "isTerminal": false,
+          "observationString": "8/8/p7/3Rp3/1R6/7P/2kB1PP1/6K1 b - - 5 46",
+          "playerId": 0,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n2426\n3572\n656\n2974\n89\n919\n3572\n4673\n2977\n2949\n674\n277\n1841\n1257\n4673\n4177\n1380\n788\n1258\n1842\n1809\n1987\n289\n673\n1527\n654\n3133\n1894\n3010\n2599\n1214\n1287\n2938\n2992\n3154\n3138\n3096\n3862\n1270\n3718\n800\n1771\n702\n3280\n3561\n2841\n3050\n1330\n2408\n2112\n2525\n1672\n1882\n1212\n847\n774\n3131\n30\n1891\n582\n3678\n1018\n1372\n605\n1883\n2112\n2393\n1675\n1869\n1056\n1914\n1431\n2539\n3972\n2028\n2354\n1504\n2570\n2174\n4552\n1403\n2510\n1663\n1330\n1138\n1415\n496\n249\n993\n2204\n\n",
+          "step": 93
+        },
+        "reward": -1,
+        "status": "DONE"
+      },
+      {
+        "action": { "submission": -1 },
+        "info": {},
+        "observation": {
+          "currentPlayer": 0,
+          "isTerminal": false,
+          "observationString": "8/8/p7/3Rp3/1R6/7P/2kB1PP1/6K1 b - - 5 46",
+          "playerId": 1,
+          "remainingOverageTime": 12,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nchess(chess960=False)\n[State]\nFEN: \n2426\n2426\n3572\n656\n2974\n89\n919\n3572\n4673\n2977\n2949\n674\n277\n1841\n1257\n4673\n4177\n1380\n788\n1258\n1842\n1809\n1987\n289\n673\n1527\n654\n3133\n1894\n3010\n2599\n1214\n1287\n2938\n2992\n3154\n3138\n3096\n3862\n1270\n3718\n800\n1771\n702\n3280\n3561\n2841\n3050\n1330\n2408\n2112\n2525\n1672\n1882\n1212\n847\n774\n3131\n30\n1891\n582\n3678\n1018\n1372\n605\n1883\n2112\n2393\n1675\n1869\n1056\n1914\n1431\n2539\n3972\n2028\n2354\n1504\n2570\n2174\n4552\n1403\n2510\n1663\n1330\n1138\n1415\n496\n249\n993\n2204\n\n"
+        },
+        "reward": 1,
+        "status": "DONE"
       }
     ]
   ],

--- a/kaggle_environments/envs/open_spiel_env/games/chess/visualizer/v2/src/App.tsx
+++ b/kaggle_environments/envs/open_spiel_env/games/chess/visualizer/v2/src/App.tsx
@@ -1,6 +1,8 @@
 import { useCallback } from 'react';
 import { createReplayVisualizer, ReplayAdapter } from '@kaggle-environments/core';
 import { transformer } from './transformers/transformer';
+import { getChessStepDescription } from './transformers/chessTransformer';
+import { ChessStep } from './transformers/chessReplayTypes';
 import { getStepRenderTime } from './utils/getStepRenderTime';
 import { getStepLabel } from './utils/getStepLabel';
 import GameRenderer from './components/GameRenderer';
@@ -17,6 +19,7 @@ export default function App() {
       transformer,
       getStepRenderTime,
       getStepLabel,
+      getStepDescription: (step) => getChessStepDescription(step as ChessStep),
     });
     createReplayVisualizer(element, adapter);
   }, []);

--- a/kaggle_environments/envs/open_spiel_env/games/chess/visualizer/v2/src/components/GameBoard.tsx
+++ b/kaggle_environments/envs/open_spiel_env/games/chess/visualizer/v2/src/components/GameBoard.tsx
@@ -3,7 +3,16 @@ import { useShallow } from 'zustand/react/shallow';
 import { createGame, type Game } from '../graphics/game';
 import useGameStore from '../stores/useGameStore';
 import usePreferences, { type PreferencesState } from '../stores/usePreferences';
+import type { ChessStep } from '../transformers/chessReplayTypes';
 import styles from './GameBoard.module.css';
+
+function isBoardUnchanged(step: ChessStep | undefined): boolean {
+  if (!step) return false;
+  // Terminal step and forfeit step both leave board state matching the prior
+  // step — no move animation should play when scrubbing onto them.
+  if (step.isTerminal) return true;
+  return step.players.some((p) => p.forfeited);
+}
 
 const selectPrefs = (s: PreferencesState): PreferencesState => ({
   showHeroAnimations: s.showHeroAnimations,
@@ -18,7 +27,9 @@ export default memo(function GameBoard() {
   const gameRef = useRef<Game | null>(null);
   const chess = useGameStore((state) => state.game);
   const step = useGameStore((state) => state.options.step);
-  const isTerminal = useGameStore((state) => state.options.replay.steps.at(state.options.step)?.isTerminal ?? false);
+  const boardUnchanged = useGameStore((state) =>
+    isBoardUnchanged(state.options.replay.steps.at(state.options.step) as ChessStep | undefined)
+  );
   const prefs = usePreferences(useShallow(selectPrefs));
 
   useEffect(() => {
@@ -37,8 +48,8 @@ export default memo(function GameBoard() {
         }
         gameRef.current = game;
         const state = useGameStore.getState();
-        const terminal = state.options.replay.steps.at(state.options.step)?.isTerminal ?? false;
-        game.update(state.game, state.options.step, selectPrefs(usePreferences.getState()), terminal);
+        const unchanged = isBoardUnchanged(state.options.replay.steps.at(state.options.step) as ChessStep | undefined);
+        game.update(state.game, state.options.step, selectPrefs(usePreferences.getState()), unchanged);
       });
     });
 
@@ -51,8 +62,8 @@ export default memo(function GameBoard() {
   }, []);
 
   useEffect(() => {
-    gameRef.current?.update(chess, step, prefs, isTerminal);
-  }, [chess, step, prefs, isTerminal]);
+    gameRef.current?.update(chess, step, prefs, boardUnchanged);
+  }, [chess, step, prefs, boardUnchanged]);
 
   return (
     <div id="board" className={styles.board}>

--- a/kaggle_environments/envs/open_spiel_env/games/chess/visualizer/v2/src/components/GameRenderer.tsx
+++ b/kaggle_environments/envs/open_spiel_env/games/chess/visualizer/v2/src/components/GameRenderer.tsx
@@ -13,7 +13,11 @@ export default memo(function GameRenderer(options: GameRendererProps<ChessStep[]
 
     for (const step of options.replay.steps) {
       if (step.step > options.step) break;
-      const move = step.players.find((p) => p.isTurn)?.actionDisplayText;
+      const player = step.players.find((p) => p.isTurn);
+      // Forfeit "turns" have a non-legal actionDisplayText — skip them so
+      // chess.js doesn't reject the move and crash the renderer.
+      if (!player || player.forfeited) continue;
+      const move = player.actionDisplayText;
       if (move) game.move(move);
     }
 

--- a/kaggle_environments/envs/open_spiel_env/games/chess/visualizer/v2/src/components/GameRenderer.tsx
+++ b/kaggle_environments/envs/open_spiel_env/games/chess/visualizer/v2/src/components/GameRenderer.tsx
@@ -2,6 +2,7 @@ import { memo, useEffect } from 'react';
 import { Chess } from 'chess.js';
 import { GameRendererProps } from '@kaggle-environments/core';
 import { ChessStep } from '../transformers/chessReplayTypes';
+import { getPlayedMove } from '../utils/getPlayedMove';
 import useGameStore from '../stores/useGameStore';
 import Layout from './Layout';
 
@@ -13,11 +14,7 @@ export default memo(function GameRenderer(options: GameRendererProps<ChessStep[]
 
     for (const step of options.replay.steps) {
       if (step.step > options.step) break;
-      const player = step.players.find((p) => p.isTurn);
-      // Forfeit "turns" have a non-legal actionDisplayText — skip them so
-      // chess.js doesn't reject the move and crash the renderer.
-      if (!player || player.forfeited) continue;
-      const move = player.actionDisplayText;
+      const move = getPlayedMove(step);
       if (move) game.move(move);
     }
 

--- a/kaggle_environments/envs/open_spiel_env/games/chess/visualizer/v2/src/graphics/game.ts
+++ b/kaggle_environments/envs/open_spiel_env/games/chess/visualizer/v2/src/graphics/game.ts
@@ -10,19 +10,20 @@ import type { PreferencesState } from '../stores/usePreferences';
 import usePreloader from '../stores/usePreloader';
 
 export interface Game {
-  update: (chess: Chess, step: number, prefs: PreferencesState, isTerminal: boolean) => void;
+  update: (chess: Chess, step: number, prefs: PreferencesState, boardUnchanged: boolean) => void;
   destroy: () => void;
 }
 
-function detectSnap(eng: Engine, step: number, reducedMotion: boolean, isTerminal: boolean, now: number): boolean {
+function detectSnap(eng: Engine, step: number, reducedMotion: boolean, boardUnchanged: boolean, now: number): boolean {
   const isFirstUpdate = eng.lastUpdateTime === 0;
   const timeSinceLastUpdate = now - eng.lastUpdateTime;
   // Re-runs at the same step (e.g. preference toggles) shouldn't replay the move animation.
   const isAdvancing = step > eng.lastStep;
   const scrubbingForward = !isFirstUpdate && timeSinceLastUpdate < SCRUB_THRESHOLD_MS;
-  // The terminal step doesn't add a new move — board state matches the prior step.
-  // Snapping avoids replaying the last move's animation when the game-over modal opens.
-  return reducedMotion || !isAdvancing || scrubbingForward || isTerminal;
+  // Steps that don't add a new move (terminal step, forfeit step) leave the
+  // board state matching the prior step. Snap so we don't replay the last
+  // move's animation as the step advances over them.
+  return reducedMotion || !isAdvancing || scrubbingForward || boardUnchanged;
 }
 
 export async function createGame(canvas: HTMLCanvasElement): Promise<Game> {
@@ -41,13 +42,13 @@ export async function createGame(canvas: HTMLCanvasElement): Promise<Game> {
   usePreloader.getState().setPixiReady();
 
   return {
-    update(chess: Chess, step: number, prefs: PreferencesState, isTerminal: boolean) {
+    update(chess: Chess, step: number, prefs: PreferencesState, boardUnchanged: boolean) {
       // Stop all in-flight animations before rebuilding sprites.
       for (const anim of eng.animations) anim.stop();
       eng.animations.clear();
 
       const now = performance.now();
-      const snap = detectSnap(eng, step, prefs.reducedMotion, isTerminal, now);
+      const snap = detectSnap(eng, step, prefs.reducedMotion, boardUnchanged, now);
       eng.lastUpdateTime = now;
       eng.lastStep = step;
 

--- a/kaggle_environments/envs/open_spiel_env/games/chess/visualizer/v2/src/transformers/chessTransformer.ts
+++ b/kaggle_environments/envs/open_spiel_env/games/chess/visualizer/v2/src/transformers/chessTransformer.ts
@@ -48,6 +48,67 @@ function parseFen(fen?: string): FenState {
   };
 }
 
+export function getChessStepDescription(step: ChessStep) {
+  if (step.isTerminal) {
+    // Terminal step's headline (winner + forfeit reason) is rendered by
+    // getStepLabel and the GameOver overlay — no per-attempt body to add.
+    return '';
+  }
+
+  const player = step.players.find((p) => p.isTurn);
+  if (!player) return '';
+  return renderAttemptsMarkdown(player);
+}
+
+/**
+ * Render a player's per-attempt LLM calls as markdown. When there's only one
+ * attempt this collapses to just the response (the legacy behavior). When
+ * there are retries each attempt gets a header showing its outcome:
+ *   - intermediate attempts → ❌ Attempt N (illegal — retried)
+ *   - final attempt on a successful turn → ✅ Attempt N (submitted)
+ *   - all attempts on a forfeit → ❌ Attempt N (illegal — forfeited on last)
+ *
+ * Falls back to player.thoughts if call_details aren't available (older
+ * replays from before the harness wrote call_details).
+ */
+function renderAttemptsMarkdown(player: ChessPlayer): string {
+  const attempts = player.attempts ?? [];
+  const fallback = player.thoughts ?? '';
+
+  if (attempts.length === 0) return fallback;
+
+  if (attempts.length === 1 && !player.forfeited) {
+    // Single legal attempt — keep the original clean rendering.
+    return attempts[0].response || fallback;
+  }
+
+  const total = attempts.length;
+  const lines: string[] = [];
+
+  if (player.forfeited) {
+    const lastMove = player.forfeitLastAttempt ? ` \`${player.forfeitLastAttempt}\`` : '';
+    lines.push(`> ⚠️ **Forfeited after ${total} attempt${total === 1 ? '' : 's'}.** Last attempt:${lastMove}`);
+    lines.push('');
+  } else {
+    lines.push(`> 🔁 **Took ${total} attempts** to find a legal move.`);
+    lines.push('');
+  }
+
+  attempts.forEach((attempt, i) => {
+    const isLast = i === attempts.length - 1;
+    const ok = isLast && !player.forfeited;
+    const tag = ok
+      ? `✅ **Attempt ${i + 1} of ${total}** (submitted)`
+      : `❌ **Attempt ${i + 1} of ${total}** (illegal — ${isLast ? 'forfeited' : 'retried'})`;
+    lines.push(`### ${tag}`);
+    lines.push('');
+    lines.push(attempt.response || '_(empty response)_');
+    lines.push('');
+  });
+
+  return lines.join('\n').trim();
+}
+
 function deriveWinner(step: ChessReplayStep[]): string | null {
   if (step[0].reward === 1) return 'black';
   if (step[1].reward === 1) return 'white';
@@ -133,9 +194,11 @@ export const chessTransformer = (environment: any): ChessStep[] => {
         // in the reasoning panel — the player did act, they just failed every
         // attempt.
         isTurn: (typeof submission === 'number' && submission !== -1) || forfeited,
-        actionDisplayText: forfeited
-          ? `(forfeited: ${player.action?.actionString ?? 'no move'})`
-          : (player.action?.actionString ?? ''),
+        // Keep this as the raw move string so chess.js can still apply it on
+        // legal turns. Forfeit decoration is applied at display sites via the
+        // `forfeited` flag instead, since GameRenderer/getStepRenderTime feed
+        // this string straight into Chess.move().
+        actionDisplayText: player.action?.actionString ?? '',
         thoughts: player.action?.thoughts ?? '',
         reward: player.reward,
         generateReturns: player.action?.generate_returns ?? null,

--- a/kaggle_environments/envs/open_spiel_env/games/chess/visualizer/v2/src/transformers/chessTransformer.ts
+++ b/kaggle_environments/envs/open_spiel_env/games/chess/visualizer/v2/src/transformers/chessTransformer.ts
@@ -194,10 +194,8 @@ export const chessTransformer = (environment: any): ChessStep[] => {
         // in the reasoning panel — the player did act, they just failed every
         // attempt.
         isTurn: (typeof submission === 'number' && submission !== -1) || forfeited,
-        // Keep this as the raw move string so chess.js can still apply it on
-        // legal turns. Forfeit decoration is applied at display sites via the
-        // `forfeited` flag instead, since GameRenderer/getStepRenderTime feed
-        // this string straight into Chess.move().
+        // Raw move only — chess.js consumes this directly. Forfeit decoration
+        // happens at display sites (getStepLabel) using the `forfeited` flag.
         actionDisplayText: player.action?.actionString ?? '',
         thoughts: player.action?.thoughts ?? '',
         reward: player.reward,

--- a/kaggle_environments/envs/open_spiel_env/games/chess/visualizer/v2/src/transformers/chessTransformer.ts
+++ b/kaggle_environments/envs/open_spiel_env/games/chess/visualizer/v2/src/transformers/chessTransformer.ts
@@ -128,9 +128,14 @@ export const chessTransformer = (environment: any): ChessStep[] => {
         thumbnail: '',
         // A turn requires submission to be a real action id. -1 means the player
         // didn't act this step (inactive or forfeited). null/undefined shows up
-        // in init steps, we don't need those rendered.
-        isTurn: typeof submission === 'number' && submission !== -1,
-        actionDisplayText: player.action?.actionString ?? '',
+        // in init steps, we don't need those rendered. Treat forfeits as a
+        // "turn" too so the step is preserved and the failed attempts surface
+        // in the reasoning panel — the player did act, they just failed every
+        // attempt.
+        isTurn: (typeof submission === 'number' && submission !== -1) || forfeited,
+        actionDisplayText: forfeited
+          ? `(forfeited: ${player.action?.actionString ?? 'no move'})`
+          : (player.action?.actionString ?? ''),
         thoughts: player.action?.thoughts ?? '',
         reward: player.reward,
         generateReturns: player.action?.generate_returns ?? null,

--- a/kaggle_environments/envs/open_spiel_env/games/chess/visualizer/v2/src/transformers/chessTransformer.ts
+++ b/kaggle_environments/envs/open_spiel_env/games/chess/visualizer/v2/src/transformers/chessTransformer.ts
@@ -50,8 +50,6 @@ function parseFen(fen?: string): FenState {
 
 export function getChessStepDescription(step: ChessStep) {
   if (step.isTerminal) {
-    // Terminal step's headline (winner + forfeit reason) is rendered by
-    // getStepLabel and the GameOver overlay — no per-attempt body to add.
     return '';
   }
 
@@ -190,9 +188,7 @@ export const chessTransformer = (environment: any): ChessStep[] => {
         // A turn requires submission to be a real action id. -1 means the player
         // didn't act this step (inactive or forfeited). null/undefined shows up
         // in init steps, we don't need those rendered. Treat forfeits as a
-        // "turn" too so the step is preserved and the failed attempts surface
-        // in the reasoning panel — the player did act, they just failed every
-        // attempt.
+        // "turn" too so the step is preserved.
         isTurn: (typeof submission === 'number' && submission !== -1) || forfeited,
         // Raw move only — chess.js consumes this directly. Forfeit decoration
         // happens at display sites (getStepLabel) using the `forfeited` flag.

--- a/kaggle_environments/envs/open_spiel_env/games/chess/visualizer/v2/src/transformers/chessTransformer.ts
+++ b/kaggle_environments/envs/open_spiel_env/games/chess/visualizer/v2/src/transformers/chessTransformer.ts
@@ -87,10 +87,10 @@ function renderAttemptsMarkdown(player: ChessPlayer): string {
 
   if (player.forfeited) {
     const lastMove = player.forfeitLastAttempt ? ` \`${player.forfeitLastAttempt}\`` : '';
-    lines.push(`> ⚠️ **Forfeited after ${total} attempt${total === 1 ? '' : 's'}.** Last attempt:${lastMove}`);
+    lines.push(`⚠️ **Forfeited after ${total} attempt${total === 1 ? '' : 's'}.** Last attempt:${lastMove}`);
     lines.push('');
   } else {
-    lines.push(`> 🔁 **Took ${total} attempts** to find a legal move.`);
+    lines.push(`🔁 **Took ${total} attempts** to find a legal move.`);
     lines.push('');
   }
 

--- a/kaggle_environments/envs/open_spiel_env/games/chess/visualizer/v2/src/utils/getPlayedMove.ts
+++ b/kaggle_environments/envs/open_spiel_env/games/chess/visualizer/v2/src/utils/getPlayedMove.ts
@@ -1,0 +1,13 @@
+import { BaseGameStep } from '@kaggle-environments/core';
+import { ChessPlayer } from '../transformers/chessReplayTypes';
+
+/**
+ * Return the move string for a step, or null if no legal move was played
+ * (forfeit step or no active turn). Callers can pass the result straight to
+ * `chess.js`'s `Chess.move()` without an extra forfeit guard.
+ */
+export function getPlayedMove(step: BaseGameStep | undefined): string | null {
+  const player = step?.players.find((p) => p.isTurn) as ChessPlayer | undefined;
+  if (!player || player.forfeited) return null;
+  return player.actionDisplayText || null;
+}

--- a/kaggle_environments/envs/open_spiel_env/games/chess/visualizer/v2/src/utils/getPlayedMove.ts
+++ b/kaggle_environments/envs/open_spiel_env/games/chess/visualizer/v2/src/utils/getPlayedMove.ts
@@ -3,8 +3,7 @@ import { ChessPlayer } from '../transformers/chessReplayTypes';
 
 /**
  * Return the move string for a step, or null if no legal move was played
- * (forfeit step or no active turn). Callers can pass the result straight to
- * `chess.js`'s `Chess.move()` without an extra forfeit guard.
+ * (forfeit step or no active turn).
  */
 export function getPlayedMove(step: BaseGameStep | undefined): string | null {
   const player = step?.players.find((p) => p.isTurn) as ChessPlayer | undefined;

--- a/kaggle_environments/envs/open_spiel_env/games/chess/visualizer/v2/src/utils/getStepLabel.ts
+++ b/kaggle_environments/envs/open_spiel_env/games/chess/visualizer/v2/src/utils/getStepLabel.ts
@@ -1,11 +1,15 @@
 import { BaseGameStep } from '@kaggle-environments/core';
-import { ChessStep } from '../transformers/chessReplayTypes';
+import { ChessPlayer, ChessStep } from '../transformers/chessReplayTypes';
 import { FORFEIT_REASONS } from '../transformers/forfeit';
 
 export function getStepLabel(step: BaseGameStep) {
-  const player = step.players.find((p) => p.isTurn);
+  const player = step.players.find((p) => p.isTurn) as ChessPlayer | undefined;
 
   if (player) {
+    if (player.forfeited) {
+      const attempted = player.forfeitLastAttempt;
+      return attempted ? `Forfeited (last attempt: ${attempted})` : 'Forfeited';
+    }
     const move = player.actionDisplayText ?? '';
     return `Plays ${move}`;
   }

--- a/kaggle_environments/envs/open_spiel_env/games/chess/visualizer/v2/src/utils/getStepRenderTime.ts
+++ b/kaggle_environments/envs/open_spiel_env/games/chess/visualizer/v2/src/utils/getStepRenderTime.ts
@@ -1,8 +1,8 @@
 import { ReplayMode, BaseGameStep, defaultGetStepRenderTime } from '@kaggle-environments/core';
-import { ChessPlayer } from '../transformers/chessReplayTypes';
 import useGameStore from '../stores/useGameStore';
 import usePreferences from '../stores/usePreferences';
 import { detectHeroType } from './heroTypes';
+import { getPlayedMove } from './getPlayedMove';
 
 export function getStepRenderTime(step: BaseGameStep, replayMode: ReplayMode, speedModifier: number) {
   const time = defaultGetStepRenderTime(step, replayMode, speedModifier);
@@ -14,14 +14,9 @@ export function getStepRenderTime(step: BaseGameStep, replayMode: ReplayMode, sp
 
   // The step time calculation races the game render, so can't rely on game
   // render to have played the latest move before we work out the hero type
-  const player = step?.players.find((p) => p.isTurn) as ChessPlayer | undefined;
-  // Skip forfeit "turns" — their actionDisplayText isn't a legal move and
-  // would throw inside chess.js.
-  if (player && !player.forfeited) {
-    const move = player.actionDisplayText;
-    const previousMove = game.history({ verbose: true }).at(-1)?.san;
-    if (move && move !== previousMove) game.move(move);
-  }
+  const move = getPlayedMove(step);
+  const previousMove = game.history({ verbose: true }).at(-1)?.san;
+  if (move && move !== previousMove) game.move(move);
 
   if (detectHeroType(game) !== null) return 1000 * 5;
 

--- a/kaggle_environments/envs/open_spiel_env/games/chess/visualizer/v2/src/utils/getStepRenderTime.ts
+++ b/kaggle_environments/envs/open_spiel_env/games/chess/visualizer/v2/src/utils/getStepRenderTime.ts
@@ -13,9 +13,14 @@ export function getStepRenderTime(step: BaseGameStep, replayMode: ReplayMode, sp
 
   // The step time calculation races the game render, so can't rely on game
   // render to have played the latest move before we work out the hero type
-  const move = step?.players.find((p) => p.isTurn)?.actionDisplayText;
-  const previousMove = game.history({ verbose: true }).at(-1)?.san;
-  if (move && move !== previousMove) game.move(move);
+  const player = step?.players.find((p) => p.isTurn);
+  // Skip forfeit "turns" — their actionDisplayText isn't a legal move and
+  // would throw inside chess.js.
+  if (player && !player.forfeited) {
+    const move = player.actionDisplayText;
+    const previousMove = game.history({ verbose: true }).at(-1)?.san;
+    if (move && move !== previousMove) game.move(move);
+  }
 
   if (detectHeroType(game) !== null) return 1000 * 5;
 

--- a/kaggle_environments/envs/open_spiel_env/games/chess/visualizer/v2/src/utils/getStepRenderTime.ts
+++ b/kaggle_environments/envs/open_spiel_env/games/chess/visualizer/v2/src/utils/getStepRenderTime.ts
@@ -1,4 +1,5 @@
 import { ReplayMode, BaseGameStep, defaultGetStepRenderTime } from '@kaggle-environments/core';
+import { ChessPlayer } from '../transformers/chessReplayTypes';
 import useGameStore from '../stores/useGameStore';
 import usePreferences from '../stores/usePreferences';
 import { detectHeroType } from './heroTypes';
@@ -13,7 +14,7 @@ export function getStepRenderTime(step: BaseGameStep, replayMode: ReplayMode, sp
 
   // The step time calculation races the game render, so can't rely on game
   // render to have played the latest move before we work out the hero type
-  const player = step?.players.find((p) => p.isTurn);
+  const player = step?.players.find((p) => p.isTurn) as ChessPlayer | undefined;
   // Skip forfeit "turns" — their actionDisplayText isn't a legal move and
   // would throw inside chess.js.
   if (player && !player.forfeited) {


### PR DESCRIPTION
This set of changes: 
- Strings together forfeit attempts in logs
- Adds more descriptive action text for a step that resulted in a forfeit
- Blocks animation when forfeits happen (since, similar to the end step, the board is unchanged)
- Adds a more typical/complete example of a replay that ends in a forfeit

This is going to look very similar to @develra's markdown changes in #1218. Michael- can you focus on the transformer-y pieces of this while our friends from Stink look at the component bits I needed to change?

Demo:
<img width="3456" height="1916" alt="image" src="https://github.com/user-attachments/assets/6e0bb162-d66d-42a1-9021-9c0845806dc7" />
