### PR TITLE
Add agent skills not registered with claude

### DIFF
--- a/.claude/skills/create-playable-visualizer/SKILL.md
+++ b/.claude/skills/create-playable-visualizer/SKILL.md
@@ -1,0 +1,8 @@
+---
+name: create-playable-visualizer
+description: Build a standalone interactive (human vs AI) visualizer for a Kaggle game environment by porting the engine and bundled agents to TypeScript and running them in a web worker. Use after create-visualizer.
+---
+
+Follow the instructions in [.agents/skills/create-playable-visualizer/SKILL.md](../../../.agents/skills/create-playable-visualizer/SKILL.md).
+
+Use `$ARGUMENTS` as the game name if provided.

--- a/.claude/skills/run-ablation/SKILL.md
+++ b/.claude/skills/run-ablation/SKILL.md
@@ -1,0 +1,8 @@
+---
+name: run-ablation
+description: Run a prompt-ablation study on a kaggle-environments game's LLM harness. Use when the user mentions "ablation", "prompt sensitivity", "test prompt variants", "compare prompts", "ablate the prompt", "prompt rewrite study", or asks whether their prompt wording is doing real work. Bootstraps a prompt_variants.py if missing, proposes new variants interactively, then runs a paired-seat tournament and reports the leaderboards.
+---
+
+Follow the instructions in [.agents/skills/run-ablation/SKILL.md](../../../.agents/skills/run-ablation/SKILL.md).
+
+Use `$ARGUMENTS` as the game name if provided.


### PR DESCRIPTION
As called out in #1288, the ablation skill (and create playable visualizer) were missing from claude