### PR TITLE
feat: chess dense mode

### DIFF
--- a/kaggle_environments/envs/open_spiel_env/games/chess/visualizer/default/src/components/GameRenderer.tsx
+++ b/kaggle_environments/envs/open_spiel_env/games/chess/visualizer/default/src/components/GameRenderer.tsx
@@ -24,5 +24,5 @@ export default memo(function GameRenderer(options: GameRendererProps<ChessStep[]
     setState(game, options);
   }, [setState, options]);
 
-  return <Layout />;
+  return <Layout dense={options.dense} />;
 });

--- a/kaggle_environments/envs/open_spiel_env/games/chess/visualizer/default/src/components/Layout.module.css
+++ b/kaggle_environments/envs/open_spiel_env/games/chess/visualizer/default/src/components/Layout.module.css
@@ -4,7 +4,9 @@
   position: relative;
   display: grid;
   align-content: safe center;
+  justify-items: center;
   overflow: auto;
+  width: 100%;
   min-height: 100%;
   max-height: 100dvh;
   overscroll-behavior: none;
@@ -17,6 +19,12 @@
   color: #050001;
   transition: opacity 400ms ease;
   padding-block: 1.5rem;
+}
+
+.playableContent {
+  width: 100%;
+  min-width: 0;
+  container-type: inline-size;
 }
 
 .playableArea:not([data-loaded]) {
@@ -45,7 +53,25 @@
 }
 
 @container (max-width: 600px) {
-  :where(.playableArea > *) {
+  :where(.playableContent > *) {
     font-size: 11px;
+  }
+}
+
+.playableArea[data-dense] .playableContent {
+  width: min(100%, 378px);
+}
+
+.playableArea[data-dense] .board {
+  grid-template-columns: 1fr min(318px, calc(100% - 60px)) 1fr;
+  width: 100%;
+  max-width: 378px;
+  margin-inline: auto;
+}
+
+@media (max-width: 600px) {
+  .playableArea[data-dense] {
+    padding-inline: 0.75em;
+    padding-block: 1rem;
   }
 }

--- a/kaggle_environments/envs/open_spiel_env/games/chess/visualizer/default/src/components/Layout.tsx
+++ b/kaggle_environments/envs/open_spiel_env/games/chess/visualizer/default/src/components/Layout.tsx
@@ -16,7 +16,11 @@ import styles from './Layout.module.css';
 import { Vignette } from './Vignette.tsx';
 import PlayerBar from './PlayerBar.tsx';
 
-export default memo(function Layout() {
+interface Props {
+  dense?: boolean;
+}
+
+export default memo(function Layout({ dense }: Props) {
   const loaded = usePreloader((s) => s.pixiReady && s.assetsReady);
   useBoardRect();
 
@@ -25,18 +29,20 @@ export default memo(function Layout() {
   }, []);
 
   return (
-    <main id="playable-area" className={styles.playableArea} data-loaded={loaded || undefined}>
+    <main id="playable-area" className={styles.playableArea} data-loaded={loaded || undefined} data-dense={dense || undefined}>
       <SvgSprite />
       <HiddenHeader />
-      <PlayerBar color="b" />
-      <div className={styles.board}>
-        <BoardControls />
-        <GameBoard />
-        <Annotation />
+      <div className={styles.playableContent}>
+        <PlayerBar color="b" />
+        <div className={styles.board}>
+          <BoardControls />
+          <GameBoard />
+          <Annotation />
+        </div>
+        <PlayerBar color="w" />
+        <VersusBanner />
+        <CheckBanner />
       </div>
-      <PlayerBar color="w" />
-      <VersusBanner />
-      <CheckBanner />
       <Vignette />
       <SoundEffects />
       <GameOver />

--- a/kaggle_environments/envs/open_spiel_env/games/chess/visualizer/default/src/components/Layout.tsx
+++ b/kaggle_environments/envs/open_spiel_env/games/chess/visualizer/default/src/components/Layout.tsx
@@ -29,7 +29,12 @@ export default memo(function Layout({ dense }: Props) {
   }, []);
 
   return (
-    <main id="playable-area" className={styles.playableArea} data-loaded={loaded || undefined} data-dense={dense || undefined}>
+    <main
+      id="playable-area"
+      className={styles.playableArea}
+      data-loaded={loaded || undefined}
+      data-dense={dense || undefined}
+    >
       <SvgSprite />
       <HiddenHeader />
       <div className={styles.playableContent}>

--- a/kaggle_environments/envs/open_spiel_env/games/chess/visualizer/default/src/components/Playerbar.module.css
+++ b/kaggle_environments/envs/open_spiel_env/games/chess/visualizer/default/src/components/Playerbar.module.css
@@ -107,6 +107,11 @@
   }
 }
 
+.playableArea[data-dense] .playerBar {
+  width: 100%;
+  max-width: min(318px, calc(100% - 60px));
+}
+
 @container (max-width: 600px) {
   .logo {
     scale: 2.25;

--- a/web/core/src/components/EpisodePlayer.tsx
+++ b/web/core/src/components/EpisodePlayer.tsx
@@ -88,6 +88,8 @@ export interface GameRendererProps<TSteps extends BaseGameStep[] = BaseGameStep[
   onRegisterPlaybackHandlers?: (handlers: { onPlay?: () => boolean | void; onPause?: () => void }) => void;
   /** Callback to announce a message to screen readers via the aria-live region */
   onAnnounce?: (message: string) => void;
+  /** Whether the player is being rendered in a compact/embedded (dense) layout. */
+  dense?: boolean;
 }
 
 const PlayerContainer = styled('div')<{ $uiMode?: UiMode; $dense: boolean }>`
@@ -391,6 +393,7 @@ export function EpisodePlayer<TSteps extends BaseGameStep[] = BaseGameStep[]>({
           replay={processedReplay}
           step={state.step}
           agents={currentAgents}
+          dense={dense}
           onSetStep={actions.setStepOnly}
           onSetPlaying={actions.setPlayingState}
           onRegisterPlaybackHandlers={handleRegisterPlaybackHandlers}


### PR DESCRIPTION
PR to adjust chess layout for dense mode on kaggle home page

<img width="1004" height="520" alt="Screenshot 2026-07-01 at 12 30 20" src="https://github.com/user-attachments/assets/15ecd1d2-7a01-43e6-a3d2-dd4fb1fd8533" />
