### PR TITLE
Ensure chess visualizer looks polished in dense mode

### DIFF
--- a/kaggle_environments/envs/open_spiel_env/games/chess/visualizer/default/src/components/GameRenderer.tsx
+++ b/kaggle_environments/envs/open_spiel_env/games/chess/visualizer/default/src/components/GameRenderer.tsx
@@ -24,5 +24,5 @@ export default memo(function GameRenderer(options: GameRendererProps<ChessStep[]
     setState(game, options);
   }, [setState, options]);
 
-  return <Layout />;
+  return <Layout dense={options.dense} />;
 });

--- a/kaggle_environments/envs/open_spiel_env/games/chess/visualizer/default/src/components/Layout.module.css
+++ b/kaggle_environments/envs/open_spiel_env/games/chess/visualizer/default/src/components/Layout.module.css
@@ -23,6 +23,20 @@
   opacity: 0;
 }
 
+.playableArea[data-dense] {
+  /* Dense embeds cap the visualizer area at 500px tall (see VisualizerContainer
+     in @kaggle-environments/core/EpisodePlayer). Switch to size containment so
+     the board can be sized by remaining height via cqh below. */
+  container-type: size;
+}
+
+.playableArea[data-dense] .board {
+  /* Default columns let the square board grow to 512px wide; in dense mode the
+     height budget after the two player bars + padding is much smaller than that,
+     so also cap by remaining vertical space to avoid scrolling. */
+  grid-template-columns: 1fr min(512px, calc(100% - 60px), calc(100cqh - 200px)) 1fr;
+}
+
 :global([data-reduced-motion]) .playableArea {
   transition: none;
 }

--- a/kaggle_environments/envs/open_spiel_env/games/chess/visualizer/default/src/components/Layout.module.css
+++ b/kaggle_environments/envs/open_spiel_env/games/chess/visualizer/default/src/components/Layout.module.css
@@ -28,13 +28,14 @@
      in @kaggle-environments/core/EpisodePlayer). Switch to size containment so
      the board can be sized by remaining height via cqh below. */
   container-type: size;
+  padding-block: 0;
 }
 
 .playableArea[data-dense] .board {
   /* Default columns let the square board grow to 512px wide; in dense mode the
-     height budget after the two player bars + padding is much smaller than that,
-     so also cap by remaining vertical space to avoid scrolling. */
-  grid-template-columns: 1fr min(512px, calc(100% - 60px), calc(100cqh - 200px)) 1fr;
+     height budget after the two (shrunken) player bars is much smaller than
+     that, so also cap by remaining vertical space to avoid scrolling. */
+  grid-template-columns: 1fr min(512px, calc(100% - 60px), calc(100cqh - 130px)) 1fr;
 }
 
 :global([data-reduced-motion]) .playableArea {

--- a/kaggle_environments/envs/open_spiel_env/games/chess/visualizer/default/src/components/Layout.tsx
+++ b/kaggle_environments/envs/open_spiel_env/games/chess/visualizer/default/src/components/Layout.tsx
@@ -16,7 +16,11 @@ import styles from './Layout.module.css';
 import { Vignette } from './Vignette.tsx';
 import PlayerBar from './PlayerBar.tsx';
 
-export default memo(function Layout() {
+interface Props {
+  dense?: boolean;
+}
+
+export default memo(function Layout({ dense }: Props) {
   const loaded = usePreloader((s) => s.pixiReady && s.assetsReady);
   useBoardRect();
 
@@ -25,7 +29,12 @@ export default memo(function Layout() {
   }, []);
 
   return (
-    <main id="playable-area" className={styles.playableArea} data-loaded={loaded || undefined}>
+    <main
+      id="playable-area"
+      className={styles.playableArea}
+      data-loaded={loaded || undefined}
+      data-dense={dense || undefined}
+    >
       <SvgSprite />
       <HiddenHeader />
       <PlayerBar color="b" />

--- a/kaggle_environments/envs/open_spiel_env/games/chess/visualizer/default/src/components/Playerbar.module.css
+++ b/kaggle_environments/envs/open_spiel_env/games/chess/visualizer/default/src/components/Playerbar.module.css
@@ -31,6 +31,11 @@
   line-height: 1.3;
   min-height: 40px;
 
+  [data-dense] & {
+    padding-block: 0.25em;
+    min-height: 28px;
+  }
+
   [data-player="b"] & {
     padding-left: 2em;
 
@@ -66,6 +71,10 @@
   height: calc(var(--max-rows) * var(--capture-size));
   align-content: start;
   user-select: none;
+
+  [data-dense] & {
+    --capture-size: 1.25em;
+  }
 
   [data-player="w"] & {
     margin-left: var(--board-inset);

--- a/web/core/src/components/EpisodePlayer.tsx
+++ b/web/core/src/components/EpisodePlayer.tsx
@@ -88,6 +88,8 @@ export interface GameRendererProps<TSteps extends BaseGameStep[] = BaseGameStep[
   onRegisterPlaybackHandlers?: (handlers: { onPlay?: () => boolean | void; onPause?: () => void }) => void;
   /** Callback to announce a message to screen readers via the aria-live region */
   onAnnounce?: (message: string) => void;
+  /** Whether the player is being rendered in a compact/embedded (dense) layout. */
+  dense?: boolean;
 }
 
 const PlayerContainer = styled('div')<{ $uiMode?: UiMode; $dense: boolean }>`
@@ -395,6 +397,7 @@ export function EpisodePlayer<TSteps extends BaseGameStep[] = BaseGameStep[]>({
           onSetPlaying={actions.setPlayingState}
           onRegisterPlaybackHandlers={handleRegisterPlaybackHandlers}
           onAnnounce={handleAnnounce}
+          dense={dense}
         />
       </VisualizerContainer>
 


### PR DESCRIPTION
Another quick patch. This is an oversight on my part- I forgot to mention we recently started embedding visualizers in the [game arena homepage](https://www.kaggle.com/game-arena) in a `dense` mode. This set of changes just ensures that the visualizer doesn't overflow vertically and gives the chess board a bit more real estate in that confined space. 

The scope here is pretty small and is more on the kaggle platform side of things so I went ahead and fixed it, but lmk if you guys would like to see something more comprehensive and own this. Just wanted to get something in before I announce y'alls shiny new visualizer to the whole kaggle team :)

<img width="1291" height="848" alt="image" src="https://github.com/user-attachments/assets/13b9b7a4-9ef3-4f8d-b5e0-a519efe990d2" />
