### PR TITLE
Fix Word Association memory nits

### DIFF
--- a/kaggle_environments/envs/word_association/harness/main.py
+++ b/kaggle_environments/envs/word_association/harness/main.py
@@ -21,6 +21,7 @@ from typing import Any, Mapping, Sequence
 from kaggle_environments.core_harness import (
     ParseResult,
     extract_last_json_object,
+    render_rethink_suffix,
 )
 
 BOARD_SIZE = 25
@@ -211,13 +212,24 @@ def _extract_json(response: str) -> dict[str, Any] | None:
 # --- Rethink ----------------------------------------------------------------
 
 
-RETHINK_SUFFIX = """
+RETHINK_ILLEGAL = """
 
-Your previous response was:
+You suggested "{previous_action}" but this is not a legal move right now
+(the index may be out of range, already revealed, or -1 with no prior guess
+this turn). Reconsider the current state and pick a legal action.
+
+(Keep using the same JSON output format as before -- only the value needs to change.)
+"""
+
+RETHINK_UNPARSABLE = """
+
+Your previous response ended with:
 {previous_response}
 
-You suggested "{previous_action}" but it could not be parsed as a valid
-action. Reconsider and provide a valid response in the required JSON format.
+No valid action could be parsed from that. Conclude your response with your
+final answer as JSON in the exact format the original instructions required
+(a Cluemaster answer needs both "clue" and "number"; a Guesser answer needs
+an integer "guess").
 """
 
 
@@ -390,11 +402,10 @@ def generate_prompt(
             "of the JSON block."
         )
 
-    if previous_response is not None:
-        prompt += RETHINK_SUFFIX.format(
-            previous_response=previous_response[:500],
-            previous_action=previous_action or "(could not parse)",
-        )
+    prompt += render_rethink_suffix(
+        RETHINK_ILLEGAL, RETHINK_UNPARSABLE,
+        previous_response, previous_action,
+    )
 
     return prompt
 
@@ -412,30 +423,35 @@ def parse_response(
         Returns ``ParseResult(legal_action=matched_string)``.
     """
     parsed = _extract_json(response)
+    # raw_action=None → framework routes to RETHINK_UNPARSABLE. We use this
+    # for every failure where we don't have a specific value worth quoting
+    # back at the model; RETHINK_ILLEGAL is reserved for cases where the
+    # model did produce a parseable answer that just wasn't legal.
     if parsed is None:
-        return ParseResult(raw_action=response[:200])
+        return ParseResult(raw_action=None)
+
+    thinking = parsed.get("thinking")
 
     # --- Cluemaster (free-form) ---
-    thinking = parsed.get("thinking")
     if legal_action_strings is None:
         clue = parsed.get("clue")
         number = parsed.get("number")
-        if clue is not None and number is not None:
-            try:
-                num = int(number)
-            except (ValueError, TypeError):
-                return ParseResult(raw_action=response[:200], thoughts=thinking)
-            return ParseResult(
-                submission={"clue": str(clue), "number": num},
-                raw_action=json.dumps({"clue": str(clue), "number": num}),
-                thoughts=thinking,
-            )
-        return ParseResult(raw_action=response[:200], thoughts=thinking)
+        if clue is None or number is None:
+            return ParseResult(raw_action=None, thoughts=thinking)
+        try:
+            num = int(number)
+        except (ValueError, TypeError):
+            return ParseResult(raw_action=None, thoughts=thinking)
+        return ParseResult(
+            submission={"clue": str(clue), "number": num},
+            raw_action=json.dumps({"clue": str(clue), "number": num}),
+            thoughts=thinking,
+        )
 
     # --- Guesser (enumerable) ---
     guess = parsed.get("guess")
     if guess is None:
-        return ParseResult(raw_action=response[:200], thoughts=thinking)
+        return ParseResult(raw_action=None, thoughts=thinking)
 
     raw = str(guess)
     try:

--- a/kaggle_environments/envs/word_association/memory.py
+++ b/kaggle_environments/envs/word_association/memory.py
@@ -6,66 +6,130 @@ def initialize_memory(observation, board_size):
         observation.blue_wins = 0
         observation.yellow_wins = 0
         observation.current_game_turns = []
-        observation._last_clue = ""
-        observation._last_revealed = [False] * board_size
 
-def track_turn(observation, state):
-    """Tracks clues and guesses during the game."""
+
+def _unwrap_submission(action):
+    """core_harness wraps the real action inside {"submission": ...}. Peel it."""
+    if isinstance(action, dict) and "submission" in action:
+        return action["submission"]
+    return action
+
+
+def track_turn(observation, state, acting_turn, action, pre_revealed):
+    """Record what just happened as a structured entry in current_game_turns.
+
+    Called AFTER process_action + update_visibility. Each recorded entry
+    describes what the acting agent did (clue attempt, guess, or pass) —
+    not merely which cells got revealed as a side effect. This distinction
+    matters for the invalid-clue penalty path: the penalty reveal is not a
+    guess and must not be attributed to the previous team's clue.
+    """
     obs = observation
-    
-    # Detect new clue
-    if obs.clue != obs._last_clue and obs.clue != "":
-        # current_turn is updated by prod_interpreter to the NEXT player (guesser)
-        team = "blue" if obs.current_turn in [0, 1] else "yellow"
-        obs.current_game_turns.append({
-            "team": team,
-            "clue": obs.clue,
-            "num": obs.clue_number,
-            "guesses": [],
-            "results": []
-        })
-        obs._last_clue = obs.clue
-        
-    # Detect new guesses
-    revealed = obs.revealed
+    team = "blue" if acting_turn in (0, 1) else "yellow"
+
+    action = _unwrap_submission(action)
+
+    newly_revealed = [
+        i for i in range(len(obs.revealed))
+        if obs.revealed[i] and not pre_revealed[i]
+    ]
     words = obs.words
-    
-    for i in range(len(revealed)):
-        if revealed[i] and not obs._last_revealed[i]:
-            if obs.current_game_turns:
-                last_turn = obs.current_game_turns[-1]
-                last_turn["guesses"].append(words[i])
-                # Read full roles from agent 0 (Cluemaster)
-                full_roles = state[0].observation.roles
-                last_turn["results"].append(full_roles[i])
-            obs._last_revealed[i] = True
+    # state[0] is the Blue Cluemaster; their observation carries full,
+    # unmasked roles, which is what we want to record here (any newly
+    # revealed cell's role is public info the model can already see on
+    # the board).
+    full_roles = state[0].observation.roles
+
+    # --- CLUEMASTER ACTION ------------------------------------------------
+    if acting_turn in (0, 2):
+        # Malformed cluemaster actions (None, non-dict, missing keys) end
+        # the game via INVALID; nothing meaningful to record for memory.
+        if not isinstance(action, dict) or "clue" not in action:
+            return
+
+        # Valid clue: obs.clue is the accepted, non-empty clue string.
+        if obs.clue != "":
+            obs.current_game_turns.append({
+                "team": team,
+                "clue": obs.clue,
+                "number": obs.clue_number,
+                "guesses": [],
+                "results": [],
+            })
+            return
+
+        # Invalid clue: the interpreter reset obs.clue to "" and (usually)
+        # revealed one opponent word as a penalty.
+        entry = {
+            "team": team,
+            "clue": str(action.get("clue")),
+            "number": action.get("number"),
+            "invalid_clue": True,
+        }
+        if newly_revealed:
+            i = newly_revealed[0]
+            entry["penalty_revealed_word"] = words[i]
+            entry["penalty_revealed_role"] = full_roles[i]
+        obs.current_game_turns.append(entry)
+        return
+
+    # --- GUESSER ACTION ---------------------------------------------------
+    guess_val = action.get("guess") if isinstance(action, dict) else action
+
+    # A pass with prior correct guesses is legal and ends the turn; a pass
+    # before any guess for the current clue is INVALID and ends the game.
+    # Distinguish the two so the memory doesn't teach models that "empty
+    # pass" is a fine option.
+    if guess_val == -1:
+        if obs.current_game_turns and "guesses" in obs.current_game_turns[-1]:
+            entry = obs.current_game_turns[-1]
+            if entry["guesses"]:
+                entry["passed"] = True
+            else:
+                entry["invalid_pass"] = True
+        return
+
+    # Otherwise it should be an int guess. Only append when a cell was
+    # actually revealed by this action (skips the INVALID cases: bad type,
+    # out-of-range, or already-revealed index).
+    if not isinstance(guess_val, int) or not newly_revealed:
+        return
+
+    if obs.current_game_turns and "guesses" in obs.current_game_turns[-1]:
+        last_turn = obs.current_game_turns[-1]
+        for i in newly_revealed:
+            last_turn["guesses"].append(words[i])
+            last_turn["results"].append(full_roles[i])
+
 
 def save_game_to_history(observation, winner, window_size):
     """
     Summarizes and categorizes the game, then appends to history.
-    
+
     Example of a stored game in history:
     {
       "game": 0,
       "winner": "yellow",
       "yellow_team_moves": [
-        {"clue": "FRUIT", "num": 2, "guesses": ["APPLE", "BANANA"], "results": ["yellow", "yellow"]}
+        {"clue": "FRUIT", "number": 2, "guesses": ["APPLE", "BANANA"], "results": ["yellow", "yellow"]}
       ],
       "blue_team_moves": [
-        {"clue": "OCEAN", "num": 1, "guesses": ["SHIP"], "results": ["neutral"]}
+        {"clue": "OCEAN", "number": 1, "guesses": ["SHIP"], "results": ["neutral"]},
+        {"clue": "hot-dog", "number": 2, "invalid_clue": true,
+         "penalty_revealed_word": "APPLE", "penalty_revealed_role": "yellow"}
       ]
     }
     """
     obs = observation
-    
+
     # Separate turns by team
     yellow_moves = [t for t in obs.current_game_turns if t["team"] == "yellow"]
     blue_moves = [t for t in obs.current_game_turns if t["team"] == "blue"]
-    
+
     # Remove the "team" key from the inner dictionaries to save space
     for t in yellow_moves: del t["team"]
     for t in blue_moves: del t["team"]
-    
+
     # Append the categorized game log
     obs.history.append({
         "game": obs.current_game,
@@ -73,8 +137,7 @@ def save_game_to_history(observation, winner, window_size):
         "yellow_team_moves": yellow_moves,
         "blue_team_moves": blue_moves
     })
-    
+
     # Enforce sliding window if configured
     if window_size > 0:
         obs.history = obs.history[-window_size:]
-

--- a/kaggle_environments/envs/word_association/word_association.py
+++ b/kaggle_environments/envs/word_association/word_association.py
@@ -269,16 +269,26 @@ def interpreter(state, env):
     prev_blue_reward = state[0].reward or 0
     prev_yellow_reward = state[2].reward or 0
 
+    # Snapshot pre-action context for memory tracking. track_turn needs the
+    # acting agent's index (current_turn is rewritten by process_action) and
+    # the pre-action revealed mask (so it can attribute new reveals to the
+    # right event — a guess vs. an invalid-clue penalty).
+    acting_turn = state[0].observation.current_turn
+    acting_action = state[acting_turn].action
+    pre_revealed = list(state[0].observation.revealed)
+
     process_action(state, env.configuration)
     update_visibility(state)
-    
+
     # Custom Memory Logic
     obs = state[0].observation
     games_per_episode = env.configuration.get("games_per_episode", 1)
-    
-    # Always track turns within the current game for all agents
+
+    # Track this step in every agent's observation. Each agent has its own
+    # current_game_turns list; the shared pre_revealed snapshot is safe to
+    # reuse because obs.revealed is symmetric across agents.
     for s in state:
-        track_turn(s.observation, state)
+        track_turn(s.observation, state, acting_turn, acting_action, pre_revealed)
     
     if games_per_episode > 1:
         is_done = all(s.status in ["DONE", "INVALID"] for s in state)
@@ -306,8 +316,6 @@ def interpreter(state, env):
                 for s in state:
                     s.observation.current_game += 1
                     s.observation.current_game_turns = []
-                    s.observation._last_clue = ""
-                    s.observation._last_revealed = [False] * len(s.observation.revealed)
 
                 # Reset board (re-init)
                 initialize_game(state, env.configuration)

--- a/tests/envs/word_association/test_harness.py
+++ b/tests/envs/word_association/test_harness.py
@@ -220,7 +220,9 @@ class ParseResponseTest(absltest.TestCase):
         response = '{"clue": "ANIMAL", "number": "two"}'
         result = parse_response(response, None)
         self.assertIsNone(result.submission)
-        self.assertIsNotNone(result.raw_action)
+        # raw_action=None → routes to RETHINK_UNPARSABLE (the parsed
+        # object was structurally invalid, not just illegal).
+        self.assertIsNone(result.raw_action)
 
     def test_cluemaster_number_null_returns_none(self):
         response = '{"clue": "ANIMAL", "number": null}'
@@ -308,12 +310,20 @@ class GeneratePromptTest(absltest.TestCase):
         self.assertIn("0: APPLE", prompt)
         self.assertIn("24: ZEBRA", prompt)
 
-    def test_rethink_appended(self):
+    def test_rethink_illegal_appended(self):
+        # previous_action set → RETHINK_ILLEGAL, which quotes the action
+        # but deliberately omits the full previous response.
         obs = _cluemaster_obs()
         prompt = generate_prompt(obs, [], previous_response="bad response", previous_action="FAIL")
-        self.assertIn("bad response", prompt)
         self.assertIn("FAIL", prompt)
-        self.assertIn("could not be parsed", prompt)
+        self.assertIn("not a legal move", prompt)
+
+    def test_rethink_unparsable_appended(self):
+        # previous_action=None → RETHINK_UNPARSABLE, which quotes the response.
+        obs = _cluemaster_obs()
+        prompt = generate_prompt(obs, [], previous_response="bad response", previous_action=None)
+        self.assertIn("bad response", prompt)
+        self.assertIn("No valid action could be parsed", prompt)
 
     def test_memory_context_injected(self):
         obs = _cluemaster_obs(


### PR DESCRIPTION
* Add a separate rethink prompt for ILLEGAL moves vs UNPARSEABLE moves
* When a move is UNPARSEABLE, pass the END of the last response, not the start
* Rename "num" -> "number" in move history schema
* In history tracking, distinguish words that were revealed via a guess from words that were revealed due to an invalid guess penalty.
* Explicitly include passes in move history

I verified that we don't need to rerun the existing non-memory games as these changes only meaningfully effected a negligible number of turns across all matches.