### PR TITLE
Iterate on ablation skill & bargaining example

### DIFF
--- a/.agents/skills/run-ablation/SKILL.md
+++ b/.agents/skills/run-ablation/SKILL.md
@@ -7,17 +7,22 @@ description: Run a prompt-ablation study on a kaggle-environments game's LLM har
 
 This skill drives the end-to-end prompt-sensitivity workflow for one game's harness: discover or bootstrap variants, propose additional ones in conversation with the user, run the paired-seat tournament, and report the findings. It is completely standalone — it does not depend on or modify the `create-harness`, `review-harness`, or `create-environment` skills.
 
-The runner library is `kaggle_environments/ablation.py`. The two subcommands you'll invoke are:
+Two CLI tools work together:
 
 ```bash
+# Run the tournament
 python -m kaggle_environments.ablation check --env <env_name>
 python -m kaggle_environments.ablation run --env <env_name> --models <csv> --games <N> --out <dir>
+
+# Post-hoc statistical analysis (permutation test against the null variant's noise floor)
+python -m kaggle_environments.ablation_analysis --csv <dir>/games.csv --baseline baseline --null null
 ```
 
 The runner contract:
 
 * Every game's harness directory contributes a `prompt_variants.py` exposing `VARIANTS: dict[str, GameHarness]`. Each variant **is** a `GameHarness` (implements `get_legal_moves` / `make_prompt` / `parse_response`), so `create_agent_fn(variant)` works directly.
 * The `baseline` variant must be byte-identical to the production `harness.py`. The `check` subcommand enforces this against seeded observations.
+* The `null` variant must be a byte-identical second copy of baseline. The runner schedules independent cells for it; the difference between `null`-vs-`baseline` rankings is pure LLM-sampling noise, which calibrates the noise floor for the permutation test.
 * For each variant, the runner plays a round-robin among the M models with both players using that variant. Every `{A, B}` matchup is scheduled in **seat-flipped pairs sharing one chance seed** — the same instance is played twice with seats swapped. `--games` must be even.
 
 ## Step 0: Identify the env
@@ -64,8 +69,10 @@ You can't propose a good ablation without understanding the prompt's joints. Spe
 
 Generate **3–5 candidate variants** with a one-line rationale each. Cover at least three of these generic axes:
 
-* **Compact** — same information, much terser language. Drops worked examples, repeated reminders, loss-threat sentences. Tests whether the verbose scaffolding is load-bearing.
-* **Minimal** — strips everything optional: rules, goal statement, helpers, examples. Just state + JSON schema. Tests how much the model already knows.
+* **Compact** — same *content* as baseline, just tighter prose. Drops worked examples, repeated reminders, loss-threat sentences, flavor padding. **Keeps every computed helper baseline provides** — per-turn counters, accept-previews like "you would receive [...]", rendered complements in history rows, end-of-prompt constraint reminders. Tests whether the verbose prose padding is load-bearing while holding the helper surface constant.
+* **Minimal** — strips both prose *and* derived/helper info. Keeps mechanics (private-vs-public state, action semantics, reward formula, terminal conditions) but removes anything the model can compute itself from the basic state: per-turn counters (countable from history), accept-previews (subtractable from the last offer), complement-rendered history (subtractable from pool), constraint reminders. Tests whether the model can derive what baseline spoon-feeds.
+
+Compact and Minimal are **distinct ablation axes**, not "more terse" vs "even more terse." If you're proposing both, make sure they actually test different things — Compact = "do we need the prose?", Minimal = "do we need the helpers?" The mechanics keep is non-negotiable in both (see Step 4).
 * **No goal hint** — removes any "your goal is to..." sentence. Tests whether the goal nudge is doing work.
 * **Generic labels** — swaps real names for letters (Book/Hat/Basketball → A/B/C, North/East/South/West → 0/1/2/3). Tests for semantic priors that bias decisions away from stated valuations.
 * **No legal-move list** — removes the enumeration of legal moves (if the prompt includes one). Tests whether the model can derive legality from rules.
@@ -120,10 +127,33 @@ Pick the right template based on env type:
 For each variant:
 
 1. **`baseline`** must be byte-identical to `harness.py`. Port the existing prompt template and helper logic into a `BaselineVariant` class. Do not paraphrase — the next step (`ablation check`) will fail if even one character differs.
-2. **Each new variant** is a subclass of `BaselineVariant` (or sibling class) that overrides `make_prompt` (and `parse_response` if the schema changed — e.g. `generic_names` uses `{a, b, c}` JSON keys and needs an alias map).
-3. Expose `VARIANTS = {"baseline": BaselineVariant(), ...}` at module level. The runner enforces a `"baseline"` entry.
+2. **`null`** must be byte-identical to `baseline` but registered under a separate name. The simplest implementation is just `NULL = PromptVariant(name="null", ..., build_body=<same as BASELINE>, ...)` — share every field with `BASELINE` except `name`. This guarantees no accidental drift between the two. The runner will schedule independent cells for `null`, and the resulting `null`-vs-`baseline` Σ|Δrank| measures pure LLM-sampling noise that the analysis step uses as the noise floor. **Always include `null` in `VARIANTS`** — without it, the permutation test has to estimate the noise floor by resampling, which overestimates noise at small N and drowns real effects.
+3. **Each new variant** is a subclass of `BaselineVariant` (or sibling class) that overrides `make_prompt` (and `parse_response` if the schema changed — e.g. `generic_names` uses `{a, b, c}` JSON keys and needs an alias map).
+4. Expose `VARIANTS = {"baseline": BaselineVariant(), "null": NullVariant(), ...}` at module level. The runner enforces a `"baseline"` entry; the analysis script defaults to looking for `"null"` and degrades gracefully if missing.
 
 Keep the variant code in one file. Do **not** import shared prompt fragments from a sibling helper module — `harness.py` is manually deployed and versioned separately, so a shared-module import would be a deploy-isolation footgun.
+
+### Hard rule: never strip game-mechanics information
+
+Decoration is fair game (worked examples, flavor sentences, repeated reminders, loss-threat language, computed per-turn helpers). **Mechanics is not.** Every variant — including the most aggressive `minimal` — must convey the information the model needs to *understand the game*:
+
+* **What's private vs. public.** If some piece of state is hidden from the opponent (Bargaining: per-player valuations; Werewolf: roles; Avalon: alignment), say so. Models default to assuming symmetric information and play very differently when wrong.
+* **Action semantics.** What does each move-type mean? What does each field in the JSON schema represent? ("keep" = items YOU retain; "agree" = accept opponent's last offer.)
+* **Reward / win condition.** How is the score computed?
+* **Terminal / timeout behavior.** What happens if no resolution is reached?
+
+If you find yourself stripping any of these, stop — you're testing comprehension, not prompt design. The variant's poor performance can't be attributed to the prompt-design choice you wanted to ablate. **Audit each variant by reading it as a model with no prior game knowledge would.** Can you play correctly from this prompt alone? If not, restore the missing mechanics.
+
+### Hard rule: every prompt must ask for reasoning before JSON
+
+Every variant's template — including the most aggressive `minimal` strip — must explicitly instruct the model to **output** its reasoning *before* outputting the final action JSON. The wording must make clear that the reasoning belongs in the response, not just in the model's head. Two safe phrasings:
+
+* baseline-style: `"Respond with your reasoning, then conclude with a JSON block of EITHER form:"`
+* terse-style: `"Respond with your reasoning, then end your response with JSON, one of:"`
+
+**Avoid weak verbs** like "Reason briefly through your move, then respond with JSON" — models often interpret this as "think about it internally, then output JSON" and skip writing reasoning into the response. The instruction must start with an output verb (`Respond`, `Write`, `Explain`, `Output`) applied to the reasoning, not just to the JSON.
+
+This is non-negotiable. Models perform noticeably worse on these games when they skip writing out reasoning; the chain-of-thought is load-bearing, not a stylistic preference. When you propose new variants in Step 3, when you write the variant classes in this step, and when you review the final `prompt_variants.py` before running, *check that every template's final-output instruction puts an output verb on the reasoning, not just on the JSON*. If a variant's whole point is "strip everything", strip rules and helpers and examples — but keep the reason-first instruction.
 
 ## Step 5: Verify with `ablation check`
 
@@ -151,12 +181,12 @@ If a variant errors on render (template KeyError, missing field), fix it. Do not
 
 Before spending API budget, confirm the run with the user. Use `AskUserQuestion` or open prose. Surface:
 
-* The env, the variant list, the model list, `--games` (paired games per matchup — must be even).
-* The total cell count: `K · M(M−1)/2 · games`. Add `M · games` per leaderboard if `--self-play`.
+* The env, the variant list (always including `null`), the model list, `--games` (paired games per matchup — must be even).
+* The total cell count: `K · M(M−1)/2 · games`, where K **includes** the null variant. Add `M · games` per leaderboard if `--self-play`.
 * A rough cost estimate. For Bargaining-class games (≤10 prompt-response rounds, ~1k–3k prompt tokens), assume ~20 LLM calls per game.
 * The output directory.
 
-Default suggestion if the user hasn't specified: `--games 20`, all variants, `--concurrency 8`. Wait for explicit go before invoking the runner.
+Default suggestion if the user hasn't specified: `--games 30`, all variants (including `null`), `--concurrency 8`. **Don't go below N=20** unless smoke-testing — at N=10, the permutation test has poor power and most variants come back inside noise even when their qualitative rank shifts look real. Wait for explicit go before invoking the runner.
 
 ## Step 7: Run the tournament
 
@@ -176,19 +206,44 @@ If the run is interrupted, re-run with `--resume` to skip the cells already in `
 
 ## Step 8: Report findings
 
-Read `summary.md` and surface to the user:
+**First** run the permutation-test analysis. This is the headline output — it tells you which rank shifts are real vs. noise:
 
-* **The cross-variant rank-shift table.** This is the most informative artifact. If a model's rank shifts between variants, the prompt is doing real work for that model. If ranks are stable across variants, the prompt is mostly decoration (or the variants weren't aggressive enough).
-* **The anomalies section.** Variants with >5% crash rate or hard errors usually indicate the prompt is under-specified for some model. Read those rows in `games.csv` for context.
-* **The biggest mean-score deltas.** A variant that moves a model's mean score by ≥0.5 (in a game scaled to ±1) is a strong signal — pay attention to its concrete change vs. baseline.
+```bash
+uv run python -m kaggle_environments.ablation_analysis \
+  --csv <out>/games.csv \
+  --baseline baseline --null null \
+  --permutations 2000 \
+  --out <out>/analysis.md
+```
 
-Make one or two concrete recommendations: which variant(s) look like upgrades to baseline, which look like clear regressions to avoid. Don't just dump the tables — interpret them.
+The script writes a Markdown table per real variant with:
+* **observed Σ|Δrank|** — how much the leaderboard reshuffled vs. baseline
+* **null-floor Σ|Δrank|** — what the byte-identical null variant produced (pure sampling noise)
+* **permutation p-value** — fraction of label-shuffles producing a shift this large or larger
+
+**Lead with the analysis result, not the raw `summary.md` tables.** A variant whose observed Σ|Δrank| is comfortably above the null floor *and* has p < 0.05 is a real prompt-sensitivity finding. A variant whose observed Σ|Δrank| is near or below the null floor isn't moving the leaderboard meaningfully, even if the raw rank table looks suggestive.
+
+Then surface the supporting context from `summary.md`:
+
+* **The cross-variant rank-shift table** — for the variants the analysis flagged as significant, show *what* moved (which model swapped with which).
+* **The anomalies section.** Variants with >5% crash rate or hard errors usually indicate the prompt is under-specified for some model — investigate before treating the variant's rankings as comparable to others.
+* **Mean-score deltas** for context on the *direction* of effect (variant helps or hurts each model).
+
+Make one or two concrete recommendations: which variant(s) look like statistically-supported upgrades to baseline, which look like clear regressions to avoid. Don't just dump the tables — interpret them through the lens of "did this clear the noise floor?"
+
+### When the noise floor swallows everything
+
+If every real variant has Σ|Δrank| at or below the null floor, the honest answer is **the prompt doesn't meaningfully affect rankings at this sample size with these models on this game.** Don't massage marginal results — say so plainly, and recommend either (a) running at higher N if the user has budget, (b) trying more aggressive variants (the current ones may be too close to baseline), or (c) accepting that prompt scaffolding is mostly decoration for this task.
 
 ## Common pitfalls
 
+* **Stripping mechanics, not decoration.** "Minimal" doesn't mean "remove everything." Variants must preserve private-vs-public splits, action semantics, reward computation, and terminal conditions. If a model couldn't play the game from the variant's prompt alone, you're not isolating a prompt-design effect — you're measuring comprehension failure. See the hard-rule subsection in Step 4.
+* **Omitting the reason-first instruction from a variant.** Every prompt (baseline + all variants, however terse) must ask the model to reason before outputting JSON. A variant that drops it is testing a confounded prompt — the lost performance from skipping reasoning will dominate whatever else you were trying to ablate. See the hard-rule subsection in Step 4.
 * **Forgetting `baseline` parity.** If the control arm isn't byte-identical to production, every comparison is contaminated. Run `ablation check` after every edit to `prompt_variants.py`, not just at the end.
+* **Skipping the `null` variant.** Without it, you have no calibrated noise floor and the permutation test has to estimate one by resampling (which overestimates noise at small N). The cost is one extra variant in the matrix — always include it.
+* **Reporting raw rank tables as findings.** The rank table in `summary.md` is *unweighted by significance*. A #1↔#2 swap looks dramatic but at N=10 it happens regularly from sampling noise. Always run `ablation_analysis.py` and lead with its p-values; the rank table is supporting evidence, not the headline.
 * **Asking before proposing.** "What variants would you like?" is the wrong question. The user is invoking this skill *because* they want concrete suggestions. Always propose 3–5 concrete variants first, then iterate.
-* **Picking too few games per matchup.** With N=2 (one pair per matchup), confidence intervals on win-rate span nearly the full [0%, 100%] range. Default to N=20 (10 pairs) for real signal; drop to N=4 only for smoke tests.
+* **Picking too few games per matchup.** With N=2 (one pair per matchup), confidence intervals on win-rate span nearly the full [0%, 100%] range. Default to N=30 (15 pairs) for the permutation test to have real power; drop to N=4 only for smoke tests. At N=10 most real prompt effects come back inside the noise envelope.
 * **Self-play by default.** `--self-play` doubles cost and rarely changes conclusions. Off unless the user asks.
 * **Modifying `harness.py`.** The production prompt stays in `harness.py`. All experimental prompts live in `prompt_variants.py`. If a variant turns out to be a win, promote it to `harness.py` in a *separate* PR.
 * **Per-game extra metrics.** The runner ships generic columns (score, winner, length, crash, duration). If you want game-specific columns (Bargaining's `agreement_step`, chess's `mate_in_n`), add them to `games.csv` in a follow-up post-processing step — the runner's schema is intentionally minimal.
@@ -208,9 +263,10 @@ class BaselineVariant:  # implements GameHarness
 
 VARIANTS: dict[str, GameHarness] = {
     "baseline": BaselineVariant(),
+    "null":     NullVariant(),       # byte-identical duplicate of baseline
     "compact":  CompactVariant(),
     # ...
 }
 ```
 
-The runner imports this module, picks variants by name, and passes each to `create_agent_fn(variant, model_override=...)` per game. No further wiring needed.
+The runner imports this module, picks variants by name, and passes each to `create_agent_fn(variant, model_override=...)` per game. The analysis step (`ablation_analysis.py`) reads the resulting `games.csv` and uses the `null` variant as the noise floor for permutation tests against every other variant. No further wiring needed.

--- a/.agents/skills/run-ablation/templates/prompt_variants_generic.py.tmpl
+++ b/.agents/skills/run-ablation/templates/prompt_variants_generic.py.tmpl
@@ -41,6 +41,14 @@ _PAYLOAD_KEYS = ("action", "move")
 # across seeded observations and fail loudly if they diverge.
 
 # TODO: paste your harness.py prompt template here unchanged.
+#
+# HARD RULE: every prompt template (baseline AND every variant) must
+# explicitly ask the model to reason BEFORE outputting the final JSON.
+# Something like "Respond with your reasoning, then conclude with a
+# JSON block:" right above the JSON schema. Models perform noticeably
+# worse when they skip straight to JSON; reasoning is a load-bearing
+# part of the harness contract, not a stylistic nicety. If you strip
+# *anything* from baseline, keep the reasoning ask.
 _BASELINE_TEMPLATE = """\
 {TODO: copy from harness.py — must be byte-identical}
 """
@@ -133,7 +141,8 @@ class BaselineVariant:
 # ---------------------------------------------------------------------------
 
 _COMPACT_TEMPLATE = """\
-{TODO: terser rewrite of the baseline template — same fields, less prose}
+{TODO: terser rewrite of the baseline template — same fields, less prose.
+ KEEP the "reason first, then JSON" instruction; that is non-negotiable.}
 """
 
 

--- a/.agents/skills/run-ablation/templates/prompt_variants_openspiel.py.tmpl
+++ b/.agents/skills/run-ablation/templates/prompt_variants_openspiel.py.tmpl
@@ -68,6 +68,15 @@ def _parse_observation_payload(observation: Mapping[str, Any]) -> dict[str, Any]
 # across seeded observations and fail loudly if they diverge.
 
 # TODO: paste your harness.py prompt template here unchanged.
+#
+# HARD RULE: every prompt template (baseline AND every variant) must
+# explicitly ask the model to reason BEFORE outputting the final JSON.
+# Something like "Respond with your reasoning, then conclude with a
+# JSON block of EITHER form:" right above the JSON schema. Models
+# perform noticeably worse on these games when they skip straight to
+# JSON; reasoning is a load-bearing part of the harness contract, not
+# a stylistic nicety. If you strip *anything* from baseline, keep the
+# reasoning ask.
 _BASELINE_TEMPLATE = """\
 {TODO: copy from harness.py — must be byte-identical}
 """
@@ -165,7 +174,8 @@ class BaselineVariant:
 # ---------------------------------------------------------------------------
 
 _COMPACT_TEMPLATE = """\
-{TODO: terser rewrite of the baseline template — same fields, less prose}
+{TODO: terser rewrite of the baseline template — same fields, less prose.
+ KEEP the "reason first, then JSON" instruction; that is non-negotiable.}
 """
 
 

--- a/kaggle_environments/ablation.py
+++ b/kaggle_environments/ablation.py
@@ -371,8 +371,19 @@ def run_one_game(
     )
 
 
+class _AblationTimeout(BaseException):
+    """Raised by the SIGALRM handler to enforce --game-timeout.
+
+    Subclasses BaseException (not Exception) on purpose: the LLM agent loop
+    in core_harness.agent_fn catches Exception broadly and retries on
+    failure, which would swallow a plain TimeoutError. BaseException
+    subclasses propagate through that handler so the timeout actually
+    fires through to the worker's outer catch.
+    """
+
+
 def _alarm_handler(signum, frame):
-    raise TimeoutError("game exceeded --game-timeout")
+    raise _AblationTimeout("game exceeded --game-timeout")
 
 
 def _worker_entry(args: tuple) -> GameResult:
@@ -397,7 +408,7 @@ def _worker_entry(args: tuple) -> GameResult:
             env_name, cell, variant_obj, api_key, api_base,
             status_dir=status_dir, started_at=started_at,
         )
-    except TimeoutError:
+    except _AblationTimeout:
         return GameResult(
             variant=cell.variant, model_p0=cell.model_p0, model_p1=cell.model_p1,
             pair_role=cell.pair_role, seed=cell.seed,
@@ -819,6 +830,11 @@ def cmd_run(args: argparse.Namespace) -> int:
         )
         return 2
 
+    # Propagate the per-call timeout via env var so forked workers (and the
+    # core_harness._call_llm inside them) inherit it without an API change.
+    if args.llm_call_timeout and args.llm_call_timeout > 0:
+        os.environ["LLM_CALL_TIMEOUT"] = str(int(args.llm_call_timeout))
+
     out_dir = Path(args.out)
     out_dir.mkdir(parents=True, exist_ok=True)
     csv_path = out_dir / "games.csv"
@@ -1014,11 +1030,18 @@ def _build_parser() -> argparse.ArgumentParser:
                     help="Comma-separated variant names; default all.")
     pr.add_argument("--concurrency", type=int, default=8,
                     help="Max concurrent games (worker process count).")
-    pr.add_argument("--game-timeout", type=int, default=180,
-                    help="Per-game timeout in seconds (SIGALRM watchdog "
-                         "in the worker). Stuck games return a crash row "
-                         "and the worker is freed for the next cell. "
-                         "Set to 0 to disable.")
+    pr.add_argument("--llm-call-timeout", type=int, default=900,
+                    help="Per-LLM-call timeout in seconds. Passed to "
+                         "litellm via the LLM_CALL_TIMEOUT env var, which "
+                         "core_harness._call_llm reads. Single hung calls "
+                         "fail at this limit so the agent's retry loop "
+                         "can recover. Default 900s = 15 min.")
+    pr.add_argument("--game-timeout", type=int, default=0,
+                    help="Per-game SIGALRM watchdog (seconds). Default 0 "
+                         "(disabled) -- the per-call timeout above is the "
+                         "primary protection. Set to e.g. 3600 if you want "
+                         "a hard ceiling on cumulative game wall time on "
+                         "top of the per-call limit.")
     pr.add_argument("--status-interval", type=float, default=10.0,
                     help="Seconds between live status snapshots printed "
                          "by the monitor thread. Set to 0 to disable.")

--- a/kaggle_environments/ablation_analysis.py
+++ b/kaggle_environments/ablation_analysis.py
@@ -1,0 +1,354 @@
+"""Post-hoc statistical analysis of ablation results.
+
+Reads a ``games.csv`` produced by :mod:`kaggle_environments.ablation` and
+quantifies how much each prompt variant actually shifts the leaderboard,
+relative to a noise floor estimated from a duplicated "null" variant.
+
+The headline statistic is ``Sum |delta rank|`` (Σ|Δrank|) -- for a given
+variant, the sum across all models of how many ranks each model moved
+versus baseline. Higher = the variant reorders who wins. The null
+variant (byte-identical to baseline) gives us the distribution of this
+statistic under the null hypothesis that prompts have no effect; the
+permutation test compares each real variant's observed value to that
+distribution to produce a p-value.
+
+Usage::
+
+    python -m kaggle_environments.ablation_analysis \\
+        --csv results/bargaining/games.csv \\
+        --baseline baseline --null null \\
+        --permutations 2000
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import random
+import statistics
+import sys
+from collections import defaultdict
+from pathlib import Path
+from typing import Iterable
+
+
+def _load(csv_path: Path) -> list[dict]:
+    """Load games.csv, dropping rows with errors (timeout/crash/etc).
+
+    Permutation logic depends on each cell having a real pair-outcome,
+    so half-played or crashed games would contaminate the test.
+    """
+    with csv_path.open() as f:
+        rows = list(csv.DictReader(f))
+    clean = [
+        r for r in rows
+        if not r.get("error")
+        and str(r.get("crash_p0", "")).lower() != "true"
+        and str(r.get("crash_p1", "")).lower() != "true"
+    ]
+    dropped = len(rows) - len(clean)
+    if dropped:
+        print(f"# dropped {dropped} rows with errors/crashes", file=sys.stderr)
+    return clean
+
+
+def _models_in(rows: list[dict]) -> list[str]:
+    seen = set()
+    for r in rows:
+        seen.add(r["model_p0"])
+        seen.add(r["model_p1"])
+    return sorted(seen)
+
+
+def _pair_id(row: dict) -> tuple:
+    """Canonical pair id: unordered model pair + chance seed.
+
+    Two seat-flipped games share this id (and share the same instance via
+    the pinned chance seed). The permutation test shuffles labels at this
+    granularity so seat-flip pairing is preserved.
+    """
+    a, b = sorted((row["model_p0"], row["model_p1"]))
+    return (a, b, int(row["seed"]))
+
+
+def _pair_score_per_model(
+    rows: list[dict],
+) -> dict[tuple, dict[str, float]]:
+    """Aggregate raw rows into ``{pair_id: {model: total_score_in_pair}}``."""
+    totals: dict[tuple, dict[str, float]] = defaultdict(lambda: defaultdict(float))
+    counts: dict[tuple, int] = defaultdict(int)
+    for r in rows:
+        pid = _pair_id(r)
+        totals[pid][r["model_p0"]] += float(r["score_p0"])
+        totals[pid][r["model_p1"]] += float(r["score_p1"])
+        counts[pid] += 1
+    # Only keep complete pairs (both seat-flipped games present).
+    return {pid: ts for pid, ts in totals.items() if counts[pid] == 2}
+
+
+def _leaderboard_from_pairs(
+    pair_scores: Iterable[dict[str, float]],
+    models: list[str],
+) -> list[tuple[str, float]]:
+    """Score each model = sum of its pair-totals. Returns sorted descending."""
+    cum: dict[str, float] = defaultdict(float)
+    seen: dict[str, int] = defaultdict(int)
+    for totals in pair_scores:
+        for m, s in totals.items():
+            cum[m] += s
+            seen[m] += 1
+    scored = [
+        (m, cum.get(m, 0.0) / max(seen.get(m, 1), 1))
+        for m in models
+    ]
+    scored.sort(key=lambda x: -x[1])
+    return scored
+
+
+def _ranks_from_leaderboard(
+    leaderboard: list[tuple[str, float]],
+) -> dict[str, int]:
+    return {m: i + 1 for i, (m, _) in enumerate(leaderboard)}
+
+
+def _sum_abs_delta_rank(
+    ranks_a: dict[str, int],
+    ranks_b: dict[str, int],
+) -> int:
+    return sum(abs(ranks_a[m] - ranks_b[m]) for m in ranks_a if m in ranks_b)
+
+
+def _variant_pairs(rows: list[dict], variant: str) -> dict[tuple, dict[str, float]]:
+    return _pair_score_per_model([r for r in rows if r["variant"] == variant])
+
+
+def _observed_delta(
+    baseline_pairs: dict[tuple, dict[str, float]],
+    variant_pairs: dict[tuple, dict[str, float]],
+    models: list[str],
+) -> int:
+    lb_baseline = _leaderboard_from_pairs(baseline_pairs.values(), models)
+    lb_variant = _leaderboard_from_pairs(variant_pairs.values(), models)
+    return _sum_abs_delta_rank(
+        _ranks_from_leaderboard(lb_baseline),
+        _ranks_from_leaderboard(lb_variant),
+    )
+
+
+def _permutation_distribution(
+    baseline_pairs: dict[tuple, dict[str, float]],
+    variant_pairs: dict[tuple, dict[str, float]],
+    models: list[str],
+    n_permutations: int,
+    rng: random.Random,
+) -> list[int]:
+    """Shuffle labels across the pooled pairs, recompute Σ|Δrank| each time.
+
+    Under H0 ("baseline and variant come from the same distribution"),
+    the label is arbitrary. The fraction of permutations producing a
+    statistic at least as extreme as observed is the p-value.
+
+    Both arms must have the same number of pairs for the permutation to
+    be well-defined; we subsample the larger to match the smaller.
+    """
+    a_ids = list(baseline_pairs.keys())
+    b_ids = list(variant_pairs.keys())
+    n = min(len(a_ids), len(b_ids))
+    if n == 0:
+        return []
+
+    # Pool of (pair_id, source-arm) tuples. Each pair_id may appear once
+    # per source arm (the two arms are independent draws from
+    # comparable matchups, not the literal same pair).
+    pool: list[tuple[str, dict[str, float]]] = []
+    for pid in a_ids[:n]:
+        pool.append(("A", baseline_pairs[pid]))
+    for pid in b_ids[:n]:
+        pool.append(("B", variant_pairs[pid]))
+
+    dist: list[int] = []
+    for _ in range(n_permutations):
+        rng.shuffle(pool)
+        a_sample = [p[1] for p in pool[:n]]
+        b_sample = [p[1] for p in pool[n:2 * n]]
+        lb_a = _leaderboard_from_pairs(a_sample, models)
+        lb_b = _leaderboard_from_pairs(b_sample, models)
+        dist.append(_sum_abs_delta_rank(
+            _ranks_from_leaderboard(lb_a),
+            _ranks_from_leaderboard(lb_b),
+        ))
+    return dist
+
+
+def _summary_stats(xs: list[int]) -> tuple[float, float]:
+    if not xs:
+        return float("nan"), float("nan")
+    return statistics.mean(xs), statistics.pstdev(xs)
+
+
+def _p_value(observed: int, dist: list[int]) -> float:
+    """P(permuted >= observed). One-sided; Σ|Δrank| can only be positive."""
+    if not dist:
+        return float("nan")
+    return sum(1 for x in dist if x >= observed) / len(dist)
+
+
+def analyze(
+    csv_path: Path,
+    baseline_name: str,
+    null_name: str | None,
+    n_permutations: int,
+    seed: int,
+) -> str:
+    """Run the full analysis; return a Markdown-formatted report."""
+    rows = _load(csv_path)
+    if not rows:
+        return "No clean rows in CSV."
+
+    variants = sorted({r["variant"] for r in rows})
+    if baseline_name not in variants:
+        raise SystemExit(
+            f"baseline variant '{baseline_name}' not found. "
+            f"Available: {variants}"
+        )
+    if null_name and null_name not in variants:
+        print(
+            f"# warning: null variant '{null_name}' not in data; "
+            f"no calibrated noise floor",
+            file=sys.stderr,
+        )
+        null_name = None
+
+    models = _models_in(rows)
+    baseline_pairs = _variant_pairs(rows, baseline_name)
+    rng = random.Random(seed)
+
+    lines: list[str] = []
+    lines.append(f"# Permutation-test analysis")
+    lines.append("")
+    lines.append(f"- CSV: `{csv_path}`")
+    lines.append(f"- Baseline: `{baseline_name}` ({len(baseline_pairs)} complete pairs)")
+    if null_name:
+        null_pairs = _variant_pairs(rows, null_name)
+        lines.append(f"- Null: `{null_name}` ({len(null_pairs)} complete pairs)")
+    lines.append(f"- Permutations per test: {n_permutations}")
+    lines.append(f"- Models ({len(models)}): {', '.join(models)}")
+    lines.append("")
+
+    # Noise floor: null vs baseline observed + its permutation distribution.
+    noise_floor_observed: float | None = None
+    if null_name:
+        null_observed = _observed_delta(
+            baseline_pairs, null_pairs, models,
+        )
+        null_dist = _permutation_distribution(
+            baseline_pairs, null_pairs, models, n_permutations, rng,
+        )
+        nm, ns = _summary_stats(null_dist)
+        noise_floor_observed = float(null_observed)
+        lines.append(f"## Noise floor")
+        lines.append("")
+        lines.append(
+            f"Observed Σ|Δrank| of `{null_name}` vs `{baseline_name}`: "
+            f"**{null_observed}**"
+        )
+        lines.append("")
+        lines.append(
+            f"Distribution under label-permutation: mean **{nm:.2f}**, "
+            f"sd **{ns:.2f}**"
+        )
+        lines.append("")
+        lines.append(
+            f"This is the Σ|Δrank| we expect from LLM-sampling noise alone, "
+            f"when prompts are byte-identical. Any real variant whose "
+            f"observed Σ|Δrank| sits comfortably above this is a "
+            f"statistically detectable shift."
+        )
+        lines.append("")
+
+    # Each real variant: observed Σ|Δrank|, permutation p-value.
+    lines.append(f"## Per-variant tests vs `{baseline_name}`")
+    lines.append("")
+    header = (
+        "| variant | n pairs | obs Σ|Δrank| | perm mean ± sd | p-value | "
+        "vs noise floor |"
+    )
+    sep = (
+        "|---------|--------:|-------------:|---------------:|--------:|"
+        "----------------|"
+    )
+    lines.append(header)
+    lines.append(sep)
+
+    real_variants = [v for v in variants if v not in {baseline_name, null_name}]
+    for v in real_variants:
+        v_pairs = _variant_pairs(rows, v)
+        if not v_pairs:
+            lines.append(f"| {v} | 0 | — | — | — | (no pairs) |")
+            continue
+        observed = _observed_delta(baseline_pairs, v_pairs, models)
+        dist = _permutation_distribution(
+            baseline_pairs, v_pairs, models, n_permutations, rng,
+        )
+        m, s = _summary_stats(dist)
+        p = _p_value(observed, dist)
+        if noise_floor_observed is not None:
+            comp = (
+                "above" if observed > noise_floor_observed
+                else ("at" if observed == noise_floor_observed else "below")
+            )
+            comp_str = f"{comp} ({observed - noise_floor_observed:+.0f})"
+        else:
+            comp_str = "—"
+        lines.append(
+            f"| {v} | {len(v_pairs)} | {observed} | "
+            f"{m:.2f} ± {s:.2f} | {p:.4f} | {comp_str} |"
+        )
+
+    lines.append("")
+    lines.append(
+        "*p-value = fraction of label-permutations producing Σ|Δrank| ≥ "
+        "observed. Small p (e.g. <0.05) means the variant reorders the "
+        "leaderboard more than chance would.*"
+    )
+    return "\n".join(lines)
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog="python -m kaggle_environments.ablation_analysis",
+        description="Permutation test for prompt-ablation rank shifts.",
+    )
+    p.add_argument("--csv", required=True, help="Path to games.csv.")
+    p.add_argument("--baseline", default="baseline",
+                   help="Name of the baseline variant (default: baseline).")
+    p.add_argument("--null", default="null",
+                   help="Name of the null variant (byte-identical to "
+                        "baseline). Set to empty string to disable.")
+    p.add_argument("--permutations", type=int, default=2000,
+                   help="Number of label-shuffles per test (default 2000).")
+    p.add_argument("--seed", type=int, default=0,
+                   help="RNG seed for the permutation shuffles.")
+    p.add_argument("--out", default="",
+                   help="Optional output file for the Markdown report; "
+                        "default prints to stdout.")
+    return p
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    null_name = args.null or None
+    report = analyze(
+        Path(args.csv), args.baseline, null_name,
+        args.permutations, args.seed,
+    )
+    if args.out:
+        Path(args.out).write_text(report)
+        print(f"Wrote {args.out}")
+    else:
+        print(report)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/kaggle_environments/core_harness.py
+++ b/kaggle_environments/core_harness.py
@@ -443,10 +443,15 @@ def _call_llm(
     start = time.perf_counter()
     first_token_secs: float | None = None
     try:
+        # Per-LLM-call timeout. Honors LLM_CALL_TIMEOUT env var so the
+        # ablation runner (or any orchestrator) can dial it without
+        # changing the harness contract. Default 3600s preserves the
+        # historical behavior.
+        call_timeout = int(os.environ.get("LLM_CALL_TIMEOUT", "3600"))
         stream = litellm.completion(
             model=model_name,
             messages=[{"role": "user", "content": prompt}],
-            timeout=3600,
+            timeout=call_timeout,
             stream=True,
             stream_options={"include_usage": True},
             **litellm_kwargs,

--- a/kaggle_environments/envs/open_spiel_env/games/bargaining/prompt_variants.py
+++ b/kaggle_environments/envs/open_spiel_env/games/bargaining/prompt_variants.py
@@ -551,14 +551,15 @@ hidden from you.)
 Each turn, either OFFER an allocation you keep (the opponent gets the
 complement) or AGREE to the opponent's last offer. Agreement ends the
 game; each player scores the dot product of their valuations with what
-they receive. If {max_turns} offers pass without agreement, both score
-0. Win by ending with a higher score than the opponent.
+they receive. If {max_turns} total offers (combined from both players)
+pass without agreement, both score 0. Win by ending with a higher score
+than the opponent.
 {discount_note}
 History ({num_offers}/{max_turns} offers used):
 {history_str}
 {accept_help}
 
-End your response with JSON:
+Respond with your reasoning, then end your response with JSON:
 
 ```json
 {{"action": "offer", "keep": {{"book": <int>, "hat": <int>, "basketball": <int>}}}}
@@ -602,21 +603,26 @@ def _build_compact(ctx: PromptContext, variant: PromptVariant) -> str:
 _MINIMAL_TEMPLATE = """Bargaining. Player {player_label}.
 
 Pool: {pool_inline}
-Values: {values_inline}
+Your private values (opponent has different, hidden values): {values_inline}
+Reward = your values dotted with the items you receive. Max possible reward = 10 for each player (your values dot the pool sum to 10). If {max_turns} total offers (combined from both players) pass without agreement, both score 0.
+Each turn: OFFER = what YOU keep (opponent gets the complement). AGREE = accept opponent's last offer, ending the game.
 
 History:
 {history_str}
 
-Respond with JSON, one of:
+Respond with your reasoning, then end your response with JSON, one of:
 {{"action": "offer", "keep": {{"book": N, "hat": N, "basketball": N}}}}
 {{"action": "agree"}}
 """
 
 
 def _build_minimal(ctx: PromptContext, variant: PromptVariant) -> str:
-    # Deliberately drops the rules, goal, accept-help branch, discount
-    # note, and offers-remaining counter. The history uses the terse
-    # formatter (no per-row complement). Tests how much the model knows.
+    # Strips decoration (worked examples, rules paragraphs, accept-help
+    # branch, discount note, offers-remaining counter, complement-rendered
+    # history) but keeps every piece of game-mechanics info -- values are
+    # private, action semantics, reward formula, tie condition. Without
+    # those, performance would conflate "model didn't understand the
+    # game" with "model is good at this specific prompt design".
     labels = variant.item_labels
     pool_inline = " ".join(f"{labels[k]}={int(ctx.pool.get(k, 0))}" for k in _ITEM_KEYS)
     values_inline = " ".join(
@@ -627,6 +633,7 @@ def _build_minimal(ctx: PromptContext, variant: PromptVariant) -> str:
         player_label=ctx.player_id + 1,
         pool_inline=pool_inline,
         values_inline=values_inline,
+        max_turns=ctx.max_turns,
         history_str=history_str,
     )
 
@@ -649,12 +656,14 @@ _MINIMAL_WITH_GOAL_TEMPLATE = """Bargaining. Player {player_label}.
 Your goal is to end the game with a higher reward than your opponent.
 
 Pool: {pool_inline}
-Values: {values_inline}
+Your private values (opponent has different, hidden values): {values_inline}
+Reward = your values dotted with the items you receive. Max possible reward = 10 for each player (your values dot the pool sum to 10). If {max_turns} total offers (combined from both players) pass without agreement, both score 0.
+Each turn: OFFER = what YOU keep (opponent gets the complement). AGREE = accept opponent's last offer, ending the game.
 
 History:
 {history_str}
 
-Respond with JSON, one of:
+Respond with your reasoning, then end your response with JSON, one of:
 {{"action": "offer", "keep": {{"book": N, "hat": N, "basketball": N}}}}
 {{"action": "agree"}}
 """
@@ -671,6 +680,7 @@ def _build_minimal_with_goal(ctx: PromptContext, variant: PromptVariant) -> str:
         player_label=ctx.player_id + 1,
         pool_inline=pool_inline,
         values_inline=values_inline,
+        max_turns=ctx.max_turns,
         history_str=history_str,
     )
 
@@ -815,6 +825,21 @@ BASELINE = PromptVariant(
     rethink_unparsable=_make_rethink_unparsable(("book", "hat", "basketball")),
 )
 
+# Null variant: a second copy of BASELINE with a different name so the
+# runner schedules independent cells for it. Rendered prompts are
+# byte-identical to baseline, so any observed Σ|Δrank| between null and
+# baseline is pure LLM sampling noise. Use it as the noise floor in
+# permutation tests on the real variants.
+NULL = PromptVariant(
+    name="null",
+    item_labels=_BASELINE_LABELS,
+    schema_keys=("book", "hat", "basketball"),
+    aliases=_BASELINE_ALIASES,
+    build_body=_build_baseline,
+    rethink_illegal=_RETHINK_ILLEGAL,
+    rethink_unparsable=_make_rethink_unparsable(("book", "hat", "basketball")),
+)
+
 COMPACT = PromptVariant(
     name="compact",
     item_labels=_BASELINE_LABELS,
@@ -868,6 +893,7 @@ GENERIC_NAMES = PromptVariant(
 
 VARIANTS: dict[str, PromptVariant] = {
     BASELINE.name: BASELINE,
+    NULL.name: NULL,
     COMPACT.name: COMPACT,
     MINIMAL.name: MINIMAL,
     MINIMAL_WITH_GOAL.name: MINIMAL_WITH_GOAL,


### PR DESCRIPTION
- Include a "null" prompt variant, which is an exact copy of "baseline" to measure noise from nondeterminism
- Clarify two core variants: "compact" (strips prose, keeps helper info) and "minimal" (strips everything except core mechanics)
- Add some rules for all prompts (must ask for model reasoning, must not remove mechanics required to understand the game)
- Apply all of the above to Bargaining (currently running)
- Add an analysis script