### PR TITLE
Make chess visualizer v2 the default via index.json

### DIFF
--- a/web/config/default-visualizers.json
+++ b/web/config/default-visualizers.json
@@ -1,0 +1,3 @@
+{
+  "open_spiel_chess": "v2"
+}

--- a/web/scripts/merge-game-indexes.py
+++ b/web/scripts/merge-game-indexes.py
@@ -2,9 +2,20 @@
 """
 Merge per-game index.json files with existing versions in GCS.
 
-Each game's index.json is a JSON array of available visualizer names
-(e.g., ["default", "v2"]). This script performs a union merge so that
-visualizers deployed by different branches coexist in the index.
+Each game's index.json is a JSON object describing the available visualizer
+versions and which one should be used by default:
+
+  {"versions": ["default", "v2"], "default": "v2"}
+
+The "default" field is optional and is sourced from
+web/config/default-visualizers.json (a game -> default-version map). When a
+game has no entry there, the field is omitted and consumers fall back to
+versions[0].
+
+This script performs a union merge of the "versions" list so that visualizers
+deployed by different branches coexist in the index. The legacy plain-array
+format (e.g., ["default", "v2"]) is still accepted when reading an existing
+index for backwards compatibility.
 
 Usage:
   # Merge all games from a build directory (main branch builds):
@@ -18,6 +29,10 @@ import json
 import os
 import subprocess
 import sys
+
+DEFAULT_CONFIG_PATH = os.path.join(
+    os.path.dirname(os.path.abspath(__file__)), "..", "config", "default-visualizers.json"
+)
 
 
 def gcs_cat(path):
@@ -40,19 +55,52 @@ def gcs_cp_stdin(content, dest):
     )
 
 
+def load_default_visualizers(config_path):
+    """Load the game -> default-version map. Returns {} if the file is absent."""
+    if config_path and os.path.exists(config_path):
+        with open(config_path) as f:
+            return json.load(f)
+    return {}
+
+
 def merge_visualizers(existing_json, new_names):
-    """Union existing visualizer list with new names, sorted for stability."""
-    existing = json.loads(existing_json) if existing_json else []
+    """Union existing visualizer versions with new names, sorted for stability.
+
+    Accepts both the legacy plain-array format (["default", "v2"]) and the
+    object format ({"versions": [...], "default": ...}) for the existing index.
+    Returns the merged, sorted list of version names.
+    """
+    existing = []
+    if existing_json:
+        parsed = json.loads(existing_json)
+        if isinstance(parsed, dict):
+            existing = parsed.get("versions", [])
+        else:
+            existing = parsed
     return sorted(set(existing) | set(new_names))
 
 
-def update_game_index(bucket, game, visualizers):
+def build_index(versions, default=None):
+    """Build the index.json object from a version list and optional default.
+
+    The "default" field is only included when it names a version that is
+    actually present, so the index never points at a missing visualizer.
+    """
+    index = {"versions": versions}
+    if default and default in versions:
+        index["default"] = default
+    return index
+
+
+def update_game_index(bucket, game, visualizers, defaults=None):
     """Download existing index for a game, merge in new visualizers, upload."""
     gcs_path = f"gs://{bucket}/episode-visualizers/{game}/index.json"
     existing = gcs_cat(gcs_path)
-    merged = merge_visualizers(existing, visualizers)
-    print(f"  {game}: {merged}")
-    gcs_cp_stdin(json.dumps(merged), gcs_path)
+    versions = merge_visualizers(existing, visualizers)
+    default = (defaults or {}).get(game)
+    index = build_index(versions, default)
+    print(f"  {game}: {index}")
+    gcs_cp_stdin(json.dumps(index), gcs_path)
 
 
 def main():
@@ -63,12 +111,19 @@ def main():
     parser.add_argument("--build-dir", help="Build directory with game subdirs (batch mode)")
     parser.add_argument("--game", help="Single game name (single mode)")
     parser.add_argument("--visualizer", help="Single visualizer name (single mode)")
+    parser.add_argument(
+        "--default-config",
+        default=DEFAULT_CONFIG_PATH,
+        help="Path to the game -> default-visualizer JSON config",
+    )
     args = parser.parse_args()
+
+    defaults = load_default_visualizers(args.default_config)
 
     if args.game and args.visualizer:
         # Single game mode (branch builds)
         print(f"Updating index for {args.game}...")
-        update_game_index(args.bucket, args.game, [args.visualizer])
+        update_game_index(args.bucket, args.game, [args.visualizer], defaults)
     elif args.build_dir:
         # Batch mode (main branch builds)
         print("Updating per-game indexes...")
@@ -82,7 +137,7 @@ def main():
                 if os.path.isdir(os.path.join(game_path, d))
             ]
             if visualizers:
-                update_game_index(args.bucket, game, visualizers)
+                update_game_index(args.bucket, game, visualizers, defaults)
         print("Per-game index update complete.")
     else:
         parser.error("Provide either --build-dir (batch mode) or --game and --visualizer (single mode)")

--- a/web/scripts/test_merge_game_indexes.py
+++ b/web/scripts/test_merge_game_indexes.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+"""Tests for merge-game-indexes.py (hyphenated module loaded via importlib).
+
+Run directly with: python3 web/scripts/test_merge_game_indexes.py
+"""
+import importlib.util
+import json
+import os
+import tempfile
+import unittest
+
+_MODULE_PATH = os.path.join(os.path.dirname(os.path.abspath(__file__)), "merge-game-indexes.py")
+_spec = importlib.util.spec_from_file_location("merge_game_indexes", _MODULE_PATH)
+mgi = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(mgi)
+
+
+class MergeVisualizersTest(unittest.TestCase):
+    def test_none_existing(self):
+        self.assertEqual(mgi.merge_visualizers(None, ["v2"]), ["v2"])
+
+    def test_legacy_array_format(self):
+        existing = json.dumps(["default"])
+        self.assertEqual(mgi.merge_visualizers(existing, ["v2"]), ["default", "v2"])
+
+    def test_object_format(self):
+        existing = json.dumps({"versions": ["default", "v2"], "default": "v2"})
+        self.assertEqual(mgi.merge_visualizers(existing, ["v3"]), ["default", "v2", "v3"])
+
+    def test_object_format_missing_versions_key(self):
+        existing = json.dumps({"default": "v2"})
+        self.assertEqual(mgi.merge_visualizers(existing, ["v2"]), ["v2"])
+
+    def test_union_dedupes_and_sorts(self):
+        existing = json.dumps(["v2", "default"])
+        self.assertEqual(mgi.merge_visualizers(existing, ["v2", "default"]), ["default", "v2"])
+
+
+class BuildIndexTest(unittest.TestCase):
+    def test_no_default(self):
+        self.assertEqual(mgi.build_index(["default", "v2"]), {"versions": ["default", "v2"]})
+
+    def test_with_default(self):
+        self.assertEqual(
+            mgi.build_index(["default", "v2"], "v2"),
+            {"versions": ["default", "v2"], "default": "v2"},
+        )
+
+    def test_default_not_in_versions_is_omitted(self):
+        # A misconfigured default must never point at a missing visualizer.
+        self.assertEqual(
+            mgi.build_index(["default"], "v2"),
+            {"versions": ["default"]},
+        )
+
+    def test_empty_default_is_omitted(self):
+        self.assertEqual(mgi.build_index(["default"], ""), {"versions": ["default"]})
+
+
+class LoadDefaultVisualizersTest(unittest.TestCase):
+    def test_missing_file_returns_empty(self):
+        self.assertEqual(mgi.load_default_visualizers("/nonexistent/path.json"), {})
+
+    def test_none_path_returns_empty(self):
+        self.assertEqual(mgi.load_default_visualizers(None), {})
+
+    def test_reads_mapping(self):
+        with tempfile.NamedTemporaryFile("w", suffix=".json", delete=False) as f:
+            json.dump({"open_spiel_chess": "v2"}, f)
+            path = f.name
+        try:
+            self.assertEqual(
+                mgi.load_default_visualizers(path), {"open_spiel_chess": "v2"}
+            )
+        finally:
+            os.unlink(path)
+
+
+class ShippedConfigTest(unittest.TestCase):
+    def test_chess_default_is_v2(self):
+        config_path = os.path.join(
+            os.path.dirname(os.path.abspath(__file__)), "..", "config", "default-visualizers.json"
+        )
+        defaults = mgi.load_default_visualizers(config_path)
+        self.assertEqual(defaults.get("open_spiel_chess"), "v2")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
The per-game index.json was a flat array and both consumers defaulted to
visualizers[0], which alphabetical sorting pinned to "default". Switch the
merge script to emit an object ({"versions": [...], "default": "v2"}) so a
default can be declared explicitly, sourced from a new
web/config/default-visualizers.json map. Existing arrays are still read for
backwards compatibility, and the default is omitted when a game has no
config entry so consumers fall back to versions[0].

Co-authored-by: kaggle-agent <kaggle-agent@users.noreply.github.com>

---

Task: [dominoweir-20260618195611-e5f49340](https://agents.dev.kaggle.net/tasks/dominoweir-20260618195611-e5f49340)
Context: https://chat.kaggle.net/kaggle/pl/1fjjabccutgtdgf7fduqqcgpuw

