### PR TITLE
Add a simple harness ablation tool/skill

### DIFF
--- a/.agents/skills/run-ablation/SKILL.md
+++ b/.agents/skills/run-ablation/SKILL.md
@@ -1,0 +1,216 @@
+---
+name: run-ablation
+description: Run a prompt-ablation study on a kaggle-environments game's LLM harness. Use when the user mentions "ablation", "prompt sensitivity", "test prompt variants", "compare prompts", "ablate the prompt", "prompt rewrite study", or asks whether their prompt wording is doing real work. Bootstraps a prompt_variants.py if missing, proposes new variants interactively, then runs a paired-seat tournament and reports the leaderboards.
+---
+
+# Run a Prompt Ablation Study
+
+This skill drives the end-to-end prompt-sensitivity workflow for one game's harness: discover or bootstrap variants, propose additional ones in conversation with the user, run the paired-seat tournament, and report the findings. It is completely standalone — it does not depend on or modify the `create-harness`, `review-harness`, or `create-environment` skills.
+
+The runner library is `kaggle_environments/ablation.py`. The two subcommands you'll invoke are:
+
+```bash
+python -m kaggle_environments.ablation check --env <env_name>
+python -m kaggle_environments.ablation run --env <env_name> --models <csv> --games <N> --out <dir>
+```
+
+The runner contract:
+
+* Every game's harness directory contributes a `prompt_variants.py` exposing `VARIANTS: dict[str, GameHarness]`. Each variant **is** a `GameHarness` (implements `get_legal_moves` / `make_prompt` / `parse_response`), so `create_agent_fn(variant)` works directly.
+* The `baseline` variant must be byte-identical to the production `harness.py`. The `check` subcommand enforces this against seeded observations.
+* For each variant, the runner plays a round-robin among the M models with both players using that variant. Every `{A, B}` matchup is scheduled in **seat-flipped pairs sharing one chance seed** — the same instance is played twice with seats swapped. `--games` must be even.
+
+## Step 0: Identify the env
+
+Confirm with the user which env they want to ablate. Acceptable forms: `open_spiel_bargaining`, `werewolf`, `tictactoe`, etc. The env name is what gets passed to `kaggle_environments.make(env_name)`.
+
+Resolve the harness directory:
+* `open_spiel_<game>` → `kaggle_environments/envs/open_spiel_env/games/<game>/`
+* `<env>` → `kaggle_environments/envs/<env>/`
+
+Confirm `harness.py` exists at that path. If not, stop and tell the user: the production harness has to exist before you can ablate it. Suggest they run `create-harness` first.
+
+## Step 1: Inventory existing variants
+
+Read `prompt_variants.py` if it exists at the harness directory. List the names found and one-line summaries:
+
+```
+Found prompt_variants.py with: baseline, compact, minimal, no_accept_preview, generic_names
+```
+
+If the file doesn't exist, you'll bootstrap it in Step 4. Tell the user you're going to:
+
+```
+No prompt_variants.py yet — I'll bootstrap one from harness.py.
+The 'baseline' variant will be byte-identical to the production prompt;
+I'll also propose a few ablations for your review.
+```
+
+## Step 2: Read the production prompt
+
+Open `harness.py` and read the `make_prompt` (or `generate_prompt`) function plus any prompt-template constants it uses. Note the prompt's *structural* features — these are what your variant proposals will target:
+
+* What rules / mechanics paragraphs are in there?
+* What helper text (legal-move list, current-state summary, payoff hints, "you would receive...", "you may agree")?
+* What domain-specific labels (item names, square notation, color names)?
+* Is there a goal/strategy nudge ("end the game with a higher reward than your opponent")?
+* What's the JSON schema?
+
+You can't propose a good ablation without understanding the prompt's joints. Spend a turn here.
+
+## Step 3: ALWAYS propose new variants
+
+**This step is mandatory.** Even if `prompt_variants.py` already has variants, propose new ones. Skipping this step defeats the purpose of the skill — the point is to force a "what am I actually testing?" beat before any LLM money is spent.
+
+Generate **3–5 candidate variants** with a one-line rationale each. Cover at least three of these generic axes:
+
+* **Compact** — same information, much terser language. Drops worked examples, repeated reminders, loss-threat sentences. Tests whether the verbose scaffolding is load-bearing.
+* **Minimal** — strips everything optional: rules, goal statement, helpers, examples. Just state + JSON schema. Tests how much the model already knows.
+* **No goal hint** — removes any "your goal is to..." sentence. Tests whether the goal nudge is doing work.
+* **Generic labels** — swaps real names for letters (Book/Hat/Basketball → A/B/C, North/East/South/West → 0/1/2/3). Tests for semantic priors that bias decisions away from stated valuations.
+* **No legal-move list** — removes the enumeration of legal moves (if the prompt includes one). Tests whether the model can derive legality from rules.
+* **Raw observation** — uses the env's raw observation string instead of any reformatting the prompt does. Tests whether the prompt's restructuring is helping.
+* **Drop a specific helper** — pick one piece of computed help in the prompt (e.g. Bargaining's "you would receive [...]" accept preview, Chess's notation explainer, Go's territory hint) and remove it. Tests whether that helper is load-bearing.
+
+Then propose **1–2 game-specific axes** that you identify from reading the prompt in Step 2. These are the most interesting ablations because they're tailored to the actual prompt design choices the author made.
+
+Each proposal should include:
+* A short name (snake_case, e.g. `no_payoff_hint`)
+* One sentence of rationale (what hypothesis it tests)
+* The concrete change vs. baseline (one or two bullet points)
+
+**Use the `AskUserQuestion` tool to surface the proposals**, with one question per group of related variants, options for accept/skip/rewrite/replace. Concrete usage pattern:
+
+```
+AskUserQuestion({
+  questions: [
+    {
+      question: "Which of these structural ablations should we include?",
+      header: "Structural",
+      multiSelect: true,
+      options: [
+        {label: "compact",       description: "Same info, terser — drops worked example + loss threat"},
+        {label: "minimal",       description: "Strip rules/goal/helpers, just state + JSON schema"},
+        {label: "no_goal_hint",  description: "Remove the 'win by ending with higher reward' sentence"},
+      ]
+    },
+    {
+      question: "Which game-specific ablations should we include?",
+      header: "Game-specific",
+      multiSelect: true,
+      options: [
+        {label: "no_accept_preview", description: "Drop 'you would receive [...]' — model must compute complement itself"},
+        {label: "generic_names",     description: "Book/Hat/Basketball → A/B/C — strip semantic priors"},
+      ]
+    },
+  ]
+})
+```
+
+After the user responds, ask one follow-up if anything is ambiguous (a rewritten rationale, a swap of one axis for another). It's fine to loop two or three times. **You may not skip the proposal — even if the user accepts everything immediately, you must have surfaced concrete proposals first.**
+
+## Step 4: Write the variants
+
+Bootstrap `prompt_variants.py` if it doesn't exist; otherwise update it.
+
+Pick the right template based on env type:
+* OpenSpiel games (`open_spiel_*`) → start from `templates/prompt_variants_openspiel.py.tmpl`
+* Anything else → start from `templates/prompt_variants_generic.py.tmpl`
+
+For each variant:
+
+1. **`baseline`** must be byte-identical to `harness.py`. Port the existing prompt template and helper logic into a `BaselineVariant` class. Do not paraphrase — the next step (`ablation check`) will fail if even one character differs.
+2. **Each new variant** is a subclass of `BaselineVariant` (or sibling class) that overrides `make_prompt` (and `parse_response` if the schema changed — e.g. `generic_names` uses `{a, b, c}` JSON keys and needs an alias map).
+3. Expose `VARIANTS = {"baseline": BaselineVariant(), ...}` at module level. The runner enforces a `"baseline"` entry.
+
+Keep the variant code in one file. Do **not** import shared prompt fragments from a sibling helper module — `harness.py` is manually deployed and versioned separately, so a shared-module import would be a deploy-isolation footgun.
+
+## Step 5: Verify with `ablation check`
+
+```bash
+uv run python -m kaggle_environments.ablation check --env <env_name>
+```
+
+Required output:
+```
+env: <env_name>
+variants: ['baseline', 'compact', ...]
+  baseline parity obs[0]: ok (NNNN chars)
+  baseline parity obs[1]: ok (NNNN chars)
+  ...
+  variant 'compact': rendered ok across 5 observations
+  ...
+OK
+```
+
+If baseline parity fails, **stop and fix the BaselineVariant port** before proceeding. The most common cause is a paraphrased docstring or a stripped trailing newline. Show the user the diff (use `harness.generate_prompt(obs, [])` vs `VARIANTS["baseline"].make_prompt(obs, [])`) so they can confirm what changed.
+
+If a variant errors on render (template KeyError, missing field), fix it. Do not move on with broken variants.
+
+## Step 6: Confirm the run plan
+
+Before spending API budget, confirm the run with the user. Use `AskUserQuestion` or open prose. Surface:
+
+* The env, the variant list, the model list, `--games` (paired games per matchup — must be even).
+* The total cell count: `K · M(M−1)/2 · games`. Add `M · games` per leaderboard if `--self-play`.
+* A rough cost estimate. For Bargaining-class games (≤10 prompt-response rounds, ~1k–3k prompt tokens), assume ~20 LLM calls per game.
+* The output directory.
+
+Default suggestion if the user hasn't specified: `--games 20`, all variants, `--concurrency 8`. Wait for explicit go before invoking the runner.
+
+## Step 7: Run the tournament
+
+```bash
+MODEL_PROXY_KEY=$KEY MODEL_PROXY_URL=$URL \
+uv run python -m kaggle_environments.ablation run \
+  --env <env_name> \
+  --models <csv of model names> \
+  --games <N> \
+  --concurrency 8 \
+  --out results/<env>_<date>/
+```
+
+Stream the runner's progress to the user. It writes `games.csv` (one row per game) and `summary.md` (per-variant leaderboards + cross-variant rank shifts + anomalies) into `--out`.
+
+If the run is interrupted, re-run with `--resume` to skip the cells already in `games.csv`.
+
+## Step 8: Report findings
+
+Read `summary.md` and surface to the user:
+
+* **The cross-variant rank-shift table.** This is the most informative artifact. If a model's rank shifts between variants, the prompt is doing real work for that model. If ranks are stable across variants, the prompt is mostly decoration (or the variants weren't aggressive enough).
+* **The anomalies section.** Variants with >5% crash rate or hard errors usually indicate the prompt is under-specified for some model. Read those rows in `games.csv` for context.
+* **The biggest mean-score deltas.** A variant that moves a model's mean score by ≥0.5 (in a game scaled to ±1) is a strong signal — pay attention to its concrete change vs. baseline.
+
+Make one or two concrete recommendations: which variant(s) look like upgrades to baseline, which look like clear regressions to avoid. Don't just dump the tables — interpret them.
+
+## Common pitfalls
+
+* **Forgetting `baseline` parity.** If the control arm isn't byte-identical to production, every comparison is contaminated. Run `ablation check` after every edit to `prompt_variants.py`, not just at the end.
+* **Asking before proposing.** "What variants would you like?" is the wrong question. The user is invoking this skill *because* they want concrete suggestions. Always propose 3–5 concrete variants first, then iterate.
+* **Picking too few games per matchup.** With N=2 (one pair per matchup), confidence intervals on win-rate span nearly the full [0%, 100%] range. Default to N=20 (10 pairs) for real signal; drop to N=4 only for smoke tests.
+* **Self-play by default.** `--self-play` doubles cost and rarely changes conclusions. Off unless the user asks.
+* **Modifying `harness.py`.** The production prompt stays in `harness.py`. All experimental prompts live in `prompt_variants.py`. If a variant turns out to be a win, promote it to `harness.py` in a *separate* PR.
+* **Per-game extra metrics.** The runner ships generic columns (score, winner, length, crash, duration). If you want game-specific columns (Bargaining's `agreement_step`, chess's `mate_in_n`), add them to `games.csv` in a follow-up post-processing step — the runner's schema is intentionally minimal.
+
+## Reference: the contract enforced by the runner
+
+```python
+# prompt_variants.py
+from kaggle_environments.core_harness import GameHarness, ParseResult
+
+class BaselineVariant:  # implements GameHarness
+    def get_legal_moves(self, observation): ...
+    def make_prompt(self, observation, move_history,
+                    previous_response=None, previous_action=None): ...
+    def parse_response(self, response, legal_action_strings,
+                       *, observation=None): ...
+
+VARIANTS: dict[str, GameHarness] = {
+    "baseline": BaselineVariant(),
+    "compact":  CompactVariant(),
+    # ...
+}
+```
+
+The runner imports this module, picks variants by name, and passes each to `create_agent_fn(variant, model_override=...)` per game. No further wiring needed.

--- a/.agents/skills/run-ablation/templates/prompt_variants_generic.py.tmpl
+++ b/.agents/skills/run-ablation/templates/prompt_variants_generic.py.tmpl
@@ -1,0 +1,162 @@
+"""Prompt variants for the {GAME_NAME} ablation study.
+
+Each variant implements the :class:`core_harness.GameHarness` protocol so the
+ablation runner can do ``create_agent_fn(variant)`` directly. The production
+prompt lives in :mod:`harness`; this file is the experimental surface.
+
+Conventions enforced by ``python -m kaggle_environments.ablation check``:
+  * The ``baseline`` variant in ``VARIANTS`` must produce a prompt
+    BYTE-IDENTICAL to ``harness.generate_prompt`` for the same observation.
+  * Every variant must render without error on five seeded observations.
+
+This template is for non-OpenSpiel envs (custom kaggle-environments games
+with their own observation format). For OpenSpiel games, use
+``prompt_variants_openspiel.py.tmpl`` instead — it has the proxy/serialized-
+state plumbing pre-wired.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Mapping, Sequence
+
+from kaggle_environments.core_harness import (
+    ParseResult,
+    extract_last_json_object,
+    render_rethink_suffix,
+)
+
+# JSON keys we treat as carriers of a real action (filters stray JSON objects
+# in the model's reasoning blocks). Replace with your game's keys.
+_PAYLOAD_KEYS = ("action", "move")
+
+
+# ---------------------------------------------------------------------------
+# BASELINE — port the production prompt VERBATIM
+# ---------------------------------------------------------------------------
+#
+# This is the control arm. Copy the prompt template and per-state helpers
+# from harness.py into the methods below WITHOUT paraphrasing. The
+# ``ablation check`` subcommand will diff this against ``harness.generate_prompt``
+# across seeded observations and fail loudly if they diverge.
+
+# TODO: paste your harness.py prompt template here unchanged.
+_BASELINE_TEMPLATE = """\
+{TODO: copy from harness.py — must be byte-identical}
+"""
+
+# TODO: paste your rethink templates here unchanged.
+_RETHINK_ILLEGAL = """{TODO: copy from harness.py}"""
+_RETHINK_UNPARSABLE = """{TODO: copy from harness.py}"""
+
+
+class BaselineVariant:
+    """Byte-identical port of harness.py. DO NOT paraphrase."""
+
+    name = "baseline"
+
+    # -- GameHarness protocol -------------------------------------------------
+
+    def get_legal_moves(
+        self,
+        observation: Mapping[str, Any],
+    ) -> dict[int, str] | None:
+        """Return {action_id: action_string} for legal moves, or None for
+        free-form action spaces. Copy the production logic from harness.py.
+        """
+        raise NotImplementedError("TODO: port from harness.py get_legal_moves")
+
+    def make_prompt(
+        self,
+        observation: Mapping[str, Any],
+        move_history: list[str],
+        previous_response: str | None = None,
+        previous_action: str | None = None,
+    ) -> str:
+        body = self._build_body(observation, move_history)
+        body += render_rethink_suffix(
+            _RETHINK_ILLEGAL,
+            _RETHINK_UNPARSABLE,
+            previous_response,
+            previous_action,
+        )
+        return body
+
+    def parse_response(
+        self,
+        response: str,
+        legal_action_strings: Sequence[str] | None,
+        *,
+        observation: Mapping[str, Any] | None = None,
+    ) -> ParseResult:
+        del observation
+        if not legal_action_strings:
+            return ParseResult(raw_action=None)
+        payload = extract_last_json_object(response, required_keys=_PAYLOAD_KEYS)
+        if payload is None:
+            return ParseResult(legal_action=None, raw_action=None)
+        candidate = self._payload_to_action_string(payload)
+        if candidate is None:
+            return ParseResult(legal_action=None, raw_action=None)
+        raw_repr = json.dumps(payload, separators=(",", ":"))
+        if candidate in set(legal_action_strings):
+            return ParseResult(legal_action=candidate, raw_action=raw_repr)
+        return ParseResult(legal_action=None, raw_action=raw_repr)
+
+    # -- Variants typically override these -----------------------------------
+
+    def _build_body(
+        self,
+        observation: Mapping[str, Any],
+        move_history: list[str],
+    ) -> str:
+        """Render the prompt body (no rethink suffix).
+
+        TODO: implement using _BASELINE_TEMPLATE.format(...) with whatever
+        fields the production prompt needs.
+        """
+        return _BASELINE_TEMPLATE.format()  # TODO: pass fields
+
+    def _payload_to_action_string(self, payload: Mapping[str, Any]) -> str | None:
+        """Convert a parsed JSON dict into the canonical action string.
+
+        TODO: implement the same conversion harness.py's parse_response does.
+        Variants that change the JSON schema override this method to use a
+        different alias map but emit the SAME canonical action string the
+        env expects.
+        """
+        raise NotImplementedError("TODO: port from harness.py parse_response")
+
+
+# ---------------------------------------------------------------------------
+# Example variant: COMPACT (same info, terser language)
+# ---------------------------------------------------------------------------
+
+_COMPACT_TEMPLATE = """\
+{TODO: terser rewrite of the baseline template — same fields, less prose}
+"""
+
+
+class CompactVariant(BaselineVariant):
+    """Same information as baseline, much terser. Drops worked examples,
+    repeated reminders, loss-threat sentences. Tests whether the verbose
+    scaffolding in the baseline is load-bearing."""
+
+    name = "compact"
+
+    def _build_body(self, observation, move_history):
+        return _COMPACT_TEMPLATE.format()  # TODO
+
+
+# ---------------------------------------------------------------------------
+# Add more variants here. One class per variant; subclass BaselineVariant
+# unless the variant changes the parser schema (in that case also override
+# _payload_to_action_string).
+# ---------------------------------------------------------------------------
+
+
+VARIANTS = {
+    "baseline": BaselineVariant(),
+    "compact": CompactVariant(),
+    # TODO: add the variants you and the user agreed on in Step 3.
+}

--- a/.agents/skills/run-ablation/templates/prompt_variants_openspiel.py.tmpl
+++ b/.agents/skills/run-ablation/templates/prompt_variants_openspiel.py.tmpl
@@ -1,0 +1,196 @@
+"""Prompt variants for the {GAME_NAME} ablation study.
+
+Each variant implements the :class:`core_harness.GameHarness` protocol so the
+ablation runner can do ``create_agent_fn(variant)`` directly. The production
+prompt lives in :mod:`harness`; this file is the experimental surface.
+
+Conventions enforced by ``python -m kaggle_environments.ablation check``:
+  * The ``baseline`` variant in ``VARIANTS`` must produce a prompt
+    BYTE-IDENTICAL to ``harness.generate_prompt`` for the same observation.
+  * Every variant must render without error on five seeded observations.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Mapping, Sequence
+
+import pyspiel
+
+from kaggle_environments.core_harness import (
+    ParseResult,
+    extract_last_json_object,
+    render_rethink_suffix,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers shared across variants
+# ---------------------------------------------------------------------------
+
+# JSON keys we treat as carriers of a real action (filters stray JSON objects
+# in the model's reasoning blocks).
+_PAYLOAD_KEYS = ("action", "move")  # TODO: replace with your game's keys.
+
+
+def _parse_observation_payload(observation: Mapping[str, Any]) -> dict[str, Any]:
+    """Extract structured game state from the observation.
+
+    OpenSpiel envs with a proxy expose a JSON ``observationString``; without
+    a proxy, fall back to ``pyspiel.deserialize_game_and_state`` and call the
+    state's observation_string for the current player.
+    """
+    raw = observation.get("observationString", "") or ""
+    if raw:
+        try:
+            parsed = json.loads(raw)
+            if isinstance(parsed, dict):
+                return parsed
+        except json.JSONDecodeError:
+            pass
+    serialized = observation.get("serializedGameAndState", "")
+    if serialized:
+        _, state = pyspiel.deserialize_game_and_state(serialized)
+        player_id = int(observation.get("playerId", 0))
+        try:
+            return json.loads(state.observation_string(player_id))
+        except (json.JSONDecodeError, RuntimeError):
+            pass
+    return {}
+
+
+# ---------------------------------------------------------------------------
+# BASELINE — port the production prompt VERBATIM
+# ---------------------------------------------------------------------------
+#
+# This is the control arm. Copy the prompt template and any per-state helpers
+# from harness.py into the methods below WITHOUT paraphrasing. The
+# ``ablation check`` subcommand will diff this against ``harness.generate_prompt``
+# across seeded observations and fail loudly if they diverge.
+
+# TODO: paste your harness.py prompt template here unchanged.
+_BASELINE_TEMPLATE = """\
+{TODO: copy from harness.py — must be byte-identical}
+"""
+
+# TODO: paste your rethink templates here unchanged.
+_RETHINK_ILLEGAL = """{TODO: copy from harness.py}"""
+_RETHINK_UNPARSABLE = """{TODO: copy from harness.py}"""
+
+
+class BaselineVariant:
+    """Byte-identical port of harness.py. DO NOT paraphrase."""
+
+    name = "baseline"
+
+    # -- GameHarness protocol -------------------------------------------------
+
+    def get_legal_moves(self, observation: Mapping[str, Any]) -> dict[int, str]:
+        legal_actions = observation.get("legalActions")
+        legal_action_strings = observation.get("legalActionStrings")
+        if legal_actions and legal_action_strings:
+            return dict(zip(legal_actions, legal_action_strings))
+        serialized = observation.get("serializedGameAndState", "")
+        if not serialized:
+            return {}
+        _, state = pyspiel.deserialize_game_and_state(serialized)
+        return {a: state.action_to_string(a) for a in state.legal_actions()}
+
+    def make_prompt(
+        self,
+        observation: Mapping[str, Any],
+        move_history: list[str],
+        previous_response: str | None = None,
+        previous_action: str | None = None,
+    ) -> str:
+        body = self._build_body(observation, move_history)
+        body += render_rethink_suffix(
+            _RETHINK_ILLEGAL,
+            _RETHINK_UNPARSABLE,
+            previous_response,
+            previous_action,
+        )
+        return body
+
+    def parse_response(
+        self,
+        response: str,
+        legal_action_strings: Sequence[str] | None,
+        *,
+        observation: Mapping[str, Any] | None = None,
+    ) -> ParseResult:
+        del observation
+        if not legal_action_strings:
+            return ParseResult(raw_action=None)
+        payload = extract_last_json_object(response, required_keys=_PAYLOAD_KEYS)
+        if payload is None:
+            return ParseResult(legal_action=None, raw_action=None)
+        candidate = self._payload_to_action_string(payload)
+        if candidate is None:
+            return ParseResult(legal_action=None, raw_action=None)
+        raw_repr = json.dumps(payload, separators=(",", ":"))
+        if candidate in set(legal_action_strings):
+            return ParseResult(legal_action=candidate, raw_action=raw_repr)
+        return ParseResult(legal_action=None, raw_action=raw_repr)
+
+    # -- Variant-specific overrides typically override these -----------------
+
+    def _build_body(
+        self,
+        observation: Mapping[str, Any],
+        move_history: list[str],
+    ) -> str:
+        """Render the prompt body (no rethink suffix).
+
+        TODO: implement using _BASELINE_TEMPLATE.format(...) with whatever
+        fields the production prompt needs. Use _parse_observation_payload
+        to get structured game state.
+        """
+        state = _parse_observation_payload(observation)
+        # ... compute fields ...
+        return _BASELINE_TEMPLATE.format()  # TODO: pass fields
+
+    def _payload_to_action_string(self, payload: Mapping[str, Any]) -> str | None:
+        """Convert a parsed JSON dict into the canonical action string.
+
+        TODO: implement the same conversion harness.py's parse_response does.
+        Variants that change the JSON schema (e.g. generic_names) override
+        this method to use a different alias map but emit the SAME canonical
+        action string (whatever the env's action_to_string returns).
+        """
+        raise NotImplementedError("TODO: port from harness.py parse_response")
+
+
+# ---------------------------------------------------------------------------
+# Example variant: COMPACT (same info, terser language)
+# ---------------------------------------------------------------------------
+
+_COMPACT_TEMPLATE = """\
+{TODO: terser rewrite of the baseline template — same fields, less prose}
+"""
+
+
+class CompactVariant(BaselineVariant):
+    """Same information as baseline, much terser. Drops worked examples,
+    repeated reminders, loss-threat sentences. Tests whether the verbose
+    scaffolding in the baseline is load-bearing."""
+
+    name = "compact"
+
+    def _build_body(self, observation, move_history):
+        state = _parse_observation_payload(observation)
+        # ... compute the same fields the baseline does ...
+        return _COMPACT_TEMPLATE.format()  # TODO
+
+
+# ---------------------------------------------------------------------------
+# Add more variants here. One class per variant; subclass BaselineVariant
+# unless the variant changes the parser (e.g. generic_names with a/b/c
+# JSON keys — in that case also override _payload_to_action_string).
+# ---------------------------------------------------------------------------
+
+
+VARIANTS = {
+    "baseline": BaselineVariant(),
+    "compact": CompactVariant(),
+    # TODO: add the variants you and the user agreed on in Step 3.
+}

--- a/kaggle_environments/ablation.py
+++ b/kaggle_environments/ablation.py
@@ -1,0 +1,1051 @@
+"""Prompt-ablation runner for Kaggle game environments.
+
+Cross-game tool for running parallel leaderboards across prompt variants.
+Each game's harness directory contributes a ``prompt_variants.py`` whose
+top-level ``VARIANTS: dict[str, GameHarness]`` is the experiment surface.
+This runner discovers that module, schedules paired-seat round-robin
+games per variant, and writes ``games.csv`` + ``summary.md``.
+
+CLI
+---
+
+::
+
+    python -m kaggle_environments.ablation check --env open_spiel_bargaining
+    python -m kaggle_environments.ablation run \\
+        --env open_spiel_bargaining \\
+        --models gpt-5,claude-opus-4-7,gemini-2.5-pro \\
+        --games 20 \\
+        --concurrency 16 \\
+        --out results/bargaining/
+
+``MODEL_PROXY_KEY`` and ``MODEL_PROXY_URL`` come from env. The same key
+authenticates every model (proxy fans out internally).
+
+Design notes
+------------
+
+* Matrix shape (per the design doc): K parallel leaderboards, where each
+  leaderboard runs a round-robin among the M models with both players
+  using the same variant. Self-play is opt-in (``--self-play``).
+* Every (A, B) matchup is scheduled in **seat-flipped pairs sharing one
+  chance seed** -- the same instance is played twice with seats swapped,
+  cancelling first-mover advantage and instance luck. ``--games`` counts
+  individual games and must be even.
+* Concurrency uses a ``ProcessPoolExecutor`` with the ``fork`` start
+  method (one game per worker process). Threads turn out to deadlock
+  inside ``env.run`` + the full harness path -- some shared state in
+  the env or pyspiel interpreter is not thread-safe. Processes are also
+  the right semantic match: each game has its own pyspiel state and its
+  own model selection via ``model_override``, with zero cross-game
+  interference. Fork preserves monkey-patched ``core_harness._call_llm``
+  for smoke tests, so the in-process mocking pattern still works.
+* No per-model concurrency cap yet -- a ``threading.Semaphore`` doesn't
+  cross process boundaries, so the simple total ``--concurrency`` cap is
+  the only knob. (Future: ``multiprocessing.Manager().Semaphore``.)
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import dataclasses
+import importlib
+import json
+import logging
+import math
+import multiprocessing as mp
+import os
+import signal
+import sys
+import threading
+import time
+import traceback
+from collections import defaultdict
+from concurrent.futures import ProcessPoolExecutor, as_completed
+from pathlib import Path
+from typing import Any, Iterable, Mapping
+
+from kaggle_environments import make
+from kaggle_environments.core_harness import GameHarness, create_agent_fn
+
+_log = logging.getLogger("kaggle_environments.ablation")
+
+
+# ---------------------------------------------------------------------------
+# Variant discovery
+# ---------------------------------------------------------------------------
+
+
+def _variants_module_path(env_name: str) -> str:
+    """Map env name to the dotted path of its ``prompt_variants`` module."""
+    if env_name.startswith("open_spiel_"):
+        game = env_name[len("open_spiel_") :]
+        return f"kaggle_environments.envs.open_spiel_env.games.{game}.prompt_variants"
+    return f"kaggle_environments.envs.{env_name}.prompt_variants"
+
+
+def load_variants(env_name: str) -> dict[str, GameHarness]:
+    """Return the ``VARIANTS`` registry for ``env_name``, or raise."""
+    module_path = _variants_module_path(env_name)
+    try:
+        module = importlib.import_module(module_path)
+    except ModuleNotFoundError as e:
+        raise SystemExit(
+            f"No prompt_variants.py found for env '{env_name}' "
+            f"(expected at {module_path}). Bootstrap one with the "
+            f"run-ablation skill."
+        ) from e
+    variants = getattr(module, "VARIANTS", None)
+    if not isinstance(variants, dict) or not variants:
+        raise SystemExit(
+            f"{module_path} must expose a non-empty VARIANTS "
+            f"dict[str, GameHarness]."
+        )
+    if "baseline" not in variants:
+        raise SystemExit(
+            f"{module_path}.VARIANTS must include a 'baseline' entry "
+            f"(byte-identical to harness.py)."
+        )
+    return variants
+
+
+# ---------------------------------------------------------------------------
+# Model wiring
+# ---------------------------------------------------------------------------
+
+
+def build_model_setup(
+    model_name: str,
+    api_key: str,
+    api_base: str,
+) -> tuple[str, dict[str, Any]]:
+    """Compose ``(model_name, litellm_kwargs)`` for one agent.
+
+    Mirrors :func:`core_harness._setup_model` but takes explicit args so
+    callers can pick a model per-agent without touching the global env.
+    """
+    if api_base and api_base != "dummy_url":
+        return f"openai/{model_name}", {
+            "api_base": f"{api_base.rstrip('/')}/openapi",
+            "api_key": api_key,
+            "reasoning_effort": "high",
+        }
+    if "gemini" in model_name.lower() and not model_name.startswith("gemini/"):
+        return f"gemini/{model_name}", {}
+    return model_name, {}
+
+
+# ---------------------------------------------------------------------------
+# Cell scheduling
+# ---------------------------------------------------------------------------
+
+
+@dataclasses.dataclass(frozen=True)
+class GameCell:
+    """One scheduled game.
+
+    ``seed`` is shared across the two seat-flipped games of a pair; the
+    pair as a whole is identified by ``(variant, frozenset({model_p0,
+    model_p1}), seed)``. ``pair_role`` is ``"AB"`` or ``"BA"`` for the
+    flipped games, or ``"SELF"`` for self-play (which doesn't pair).
+    """
+
+    variant: str
+    model_p0: str
+    model_p1: str
+    seed: int
+    pair_role: str
+
+
+def build_cells(
+    variants: Iterable[str],
+    models: list[str],
+    games_per_matchup: int,
+    *,
+    include_self_play: bool,
+) -> list[GameCell]:
+    """Enumerate every cell to play (K * M(M-1)/2 * games + optional self-play).
+
+    For each variant, each unordered model pair contributes
+    ``games_per_matchup`` games -- ``games_per_matchup / 2`` seat-flipped
+    pairs sharing one chance seed each.
+    """
+    if games_per_matchup % 2 != 0:
+        raise SystemExit(
+            f"--games must be even (got {games_per_matchup}); each "
+            f"matchup is scheduled in seat-flipped pairs."
+        )
+    pairs_per_matchup = games_per_matchup // 2
+    cells: list[GameCell] = []
+    for v in variants:
+        # Round-robin over unordered model pairs.
+        for i, a in enumerate(models):
+            for b in models[i + 1 :]:
+                for pair_idx in range(pairs_per_matchup):
+                    cells.append(GameCell(v, a, b, seed=pair_idx, pair_role="AB"))
+                    cells.append(GameCell(v, b, a, seed=pair_idx, pair_role="BA"))
+            if include_self_play:
+                for game_idx in range(games_per_matchup):
+                    cells.append(
+                        GameCell(v, a, a, seed=game_idx, pair_role="SELF")
+                    )
+    return cells
+
+
+# ---------------------------------------------------------------------------
+# Game execution
+# ---------------------------------------------------------------------------
+
+
+@dataclasses.dataclass
+class GameResult:
+    """Per-game row written to games.csv."""
+
+    variant: str
+    model_p0: str
+    model_p1: str
+    pair_role: str
+    seed: int
+    score_p0: float
+    score_p1: float
+    winner: int  # -1 P1, 0 draw, +1 P0
+    length_moves: int
+    crash_p0: bool
+    crash_p1: bool
+    error: str
+    duration_s: float
+
+
+def _extract_scores(env: Any) -> tuple[float, float, int]:
+    """Return (score_p0, score_p1, winner) from a terminated env."""
+    p0 = float(env.state[0].reward or 0.0)
+    p1 = float(env.state[1].reward or 0.0)
+    if p0 > p1:
+        winner = 1
+    elif p1 > p0:
+        winner = -1
+    else:
+        winner = 0
+    return p0, p1, winner
+
+
+def _agent_crashed(env: Any, idx: int) -> bool:
+    """True if agent ``idx`` ended in a non-DONE/INACTIVE status."""
+    status = env.state[idx].status if env.state[idx] else None
+    if not status:
+        return False
+    return str(status).upper() not in {"DONE", "INACTIVE", "ACTIVE"}
+
+
+# ---------------------------------------------------------------------------
+# Status files (real-time progress for the monitor thread)
+# ---------------------------------------------------------------------------
+
+
+def _status_filename(cell: GameCell) -> str:
+    """Sanitize cell coords into a single filesystem-safe filename."""
+    def s(x: str) -> str:
+        return str(x).replace("/", "_").replace(" ", "_")
+    return (
+        f"{s(cell.variant)}__{s(cell.model_p0)}__vs__{s(cell.model_p1)}"
+        f"__{s(cell.pair_role)}__seed{cell.seed}.json"
+    )
+
+
+def _write_status(status_dir: str, cell: GameCell, state: str,
+                  started_at: float, **extra: Any) -> None:
+    """Atomically write a per-cell status snapshot.
+
+    Workers call this on each agent invocation so the parent's monitor
+    thread can show move-by-move progress for in-flight games.
+    """
+    if not status_dir:
+        return
+    path = os.path.join(status_dir, _status_filename(cell))
+    payload = {
+        "variant": cell.variant,
+        "model_p0": cell.model_p0,
+        "model_p1": cell.model_p1,
+        "seed": cell.seed,
+        "pair_role": cell.pair_role,
+        "state": state,
+        "started_at": started_at,
+        "updated_at": time.time(),
+        **extra,
+    }
+    tmp = path + ".tmp"
+    with open(tmp, "w") as f:
+        json.dump(payload, f)
+    os.replace(tmp, path)
+
+
+def _clear_status(status_dir: str, cell: GameCell) -> None:
+    if not status_dir:
+        return
+    try:
+        os.remove(os.path.join(status_dir, _status_filename(cell)))
+    except FileNotFoundError:
+        pass
+
+
+def run_one_game(
+    env_name: str,
+    cell: GameCell,
+    variant_obj: GameHarness,
+    api_key: str,
+    api_base: str,
+    *,
+    configuration_extras: Mapping[str, Any] | None = None,
+    status_dir: str | None = None,
+    started_at: float | None = None,
+) -> GameResult:
+    """Play one cell to completion and return its row.
+
+    Called in a worker process by :func:`cmd_run`. Safe to call directly
+    for testing -- no shared state beyond what's passed in.
+
+    If ``status_dir`` is provided, each agent invocation triggers a
+    status-file write so the parent's monitor thread can show live
+    per-game progress.
+    """
+    start = time.perf_counter()
+    if started_at is None:
+        started_at = time.time()
+    config: dict[str, Any] = {"seed": int(cell.seed)}
+    if configuration_extras:
+        config.update(configuration_extras)
+    error = ""
+
+    # Per-seat move counters used by the status writer below.
+    moves = [0, 0]
+
+    def _wrap(seat: int, real_agent):
+        def tracked(obs: Any, cfg: dict[str, Any]) -> dict[str, Any]:
+            moves[seat] += 1
+            _write_status(
+                status_dir or "", cell, "running", started_at,
+                moves_p0=moves[0], moves_p1=moves[1],
+            )
+            return real_agent(obs, cfg)
+        return tracked
+
+    agent_p0 = _wrap(0, create_agent_fn(
+        variant_obj,
+        model_override=build_model_setup(cell.model_p0, api_key, api_base),
+    ))
+    agent_p1 = _wrap(1, create_agent_fn(
+        variant_obj,
+        model_override=build_model_setup(cell.model_p1, api_key, api_base),
+    ))
+
+    env = make(env_name, configuration=config, debug=False)
+    try:
+        env.run([agent_p0, agent_p1])
+        p0, p1, winner = _extract_scores(env)
+        length = len(env.steps)
+        crash_p0 = _agent_crashed(env, 0)
+        crash_p1 = _agent_crashed(env, 1)
+    except Exception as exc:
+        error = f"{type(exc).__name__}: {exc}"
+        _log.warning("Game crashed (%s): %s", cell, exc)
+        p0 = p1 = 0.0
+        winner = 0
+        length = 0
+        crash_p0 = crash_p1 = True
+
+    return GameResult(
+        variant=cell.variant,
+        model_p0=cell.model_p0,
+        model_p1=cell.model_p1,
+        pair_role=cell.pair_role,
+        seed=cell.seed,
+        score_p0=p0,
+        score_p1=p1,
+        winner=winner,
+        length_moves=length,
+        crash_p0=crash_p0,
+        crash_p1=crash_p1,
+        error=error,
+        duration_s=time.perf_counter() - start,
+    )
+
+
+def _alarm_handler(signum, frame):
+    raise TimeoutError("game exceeded --game-timeout")
+
+
+def _worker_entry(args: tuple) -> GameResult:
+    """Picklable worker entrypoint for ProcessPoolExecutor.map / submit.
+
+    Wraps :func:`run_one_game` in a SIGALRM watchdog so a single stuck LLM
+    call doesn't block the worker process forever (the staging proxy is
+    known to drop connections mid-stream, and litellm's retry loop can
+    spin indefinitely). On timeout the worker returns a crash result and
+    is free to take the next cell.
+    """
+    env_name, cell, variant_obj, api_key, api_base, timeout_secs, status_dir = args
+    start = time.perf_counter()
+    started_at = time.time()
+    _write_status(status_dir or "", cell, "starting", started_at,
+                  moves_p0=0, moves_p1=0)
+    if timeout_secs and timeout_secs > 0:
+        signal.signal(signal.SIGALRM, _alarm_handler)
+        signal.alarm(int(timeout_secs))
+    try:
+        return run_one_game(
+            env_name, cell, variant_obj, api_key, api_base,
+            status_dir=status_dir, started_at=started_at,
+        )
+    except TimeoutError:
+        return GameResult(
+            variant=cell.variant, model_p0=cell.model_p0, model_p1=cell.model_p1,
+            pair_role=cell.pair_role, seed=cell.seed,
+            score_p0=0.0, score_p1=0.0, winner=0, length_moves=0,
+            crash_p0=True, crash_p1=True,
+            error=f"TimeoutError: exceeded {timeout_secs}s",
+            duration_s=time.perf_counter() - start,
+        )
+    except Exception as exc:  # noqa: BLE001
+        return GameResult(
+            variant=cell.variant, model_p0=cell.model_p0, model_p1=cell.model_p1,
+            pair_role=cell.pair_role, seed=cell.seed,
+            score_p0=0.0, score_p1=0.0, winner=0, length_moves=0,
+            crash_p0=True, crash_p1=True,
+            error=f"{type(exc).__name__}: {exc}",
+            duration_s=time.perf_counter() - start,
+        )
+    finally:
+        if timeout_secs and timeout_secs > 0:
+            signal.alarm(0)
+        _clear_status(status_dir or "", cell)
+
+
+# ---------------------------------------------------------------------------
+# CSV / summary writers
+# ---------------------------------------------------------------------------
+
+
+# ---------------------------------------------------------------------------
+# Real-time monitor (parent-side)
+# ---------------------------------------------------------------------------
+
+
+def _read_status_dir(status_dir: str) -> list[dict[str, Any]]:
+    """Snapshot of all in-flight cells. Tolerates partial writes / races."""
+    out: list[dict[str, Any]] = []
+    try:
+        names = os.listdir(status_dir)
+    except FileNotFoundError:
+        return out
+    for name in names:
+        if not name.endswith(".json"):
+            continue
+        try:
+            with open(os.path.join(status_dir, name)) as f:
+                out.append(json.load(f))
+        except (FileNotFoundError, json.JSONDecodeError):
+            continue
+    return out
+
+
+def _classify_csv(csv_path: Path) -> tuple[int, int, int]:
+    """Return (done, timed_out, crashed_other) from games.csv."""
+    if not csv_path.exists():
+        return 0, 0, 0
+    done = timed_out = crashed = 0
+    try:
+        with csv_path.open() as f:
+            for row in csv.DictReader(f):
+                done += 1
+                err = row.get("error") or ""
+                if "TimeoutError" in err:
+                    timed_out += 1
+                elif err:
+                    crashed += 1
+                else:
+                    # Even with no error string, crash_p* may be true
+                    # (agent ERROR detected by env without raising).
+                    if (str(row.get("crash_p0", "")).lower() == "true"
+                            or str(row.get("crash_p1", "")).lower() == "true"):
+                        crashed += 1
+    except FileNotFoundError:
+        pass
+    return done, timed_out, crashed
+
+
+def _fmt_elapsed(secs: float) -> str:
+    if secs < 60:
+        return f"{int(secs):2d}s"
+    return f"{int(secs // 60):2d}m{int(secs % 60):02d}s"
+
+
+def _print_snapshot(status_dir: str, csv_path: Path, total: int,
+                    overall_start: float) -> None:
+    done, timed_out, crashed = _classify_csv(csv_path)
+    in_flight = _read_status_dir(status_dir)
+    in_flight.sort(key=lambda r: r.get("started_at", 0))
+    now = time.time()
+    overall_elapsed = _fmt_elapsed(now - overall_start)
+    print(
+        f"\n[{overall_elapsed}] {done}/{total} done "
+        f"({timed_out} timeouts, {crashed} crashes) | {len(in_flight)} running:",
+        flush=True,
+    )
+    for r in in_flight:
+        cell_elapsed = now - r.get("started_at", now)
+        moves = (r.get("moves_p0", 0) or 0) + (r.get("moves_p1", 0) or 0)
+        m0 = (r.get("model_p0") or "")[-25:]
+        m1 = (r.get("model_p1") or "")[-25:]
+        print(
+            f"  {r.get('variant',''):18s} {m0:25s} vs {m1:25s}"
+            f"  seed={r.get('seed')} {r.get('pair_role',''):4s}"
+            f"  moves={moves:2d}  {_fmt_elapsed(cell_elapsed)}"
+            f"  ({r.get('state','?')})",
+            flush=True,
+        )
+
+
+def _monitor_thread_target(
+    status_dir: str, csv_path: Path, total: int,
+    stop_event: threading.Event, overall_start: float,
+    interval: float,
+) -> None:
+    while not stop_event.wait(interval):
+        try:
+            _print_snapshot(status_dir, csv_path, total, overall_start)
+        except Exception as e:  # noqa: BLE001
+            _log.warning("monitor snapshot failed: %s", e)
+
+
+_CSV_FIELDS = [
+    "variant", "model_p0", "model_p1", "pair_role", "seed",
+    "score_p0", "score_p1", "winner", "length_moves",
+    "crash_p0", "crash_p1", "error", "duration_s",
+]
+
+
+def _read_existing_cells(csv_path: Path) -> set[tuple]:
+    """Return the set of cell keys already present in games.csv (for --resume)."""
+    if not csv_path.exists():
+        return set()
+    done: set[tuple] = set()
+    with csv_path.open() as f:
+        for row in csv.DictReader(f):
+            done.add((
+                row["variant"], row["model_p0"], row["model_p1"],
+                row["pair_role"], int(row["seed"]),
+            ))
+    return done
+
+
+def _cell_key(c: GameCell) -> tuple:
+    return (c.variant, c.model_p0, c.model_p1, c.pair_role, c.seed)
+
+
+def _open_csv_for_append(csv_path: Path) -> tuple[Any, csv.DictWriter]:
+    """Open ``games.csv`` for appending; write header if new."""
+    new_file = not csv_path.exists()
+    csv_path.parent.mkdir(parents=True, exist_ok=True)
+    f = csv_path.open("a", newline="")
+    writer = csv.DictWriter(f, fieldnames=_CSV_FIELDS)
+    if new_file:
+        writer.writeheader()
+        f.flush()
+    return f, writer
+
+
+def _row_dict(r: GameResult) -> dict[str, Any]:
+    return dataclasses.asdict(r)
+
+
+# ---------------------------------------------------------------------------
+# Summary rendering
+# ---------------------------------------------------------------------------
+
+
+def _aggregate(rows: list[dict[str, Any]]) -> dict[str, Any]:
+    """Build the per-variant / per-model statistics shown in summary.md."""
+    # Per (variant, model) accumulators.
+    games_played: dict[tuple[str, str], int] = defaultdict(int)
+    game_wins: dict[tuple[str, str], float] = defaultdict(float)
+    score_sum: dict[tuple[str, str], float] = defaultdict(float)
+    score_n: dict[tuple[str, str], int] = defaultdict(int)
+    crash_count: dict[tuple[str, str], int] = defaultdict(int)
+
+    # Per (variant, pair_key) for pair-win aggregation. pair_key is the
+    # unordered pair tuple + seed, so we can sum both seat-flipped games.
+    # pair_totals[(variant, frozenset({A,B}), seed)][model] = total_score
+    pair_totals: dict[tuple, dict[str, float]] = defaultdict(lambda: defaultdict(float))
+    pair_games: dict[tuple, int] = defaultdict(int)
+
+    for row in rows:
+        v = row["variant"]
+        m0, m1 = row["model_p0"], row["model_p1"]
+        s0, s1 = float(row["score_p0"]), float(row["score_p1"])
+        winner = int(row["winner"])
+        seed = int(row["seed"])
+
+        for model, score, crashed, won_flag in (
+            (m0, s0, row["crash_p0"], 1.0 if winner == 1 else 0.5 if winner == 0 else 0.0),
+            (m1, s1, row["crash_p1"], 1.0 if winner == -1 else 0.5 if winner == 0 else 0.0),
+        ):
+            games_played[(v, model)] += 1
+            game_wins[(v, model)] += won_flag
+            score_sum[(v, model)] += score
+            score_n[(v, model)] += 1
+            if str(crashed).lower() == "true":
+                crash_count[(v, model)] += 1
+
+        if row["pair_role"] in ("AB", "BA") and m0 != m1:
+            pair_key = (v, frozenset((m0, m1)), seed)
+            pair_totals[pair_key][m0] += s0
+            pair_totals[pair_key][m1] += s1
+            pair_games[pair_key] += 1
+
+    # Per (variant, model) pair-wins. A pair counts when both seat-flipped
+    # games for that pair_key are complete (pair_games[k] == 2).
+    pair_wins: dict[tuple[str, str], float] = defaultdict(float)
+    pair_counts: dict[tuple[str, str], int] = defaultdict(int)
+    for pair_key, totals in pair_totals.items():
+        if pair_games[pair_key] != 2:
+            continue
+        v = pair_key[0]
+        models_in_pair = list(totals.keys())
+        if len(models_in_pair) != 2:
+            continue
+        a, b = models_in_pair
+        ta, tb = totals[a], totals[b]
+        for m in (a, b):
+            pair_counts[(v, m)] += 1
+        if ta > tb:
+            pair_wins[(v, a)] += 1.0
+        elif tb > ta:
+            pair_wins[(v, b)] += 1.0
+        else:
+            pair_wins[(v, a)] += 0.5
+            pair_wins[(v, b)] += 0.5
+
+    return {
+        "games_played": games_played,
+        "game_wins": game_wins,
+        "score_sum": score_sum,
+        "score_n": score_n,
+        "crash_count": crash_count,
+        "pair_wins": pair_wins,
+        "pair_counts": pair_counts,
+    }
+
+
+def _format_leaderboard(
+    variant: str,
+    models: list[str],
+    agg: dict[str, Any],
+) -> str:
+    """Render one leaderboard section for summary.md."""
+    rows: list[tuple[str, float, float, float, float, float]] = []
+    for m in models:
+        gp = agg["games_played"].get((variant, m), 0)
+        if gp == 0:
+            continue
+        pair_n = agg["pair_counts"].get((variant, m), 0)
+        pair_win_pct = (
+            100.0 * agg["pair_wins"].get((variant, m), 0.0) / pair_n
+            if pair_n else float("nan")
+        )
+        game_win_pct = 100.0 * agg["game_wins"].get((variant, m), 0.0) / gp
+        mean_score = agg["score_sum"].get((variant, m), 0.0) / max(gp, 1)
+        crash_pct = 100.0 * agg["crash_count"].get((variant, m), 0) / gp
+        rows.append((m, pair_win_pct, game_win_pct, mean_score, crash_pct, gp))
+    rows.sort(
+        # Sort by pair-win% desc, fall back to game-win% if all-self-play.
+        key=lambda r: (-r[1] if not math.isnan(r[1]) else -r[2], -r[2]),
+    )
+    lines = [
+        f"## Leaderboard: {variant}",
+        "",
+        "| model | pair-win% | game-win% | mean score | crash% | games |",
+        "|-------|-----------|-----------|------------|--------|-------|",
+    ]
+    for m, pwin, gwin, sc, cr, gp in rows:
+        pwin_str = "—" if math.isnan(pwin) else f"{pwin:.1f}"
+        lines.append(
+            f"| {m} | {pwin_str} | {gwin:.1f} | {sc:+.2f} | {cr:.1f} | {gp} |"
+        )
+    return "\n".join(lines)
+
+
+def _format_rank_shifts(
+    variants: list[str],
+    models: list[str],
+    agg: dict[str, Any],
+) -> str:
+    """Cross-variant rank-of-each-model table -- the artifact worth reading."""
+    # Within each variant, rank models by pair-win% (game-win% fallback).
+    ranks: dict[tuple[str, str], int] = {}
+    for v in variants:
+        scored: list[tuple[str, float]] = []
+        for m in models:
+            gp = agg["games_played"].get((v, m), 0)
+            if gp == 0:
+                continue
+            pair_n = agg["pair_counts"].get((v, m), 0)
+            primary = (
+                agg["pair_wins"].get((v, m), 0.0) / pair_n if pair_n
+                else agg["game_wins"].get((v, m), 0.0) / gp
+            )
+            scored.append((m, primary))
+        scored.sort(key=lambda x: -x[1])
+        for rank, (m, _) in enumerate(scored, start=1):
+            ranks[(v, m)] = rank
+
+    if not ranks:
+        return ""
+
+    width = max(len(m) for m in models)
+    header = "| " + "model".ljust(width) + " | " + " | ".join(v for v in variants) + " |"
+    sep = "|" + "-" * (width + 2) + "|" + "|".join("-" * (len(v) + 2) for v in variants) + "|"
+    lines = ["## Cross-variant rank shifts", "", header, sep]
+    for m in models:
+        cells = [str(ranks.get((v, m), "—")).center(len(v)) for v in variants]
+        lines.append("| " + m.ljust(width) + " | " + " | ".join(cells) + " |")
+    return "\n".join(lines)
+
+
+def _format_anomalies(rows: list[dict[str, Any]]) -> str:
+    """Flag variants with high crash or error rates."""
+    by_variant: dict[str, list[dict]] = defaultdict(list)
+    for r in rows:
+        by_variant[r["variant"]].append(r)
+    lines: list[str] = []
+    for v, rs in sorted(by_variant.items()):
+        crashes = sum(
+            1 for r in rs
+            if str(r["crash_p0"]).lower() == "true"
+            or str(r["crash_p1"]).lower() == "true"
+        )
+        errors = sum(1 for r in rs if r["error"])
+        total = len(rs)
+        if total == 0:
+            continue
+        crash_pct = 100.0 * crashes / total
+        if crash_pct >= 5.0 or errors > 0:
+            lines.append(
+                f"- **{v}**: {crashes}/{total} games with crash "
+                f"({crash_pct:.1f}%), {errors} hard errors"
+            )
+    if not lines:
+        return "## Anomalies\n\n(none)"
+    return "## Anomalies\n\n" + "\n".join(lines)
+
+
+def render_summary(
+    env_name: str,
+    variants: list[str],
+    models: list[str],
+    rows: list[dict[str, Any]],
+) -> str:
+    """Render the full summary.md content for ``rows``."""
+    agg = _aggregate(rows)
+    parts = [
+        f"# Ablation results: {env_name}",
+        "",
+        f"Variants: {', '.join(variants)}",
+        f"Models: {', '.join(models)}",
+        f"Total games: {len(rows)}",
+        "",
+    ]
+    for v in variants:
+        parts.append(_format_leaderboard(v, models, agg))
+        parts.append("")
+    rank_shifts = _format_rank_shifts(variants, models, agg)
+    if rank_shifts:
+        parts.append(rank_shifts)
+        parts.append("")
+    parts.append(_format_anomalies(rows))
+    parts.append("")
+    return "\n".join(parts)
+
+
+# ---------------------------------------------------------------------------
+# Subcommand: run
+# ---------------------------------------------------------------------------
+
+
+def cmd_run(args: argparse.Namespace) -> int:
+    models = [m.strip() for m in args.models.split(",") if m.strip()]
+    if not models:
+        print("--models must list at least one model.", file=sys.stderr)
+        return 2
+
+    variants_all = load_variants(args.env)
+    if args.variants:
+        names = [v.strip() for v in args.variants.split(",") if v.strip()]
+        missing = [n for n in names if n not in variants_all]
+        if missing:
+            print(
+                f"Unknown variant(s): {missing}. "
+                f"Available: {sorted(variants_all)}",
+                file=sys.stderr,
+            )
+            return 2
+        variants_to_run = {n: variants_all[n] for n in names}
+    else:
+        variants_to_run = variants_all
+
+    cells = build_cells(
+        variants_to_run.keys(),
+        models,
+        args.games,
+        include_self_play=args.self_play,
+    )
+
+    if args.dry_run:
+        print(
+            f"{len(cells)} games would be scheduled "
+            f"({len(variants_to_run)} variants × {len(models)} models × "
+            f"{args.games} games/matchup"
+            f"{' + self-play' if args.self_play else ''})."
+        )
+        return 0
+
+    api_key = os.environ.get("MODEL_PROXY_KEY", "")
+    api_base = os.environ.get("MODEL_PROXY_URL", "dummy_url")
+    if not api_key and api_base != "dummy_url":
+        print(
+            "MODEL_PROXY_KEY env var is required (or set "
+            "MODEL_PROXY_URL=dummy_url for offline testing).",
+            file=sys.stderr,
+        )
+        return 2
+
+    out_dir = Path(args.out)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    csv_path = out_dir / "games.csv"
+    summary_path = out_dir / "summary.md"
+
+    done = _read_existing_cells(csv_path) if args.resume else set()
+    todo = [c for c in cells if _cell_key(c) not in done]
+    if args.resume:
+        print(f"Resume: {len(done)} cells already done, {len(todo)} to go.")
+    else:
+        print(f"Scheduling {len(todo)} games.")
+
+    csv_file, writer = _open_csv_for_append(csv_path)
+
+    # Status dir for the live monitor. Workers write per-cell JSON files
+    # here on each agent invocation; the parent's monitor thread reads
+    # them every --status-interval seconds and prints a snapshot.
+    status_dir = str(out_dir / "status")
+    os.makedirs(status_dir, exist_ok=True)
+    # Stale status files from a previous run would otherwise show as
+    # "in-flight" cells that don't exist. Clear on launch.
+    for fname in os.listdir(status_dir):
+        try:
+            os.remove(os.path.join(status_dir, fname))
+        except OSError:
+            pass
+
+    # Build the work items eagerly so workers receive a self-contained
+    # tuple they can run without any reference to the parent process.
+    work_items = [
+        (args.env, c, variants_to_run[c.variant], api_key, api_base,
+         args.game_timeout, status_dir)
+        for c in todo
+    ]
+
+    completed = 0
+    overall_start = time.time()
+    stop_event = threading.Event()
+    monitor: threading.Thread | None = None
+    if args.status_interval > 0:
+        monitor = threading.Thread(
+            target=_monitor_thread_target,
+            args=(status_dir, csv_path, len(todo), stop_event,
+                  overall_start, args.status_interval),
+            daemon=True,
+        )
+        monitor.start()
+
+    try:
+        ctx = mp.get_context("fork")
+        with ProcessPoolExecutor(
+            max_workers=args.concurrency,
+            mp_context=ctx,
+        ) as pool:
+            futures = {pool.submit(_worker_entry, item): item for item in work_items}
+            for fut in as_completed(futures):
+                result = fut.result()
+                writer.writerow(_row_dict(result))
+                csv_file.flush()
+                completed += 1
+                if (
+                    completed % max(1, len(todo) // 20) == 0
+                    or completed == len(todo)
+                ):
+                    print(
+                        f"  [{completed}/{len(todo)}] {result.variant}"
+                        f" {result.model_p0} vs {result.model_p1}"
+                        f" pair={result.pair_role} seed={result.seed}"
+                        f" -> ({result.score_p0:+.2f}, {result.score_p1:+.2f})"
+                        f" in {result.duration_s:.1f}s"
+                    )
+    finally:
+        stop_event.set()
+        if monitor is not None:
+            monitor.join(timeout=2.0)
+        csv_file.close()
+
+    # Re-read everything to build the summary (works under --resume).
+    with csv_path.open() as f:
+        all_rows = list(csv.DictReader(f))
+    summary = render_summary(
+        args.env, list(variants_to_run.keys()), models, all_rows,
+    )
+    summary_path.write_text(summary)
+    print(f"\nWrote {len(all_rows)} rows to {csv_path}")
+    print(f"Wrote summary to {summary_path}")
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# Subcommand: check
+# ---------------------------------------------------------------------------
+
+
+def _seeded_observations(env_name: str, n: int = 5) -> list[dict[str, Any]]:
+    """Build N observations from a few seeded steps of the env for parity checks."""
+    obs_list: list[dict[str, Any]] = []
+    for seed in range(n):
+        env = make(env_name, configuration={"seed": seed}, debug=False)
+        # Trigger interpreter to populate per-agent observation.
+        env.reset()
+        # First state with a real current player. For OpenSpiel-backed
+        # envs the proxy obs lives on env.state[player].observation.
+        for player_idx in range(len(env.state)):
+            agent_state = env.state[player_idx]
+            obs = agent_state.observation
+            if not obs:
+                continue
+            d = dict(obs) if isinstance(obs, dict) else dict(vars(obs))
+            d.setdefault("playerId", player_idx)
+            obs_list.append(d)
+            break
+    return obs_list
+
+
+def cmd_check(args: argparse.Namespace) -> int:
+    variants = load_variants(args.env)
+    print(f"env: {args.env}")
+    print(f"variants: {sorted(variants)}")
+
+    # Baseline parity: BASELINE.make_prompt must equal harness.generate_prompt
+    # for the same observation. Loaded via the per-env harness module.
+    try:
+        harness_mod_path = _variants_module_path(args.env).rsplit(".", 1)[0] + ".harness"
+        harness_mod = importlib.import_module(harness_mod_path)
+        prod_make_prompt = getattr(harness_mod, "generate_prompt", None)
+    except ModuleNotFoundError:
+        prod_make_prompt = None
+
+    obs_list = _seeded_observations(args.env, n=args.parity_seeds)
+    if not obs_list:
+        print("  (could not build seeded observations -- skipping render check)")
+        return 0
+
+    failed = False
+
+    baseline = variants["baseline"]
+    if prod_make_prompt is None:
+        print("  (no harness.generate_prompt found -- skipping baseline parity)")
+    else:
+        for i, obs in enumerate(obs_list):
+            try:
+                a = prod_make_prompt(obs, [])
+                b = baseline.make_prompt(obs, [])
+            except Exception as e:
+                print(f"  baseline parity obs[{i}]: ERROR {e}")
+                failed = True
+                continue
+            if a != b:
+                print(f"  baseline parity obs[{i}]: MISMATCH")
+                failed = True
+            else:
+                print(f"  baseline parity obs[{i}]: ok ({len(a)} chars)")
+
+    # Render check: every variant must render without error on each obs.
+    for name, variant in variants.items():
+        for i, obs in enumerate(obs_list):
+            try:
+                prompt = variant.make_prompt(obs, [])
+                assert isinstance(prompt, str) and prompt
+            except Exception as e:
+                print(f"  variant '{name}' obs[{i}]: RENDER ERROR {e}")
+                traceback.print_exc()
+                failed = True
+        print(f"  variant '{name}': rendered ok across {len(obs_list)} observations")
+
+    if failed:
+        print("FAIL")
+        return 1
+    print("OK")
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# CLI plumbing
+# ---------------------------------------------------------------------------
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog="python -m kaggle_environments.ablation",
+        description="Prompt-ablation runner for Kaggle game environments.",
+    )
+    sub = p.add_subparsers(dest="cmd", required=True)
+
+    pr = sub.add_parser("run", help="Run a paired-seat ablation tournament.")
+    pr.add_argument("--env", required=True, help="Env name, e.g. open_spiel_bargaining.")
+    pr.add_argument("--models", required=True,
+                    help="Comma-separated model names (proxy-side, no openai/ prefix).")
+    pr.add_argument("--games", type=int, default=20,
+                    help="Games per matchup (must be even; default 20).")
+    pr.add_argument("--variants", default="",
+                    help="Comma-separated variant names; default all.")
+    pr.add_argument("--concurrency", type=int, default=8,
+                    help="Max concurrent games (worker process count).")
+    pr.add_argument("--game-timeout", type=int, default=180,
+                    help="Per-game timeout in seconds (SIGALRM watchdog "
+                         "in the worker). Stuck games return a crash row "
+                         "and the worker is freed for the next cell. "
+                         "Set to 0 to disable.")
+    pr.add_argument("--status-interval", type=float, default=10.0,
+                    help="Seconds between live status snapshots printed "
+                         "by the monitor thread. Set to 0 to disable.")
+    pr.add_argument("--self-play", action="store_true",
+                    help="Add the M self-play cells per leaderboard.")
+    pr.add_argument("--resume", action="store_true",
+                    help="Skip cells already present in games.csv.")
+    pr.add_argument("--dry-run", action="store_true",
+                    help="Print the cell count and exit.")
+    pr.add_argument("--out", default="ablation_results",
+                    help="Output directory for games.csv + summary.md.")
+    pr.set_defaults(func=cmd_run)
+
+    pc = sub.add_parser("check", help="Verify baseline parity + variant rendering.")
+    pc.add_argument("--env", required=True)
+    pc.add_argument("--parity-seeds", type=int, default=5,
+                    help="How many seeded observations to test.")
+    pc.set_defaults(func=cmd_check)
+    return p
+
+
+def main(argv: list[str] | None = None) -> int:
+    logging.basicConfig(level=logging.WARNING, format="%(levelname)s %(name)s: %(message)s")
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/kaggle_environments/core_harness.py
+++ b/kaggle_environments/core_harness.py
@@ -611,6 +611,7 @@ def create_agent_fn(
     game_harness: GameHarness,
     *,
     max_retries: int = 2,
+    model_override: tuple[str, dict[str, Any]] | None = None,
 ) -> Callable[[Any, dict[str, Any]], dict[str, Any]]:
     """Create a Kaggle-compatible agent function from a ``GameHarness``.
 
@@ -619,6 +620,13 @@ def create_agent_fn(
             methods.
         max_retries: Maximum number of prompt attempts (including the initial
             attempt).
+        model_override: Optional ``(model_name, litellm_kwargs)`` pair. When
+            provided, ``_setup_model`` is bypassed entirely -- useful for
+            test harnesses or multi-agent runners (e.g. the ablation runner)
+            that need per-agent model selection without polluting global env
+            vars. The caller is responsible for any model-name prefixing
+            (``openai/...``, ``gemini/...``) and litellm kwargs (api_base,
+            api_key, reasoning_effort) the chosen model needs.
 
     Returns:
         ``agent_fn(obs, config) -> {"submission": <action>, ...}``
@@ -637,7 +645,10 @@ def create_agent_fn(
 
         # -- one-time setup --
         if not setup_done:
-            model_name, litellm_kwargs = _setup_model()
+            if model_override is not None:
+                model_name, litellm_kwargs = model_override
+            else:
+                model_name, litellm_kwargs = _setup_model()
             _TELEMETRY(
                 setup_complete=True,
                 model_name=model_name,

--- a/kaggle_environments/envs/open_spiel_env/games/bargaining/prompt_variants.py
+++ b/kaggle_environments/envs/open_spiel_env/games/bargaining/prompt_variants.py
@@ -1,0 +1,876 @@
+"""Bargaining prompt variants for prompt-sensitivity ablation studies.
+
+The canonical production prompt lives in :mod:`harness`. This module holds
+alternative variants so :mod:`harness_experiment` can A/B their effect on
+agent behavior without touching the deployed file.
+
+Each variant is a :class:`PromptVariant` carrying:
+
+* ``item_labels`` -- display labels for the three items (e.g.
+  ``Book/Hat/Basketball`` or ``A/B/C``).
+* ``schema_keys`` -- the JSON keys the prompt asks the model to use in its
+  ``"keep"`` dict (matches the display labels' lowercase form for the
+  baseline; diverges for the GENERIC_NAMES variant).
+* ``aliases`` -- the full parser alias map mapping any JSON key the model
+  might emit (case-folded, stripped) back to a canonical item key
+  (``book``/``hat``/``basketball``). Each variant ships a complete map; the
+  experiment harness picks it up directly.
+* ``build_body`` -- a callable that renders the per-state prompt body
+  (everything before the rethink suffix).
+* ``rethink_illegal`` / ``rethink_unparsable`` -- the templates appended by
+  :func:`core_harness.render_rethink_suffix` on retry. The unparsable
+  template embeds the JSON schema, so it has to vary with ``schema_keys``.
+
+Variants shipped:
+
+* ``BASELINE`` -- byte-identical to ``harness.py`` (control arm).
+* ``COMPACT`` -- same information, terser language; rules and reminders are
+  collapsed and the worked example / loss-threat are dropped.
+* ``MINIMAL`` -- maximally stripped: just pool, values, history, schema.
+  Tests how much of the game mechanics the model already knows.
+* ``NO_ACCEPT_PREVIEW`` -- baseline minus the "you would receive [...]"
+  preview on the accept branch. Tests whether models can compute the
+  acceptance allocation themselves.
+* ``GENERIC_NAMES`` -- baseline with items renamed Book/Hat/Basketball ->
+  A/B/C (in display labels, history, and JSON schema). Tests whether the
+  real names carry semantic priors that bias allocations.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import Any, Callable, Mapping, Sequence
+
+import pyspiel
+
+from kaggle_environments.core_harness import (
+    ParseResult,
+    extract_last_json_object,
+    render_rethink_suffix,
+)
+
+_ITEM_KEYS = ("book", "hat", "basketball")
+_AGREE_ACTION_STRING = "Agree"
+# JSON keys we accept as carriers of a bargaining action (used to filter
+# stray JSON objects in the model's reasoning).
+_PAYLOAD_KEYS = ("action", "keep", "items", "offer", "agree")
+
+
+# ---------------------------------------------------------------------------
+# Shared rendering helpers
+# ---------------------------------------------------------------------------
+
+
+def parse_observation_payload(observation: Mapping[str, Any]) -> dict[str, Any]:
+    """Pull the structured bargaining state dict out of the observation.
+
+    Same fallback chain as :mod:`harness`: prefer the proxy's JSON
+    ``observationString``; if absent, deserialize the pyspiel state and ask
+    it directly.
+    """
+    raw = observation.get("observationString", "") or ""
+    if raw:
+        try:
+            parsed = json.loads(raw)
+            if isinstance(parsed, dict):
+                return parsed
+        except json.JSONDecodeError:
+            pass
+    serialized = observation.get("serializedGameAndState", "")
+    if serialized:
+        _, state = pyspiel.deserialize_game_and_state(serialized)
+        player_id = int(observation.get("playerId", 0))
+        try:
+            return json.loads(state.observation_string(player_id))
+        except (json.JSONDecodeError, RuntimeError):
+            pass
+    return {}
+
+
+def _complement(items: Mapping[str, int], pool: Mapping[str, int]) -> dict[str, int]:
+    """Pool minus items, floored at 0."""
+    return {k: max(0, int(pool.get(k, 0)) - int(items.get(k, 0))) for k in _ITEM_KEYS}
+
+
+def _format_items_dict(items: Mapping[str, int], labels: Mapping[str, str]) -> str:
+    """Render a {book, hat, basketball} dict as ``L1=A, L2=B, L3=C``."""
+    return ", ".join(f"{labels[k]}={int(items.get(k, 0))}" for k in _ITEM_KEYS)
+
+
+def _unit_word(n: int) -> str:
+    return "unit" if n == 1 else "units"
+
+
+def _format_history_rich(state: Mapping[str, Any], labels: Mapping[str, str]) -> str:
+    """Numbered timeline showing both ``keep`` and the complement per offer."""
+    history = state.get("offer_history") or []
+    pool = state.get("pool") or {}
+    if not history:
+        return "(no offers yet -- you are opening the negotiation)"
+    lines: list[str] = []
+    for i, event in enumerate(history, start=1):
+        player = int(event.get("player", 0))
+        who = f"Player {player + 1}"
+        if event.get("type") == "agree":
+            lines.append(f"  {i}. {who} ACCEPTS the previous offer (game ends).")
+            continue
+        items = event.get("items") or {}
+        offered = _complement(items, pool)
+        lines.append(
+            f"  {i}. {who} offers: keep [{_format_items_dict(items, labels)}]"
+            f" / opponent gets [{_format_items_dict(offered, labels)}]"
+        )
+    return "\n".join(lines)
+
+
+def _format_history_minimal(state: Mapping[str, Any], labels: Mapping[str, str]) -> str:
+    """Terser history: just ``Px keep: L1=A L2=B L3=C`` per row, no complement."""
+    history = state.get("offer_history") or []
+    if not history:
+        return "  (none)"
+    lines: list[str] = []
+    for event in history:
+        player = int(event.get("player", 0))
+        who = f"P{player + 1}"
+        if event.get("type") == "agree":
+            lines.append(f"  {who} agree")
+            continue
+        items = event.get("items") or {}
+        parts = " ".join(f"{labels[k]}={int(items.get(k, 0))}" for k in _ITEM_KEYS)
+        lines.append(f"  {who} keep: {parts}")
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# Per-state context passed to each variant's build function
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class PromptContext:
+    """Everything build_body needs that's derived from the live observation."""
+
+    state: Mapping[str, Any]
+    player_id: int
+    pool: Mapping[str, int]
+    my_values: Mapping[str, int]
+    max_turns: int
+    discount: float
+    num_offers: int
+    turns_left: int
+    offer_history: list
+    can_accept: bool
+    last_offer_event: Mapping[str, Any] | None
+
+
+def build_context(observation: Mapping[str, Any]) -> PromptContext:
+    """Parse the observation into a :class:`PromptContext`.
+
+    Lives here (not in harness_experiment.py) so variant build functions
+    can also be exercised directly from tests or a sweep runner.
+    """
+    state = parse_observation_payload(observation)
+    player_id = int(observation.get("playerId", 0))
+
+    pool = state.get("pool") or {k: 0 for k in _ITEM_KEYS}
+    my_values = state.get("my_values") or {k: 0 for k in _ITEM_KEYS}
+    params = state.get("params") or {}
+    max_turns = int(params.get("max_turns", state.get("max_turns", 10)))
+    discount = float(params.get("discount", 1.0))
+    num_offers = int(state.get("num_offers", 0))
+    turns_left = max(0, max_turns - num_offers)
+    offer_history = state.get("offer_history") or []
+
+    last_offer_event = offer_history[-1] if offer_history else None
+    can_accept = bool(
+        last_offer_event
+        and last_offer_event.get("type") == "offer"
+        and int(last_offer_event.get("player", -1)) != player_id
+    )
+
+    return PromptContext(
+        state=state,
+        player_id=player_id,
+        pool=pool,
+        my_values=my_values,
+        max_turns=max_turns,
+        discount=discount,
+        num_offers=num_offers,
+        turns_left=turns_left,
+        offer_history=offer_history,
+        can_accept=can_accept,
+        last_offer_event=last_offer_event,
+    )
+
+
+# ---------------------------------------------------------------------------
+# PromptVariant
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class PromptVariant:
+    """A self-contained Bargaining prompt configuration.
+
+    Implements the :class:`core_harness.GameHarness` protocol directly so
+    the ablation runner can do ``create_agent_fn(variant)`` with no wrapper.
+    Production stays on :mod:`harness`; this is the experimental surface.
+    """
+
+    name: str
+    item_labels: Mapping[str, str]
+    schema_keys: tuple[str, str, str]
+    aliases: Mapping[str, str]
+    build_body: Callable[[PromptContext, "PromptVariant"], str]
+    rethink_illegal: str
+    rethink_unparsable: str
+
+    # -- GameHarness protocol ------------------------------------------------
+
+    def get_legal_moves(self, observation: Mapping[str, Any]) -> dict[int, str]:
+        """Return ``{action_id: action_string}`` for the current state.
+
+        Legality is a property of the OpenSpiel state, not the prompt, so
+        every variant uses the same lookup path.
+        """
+        legal_actions = observation.get("legalActions")
+        legal_action_strings = observation.get("legalActionStrings")
+        if legal_actions and legal_action_strings:
+            return dict(zip(legal_actions, legal_action_strings))
+        serialized = observation.get("serializedGameAndState", "")
+        if not serialized:
+            return {}
+        _, state = pyspiel.deserialize_game_and_state(serialized)
+        return {a: state.action_to_string(a) for a in state.legal_actions()}
+
+    def make_prompt(
+        self,
+        observation: Mapping[str, Any],
+        move_history: list[str],
+        previous_response: str | None = None,
+        previous_action: str | None = None,
+    ) -> str:
+        """Render the prompt body via this variant + the variant's rethink suffix."""
+        del move_history  # offer history lives in the proxy state
+        ctx = build_context(observation)
+        body = self.build_body(ctx, self)
+        body += render_rethink_suffix(
+            self.rethink_illegal,
+            self.rethink_unparsable,
+            previous_response,
+            previous_action,
+        )
+        return body
+
+    def parse_response(
+        self,
+        response: str,
+        legal_action_strings: Sequence[str] | None,
+        *,
+        observation: Mapping[str, Any] | None = None,
+    ) -> ParseResult:
+        """Extract the model's chosen action and match it to a legal one.
+
+        Same single-intent-surface contract as ``harness.parse_response``:
+        the LAST JSON object carrying any bargaining payload key, normalized
+        via this variant's alias map.
+        """
+        del observation
+        if not legal_action_strings:
+            return ParseResult(raw_action=None)
+        payload = extract_last_json_object(response, required_keys=_PAYLOAD_KEYS)
+        if payload is None:
+            return ParseResult(legal_action=None, raw_action=None)
+        candidate = self._payload_to_action_string(payload)
+        if candidate is None:
+            return ParseResult(legal_action=None, raw_action=None)
+        raw_repr = json.dumps(payload, separators=(",", ":"))
+        if candidate in set(legal_action_strings):
+            return ParseResult(legal_action=candidate, raw_action=raw_repr)
+        return ParseResult(legal_action=None, raw_action=raw_repr)
+
+    # -- helpers used by parse_response --------------------------------------
+
+    def _payload_to_action_string(self, payload: Mapping[str, Any]) -> str | None:
+        """Convert a parsed JSON dict into the canonical OpenSpiel action string.
+
+        Output is always ``"Offer: Book: A, Hat: B, Basketball: C"`` /
+        ``"Agree"`` regardless of variant -- only the input JSON keys vary,
+        and the variant's alias map normalizes those.
+        """
+        action_val = payload.get("action")
+        action = str(action_val).strip().lower() if action_val is not None else ""
+        if action in ("agree", "accept") or payload.get("agree") is True:
+            return _AGREE_ACTION_STRING
+
+        keep_obj = payload.get("keep") or payload.get("items") or payload.get("offer")
+        if not isinstance(keep_obj, Mapping):
+            return None
+        normalized: dict[str, Any] = {}
+        for k, v in keep_obj.items():
+            canonical = self.aliases.get(str(k).strip().lower())
+            if canonical is not None:
+                normalized[canonical] = v
+        try:
+            counts = {k: int(normalized.get(k, 0)) for k in _ITEM_KEYS}
+        except (TypeError, ValueError):
+            return None
+        if any(v < 0 for v in counts.values()):
+            return None
+        return (
+            f"Offer: Book: {counts['book']}, "
+            f"Hat: {counts['hat']}, "
+            f"Basketball: {counts['basketball']}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Label sets and parser aliases
+# ---------------------------------------------------------------------------
+
+
+_BASELINE_LABELS: Mapping[str, str] = {
+    "book": "Book",
+    "hat": "Hat",
+    "basketball": "Basketball",
+}
+_GENERIC_LABELS: Mapping[str, str] = {
+    "book": "A",
+    "hat": "B",
+    "basketball": "C",
+}
+
+_BASELINE_ALIASES: Mapping[str, str] = {
+    "book": "book", "books": "book",
+    "hat": "hat", "hats": "hat",
+    "basketball": "basketball", "basketballs": "basketball",
+    "ball": "basketball", "balls": "basketball",
+}
+# GENERIC_NAMES intentionally still accepts the real names. The ablation is
+# about what's in the PROMPT, not about parser tolerance -- if the model
+# leaks "book" we want the move to land so the run isn't lost to a parse
+# failure that confounds the signal.
+_GENERIC_ALIASES: Mapping[str, str] = {
+    **_BASELINE_ALIASES,
+    "a": "book",
+    "b": "hat",
+    "c": "basketball",
+}
+
+
+# ---------------------------------------------------------------------------
+# Rethink templates
+# ---------------------------------------------------------------------------
+
+
+# The illegal-action template is schema-agnostic: it points the model at
+# the pool / offer-history constraint, not at the schema. Shared verbatim
+# across all variants.
+_RETHINK_ILLEGAL = """
+
+You suggested action "{previous_action}" but this is not legal in the
+current state. Either the kept counts exceed the pool, or you tried to
+ACCEPT when no opponent offer exists yet. Reconsider the pool quantities
+and the offer history, then pick a legal action.
+
+(Keep using the same JSON output format as before -- only the action value needs to change.)
+"""
+
+
+def _make_rethink_unparsable(schema_keys: tuple[str, str, str]) -> str:
+    """Build an unparsable-rethink template carrying this variant's schema."""
+    a, b, c = schema_keys
+    return f"""
+
+Your previous response ended with:
+{{previous_response}}
+
+No valid action JSON could be extracted from that. Conclude your response
+with your final action as JSON in a ```json fenced block, exactly as the
+original instructions required:
+
+```json
+{{{{"action": "offer", "keep": {{{{"{a}": <int>, "{b}": <int>, "{c}": <int>}}}}}}}}
+```
+or
+```json
+{{{{"action": "agree"}}}}
+```
+
+For example: `{{{{"action": "offer", "keep": {{{{"{a}": 1, "{b}": 0, "{c}": 2}}}}}}}}`
+
+The action you choose must also be legal in the current state.
+"""
+
+
+# ---------------------------------------------------------------------------
+# Variant: BASELINE  (byte-identical to harness.py)
+# ---------------------------------------------------------------------------
+
+
+_BASELINE_TEMPLATE = """Let's play Bargaining (a.k.a. "Deal or No Deal").
+
+Two players negotiate over a shared pool of three item types: Book, Hat,
+Basketball. The pool for this game contains:
+{pool_lines}
+
+Each player has a PRIVATE integer valuation per item (the opponent's values are
+HIDDEN from you). Your reward at the end of the game is the dot product of your
+valuation vector with the items you actually receive; the opponent's reward is
+computed from their own (hidden) valuation vector. Each per-item valuation is
+between 0 and 10 inclusive, and the values are sampled such that each player's
+dot product with the pool equals 10 (their maximum possible reward).
+
+Your goal is to end the game with a higher reward than your opponent.
+
+Your private valuations (per unit):
+{my_value_lines}
+
+How a turn works:
+  * On an OFFER turn, you propose an allocation that YOU would keep. The
+    opponent would then receive the complement (pool minus your kept items).
+    Each kept count must be an integer between 0 and the pool quantity for
+    that item, inclusive.
+  * If a previous opponent offer exists, you may instead ACCEPT it.
+    Acceptance ENDS the game immediately: you receive the items the
+    opponent offered you (= the complement of what they wanted to keep),
+    and the opponent receives the items they wanted to keep. Each player
+    then scores their own private dot product over what they received.
+  * If {max_turns} offers go by without acceptance, the game ends with
+    ZERO reward for both players (this is a tie).
+{discount_note}
+Offers made so far (most recent last; each shows what the OFFERING player
+wanted to keep -- the other player would receive the complement):
+{history_str}
+
+Offers used so far: {num_offers} of {max_turns}. Offers remaining
+(including this one if you OFFER): {turns_left}.
+
+You are Player {player_label}. It is your turn.
+{accept_help}
+
+Respond with your reasoning, then conclude with a JSON block of EITHER form:
+
+```json
+{{"action": "offer", "keep": {{"book": <int>, "hat": <int>, "basketball": <int>}}}}
+```
+or
+```json
+{{"action": "agree"}}
+```
+
+For example: `{{"action": "offer", "keep": {{"book": 1, "hat": 0, "basketball": 2}}}}`
+
+The "keep" counts describe what YOU retain -- the opponent receives the
+pool minus your kept items. Each kept value must satisfy
+``0 <= keep[item] <= pool[item]``.
+
+Failure to output your final answer in the specified JSON format, or
+choosing an illegal allocation, will result in a loss.
+"""
+
+
+def _discount_note_baseline(discount: float) -> str:
+    """Same wording as harness.py; suppressed entirely when gamma == 1."""
+    if discount >= 1.0:
+        return ""
+    return (
+        f"  * Payoffs are discounted by a factor of {discount} per"
+        " additional offer past the first. Accepting the very first"
+        " offer is UNDISCOUNTED; if agreement is reached only after a"
+        f" 2nd offer has been made, both players' payoffs are multiplied"
+        f" by {discount}; after a 3rd offer, by {discount}^2; in"
+        f" general, after the Nth offer, by {discount}^(N-1). Earlier"
+        " acceptance preserves more reward.\n"
+    )
+
+
+def _accept_help_with_preview(ctx: PromptContext, labels: Mapping[str, str]) -> str:
+    accepted_items = (ctx.last_offer_event or {}).get("items") or {}
+    you_would_receive = _complement(accepted_items, ctx.pool)
+    return (
+        "You MAY accept the opponent's most recent offer with"
+        ' `{"action": "agree"}`. If you accept, you would receive '
+        f"[{_format_items_dict(you_would_receive, labels)}] (their offer to you)."
+    )
+
+
+def _accept_help_no_preview() -> str:
+    return (
+        "You MAY accept the opponent's most recent offer with"
+        ' `{"action": "agree"}`.'
+    )
+
+
+def _accept_help_opening() -> str:
+    return (
+        "No opponent offer exists yet -- you are opening, so you MUST"
+        " make an offer (you cannot accept on the first turn)."
+    )
+
+
+def _build_baseline(ctx: PromptContext, variant: PromptVariant) -> str:
+    labels = variant.item_labels
+    pool_lines = "\n".join(
+        f"  {labels[k]}: {int(ctx.pool.get(k, 0))} {_unit_word(int(ctx.pool.get(k, 0)))}"
+        for k in _ITEM_KEYS
+    )
+    my_value_lines = "\n".join(
+        f"  {labels[k]}: {int(ctx.my_values.get(k, 0))}" for k in _ITEM_KEYS
+    )
+    history_str = _format_history_rich(ctx.state, labels)
+    accept_help = (
+        _accept_help_with_preview(ctx, labels) if ctx.can_accept else _accept_help_opening()
+    )
+    return _BASELINE_TEMPLATE.format(
+        pool_lines=pool_lines,
+        my_value_lines=my_value_lines,
+        max_turns=ctx.max_turns,
+        discount_note=_discount_note_baseline(ctx.discount),
+        num_offers=ctx.num_offers,
+        turns_left=ctx.turns_left,
+        history_str=history_str,
+        player_label=ctx.player_id + 1,
+        accept_help=accept_help,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Variant: COMPACT  (same info, terser)
+# ---------------------------------------------------------------------------
+
+
+_COMPACT_TEMPLATE = """Bargaining (Deal or No Deal). You are Player {player_label}.
+
+Pool: {pool_inline}
+Your valuations (private): {values_inline}
+(Each player's valuations sum to 10 over the pool. The opponent's are
+hidden from you.)
+
+Each turn, either OFFER an allocation you keep (the opponent gets the
+complement) or AGREE to the opponent's last offer. Agreement ends the
+game; each player scores the dot product of their valuations with what
+they receive. If {max_turns} offers pass without agreement, both score
+0. Win by ending with a higher score than the opponent.
+{discount_note}
+History ({num_offers}/{max_turns} offers used):
+{history_str}
+{accept_help}
+
+End your response with JSON:
+
+```json
+{{"action": "offer", "keep": {{"book": <int>, "hat": <int>, "basketball": <int>}}}}
+```
+or
+```json
+{{"action": "agree"}}
+```
+
+Each keep count must satisfy 0 <= keep[item] <= pool[item].
+"""
+
+
+def _build_compact(ctx: PromptContext, variant: PromptVariant) -> str:
+    labels = variant.item_labels
+    pool_inline = ", ".join(f"{labels[k]} {int(ctx.pool.get(k, 0))}" for k in _ITEM_KEYS)
+    values_inline = ", ".join(
+        f"{labels[k]} {int(ctx.my_values.get(k, 0))}" for k in _ITEM_KEYS
+    )
+    history_str = _format_history_rich(ctx.state, labels)
+    accept_help = (
+        _accept_help_with_preview(ctx, labels) if ctx.can_accept else _accept_help_opening()
+    )
+    return _COMPACT_TEMPLATE.format(
+        player_label=ctx.player_id + 1,
+        pool_inline=pool_inline,
+        values_inline=values_inline,
+        max_turns=ctx.max_turns,
+        discount_note=_discount_note_baseline(ctx.discount),
+        num_offers=ctx.num_offers,
+        history_str=history_str,
+        accept_help=accept_help,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Variant: MINIMAL  (maximally stripped)
+# ---------------------------------------------------------------------------
+
+
+_MINIMAL_TEMPLATE = """Bargaining. Player {player_label}.
+
+Pool: {pool_inline}
+Values: {values_inline}
+
+History:
+{history_str}
+
+Respond with JSON, one of:
+{{"action": "offer", "keep": {{"book": N, "hat": N, "basketball": N}}}}
+{{"action": "agree"}}
+"""
+
+
+def _build_minimal(ctx: PromptContext, variant: PromptVariant) -> str:
+    # Deliberately drops the rules, goal, accept-help branch, discount
+    # note, and offers-remaining counter. The history uses the terse
+    # formatter (no per-row complement). Tests how much the model knows.
+    labels = variant.item_labels
+    pool_inline = " ".join(f"{labels[k]}={int(ctx.pool.get(k, 0))}" for k in _ITEM_KEYS)
+    values_inline = " ".join(
+        f"{labels[k]}={int(ctx.my_values.get(k, 0))}" for k in _ITEM_KEYS
+    )
+    history_str = _format_history_minimal(ctx.state, labels)
+    return _MINIMAL_TEMPLATE.format(
+        player_label=ctx.player_id + 1,
+        pool_inline=pool_inline,
+        values_inline=values_inline,
+        history_str=history_str,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Variant: MINIMAL_WITH_GOAL
+# ---------------------------------------------------------------------------
+#
+# Same as MINIMAL plus the one "win condition" sentence from baseline.
+# Tests the prior hypothesis that the goal sentence is load-bearing
+# (models that maximize their own score in isolation play very differently
+# from models that frame the task as "win the negotiation"). If this
+# variant's pair-win% on equal-skill matchups shifts vs MINIMAL, the goal
+# framing was doing real work even when nothing else from baseline is
+# present.
+
+
+_MINIMAL_WITH_GOAL_TEMPLATE = """Bargaining. Player {player_label}.
+
+Your goal is to end the game with a higher reward than your opponent.
+
+Pool: {pool_inline}
+Values: {values_inline}
+
+History:
+{history_str}
+
+Respond with JSON, one of:
+{{"action": "offer", "keep": {{"book": N, "hat": N, "basketball": N}}}}
+{{"action": "agree"}}
+"""
+
+
+def _build_minimal_with_goal(ctx: PromptContext, variant: PromptVariant) -> str:
+    labels = variant.item_labels
+    pool_inline = " ".join(f"{labels[k]}={int(ctx.pool.get(k, 0))}" for k in _ITEM_KEYS)
+    values_inline = " ".join(
+        f"{labels[k]}={int(ctx.my_values.get(k, 0))}" for k in _ITEM_KEYS
+    )
+    history_str = _format_history_minimal(ctx.state, labels)
+    return _MINIMAL_WITH_GOAL_TEMPLATE.format(
+        player_label=ctx.player_id + 1,
+        pool_inline=pool_inline,
+        values_inline=values_inline,
+        history_str=history_str,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Variant: NO_ACCEPT_PREVIEW  (baseline minus the receive-preview)
+# ---------------------------------------------------------------------------
+
+
+def _build_no_accept_preview(ctx: PromptContext, variant: PromptVariant) -> str:
+    # Same as baseline, except the can_accept branch drops the
+    # "you would receive [...]" line. The model still knows accepting is
+    # legal; it has to compute the resulting allocation itself.
+    labels = variant.item_labels
+    pool_lines = "\n".join(
+        f"  {labels[k]}: {int(ctx.pool.get(k, 0))} {_unit_word(int(ctx.pool.get(k, 0)))}"
+        for k in _ITEM_KEYS
+    )
+    my_value_lines = "\n".join(
+        f"  {labels[k]}: {int(ctx.my_values.get(k, 0))}" for k in _ITEM_KEYS
+    )
+    history_str = _format_history_rich(ctx.state, labels)
+    accept_help = _accept_help_no_preview() if ctx.can_accept else _accept_help_opening()
+    return _BASELINE_TEMPLATE.format(
+        pool_lines=pool_lines,
+        my_value_lines=my_value_lines,
+        max_turns=ctx.max_turns,
+        discount_note=_discount_note_baseline(ctx.discount),
+        num_offers=ctx.num_offers,
+        turns_left=ctx.turns_left,
+        history_str=history_str,
+        player_label=ctx.player_id + 1,
+        accept_help=accept_help,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Variant: GENERIC_NAMES  (Book/Hat/Basketball -> A/B/C, schema uses a/b/c)
+# ---------------------------------------------------------------------------
+
+
+_GENERIC_TEMPLATE = """Let's play Bargaining (a.k.a. "Deal or No Deal").
+
+Two players negotiate over a shared pool of three item types: A, B, C.
+The pool for this game contains:
+{pool_lines}
+
+Each player has a PRIVATE integer valuation per item (the opponent's values are
+HIDDEN from you). Your reward at the end of the game is the dot product of your
+valuation vector with the items you actually receive; the opponent's reward is
+computed from their own (hidden) valuation vector. Each per-item valuation is
+between 0 and 10 inclusive, and the values are sampled such that each player's
+dot product with the pool equals 10 (their maximum possible reward).
+
+Your goal is to end the game with a higher reward than your opponent.
+
+Your private valuations (per unit):
+{my_value_lines}
+
+How a turn works:
+  * On an OFFER turn, you propose an allocation that YOU would keep. The
+    opponent would then receive the complement (pool minus your kept items).
+    Each kept count must be an integer between 0 and the pool quantity for
+    that item, inclusive.
+  * If a previous opponent offer exists, you may instead ACCEPT it.
+    Acceptance ENDS the game immediately: you receive the items the
+    opponent offered you (= the complement of what they wanted to keep),
+    and the opponent receives the items they wanted to keep. Each player
+    then scores their own private dot product over what they received.
+  * If {max_turns} offers go by without acceptance, the game ends with
+    ZERO reward for both players (this is a tie).
+{discount_note}
+Offers made so far (most recent last; each shows what the OFFERING player
+wanted to keep -- the other player would receive the complement):
+{history_str}
+
+Offers used so far: {num_offers} of {max_turns}. Offers remaining
+(including this one if you OFFER): {turns_left}.
+
+You are Player {player_label}. It is your turn.
+{accept_help}
+
+Respond with your reasoning, then conclude with a JSON block of EITHER form:
+
+```json
+{{"action": "offer", "keep": {{"a": <int>, "b": <int>, "c": <int>}}}}
+```
+or
+```json
+{{"action": "agree"}}
+```
+
+For example: `{{"action": "offer", "keep": {{"a": 1, "b": 0, "c": 2}}}}`
+
+The "keep" counts describe what YOU retain -- the opponent receives the
+pool minus your kept items. Each kept value must satisfy
+``0 <= keep[item] <= pool[item]``.
+
+Failure to output your final answer in the specified JSON format, or
+choosing an illegal allocation, will result in a loss.
+"""
+
+
+def _build_generic_names(ctx: PromptContext, variant: PromptVariant) -> str:
+    labels = variant.item_labels  # A / B / C
+    pool_lines = "\n".join(
+        f"  {labels[k]}: {int(ctx.pool.get(k, 0))} {_unit_word(int(ctx.pool.get(k, 0)))}"
+        for k in _ITEM_KEYS
+    )
+    my_value_lines = "\n".join(
+        f"  {labels[k]}: {int(ctx.my_values.get(k, 0))}" for k in _ITEM_KEYS
+    )
+    history_str = _format_history_rich(ctx.state, labels)
+    accept_help = (
+        _accept_help_with_preview(ctx, labels) if ctx.can_accept else _accept_help_opening()
+    )
+    return _GENERIC_TEMPLATE.format(
+        pool_lines=pool_lines,
+        my_value_lines=my_value_lines,
+        max_turns=ctx.max_turns,
+        discount_note=_discount_note_baseline(ctx.discount),
+        num_offers=ctx.num_offers,
+        turns_left=ctx.turns_left,
+        history_str=history_str,
+        player_label=ctx.player_id + 1,
+        accept_help=accept_help,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Public variants
+# ---------------------------------------------------------------------------
+
+
+BASELINE = PromptVariant(
+    name="baseline",
+    item_labels=_BASELINE_LABELS,
+    schema_keys=("book", "hat", "basketball"),
+    aliases=_BASELINE_ALIASES,
+    build_body=_build_baseline,
+    rethink_illegal=_RETHINK_ILLEGAL,
+    rethink_unparsable=_make_rethink_unparsable(("book", "hat", "basketball")),
+)
+
+COMPACT = PromptVariant(
+    name="compact",
+    item_labels=_BASELINE_LABELS,
+    schema_keys=("book", "hat", "basketball"),
+    aliases=_BASELINE_ALIASES,
+    build_body=_build_compact,
+    rethink_illegal=_RETHINK_ILLEGAL,
+    rethink_unparsable=_make_rethink_unparsable(("book", "hat", "basketball")),
+)
+
+MINIMAL = PromptVariant(
+    name="minimal",
+    item_labels=_BASELINE_LABELS,
+    schema_keys=("book", "hat", "basketball"),
+    aliases=_BASELINE_ALIASES,
+    build_body=_build_minimal,
+    rethink_illegal=_RETHINK_ILLEGAL,
+    rethink_unparsable=_make_rethink_unparsable(("book", "hat", "basketball")),
+)
+
+MINIMAL_WITH_GOAL = PromptVariant(
+    name="minimal_with_goal",
+    item_labels=_BASELINE_LABELS,
+    schema_keys=("book", "hat", "basketball"),
+    aliases=_BASELINE_ALIASES,
+    build_body=_build_minimal_with_goal,
+    rethink_illegal=_RETHINK_ILLEGAL,
+    rethink_unparsable=_make_rethink_unparsable(("book", "hat", "basketball")),
+)
+
+NO_ACCEPT_PREVIEW = PromptVariant(
+    name="no_accept_preview",
+    item_labels=_BASELINE_LABELS,
+    schema_keys=("book", "hat", "basketball"),
+    aliases=_BASELINE_ALIASES,
+    build_body=_build_no_accept_preview,
+    rethink_illegal=_RETHINK_ILLEGAL,
+    rethink_unparsable=_make_rethink_unparsable(("book", "hat", "basketball")),
+)
+
+GENERIC_NAMES = PromptVariant(
+    name="generic_names",
+    item_labels=_GENERIC_LABELS,
+    schema_keys=("a", "b", "c"),
+    aliases=_GENERIC_ALIASES,
+    build_body=_build_generic_names,
+    rethink_illegal=_RETHINK_ILLEGAL,
+    rethink_unparsable=_make_rethink_unparsable(("a", "b", "c")),
+)
+
+
+VARIANTS: dict[str, PromptVariant] = {
+    BASELINE.name: BASELINE,
+    COMPACT.name: COMPACT,
+    MINIMAL.name: MINIMAL,
+    MINIMAL_WITH_GOAL.name: MINIMAL_WITH_GOAL,
+    NO_ACCEPT_PREVIEW.name: NO_ACCEPT_PREVIEW,
+    GENERIC_NAMES.name: GENERIC_NAMES,
+}


### PR DESCRIPTION
Intended as an MVP for small scale studies (starting with Bargaining) which is generic and easily set up per-game / ran automatically with an agent.

Invocations of `run-ablation` should be completely free of manual effort. There's some back and forth to determine which prompt variants to run, but the work is handled by the agent. Users must only ensure that the `MODEL_PROXY_KEY` and `MODEL_PROXY_URL` env vars are set, and choose which models they want to test.