### PR TITLE
Improve Go harness prompt state

### DIFF
--- a/kaggle_environments/envs/open_spiel_env/games/go/go_proxy.py
+++ b/kaggle_environments/envs/open_spiel_env/games/go/go_proxy.py
@@ -136,6 +136,12 @@ class GoState(proxy.State):
             ])
         return result
 
+    def _ascii_board_string(self) -> str:
+        """Return the engine's board diagram without the state metadata line."""
+        board_string = self.__wrapped__.__str__()
+        lines = board_string.strip("\n").splitlines()
+        return "\n".join(lines[2:])
+
     def state_dict(self) -> dict[str, Any]:
         clone_state = self.get_game().__wrapped__.new_initial_state()
         action_strs = []
@@ -149,7 +155,9 @@ class GoState(proxy.State):
             "komi": self.get_game().get_parameters()["komi"],
             "current_player_to_move": self._player_string(self.current_player()),
             "move_number": len(self.history()) + 1,
-            "previous_move_a1": prev_move,
+            "previous_move": prev_move,
+            "move_history": action_strs,
+            "ascii_board": self._ascii_board_string(),
             "board_grid": self._board_string_to_dict(),
         }
         if self.is_terminal():

--- a/kaggle_environments/envs/open_spiel_env/games/go/harness.py
+++ b/kaggle_environments/envs/open_spiel_env/games/go/harness.py
@@ -122,7 +122,7 @@ def _coordinate_guidance(board_size: int | None) -> str:
     if board_size is None or board_size <= 0:
         return (
             "Coordinates use GTP notation: column letters shown in "
-            'the board state, skipping "i", followed by row numbers starting '
+            'the board state, skipping "I", followed by row numbers starting '
             'from 1.'
         )
     return (

--- a/kaggle_environments/envs/open_spiel_env/games/go/harness.py
+++ b/kaggle_environments/envs/open_spiel_env/games/go/harness.py
@@ -8,12 +8,17 @@ functions: ``get_legal_moves``, ``generate_prompt``, ``parse_response``.
 from __future__ import annotations
 
 import json
-import re
 from typing import Any, Mapping, Sequence
 
 import pyspiel
 
-from kaggle_environments.core_harness import ParseResult, parse_json_action, render_rethink_suffix
+from kaggle_environments.core_harness import (
+    ParseResult,
+    parse_json_action,
+    render_rethink_suffix,
+)
+
+_GTP_COLUMNS = "abcdefghjklmnopqrstuvwxyz"
 
 # --- Prompt ---
 
@@ -22,16 +27,23 @@ GO_PROMPT_TEMPLATE = """Let's play Go.
 
 Rules: Tromp-Taylor scoring (area scoring — count stones on the board plus
 empty territory enclosed by a single color; all stones are treated as alive).
-Komi is given in the game state below. Two differences from standard
+Komi is given in the game state JSON below. Two differences from standard
 Tromp-Taylor: (1) suicide is illegal — you may not place a stone that would
 be immediately captured unless it captures enemy stones first, and
 (2) positional superko violations end the game as a draw rather than simply
-making the move illegal. The game ends when both players pass consecutively.
+making the move illegal. Simple ko is also illegal: after a single-stone
+capture, the opponent may not immediately recapture on that same point.
+The game ends when both players pass consecutively.
 
-The current game state is:
+The current game state JSON is:
 {state_str}
-The moves played so far are:
+
+ASCII board for the same position (X=Black, O=White, +=empty; board labels may be uppercase):
+{ascii_board}
+
+The full game move history is:
 {move_history}
+
 You are playing as player {player_name} ({player_code}).
 It is now your turn. Play your strongest move.
 The move MUST be legal.
@@ -45,9 +57,8 @@ conclude with your final move as a JSON formatted as follows:
 ```
 
 Where move is the coordinate only (e.g. "a1", "b2", "e5") or "PASS" if you wish to pass.
-Coordinates use GTP notation: columns are lowercase letters a-h, j (the letter
-"i" is skipped to avoid confusion with "l"), rows are numbers starting from 1.
-For example on a 9x9 board, columns are a-h,j and rows are 1-9.
+{coordinate_guidance}
+The board display may use uppercase labels, but your final JSON move must use the lowercase coordinate only.
 Failure to output your final answer in the specified format will result in a loss.
 Begin!
 """
@@ -81,6 +92,72 @@ The move you choose must also be legal in the current state.
 
 
 # --- Helpers ----------------------------------------------------------------
+
+
+def _parse_state(observation: Mapping[str, Any]) -> dict[str, Any]:
+    """Parse the proxy JSON observation, returning ``{}`` on failure."""
+    raw = observation.get("observationString", "")
+    if not raw:
+        return {}
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError:
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+def _gtp_column_range(board_size: int | None) -> str:
+    """Return compact GTP column guidance for a square Go board."""
+    if board_size is None or board_size <= 0:
+        return "the columns shown in the board state"
+    columns = _GTP_COLUMNS[:board_size]
+    if board_size <= 8:
+        return f"a-{columns[-1]}"
+    if board_size == 9:
+        return "a-h,j"
+    return f"a-h,j-{columns[-1]}"
+
+
+def _coordinate_guidance(board_size: int | None) -> str:
+    if board_size is None or board_size <= 0:
+        return (
+            "Coordinates use GTP notation: lowercase column letters shown in "
+            'the board state, skipping "i", followed by row numbers starting '
+            'from 1.'
+        )
+    return (
+        f"Coordinates use GTP notation for this {board_size}x{board_size} board: "
+        f"columns are {_gtp_column_range(board_size)} (the letter \"i\" is "
+        f"skipped), and rows are 1-{board_size}."
+    )
+
+
+def _board_size_from_state(state: Mapping[str, Any]) -> int | None:
+    board_size = state.get("board_size")
+    if isinstance(board_size, int):
+        return board_size
+    if isinstance(board_size, str) and board_size.isdigit():
+        return int(board_size)
+    board_grid = state.get("board_grid")
+    if isinstance(board_grid, list) and board_grid:
+        return len(board_grid)
+    return None
+
+
+def _format_full_move_history(state: Mapping[str, Any]) -> str:
+    history = state.get("move_history")
+    if not history:
+        return "None"
+    if isinstance(history, list):
+        return " ".join(str(move) for move in history) or "None"
+    return str(history)
+
+
+def _ascii_board_from_state(state: Mapping[str, Any]) -> str:
+    board = state.get("ascii_board")
+    if isinstance(board, str) and board.strip():
+        return board
+    return "Not available in this observation."
 
 
 def _match_move_to_legal(
@@ -130,17 +207,21 @@ def generate_prompt(
 ) -> str:
     """Build the LLM prompt for the current game state."""
     obs_string = observation.get("observationString", "")
+    state = _parse_state(observation)
+    board_size = _board_size_from_state(state)
     player_id = observation.get("playerId", 0)
     player_name = "Black" if player_id == 0 else "White"
     player_code = "B" if player_id == 0 else "W"
 
-    move_history_str = " ".join(move_history) if move_history else "None"
+    del move_history
 
     prompt = GO_PROMPT_TEMPLATE.format(
         state_str=obs_string,
-        move_history=move_history_str,
+        ascii_board=_ascii_board_from_state(state),
+        move_history=_format_full_move_history(state),
         player_name=player_name,
         player_code=player_code,
+        coordinate_guidance=_coordinate_guidance(board_size),
     )
 
     prompt += render_rethink_suffix(

--- a/kaggle_environments/envs/open_spiel_env/games/go/harness.py
+++ b/kaggle_environments/envs/open_spiel_env/games/go/harness.py
@@ -27,12 +27,12 @@ GO_PROMPT_TEMPLATE = """Let's play Go.
 
 Rules: Tromp-Taylor scoring (area scoring — count stones on the board plus
 empty territory enclosed by a single color; all stones are treated as alive).
-Komi is given in the game state JSON below. Two differences from standard
-Tromp-Taylor: (1) suicide is illegal — you may not place a stone that would
-be immediately captured unless it captures enemy stones first, and
-(2) positional superko violations end the game as a draw rather than simply
-making the move illegal. Simple ko is also illegal: after a single-stone
-capture, the opponent may not immediately recapture on that same point.
+Komi is given in the game state JSON below. Suicide is illegal: you may not
+place a stone that would be immediately captured unless it captures enemy
+stones first. Immediate single-stone ko recapture is illegal: after a move
+captures exactly one enemy stone in a ko shape, the opponent cannot play on
+the point vacated by that captured stone on the very next move. A legal
+non-pass move that repeats an earlier board position ends the game in a draw.
 The game ends when both players pass consecutively.
 
 The current game state JSON is:

--- a/kaggle_environments/envs/open_spiel_env/games/go/harness.py
+++ b/kaggle_environments/envs/open_spiel_env/games/go/harness.py
@@ -56,9 +56,9 @@ conclude with your final move as a JSON formatted as follows:
 }}
 ```
 
-Where move is the coordinate only (e.g. "a1", "b2", "e5") or "PASS" if you wish to pass.
+Where move is the coordinate only (e.g. "A1", "B2", "E5") or "PASS" if you wish to pass.
 {coordinate_guidance}
-The board display may use uppercase labels, but your final JSON move must use the lowercase coordinate only.
+The final JSON move must be the coordinate only, without the player prefix.
 Failure to output your final answer in the specified format will result in a loss.
 Begin!
 """
@@ -85,7 +85,7 @@ as the original instructions required:
 {{"move": "<coordinate>"}}
 ```
 
-For example: `{{"move": "a1"}}`
+For example: `{{"move": "A1"}}`
 
 The move you choose must also be legal in the current state.
 """
@@ -112,22 +112,22 @@ def _gtp_column_range(board_size: int | None) -> str:
         return "the columns shown in the board state"
     columns = _GTP_COLUMNS[:board_size]
     if board_size <= 8:
-        return f"a-{columns[-1]}"
+        return f"A-{columns[-1].upper()}"
     if board_size == 9:
-        return "a-h,j"
-    return f"a-h,j-{columns[-1]}"
+        return "A-H,J"
+    return f"A-H,J-{columns[-1].upper()}"
 
 
 def _coordinate_guidance(board_size: int | None) -> str:
     if board_size is None or board_size <= 0:
         return (
-            "Coordinates use GTP notation: lowercase column letters shown in "
+            "Coordinates use GTP notation: column letters shown in "
             'the board state, skipping "i", followed by row numbers starting '
             'from 1.'
         )
     return (
         f"Coordinates use GTP notation for this {board_size}x{board_size} board: "
-        f"columns are {_gtp_column_range(board_size)} (the letter \"i\" is "
+        f"columns are {_gtp_column_range(board_size)} (the letter \"I\" is "
         f"skipped), and rows are 1-{board_size}."
     )
 

--- a/kaggle_environments/envs/open_spiel_env/games/go/visualizer/default/src/transformers/goReplayTypes.ts
+++ b/kaggle_environments/envs/open_spiel_env/games/go/visualizer/default/src/transformers/goReplayTypes.ts
@@ -6,7 +6,7 @@ export interface GoBoardState {
   komi: number;
   current_player_to_move: string;
   move_number: number;
-  previous_move_a1: string | null;
+  previous_move: string | null;
   board: string[][];
 }
 

--- a/kaggle_environments/envs/open_spiel_env/games/go/visualizer/default/src/transformers/goTransformer.ts
+++ b/kaggle_environments/envs/open_spiel_env/games/go/visualizer/default/src/transformers/goTransformer.ts
@@ -27,7 +27,7 @@ function parseBoardState(observationString: string): GoBoardState {
       komi: obs.komi,
       current_player_to_move: obs.current_player_to_move,
       move_number: obs.move_number,
-      previous_move_a1: obs.previous_move_a1,
+      previous_move: obs.previous_move ?? obs.previous_move_a1,
       board,
     };
   } catch {
@@ -36,7 +36,7 @@ function parseBoardState(observationString: string): GoBoardState {
       komi: 7.5,
       current_player_to_move: '',
       move_number: 0,
-      previous_move_a1: null,
+      previous_move: null,
       board: [],
     };
   }

--- a/kaggle_environments/envs/open_spiel_env/games/go/visualizer/fallback/src/renderer.ts
+++ b/kaggle_environments/envs/open_spiel_env/games/go/visualizer/fallback/src/renderer.ts
@@ -364,7 +364,8 @@ export function renderer(options: RendererOptions<GoStep[]>) {
     }
 
     const currentPlayer = step.players.find((player) => player.isTurn);
-    const { board, komi, previous_move_a1 } = step.boardState;
+    const { board, komi, previous_move } = step.boardState;
+    const previousMoveCoord = previous_move?.split(/\s+/).at(-1)?.toUpperCase();
 
     // Render stones on the board, from top to bottom
     // board[0] is the top row (row 9 in a 9x9 board), board[8] is bottom row (row 1)
@@ -387,10 +388,10 @@ export function renderer(options: RendererOptions<GoStep[]>) {
     }
 
     // Highlight the most recent move if available
-    if (previous_move_a1) {
+    if (previousMoveCoord && previousMoveCoord !== 'PASS') {
       // Parse the coordinate (e.g., "F4" -> column F, row 4)
-      const colLetter = previous_move_a1[0];
-      const rowNumber = parseInt(previous_move_a1.slice(1));
+      const colLetter = previousMoveCoord[0];
+      const rowNumber = parseInt(previousMoveCoord.slice(1));
 
       const colIndex = COLUMN_LABELS.indexOf(colLetter);
       const rowIndex = boardSize - rowNumber; // Convert Go row numbering to array index
@@ -421,8 +422,8 @@ export function renderer(options: RendererOptions<GoStep[]>) {
     // Update status display
     currentStatusTextElement.innerHTML = currentPlayer?.name || '';
 
-    if (previous_move_a1) {
-      currentWinnerTextElement.textContent = `Last move: ${previous_move_a1}${komi ? ` • Komi: ${komi}` : ''}`;
+    if (previous_move) {
+      currentWinnerTextElement.textContent = `Last move: ${previous_move}${komi ? ` • Komi: ${komi}` : ''}`;
     } else {
       currentWinnerTextElement.textContent = komi ? `Komi: ${komi}` : '';
     }

--- a/kaggle_environments/envs/open_spiel_env/games/go/visualizer/fallback/src/transformers/goReplayTypes.ts
+++ b/kaggle_environments/envs/open_spiel_env/games/go/visualizer/fallback/src/transformers/goReplayTypes.ts
@@ -5,7 +5,7 @@ export interface GoBoardState {
   komi: number;
   current_player_to_move: string;
   move_number: number;
-  previous_move_a1: string | null;
+  previous_move: string | null;
   board: string[][];
 }
 

--- a/kaggle_environments/envs/open_spiel_env/games/go/visualizer/fallback/src/transformers/goTransformer.ts
+++ b/kaggle_environments/envs/open_spiel_env/games/go/visualizer/fallback/src/transformers/goTransformer.ts
@@ -26,7 +26,7 @@ function parseBoardState(observationString: string): GoBoardState {
       komi: obs.komi,
       current_player_to_move: obs.current_player_to_move,
       move_number: obs.move_number,
-      previous_move_a1: obs.previous_move_a1,
+      previous_move: obs.previous_move ?? obs.previous_move_a1,
       board,
     };
   } catch {
@@ -35,7 +35,7 @@ function parseBoardState(observationString: string): GoBoardState {
       komi: 7.5,
       current_player_to_move: '',
       move_number: 0,
-      previous_move_a1: null,
+      previous_move: null,
       board: [],
     };
   }

--- a/tests/envs/open_spiel_env/games/go/harness_test.py
+++ b/tests/envs/open_spiel_env/games/go/harness_test.py
@@ -97,16 +97,17 @@ class ParseResponseTest(absltest.TestCase):
         self.assertEqual(result.legal_action, "B e5")
         self.assertEqual(result.raw_action, "e5")
 
-    def test_parse_returns_parse_result(self):
-        """Verify the return type is ParseResult."""
-        legal = ["B a1"]
-        result = parse_response('```json\n{"move": "a1"}\n```', legal)
-        self.assertIsInstance(result, ParseResult)
+    def test_last_json_move_wins(self):
+        legal = ["B a1", "B e5"]
+        response = (
+            'First I thought {"move": "a1"}.\n'
+            'Final answer: {"move": "e5"}'
+        )
+        result = parse_response(response, legal)
+        self.assertEqual(result.legal_action, "B e5")
+        self.assertEqual(result.raw_action, "e5")
 
     def test_illegal_json_does_not_ghost_substitute_from_prose(self):
-        # The model's JSON answer (z99) isn't legal. The parser must NOT
-        # silently substitute a legal coord from the prose -- return None
-        # so the rethink loop asks the model to fix its answer.
         legal = ["B a1", "B e5"]
         response = (
             "I considered e5 but ruled it out.\n"
@@ -116,6 +117,27 @@ class ParseResponseTest(absltest.TestCase):
         self.assertIsNone(result.legal_action)
         self.assertEqual(result.raw_action, "z99")
 
+    def test_substring_coordinates_do_not_ghost_substitute(self):
+        legal = ["B a1", "B b1", "B b12"]
+        response = (
+            "Row 12 includes B12, and A10 appears elsewhere.\n"
+            '```json\n{"move": "b12"}\n```'
+        )
+        result = parse_response(response, legal)
+        self.assertEqual(result.legal_action, "B b12")
+        self.assertEqual(result.raw_action, "b12")
+
+    def test_rejects_color_prefixed_json_move(self):
+        legal = ["B e5"]
+        result = parse_response('```json\n{"move": "B e5"}\n```', legal)
+        self.assertIsNone(result.legal_action)
+        self.assertEqual(result.raw_action, "B e5")
+
+    def test_parse_returns_parse_result(self):
+        """Verify the return type is ParseResult."""
+        legal = ["B a1"]
+        result = parse_response('```json\n{"move": "a1"}\n```', legal)
+        self.assertIsInstance(result, ParseResult)
 
 class GeneratePromptTest(absltest.TestCase):
     def test_basic_prompt(self):
@@ -128,6 +150,7 @@ class GeneratePromptTest(absltest.TestCase):
         self.assertIn("Tromp-Taylor", prompt)
         self.assertIn("suicide is illegal", prompt)
         self.assertIn("superko", prompt)
+        self.assertIn("Simple ko is also illegal", prompt)
 
     def test_white_player(self):
         observation = {
@@ -138,13 +161,53 @@ class GeneratePromptTest(absltest.TestCase):
         self.assertIn("White", prompt)
         self.assertIn("(W)", prompt)
 
-    def test_move_history_included(self):
+    def test_uses_full_move_history_from_state_not_agent_history(self):
         observation = {
-            "observationString": "{}",
+            "observationString": json.dumps({
+                "board_size": 13,
+                "move_history": ["B k10", "W d4", "B k4"],
+            }),
             "playerId": 0,
         }
-        prompt = generate_prompt(observation, ["B e5", "W d4", "B c3"])
-        self.assertIn("B e5 W d4 B c3", prompt)
+        prompt = generate_prompt(observation, ["B a1", "B b1"])
+        self.assertIn("The full game move history is:\nB k10 W d4 B k4", prompt)
+        self.assertNotIn("B a1 B b1", prompt)
+
+    def test_ascii_board_included_in_addition_to_raw_json(self):
+        state = {
+            "board_size": 9,
+            "komi": 7.5,
+            "ascii_board": " 9 +++++++++\n   ABCDEFGHJ",
+        }
+        observation = {
+            "observationString": json.dumps(state),
+            "playerId": 0,
+        }
+        prompt = generate_prompt(observation, [])
+        self.assertIn("The current game state JSON is:\n", prompt)
+        self.assertIn('"komi": 7.5', prompt)
+        self.assertIn("ASCII board for the same position", prompt)
+        self.assertIn(" 9 +++++++++\n   ABCDEFGHJ", prompt)
+
+    def test_coordinate_guidance_is_board_size_aware(self):
+        observation = {
+            "observationString": json.dumps({"board_size": 13}),
+            "playerId": 0,
+        }
+        prompt = generate_prompt(observation, [])
+        self.assertIn("this 13x13 board", prompt)
+        self.assertIn("columns are a-h,j-n", prompt)
+        self.assertIn("rows are 1-13", prompt)
+        self.assertNotIn("For example on a 9x9 board", prompt)
+
+    def test_prompt_requires_lowercase_coordinate_only(self):
+        observation = {
+            "observationString": json.dumps({"board_size": 13}),
+            "playerId": 0,
+        }
+        prompt = generate_prompt(observation, [])
+        self.assertIn("coordinate only", prompt)
+        self.assertIn("lowercase coordinate only", prompt)
 
     def test_rethink_suffix(self):
         observation = {
@@ -203,6 +266,23 @@ class GetLegalMovesTest(absltest.TestCase):
         for k, v in result.items():
             self.assertIsInstance(k, int)
             self.assertIsInstance(v, str)
+
+
+class GoProxyStateTest(absltest.TestCase):
+    def test_state_dict_includes_ascii_board_full_history_and_previous_move(self):
+        game = go_proxy.GoGame({"board_size": 9, "komi": 7.5})
+        state = game.new_initial_state()
+        state.apply_action(_gtp_to_action("E5"))
+        state.apply_action(_gtp_to_action("D4"))
+
+        data = state.state_dict()
+
+        self.assertEqual(data["move_history"], ["B e5", "W d4"])
+        self.assertEqual(data["previous_move"], "W d4")
+        self.assertNotIn("previous_move_a1", data)
+        self.assertIn("ascii_board", data)
+        self.assertIn("ABCDEFGHJ", data["ascii_board"])
+        self.assertNotIn("GoState(", data["ascii_board"])
 
 
 class _StreamDelta:

--- a/tests/envs/open_spiel_env/games/go/harness_test.py
+++ b/tests/envs/open_spiel_env/games/go/harness_test.py
@@ -197,18 +197,18 @@ class GeneratePromptTest(absltest.TestCase):
         }
         prompt = generate_prompt(observation, [])
         self.assertIn("this 13x13 board", prompt)
-        self.assertIn("columns are a-h,j-n", prompt)
+        self.assertIn("columns are A-H,J-N", prompt)
         self.assertIn("rows are 1-13", prompt)
         self.assertNotIn("For example on a 9x9 board", prompt)
 
-    def test_prompt_requires_lowercase_coordinate_only(self):
+    def test_prompt_requires_coordinate_only_without_player_prefix(self):
         observation = {
             "observationString": json.dumps({"board_size": 13}),
             "playerId": 0,
         }
         prompt = generate_prompt(observation, [])
         self.assertIn("coordinate only", prompt)
-        self.assertIn("lowercase coordinate only", prompt)
+        self.assertIn("without the player prefix", prompt)
 
     def test_rethink_suffix(self):
         observation = {

--- a/tests/envs/open_spiel_env/games/go/harness_test.py
+++ b/tests/envs/open_spiel_env/games/go/harness_test.py
@@ -148,9 +148,10 @@ class GeneratePromptTest(absltest.TestCase):
         prompt = generate_prompt(observation, [])
         self.assertIn("Black", prompt)
         self.assertIn("Tromp-Taylor", prompt)
-        self.assertIn("suicide is illegal", prompt)
-        self.assertIn("superko", prompt)
-        self.assertIn("Simple ko is also illegal", prompt)
+        self.assertIn("Suicide is illegal", prompt)
+        self.assertIn("single-stone ko recapture is illegal", prompt)
+        self.assertIn("non-pass move that repeats an earlier board position", prompt)
+        self.assertIn("ends the game in a draw", prompt)
 
     def test_white_player(self):
         observation = {


### PR DESCRIPTION
## Summary

- Keep the raw JSON state in the Go prompt while adding a readable ASCII board for the same position.
- Source full-game move history from the Go proxy instead of the per-agent core harness closure history.
- Make GTP coordinate guidance board-size-aware and clarify that final JSON uses lowercase coordinate-only moves.
- Add simple-ko wording and keep strict JSON-only parsing through the shared `core_harness.parse_json_action` helper.
- Rename new proxy state from `previous_move_a1` to `previous_move`, while visualizers still accept old replay data.

## Checklist

- [x] Keep raw JSON state in prompt as the source of metadata, including `komi`.
- [x] Add ASCII board in addition to JSON state.
- [x] Add full-game move history from `GoState.history()`.
- [x] Use full-game history in prompt instead of per-agent `core_harness` history.
- [x] Make coordinate guidance board-size-aware.
- [x] Keep parser strict: JSON `move` is coordinate-only or `PASS`; reject `"B e5"`.
- [x] Replace `previous_move_a1` with `previous_move` for new proxy state.
- [x] Keep visualizers compatible with older `previous_move_a1` replay data.
- [x] Reconcile uppercase board labels with lowercase final JSON wording.
- [x] Add simple-ko wording.

## Full Example Prompt

```text
Let's play Go.

Rules: Tromp-Taylor scoring (area scoring — count stones on the board plus
empty territory enclosed by a single color; all stones are treated as alive).
Komi is given in the game state JSON below. Two differences from standard
Tromp-Taylor: (1) suicide is illegal — you may not place a stone that would
be immediately captured unless it captures enemy stones first, and
(2) positional superko violations end the game as a draw rather than simply
making the move illegal. Simple ko is also illegal: after a single-stone
capture, the opponent may not immediately recapture on that same point.
The game ends when both players pass consecutively.

The current game state JSON is:
{"board_size": 13, "komi": 7.5, "current_player_to_move": "B", "move_number": 1, "previous_move": null, "move_history": [], "ascii_board": "13 +++++++++++++\n12 +++++++++++++\n11 +++++++++++++\n10 +++++++++++++\n 9 +++++++++++++\n 8 +++++++++++++\n 7 +++++++++++++\n 6 +++++++++++++\n 5 +++++++++++++\n 4 +++++++++++++\n 3 +++++++++++++\n 2 +++++++++++++\n 1 +++++++++++++\n   ABCDEFGHJKLMN", "board_grid": [[{"A13": "."}, {"B13": "."}, {"C13": "."}, {"D13": "."}, {"E13": "."}, {"F13": "."}, {"G13": "."}, {"H13": "."}, {"J13": "."}, {"K13": "."}, {"L13": "."}, {"M13": "."}, {"N13": "."}], [{"A12": "."}, {"B12": "."}, {"C12": "."}, {"D12": "."}, {"E12": "."}, {"F12": "."}, {"G12": "."}, {"H12": "."}, {"J12": "."}, {"K12": "."}, {"L12": "."}, {"M12": "."}, {"N12": "."}], [{"A11": "."}, {"B11": "."}, {"C11": "."}, {"D11": "."}, {"E11": "."}, {"F11": "."}, {"G11": "."}, {"H11": "."}, {"J11": "."}, {"K11": "."}, {"L11": "."}, {"M11": "."}, {"N11": "."}], [{"A10": "."}, {"B10": "."}, {"C10": "."}, {"D10": "."}, {"E10": "."}, {"F10": "."}, {"G10": "."}, {"H10": "."}, {"J10": "."}, {"K10": "."}, {"L10": "."}, {"M10": "."}, {"N10": "."}], [{"A9": "."}, {"B9": "."}, {"C9": "."}, {"D9": "."}, {"E9": "."}, {"F9": "."}, {"G9": "."}, {"H9": "."}, {"J9": "."}, {"K9": "."}, {"L9": "."}, {"M9": "."}, {"N9": "."}], [{"A8": "."}, {"B8": "."}, {"C8": "."}, {"D8": "."}, {"E8": "."}, {"F8": "."}, {"G8": "."}, {"H8": "."}, {"J8": "."}, {"K8": "."}, {"L8": "."}, {"M8": "."}, {"N8": "."}], [{"A7": "."}, {"B7": "."}, {"C7": "."}, {"D7": "."}, {"E7": "."}, {"F7": "."}, {"G7": "."}, {"H7": "."}, {"J7": "."}, {"K7": "."}, {"L7": "."}, {"M7": "."}, {"N7": "."}], [{"A6": "."}, {"B6": "."}, {"C6": "."}, {"D6": "."}, {"E6": "."}, {"F6": "."}, {"G6": "."}, {"H6": "."}, {"J6": "."}, {"K6": "."}, {"L6": "."}, {"M6": "."}, {"N6": "."}], [{"A5": "."}, {"B5": "."}, {"C5": "."}, {"D5": "."}, {"E5": "."}, {"F5": "."}, {"G5": "."}, {"H5": "."}, {"J5": "."}, {"K5": "."}, {"L5": "."}, {"M5": "."}, {"N5": "."}], [{"A4": "."}, {"B4": "."}, {"C4": "."}, {"D4": "."}, {"E4": "."}, {"F4": "."}, {"G4": "."}, {"H4": "."}, {"J4": "."}, {"K4": "."}, {"L4": "."}, {"M4": "."}, {"N4": "."}], [{"A3": "."}, {"B3": "."}, {"C3": "."}, {"D3": "."}, {"E3": "."}, {"F3": "."}, {"G3": "."}, {"H3": "."}, {"J3": "."}, {"K3": "."}, {"L3": "."}, {"M3": "."}, {"N3": "."}], [{"A2": "."}, {"B2": "."}, {"C2": "."}, {"D2": "."}, {"E2": "."}, {"F2": "."}, {"G2": "."}, {"H2": "."}, {"J2": "."}, {"K2": "."}, {"L2": "."}, {"M2": "."}, {"N2": "."}], [{"A1": "."}, {"B1": "."}, {"C1": "."}, {"D1": "."}, {"E1": "."}, {"F1": "."}, {"G1": "."}, {"H1": "."}, {"J1": "."}, {"K1": "."}, {"L1": "."}, {"M1": "."}, {"N1": "."}]]}

ASCII board for the same position (X=Black, O=White, +=empty; board labels may be uppercase):
13 +++++++++++++
12 +++++++++++++
11 +++++++++++++
10 +++++++++++++
 9 +++++++++++++
 8 +++++++++++++
 7 +++++++++++++
 6 +++++++++++++
 5 +++++++++++++
 4 +++++++++++++
 3 +++++++++++++
 2 +++++++++++++
 1 +++++++++++++
   ABCDEFGHJKLMN

The full game move history is:
None

You are playing as player Black (B).
It is now your turn. Play your strongest move.
The move MUST be legal.
Your response should include the reasoning that led you to your move, and
conclude with your final move as a JSON formatted as follows:

```json
{
  "move": "<move>" }
```

Where move is the coordinate only (e.g. "a1", "b2", "e5") or "PASS" if you wish to pass.
Coordinates use GTP notation for this 13x13 board: columns are a-h,j-n (the letter "i" is skipped), and rows are 1-13.
The board display may use uppercase labels, but your final JSON move must use the lowercase coordinate only.
Failure to output your final answer in the specified format will result in a loss.
Begin!
```

## Tests

```sh
.venv/bin/python -m pytest tests/envs/open_spiel_env/games/go/harness_test.py -q
.venv/bin/python -m py_compile kaggle_environments/envs/open_spiel_env/games/go/harness.py kaggle_environments/envs/open_spiel_env/games/go/go_proxy.py tests/envs/open_spiel_env/games/go/harness_test.py
git diff --check
```