### PR TITLE
lines_of_action: state capture-to-one suicide rule and align repetition wording with engine

### DIFF
--- a/kaggle_environments/envs/open_spiel_env/games/lines_of_action/harness.py
+++ b/kaggle_environments/envs/open_spiel_env/games/lines_of_action/harness.py
@@ -44,10 +44,12 @@ and your opponent's pieces simultaneously, you (the moving player) win.
 Conversely, if after your move only the opponent's pieces are connected
 into a single group and yours are not, the opponent wins immediately --
 so a careless capture or moving a piece that was breaking up the
-opponent's group can lose the game on your own turn.
+opponent's group can lose the game on your own turn. In particular, a
+lone piece counts as connected, so capturing the opponent's last-but-one
+piece loses the game on the spot.
 A player who has no legal moves on their turn loses. The game is drawn
-if the same position (with the same player to move) occurs for the
-second time, or if 1000 moves are played without a winner.
+if the same board position occurs for the second time, or if 1000 moves
+are played without a winner.
 
 Board ('.' = empty, 'x' = Black, 'o' = White). Each rank has its total
 piece count on the right ("row"); each file's total is below ("col"):

--- a/tests/envs/open_spiel_env/games/lines_of_action/harness_test.py
+++ b/tests/envs/open_spiel_env/games/lines_of_action/harness_test.py
@@ -168,6 +168,33 @@ class GeneratePromptTest(absltest.TestCase):
         self.assertIn("1000 moves", prompt)
         self.assertNotIn("no draws", prompt.lower())
 
+    def test_prompt_repetition_rule_matches_engine_not_rulebook(self):
+        """Regression: the engine's visited_boards_ set keys on the board
+        string only (lines_of_action.cc BoardToString), not on the
+        (board, player_to_move) pair the OpenSpiel header docstring
+        describes. The prompt previously qualified the rule with 'with the
+        same player to move' (matching the docstring); on the rare board
+        repetition where the mover differs, the engine still draws and the
+        model would be surprised. Drop the parenthetical so the prompt
+        describes realized behavior."""
+        observation = {"observationString": "{}", "playerId": 0}
+        prompt = generate_prompt(observation, [])
+        self.assertNotIn("same player to move", prompt)
+
+    def test_prompt_states_capture_to_one_loses(self):
+        """Regression: a single piece is trivially connected, so capturing
+        the opponent down to one piece makes their pieces 'connected' and
+        triggers an immediate opponent-wins terminal (lines_of_action.cc
+        CheckTerminalState flood-fill from any opponent piece yields
+        group_size == num_opponent_pieces). The previous prompt only
+        warned about 'careless capture' in general terms; make the
+        suicide-by-final-capture rule explicit so models don't blunder
+        into it."""
+        observation = {"observationString": "{}", "playerId": 0}
+        prompt = generate_prompt(observation, [])
+        self.assertIn("lone piece", prompt)
+        self.assertIn("last-but-one", prompt)
+
     def test_prompt_double_connect_awards_mover(self):
         """Regression: OpenSpiel awards the win to the moving player when a
         move connects both groups (the my_piece check fires first in


### PR DESCRIPTION
The prompt's "careless capture can lose" warning didn't make the suicide-by-final-capture trap explicit: a lone piece is trivially connected, so reducing the opponent to one piece is an immediate loss. Spell it out so the model can recognize and avoid it.

Also drop the "(with the same player to move)" parenthetical from the repetition rule. The OpenSpiel header docstring describes that rule, but the implementation's visited_boards_ set keys on the board string only; on the rare repetition where the mover differs, the engine still draws. Describe what the engine actually does.

Tests pin both claims.