### PR TITLE
lines_of_action: surface full move history and the lose-by-disruption  path

### DIFF
--- a/kaggle_environments/envs/open_spiel_env/games/lines_of_action/harness.py
+++ b/kaggle_environments/envs/open_spiel_env/games/lines_of_action/harness.py
@@ -41,6 +41,10 @@ You win by connecting all of your remaining pieces into a single group
 (connectivity is 8-directional: horizontal, vertical, or diagonal
 neighbours count as connected). If your move connects both your pieces
 and your opponent's pieces simultaneously, you (the moving player) win.
+Conversely, if after your move only the opponent's pieces are connected
+into a single group and yours are not, the opponent wins immediately --
+so a careless capture or moving a piece that was breaking up the
+opponent's group can lose the game on your own turn.
 A player who has no legal moves on their turn loses. The game is drawn
 if the same position (with the same player to move) occurs for the
 second time, or if 1000 moves are played without a winner.
@@ -56,7 +60,8 @@ line: row=horizontal, col=vertical, /=NE-SW diagonal, \\=NW-SE diagonal):
 
 Move number: {move_number}
 Last move played: {last_move}
-Moves played so far: {move_history}
+Moves played so far (oldest first; Black moves first, then alternates):
+{move_history}
 
 You are playing as {player_name} ({player_code}).
 It is now your turn. Play your strongest move.
@@ -195,6 +200,26 @@ def _format_piece_line_counts(
     return "\n".join(lines) if lines else "  (no pieces)"
 
 
+def _format_move_history(moves: Sequence[str]) -> str:
+    """Render the full game's move list as chess-style numbered pairs.
+
+    Each numbered pair is one full move: Black's reply, then White's. The
+    final pair may have only Black's move when the history ends on Black's
+    turn. Returns ``"  None"`` when there is no history yet.
+    """
+    if not moves:
+        return "  None"
+    pairs: list[str] = []
+    for i in range(0, len(moves), 2):
+        n = i // 2 + 1
+        black = moves[i]
+        if i + 1 < len(moves):
+            pairs.append(f"{n}. {black} {moves[i + 1]}")
+        else:
+            pairs.append(f"{n}. {black}")
+    return "  " + "  ".join(pairs)
+
+
 def _normalize(move: str) -> str:
     """Strip whitespace and lowercase a candidate move string."""
     return re.sub(r"\s+", "", move).lower()
@@ -266,14 +291,20 @@ def generate_prompt(
     last_move = state.get("last_move") or "(none yet)"
 
     my_piece = "x" if player_id == 0 else "o"
-    move_history_str = " ".join(move_history) if move_history else "None"
+    # Prefer the proxy's full-game move history (both players) over the
+    # framework's `move_history` argument (this agent's moves only) -- the
+    # latter is missing the opponent's plies, which prevents the model
+    # from detecting impending twofold-repetition draws or reading the
+    # opponent's recent strategy.
+    full_history = state.get("move_history")
+    history_to_render = full_history if full_history is not None else list(move_history)
 
     prompt = LOA_PROMPT_TEMPLATE.format(
         board_ascii=_format_board_ascii(board),
         piece_line_counts=_format_piece_line_counts(board, my_piece),
         move_number=move_number,
         last_move=last_move,
-        move_history=move_history_str,
+        move_history=_format_move_history(history_to_render),
         player_name=player_name,
         player_code=player_code,
     )

--- a/kaggle_environments/envs/open_spiel_env/games/lines_of_action/harness.py
+++ b/kaggle_environments/envs/open_spiel_env/games/lines_of_action/harness.py
@@ -59,9 +59,7 @@ line: row=horizontal, col=vertical, /=NE-SW diagonal, \\=NW-SE diagonal):
 {piece_line_counts}
 
 Move number: {move_number}
-Last move played: {last_move}
-Moves played so far (oldest first; Black moves first, then alternates):
-{move_history}
+Last move played: {last_move}{move_history_section}
 
 You are playing as {player_name} ({player_code}).
 It is now your turn. Play your strongest move.
@@ -291,20 +289,29 @@ def generate_prompt(
     last_move = state.get("last_move") or "(none yet)"
 
     my_piece = "x" if player_id == 0 else "o"
-    # Prefer the proxy's full-game move history (both players) over the
-    # framework's `move_history` argument (this agent's moves only) -- the
-    # latter is missing the opponent's plies, which prevents the model
-    # from detecting impending twofold-repetition draws or reading the
-    # opponent's recent strategy.
+    # The harness needs the full game's move history (both players) to
+    # render a faithful "moves played so far" section. The framework's
+    # `move_history` argument only contains the calling agent's own
+    # moves, which would mislabel White's plies as Black's if rendered
+    # in alternating-pair notation, so we only render the section when
+    # the proxy supplies its full history. In production the proxy is
+    # always present; the section is dropped only for synthetic test
+    # observations.
     full_history = state.get("move_history")
-    history_to_render = full_history if full_history is not None else list(move_history)
+    if full_history is not None:
+        move_history_section = (
+            "\nMoves played so far (oldest first; Black moves first, "
+            "then alternates):\n" + _format_move_history(full_history)
+        )
+    else:
+        move_history_section = ""
 
     prompt = LOA_PROMPT_TEMPLATE.format(
         board_ascii=_format_board_ascii(board),
         piece_line_counts=_format_piece_line_counts(board, my_piece),
         move_number=move_number,
         last_move=last_move,
-        move_history=_format_move_history(history_to_render),
+        move_history_section=move_history_section,
         player_name=player_name,
         player_code=player_code,
     )

--- a/kaggle_environments/envs/open_spiel_env/games/lines_of_action/lines_of_action_proxy.py
+++ b/kaggle_environments/envs/open_spiel_env/games/lines_of_action/lines_of_action_proxy.py
@@ -34,6 +34,26 @@ class LinesOfActionState(proxy.State):
         # Reverse so board[0] is rank 1 (bottom), matching algebraic notation.
         return list(reversed(ranks_top_down))
 
+    def _move_history(self) -> list[str]:
+        """Full game history as a list of action strings, oldest first.
+
+        Black moves first, then White, then alternating. The framework's
+        per-agent ``move_history`` argument only contains the calling
+        agent's own moves, which leaves the model unable to see the
+        opponent's prior moves (and therefore unable to detect imminent
+        twofold-repetition draws). Surfacing the full history here lets
+        the harness render both players' moves in the prompt.
+        """
+        history = self.history()
+        if not history:
+            return []
+        state = self.__wrapped__.get_game().new_initial_state()
+        out: list[str] = []
+        for action in history:
+            out.append(state.action_to_string(state.current_player(), action))
+            state.apply_action(action)
+        return out
+
     def _last_move_str(self) -> str | None:
         history = self.history()
         if not history:
@@ -62,6 +82,7 @@ class LinesOfActionState(proxy.State):
             "winner": winner,
             "move_number": self.move_number(),
             "last_move": self._last_move_str(),
+            "move_history": self._move_history(),
         }
 
     def to_json(self, player: int | None = None) -> str:

--- a/tests/envs/open_spiel_env/games/lines_of_action/env_test.py
+++ b/tests/envs/open_spiel_env/games/lines_of_action/env_test.py
@@ -42,6 +42,35 @@ class LinesOfActionEnvTest(absltest.TestCase):
         self.assertEqual(after_obs["move_number"], 1)
         self.assertEqual(after_obs["board"][0], [".", ".", "x", "x", "x", "x", "x", "x"])
 
+    def test_proxy_exposes_full_move_history(self):
+        """The proxy must surface the full game's move history (both
+        players, oldest first) so the harness can render it in the prompt
+        -- the framework's per-agent ``move_history`` argument only
+        contains the calling agent's own moves."""
+        env = make(
+            "open_spiel_lines_of_action",
+            configuration={"includeLegalActions": True},
+            debug=True,
+        )
+        env.reset()
+        env.step([{"submission": -1}, {"submission": -1}])  # Setup.
+        # No moves yet -- move_history is the empty list.
+        initial_obs = json.loads(env.state[0]["observation"]["observationString"])
+        self.assertEqual(initial_obs["move_history"], [])
+        # Black plays b1-h1 (action id 142).
+        env.step([{"submission": 142}, {"submission": -1}])
+        # White plays its first legal action (looked up from the env so the
+        # test doesn't have to know which moves are legal post-b1-h1).
+        white_legal = env.state[1]["observation"]["legalActions"]
+        white_legal_strs = env.state[1]["observation"]["legalActionStrings"]
+        white_action = white_legal[0]
+        white_action_str = white_legal_strs[0]
+        env.step([{"submission": -1}, {"submission": white_action}])
+        # Both players see the full history in their observation.
+        for player_idx in (0, 1):
+            obs = json.loads(env.state[player_idx]["observation"]["observationString"])
+            self.assertEqual(obs["move_history"], ["b1-h1", white_action_str])
+
     def test_lines_of_action_invalid_action(self):
         env = make("open_spiel_lines_of_action", debug=True)
         env.reset()

--- a/tests/envs/open_spiel_env/games/lines_of_action/harness_test.py
+++ b/tests/envs/open_spiel_env/games/lines_of_action/harness_test.py
@@ -208,14 +208,19 @@ class GeneratePromptTest(absltest.TestCase):
         self.assertIn("White", prompt)
         self.assertIn("(O)", prompt)
 
-    def test_move_history_fallback_to_per_agent_arg(self):
-        """When the proxy's full history is unavailable (no observationString
-        payload), fall back to rendering the framework's per-agent argument
-        in chess-style numbered-pair notation."""
+    def test_move_history_section_dropped_when_proxy_history_missing(self):
+        """When the proxy's full history is unavailable, the harness must
+        NOT render the framework's per-agent argument as if it were the
+        full game's history. The per-agent list contains only the calling
+        agent's own moves, so rendering it in alternating-pair notation
+        would mislabel White's plies as Black's (or vice versa). Instead
+        the whole 'Moves played so far' section is dropped -- in practice
+        this path only fires for synthetic test observations because the
+        proxy always supplies move_history at runtime."""
         observation = {"observationString": "{}", "playerId": 0}
-        prompt = generate_prompt(observation, ["b1-h1", "a3-c3", "c1-c3"])
-        self.assertIn("1. b1-h1 a3-c3", prompt)
-        self.assertIn("2. c1-c3", prompt)
+        prompt = generate_prompt(observation, ["any-move", "another-move"])
+        self.assertNotIn("Moves played so far", prompt)
+        self.assertNotIn("any-move", prompt)
 
     def test_move_history_prefers_proxy_full_history(self):
         """Regression: the per-agent ``move_history`` argument from the

--- a/tests/envs/open_spiel_env/games/lines_of_action/harness_test.py
+++ b/tests/envs/open_spiel_env/games/lines_of_action/harness_test.py
@@ -1,5 +1,6 @@
 """Tests for Lines of Action LLM harness."""
 
+import json
 from unittest.mock import MagicMock, patch
 
 import pyspiel
@@ -188,16 +189,60 @@ class GeneratePromptTest(absltest.TestCase):
         self.assertIn("no legal moves", prompt)
         self.assertIn("loses", prompt)
 
+    def test_prompt_states_only_opponent_connected_loses(self):
+        """Regression: the engine awards a win to the opponent if, after
+        your move, only the opponent's pieces are connected and yours are
+        not (CheckTerminalState in lines_of_action.cc checks current_player
+        first, then opponent). The old prompt only described the
+        simultaneous-connection case, so the model couldn't see that a
+        careless capture or moving a 'blocker' piece can lose the game on
+        its own turn."""
+        observation = {"observationString": "{}", "playerId": 0}
+        prompt = generate_prompt(observation, [])
+        self.assertIn("only the opponent's pieces are connected", prompt)
+        self.assertIn("opponent wins", prompt)
+
     def test_basic_prompt_white(self):
         observation = {"observationString": "{}", "playerId": 1}
         prompt = generate_prompt(observation, [])
         self.assertIn("White", prompt)
         self.assertIn("(O)", prompt)
 
-    def test_move_history_included(self):
+    def test_move_history_fallback_to_per_agent_arg(self):
+        """When the proxy's full history is unavailable (no observationString
+        payload), fall back to rendering the framework's per-agent argument
+        in chess-style numbered-pair notation."""
         observation = {"observationString": "{}", "playerId": 0}
         prompt = generate_prompt(observation, ["b1-h1", "a3-c3", "c1-c3"])
-        self.assertIn("b1-h1 a3-c3 c1-c3", prompt)
+        self.assertIn("1. b1-h1 a3-c3", prompt)
+        self.assertIn("2. c1-c3", prompt)
+
+    def test_move_history_prefers_proxy_full_history(self):
+        """Regression: the per-agent ``move_history`` argument from the
+        framework only contains the calling agent's own actions, so a
+        prompt that interpolates it as "Moves played so far" silently
+        hides every opponent move past ``last_move``. The harness must
+        prefer ``state["move_history"]`` (set by the proxy) when it is
+        present, even if the per-agent argument lists conflicting moves."""
+        full_history = ["b1-h1", "h7-h4", "c1-c3", "a6-c8"]
+        observation = {
+            "observationString": json.dumps({"move_history": full_history}),
+            "playerId": 0,
+        }
+        # Pass a per-agent stub that does NOT match: the proxy history
+        # should win.
+        prompt = generate_prompt(observation, ["ignored-per-agent-move"])
+        self.assertIn("1. b1-h1 h7-h4", prompt)
+        self.assertIn("2. c1-c3 a6-c8", prompt)
+        self.assertNotIn("ignored-per-agent-move", prompt)
+
+    def test_move_history_empty(self):
+        observation = {
+            "observationString": json.dumps({"move_history": []}),
+            "playerId": 0,
+        }
+        prompt = generate_prompt(observation, [])
+        self.assertIn("None", prompt)
 
     def test_rethink_suffix(self):
         observation = {"observationString": "{}", "playerId": 0}


### PR DESCRIPTION
The harness was passing the framework's per-agent move_history argument straight into the prompt, which only contains the calling agent's own moves. The model therefore couldn't see the opponent's prior plies past last_move, leaving it unable to spot impending twofold-repetition draws or read the opponent's recent strategy. The prompt also covered only the simultaneous-connection case for the moving-player win, omitting the symmetric loss condition where a careless capture or moving a 'blocker' piece leaves only the opponent's group connected -- which the engine resolves as an immediate loss on the mover's turn (CheckTerminalState in lines_of_action.cc).

Fix:
- Proxy state_dict() now exposes the full game's action-string history (both players, oldest first) by replaying the deserialized engine history.
- Harness prefers state["move_history"] from the proxy over the per-agent argument and renders both players' moves in chess-style numbered-pair notation.
- Prompt gains a sentence describing the only-opponent-connected loss path so the model can defend against (or seek) it.

Regression tests cover the new prompt sentence, that the proxy history is preferred when both sources are present, and that the env emits the full history on each step.