### PR TITLE
Refine prompt ablation skill

### DIFF
--- a/.agents/skills/run-ablation/SKILL.md
+++ b/.agents/skills/run-ablation/SKILL.md
@@ -10,8 +10,11 @@ This skill drives the end-to-end prompt-sensitivity workflow for one game's harn
 Two CLI tools work together:
 
 ```bash
-# Run the tournament
+# Verify baseline parity + variant rendering before spending any budget
 python -m kaggle_environments.ablation check --env <env_name>
+
+# Run the tournament. Auto-preflight, auto-abort on runaway crashes, and
+# --redo-crashed for recovery are all on by default; see Step 7.
 python -m kaggle_environments.ablation run --env <env_name> --models <csv> --games <N> --out <dir>
 
 # Post-hoc statistical analysis (permutation test against the null variant's noise floor)
@@ -183,10 +186,14 @@ Before spending API budget, confirm the run with the user. Use `AskUserQuestion`
 
 * The env, the variant list (always including `null`), the model list, `--games` (paired games per matchup — must be even).
 * The total cell count: `K · M(M−1)/2 · games`, where K **includes** the null variant. Add `M · games` per leaderboard if `--self-play`.
-* A rough cost estimate. For Bargaining-class games (≤10 prompt-response rounds, ~1k–3k prompt tokens), assume ~20 LLM calls per game.
+* A rough cost estimate. For Bargaining-class games (≤10 prompt-response rounds, ~1k–3k prompt tokens), assume ~20 LLM calls per game. For longer-horizon or simultaneous-move games (e.g. Markov Soccer at horizon 100), assume 40+.
 * The output directory.
 
 Default suggestion if the user hasn't specified: `--games 30`, all variants (including `null`), `--concurrency 8`. **Don't go below N=20** unless smoke-testing — at N=10, the permutation test has poor power and most variants come back inside noise even when their qualitative rank shifts look real. Wait for explicit go before invoking the runner.
+
+### Set expectations from existing leaderboard CIs
+
+If the user has an existing Bradley-Terry leaderboard for this game, look at the CI widths across models before promising results. If the middle tiers have CIs of ±30 Elo or more (overlapping bands), most prompt-ablation effects will be inside noise regardless of how well the ablation is run — the game is not distinguishing prompts because it's not distinguishing anything below the extremes. Say this upfront: the ablation can still tell them "is it safe to simplify?" (a valuable answer) but is unlikely to tell them "which prompt wins" (because no prompt does, at that noise level). Steer them toward asking specific behavioral questions ("does model X drop when helper Y is stripped?") rather than expecting wholesale rank shifts.
 
 ## Step 7: Run the tournament
 
@@ -197,12 +204,37 @@ uv run python -m kaggle_environments.ablation run \
   --models <csv of model names> \
   --games <N> \
   --concurrency 8 \
-  --out results/<env>_<date>/
+  --out results/<env>_<slug>/
 ```
+
+**Prefer a stable slug over a date** in the output directory (e.g. `open_spiel_markov_soccer_v1`, not `20260706`). Long runs can cross date boundaries and stale dates in results paths are confusing.
 
 Stream the runner's progress to the user. It writes `games.csv` (one row per game) and `summary.md` (per-variant leaderboards + cross-variant rank shifts + anomalies) into `--out`.
 
-If the run is interrupted, re-run with `--resume` to skip the cells already in `games.csv`.
+### Built-in safety nets
+
+The runner protects budget with three mechanisms — all on by default, all overridable:
+
+* **Preflight probe.** Before scheduling any game, the runner calls each model with a one-token prompt. If any model fails auth/quota/connectivity, the run aborts with the error message and zero games spent. Override with `--skip-preflight` only when you're sure your models work (CI, cached configs).
+* **Auto-abort on crash rate.** After every completed cell, the runner checks per-variant crash rate. If a variant crosses `--max-crash-rate` (default 0.6, i.e. 60%) after `--min-cells-per-variant` (default 8) completions, the run halts and prints the failure category. Combined with the interleaved scheduling (variants round-robin, not sequential), a broken variant or a dying proxy is caught in the first few minutes rather than after burning the whole budget on one leaderboard.
+* **Interleaved scheduling.** Cells are scheduled round-robin across variants, so each variant gets some completions early. Even without auto-abort, this means a systemic failure surfaces on the *first* pass through the variants rather than after 3/4 of the run.
+
+Disable auto-abort with `--max-crash-rate 0` for smoke tests.
+
+### Recovering from a partial run
+
+If the run halts mid-way — auto-abort, network hiccup, ctrl-C, quota exhaustion — `games.csv` is preserved with everything completed so far. To resume:
+
+* **Straight resume** (skip anything already in games.csv): re-run with `--resume`. Good when the interruption was clean and the completed cells are trustworthy.
+* **Redo the crashed cells** (proxy died, some cells contaminated): re-run with `--resume --redo-crashed`. This strips rows where `crash_p0` or `crash_p1` is True from games.csv and re-schedules only those cells. Cleanly-completed cells are preserved. Use this when the crashes were driven by a transient environmental cause (quota, network) rather than a real variant bug.
+
+Before choosing between these, inspect the `failure_reason` column in games.csv to diagnose:
+
+```bash
+awk -F',' 'NR>1 && $NF!="" {print $NF}' games.csv | sort | uniq -c
+```
+
+Categories: `quota` (proxy budget rejected the call), `timeout` (LLM call or game watchdog fired), `parse_failure` (model produced illegal/unparseable output after retries), `agent_error` (uncategorized agent-side exception), `env_error` (env.run itself raised). A concentration of `quota` or `timeout` is fixable with `--redo-crashed` once the environment is healthy; a concentration of `parse_failure` on one variant usually means the variant's prompt is broken and needs a fix in `prompt_variants.py` first.
 
 ## Step 8: Report findings
 
@@ -245,8 +277,26 @@ If every real variant has Σ|Δrank| at or below the null floor, the honest answ
 * **Asking before proposing.** "What variants would you like?" is the wrong question. The user is invoking this skill *because* they want concrete suggestions. Always propose 3–5 concrete variants first, then iterate.
 * **Picking too few games per matchup.** With N=2 (one pair per matchup), confidence intervals on win-rate span nearly the full [0%, 100%] range. Default to N=30 (15 pairs) for the permutation test to have real power; drop to N=4 only for smoke tests. At N=10 most real prompt effects come back inside the noise envelope.
 * **Self-play by default.** `--self-play` doubles cost and rarely changes conclusions. Off unless the user asks.
-* **Modifying `harness.py`.** The production prompt stays in `harness.py`. All experimental prompts live in `prompt_variants.py`. If a variant turns out to be a win, promote it to `harness.py` in a *separate* PR.
-* **Per-game extra metrics.** The runner ships generic columns (score, winner, length, crash, duration). If you want game-specific columns (Bargaining's `agreement_step`, chess's `mate_in_n`), add them to `games.csv` in a follow-up post-processing step — the runner's schema is intentionally minimal.
+* **Modifying `harness.py`.** The production prompt stays in `harness.py`. All experimental prompts live in `prompt_variants.py`. If a variant turns out to be a win, promote it to `harness.py` in a *separate* PR (see the promotion workflow section below).
+* **Per-game extra metrics.** The runner ships generic columns (score, winner, length, crash, duration, failure_reason). If you want game-specific columns (Bargaining's `agreement_step`, chess's `mate_in_n`), add them to `games.csv` in a follow-up post-processing step — the runner's schema is intentionally minimal.
+* **Ignoring the failure_reason column.** If crashes cluster in `quota` or `timeout`, the environment is the problem, not the variant — recover with `--resume --redo-crashed`. If they cluster in `parse_failure` on one variant, the variant's prompt is under-specified for at least one model — fix it and re-run just that variant with `--variants X --resume --redo-crashed`. Never conflate the two: rerunning a broken variant burns budget on data you'll discard again.
+* **Skipping the preflight probe habitually.** `--skip-preflight` exists for CI where the model list has been validated by a prior run. In interactive use it's the "trust me, they work" button and it will bite you. Cost of the probe is ~30s and one token per model.
+
+## Promotion workflow: from variant win to production
+
+The ablation's `prompt_variants.py` stays checked in permanently — it's the experimental surface for future re-testing. When an ablation identifies a winning variant that should replace baseline in production, do NOT edit `prompt_variants.py` to make the winner the new baseline. Instead, promote in a **separate PR**:
+
+1. **This PR (the ablation itself):** commit `prompt_variants.py`, the results directory (`games.csv`, `summary.md`, `analysis.md`), and any notes. This is the evidence trail.
+2. **Follow-up PR (the promotion):** modify `harness.py` (and its test) only, applying the winning variant's specific changes. Reference the ablation PR in the description for justification. Do not touch `prompt_variants.py` in this PR.
+
+Canonical example: Bargaining. PR [`#1279`](https://github.com/Kaggle/kaggle-environments/pull/1279) introduced the ablation tool + skill; PR [`#1273`](https://github.com/Kaggle/kaggle-environments/pull/1273) ("Save Bargaining prompt changes from experiment") promoted the winning variant into `harness.py` in an isolated 16-line diff that only touched harness + test.
+
+Why the separation:
+* The ablation stays reproducible — future runs can re-verify or challenge the finding.
+* The promotion PR is easy to review — it's just the diff to production.
+* Reverting production is a one-commit revert, not a partial rollback.
+
+If the ablation produced no statistically supported winner, just do step 1. Don't ship prompt changes on directional-but-inside-noise signal; add a note to the results dir describing what was tried so future work doesn't retread the same axes.
 
 ## Reference: the contract enforced by the runner
 

--- a/kaggle_environments/ablation.py
+++ b/kaggle_environments/ablation.py
@@ -67,7 +67,11 @@ from pathlib import Path
 from typing import Any, Iterable, Mapping
 
 from kaggle_environments import make
-from kaggle_environments.core_harness import GameHarness, create_agent_fn
+from kaggle_environments.core_harness import (
+    GameHarness,
+    _call_llm,
+    create_agent_fn,
+)
 
 _log = logging.getLogger("kaggle_environments.ablation")
 
@@ -113,6 +117,30 @@ def load_variants(env_name: str) -> dict[str, GameHarness]:
 # ---------------------------------------------------------------------------
 # Model wiring
 # ---------------------------------------------------------------------------
+
+
+def preflight_probe(
+    models: list[str],
+    api_key: str,
+    api_base: str,
+) -> list[tuple[str, str | None]]:
+    """One tiny LLM call per model. Returns ``[(model, error_or_None), ...]``.
+
+    Catches auth, quota, and connectivity failures in ~seconds so the
+    tournament doesn't spend budget on a broken configuration. Called
+    automatically from :func:`cmd_run` unless ``--skip-preflight`` is
+    passed.
+    """
+    results: list[tuple[str, str | None]] = []
+    prompt = "Reply with the single word: ok."
+    for m in models:
+        model_name, kw = build_model_setup(m, api_key, api_base)
+        try:
+            _call_llm(prompt, model_name, kw)
+            results.append((m, None))
+        except Exception as exc:  # noqa: BLE001
+            results.append((m, f"{type(exc).__name__}: {exc}"))
+    return results
 
 
 def build_model_setup(
@@ -215,6 +243,26 @@ class GameResult:
     crash_p1: bool
     error: str
     duration_s: float
+    failure_reason: str = ""
+
+
+def _categorize_failure(msg: str) -> str:
+    """Bucket an exception/error message into a coarse failure category.
+
+    Categories: "quota" (proxy budget rejected the call), "timeout" (our
+    watchdog or a per-call timeout fired), "parse_failure" (LLM produced
+    N attempts of unparseable/illegal output), "agent_error" (anything
+    else raised from inside the agent loop), "env_error" (raised from
+    env.run itself, outside any agent).
+    """
+    m = (msg or "").lower()
+    if ("quota" in m and ("cost" in m or "exceeds" in m)) or "max estimated cost" in m:
+        return "quota"
+    if "timeout" in m or "ablationtimeout" in m:
+        return "timeout"
+    if "failed to parse a legal move" in m:
+        return "parse_failure"
+    return "agent_error"
 
 
 def _extract_scores(env: Any) -> tuple[float, float, int]:
@@ -319,6 +367,11 @@ def run_one_game(
 
     # Per-seat move counters used by the status writer below.
     moves = [0, 0]
+    # Per-seat last exception captured from agent invocations. kaggle
+    # env.run swallows agent exceptions and marks the agent ERROR without
+    # surfacing the reason, so we stash the last one here to categorize
+    # into failure_reason after the game ends.
+    last_agent_exc: list[str | None] = [None, None]
 
     def _wrap(seat: int, real_agent):
         def tracked(obs: Any, cfg: dict[str, Any]) -> dict[str, Any]:
@@ -327,7 +380,11 @@ def run_one_game(
                 status_dir or "", cell, "running", started_at,
                 moves_p0=moves[0], moves_p1=moves[1],
             )
-            return real_agent(obs, cfg)
+            try:
+                return real_agent(obs, cfg)
+            except Exception as exc:  # noqa: BLE001
+                last_agent_exc[seat] = f"{type(exc).__name__}: {exc}"
+                raise
         return tracked
 
     agent_p0 = _wrap(0, create_agent_fn(
@@ -340,12 +397,19 @@ def run_one_game(
     ))
 
     env = make(env_name, configuration=config, debug=False)
+    failure_reason = ""
     try:
         env.run([agent_p0, agent_p1])
         p0, p1, winner = _extract_scores(env)
         length = len(env.steps)
         crash_p0 = _agent_crashed(env, 0)
         crash_p1 = _agent_crashed(env, 1)
+        if crash_p0 or crash_p1:
+            # Prefer the exception message from the seat that crashed.
+            src = last_agent_exc[0] if crash_p0 else last_agent_exc[1]
+            if src is None:
+                src = last_agent_exc[1] if crash_p0 and last_agent_exc[1] else src
+            failure_reason = _categorize_failure(src or "")
     except Exception as exc:
         error = f"{type(exc).__name__}: {exc}"
         _log.warning("Game crashed (%s): %s", cell, exc)
@@ -353,6 +417,8 @@ def run_one_game(
         winner = 0
         length = 0
         crash_p0 = crash_p1 = True
+        # Env-level exception; use the exception itself for categorization.
+        failure_reason = _categorize_failure(error) or "env_error"
 
     return GameResult(
         variant=cell.variant,
@@ -368,6 +434,7 @@ def run_one_game(
         crash_p1=crash_p1,
         error=error,
         duration_s=time.perf_counter() - start,
+        failure_reason=failure_reason,
     )
 
 
@@ -416,15 +483,18 @@ def _worker_entry(args: tuple) -> GameResult:
             crash_p0=True, crash_p1=True,
             error=f"TimeoutError: exceeded {timeout_secs}s",
             duration_s=time.perf_counter() - start,
+            failure_reason="timeout",
         )
     except Exception as exc:  # noqa: BLE001
+        err = f"{type(exc).__name__}: {exc}"
         return GameResult(
             variant=cell.variant, model_p0=cell.model_p0, model_p1=cell.model_p1,
             pair_role=cell.pair_role, seed=cell.seed,
             score_p0=0.0, score_p1=0.0, winner=0, length_moves=0,
             crash_p0=True, crash_p1=True,
-            error=f"{type(exc).__name__}: {exc}",
+            error=err,
             duration_s=time.perf_counter() - start,
+            failure_reason=_categorize_failure(err) or "env_error",
         )
     finally:
         if timeout_secs and timeout_secs > 0:
@@ -533,16 +603,30 @@ _CSV_FIELDS = [
     "variant", "model_p0", "model_p1", "pair_role", "seed",
     "score_p0", "score_p1", "winner", "length_moves",
     "crash_p0", "crash_p1", "error", "duration_s",
+    "failure_reason",
 ]
 
 
-def _read_existing_cells(csv_path: Path) -> set[tuple]:
-    """Return the set of cell keys already present in games.csv (for --resume)."""
+def _read_existing_cells(
+    csv_path: Path,
+    *,
+    include_crashed: bool = True,
+) -> set[tuple]:
+    """Return the set of cell keys already present in games.csv (for --resume).
+
+    If ``include_crashed`` is False, rows where crash_p0 or crash_p1 is
+    True are excluded from the "done" set -- callers using
+    ``--redo-crashed`` want to re-schedule those cells.
+    """
     if not csv_path.exists():
         return set()
     done: set[tuple] = set()
     with csv_path.open() as f:
         for row in csv.DictReader(f):
+            if not include_crashed:
+                if (str(row.get("crash_p0", "")).lower() == "true"
+                        or str(row.get("crash_p1", "")).lower() == "true"):
+                    continue
             done.add((
                 row["variant"], row["model_p0"], row["model_p1"],
                 row["pair_role"], int(row["seed"]),
@@ -550,14 +634,87 @@ def _read_existing_cells(csv_path: Path) -> set[tuple]:
     return done
 
 
+def _strip_crashed_rows(csv_path: Path) -> int:
+    """Rewrite games.csv without rows where crash_p0 or crash_p1 is True.
+
+    Returns the number of rows removed. Used by ``--redo-crashed`` so
+    those cells can be re-scheduled without leaving stale duplicates in
+    the CSV (which would double-count in aggregation).
+    """
+    if not csv_path.exists():
+        return 0
+    tmp = csv_path.with_suffix(csv_path.suffix + ".stripping")
+    removed = 0
+    with csv_path.open() as f_in, tmp.open("w", newline="") as f_out:
+        r = csv.DictReader(f_in)
+        w = csv.DictWriter(f_out, fieldnames=_CSV_FIELDS)
+        w.writeheader()
+        for row in r:
+            if (str(row.get("crash_p0", "")).lower() == "true"
+                    or str(row.get("crash_p1", "")).lower() == "true"):
+                removed += 1
+                continue
+            w.writerow({k: row.get(k, "") for k in _CSV_FIELDS})
+    tmp.replace(csv_path)
+    return removed
+
+
+def _interleave_by_variant(cells: list[GameCell]) -> list[GameCell]:
+    """Round-robin cells across variants.
+
+    Original scheduling was variant-major (all baseline, then all null,
+    ...). If a variant is broken or the proxy dies partway through, that
+    ordering means one variant is fully corrupted while others aren't
+    even started. Interleaving spreads each variant's cells across the
+    whole run so systemic failures surface early (and, combined with
+    --max-crash-rate, are caught before wasting budget on one variant).
+    """
+    by_variant: dict[str, list[GameCell]] = {}
+    for c in cells:
+        by_variant.setdefault(c.variant, []).append(c)
+    order = list(by_variant.keys())
+    out: list[GameCell] = []
+    while any(by_variant[v] for v in order):
+        for v in order:
+            if by_variant[v]:
+                out.append(by_variant[v].pop(0))
+    return out
+
+
 def _cell_key(c: GameCell) -> tuple:
     return (c.variant, c.model_p0, c.model_p1, c.pair_role, c.seed)
+
+
+def _migrate_csv_columns(csv_path: Path) -> None:
+    """Add any missing columns to an existing games.csv (fill with "")."""
+    if not csv_path.exists():
+        return
+    with csv_path.open() as f:
+        first_line = f.readline().strip()
+    if not first_line:
+        return
+    existing = first_line.split(",")
+    missing = [c for c in _CSV_FIELDS if c not in existing]
+    if not missing:
+        return
+    tmp = csv_path.with_suffix(csv_path.suffix + ".migrate")
+    with csv_path.open() as f_in, tmp.open("w", newline="") as f_out:
+        r = csv.DictReader(f_in)
+        w = csv.DictWriter(f_out, fieldnames=_CSV_FIELDS)
+        w.writeheader()
+        for row in r:
+            for c in missing:
+                row.setdefault(c, "")
+            w.writerow({k: row.get(k, "") for k in _CSV_FIELDS})
+    tmp.replace(csv_path)
 
 
 def _open_csv_for_append(csv_path: Path) -> tuple[Any, csv.DictWriter]:
     """Open ``games.csv`` for appending; write header if new."""
     new_file = not csv_path.exists()
     csv_path.parent.mkdir(parents=True, exist_ok=True)
+    if not new_file:
+        _migrate_csv_columns(csv_path)
     f = csv_path.open("a", newline="")
     writer = csv.DictWriter(f, fieldnames=_CSV_FIELDS)
     if new_file:
@@ -835,13 +992,50 @@ def cmd_run(args: argparse.Namespace) -> int:
     if args.llm_call_timeout and args.llm_call_timeout > 0:
         os.environ["LLM_CALL_TIMEOUT"] = str(int(args.llm_call_timeout))
 
+    # Preflight: one short LLM call per model to confirm auth/quota/
+    # connectivity BEFORE we spend budget on the tournament. Skips only
+    # in --dry-run mode, offline mode, or with --skip-preflight.
+    if (not args.skip_preflight
+            and api_base != "dummy_url"):
+        print(f"Preflight: probing {len(models)} model(s)...", flush=True)
+        probe_results = preflight_probe(models, api_key, api_base)
+        failed = [(m, e) for m, e in probe_results if e is not None]
+        for m, e in probe_results:
+            if e is None:
+                print(f"  {m}: ok")
+            else:
+                print(f"  {m}: FAIL -- {e}", file=sys.stderr)
+        if failed:
+            print(
+                f"\nPreflight failed for {len(failed)}/{len(models)} model(s). "
+                f"Aborting before scheduling. Re-run with --skip-preflight to "
+                f"override (not recommended).",
+                file=sys.stderr,
+            )
+            return 3
+
     out_dir = Path(args.out)
     out_dir.mkdir(parents=True, exist_ok=True)
     csv_path = out_dir / "games.csv"
     summary_path = out_dir / "summary.md"
 
-    done = _read_existing_cells(csv_path) if args.resume else set()
+    # --redo-crashed rewrites games.csv without crashed rows so those
+    # cells can be re-scheduled without leaving stale duplicates behind.
+    # Only meaningful with --resume; harmless otherwise.
+    if args.redo_crashed and args.resume:
+        removed = _strip_crashed_rows(csv_path)
+        if removed:
+            print(f"--redo-crashed: stripped {removed} crashed row(s) from games.csv.")
+
+    include_crashed_as_done = not args.redo_crashed
+    done = (
+        _read_existing_cells(csv_path, include_crashed=include_crashed_as_done)
+        if args.resume else set()
+    )
     todo = [c for c in cells if _cell_key(c) not in done]
+    # Interleave so per-variant crashes surface early even without
+    # --max-crash-rate protection.
+    todo = _interleave_by_variant(todo)
     if args.resume:
         print(f"Resume: {len(done)} cells already done, {len(todo)} to go.")
     else:
@@ -883,6 +1077,11 @@ def cmd_run(args: argparse.Namespace) -> int:
         )
         monitor.start()
 
+    # Per-variant tallies for the crash-rate auto-abort.
+    v_total: dict[str, int] = defaultdict(int)
+    v_crash: dict[str, int] = defaultdict(int)
+    auto_abort_msg: str | None = None
+
     try:
         ctx = mp.get_context("fork")
         with ProcessPoolExecutor(
@@ -895,6 +1094,9 @@ def cmd_run(args: argparse.Namespace) -> int:
                 writer.writerow(_row_dict(result))
                 csv_file.flush()
                 completed += 1
+                v_total[result.variant] += 1
+                if result.crash_p0 or result.crash_p1:
+                    v_crash[result.variant] += 1
                 if (
                     completed % max(1, len(todo) // 20) == 0
                     or completed == len(todo)
@@ -906,6 +1108,35 @@ def cmd_run(args: argparse.Namespace) -> int:
                         f" -> ({result.score_p0:+.2f}, {result.score_p1:+.2f})"
                         f" in {result.duration_s:.1f}s"
                     )
+                # Auto-abort on runaway crash rate. A variant that
+                # crosses --max-crash-rate after --min-cells-per-variant
+                # cells is almost always a broken prompt or a dead proxy
+                # -- pushing through wastes budget on data we'll discard.
+                if args.max_crash_rate > 0:
+                    tot = v_total[result.variant]
+                    if tot >= args.min_cells_per_variant:
+                        rate = v_crash[result.variant] / tot
+                        if rate >= args.max_crash_rate:
+                            auto_abort_msg = (
+                                f"AUTO-ABORT: variant '{result.variant}' "
+                                f"crash rate {v_crash[result.variant]}/{tot} "
+                                f"= {rate:.0%} (>= {args.max_crash_rate:.0%} "
+                                f"after >= {args.min_cells_per_variant} cells)."
+                            )
+                            print(f"\n{auto_abort_msg}", file=sys.stderr)
+                            print(
+                                "Cancelling remaining futures. Inspect games.csv "
+                                "'failure_reason' column to diagnose. Common "
+                                "causes: proxy quota exhausted (quota), model "
+                                "unable to comply with prompt (parse_failure), "
+                                "hung LLM calls (timeout). Re-run with "
+                                "--resume --redo-crashed once the root cause "
+                                "is fixed.",
+                                file=sys.stderr,
+                            )
+                            for other_fut in futures:
+                                other_fut.cancel()
+                            break
     finally:
         stop_event.set()
         if monitor is not None:
@@ -921,6 +1152,8 @@ def cmd_run(args: argparse.Namespace) -> int:
     summary_path.write_text(summary)
     print(f"\nWrote {len(all_rows)} rows to {csv_path}")
     print(f"Wrote summary to {summary_path}")
+    if auto_abort_msg is not None:
+        return 4
     return 0
 
 
@@ -1049,6 +1282,29 @@ def _build_parser() -> argparse.ArgumentParser:
                     help="Add the M self-play cells per leaderboard.")
     pr.add_argument("--resume", action="store_true",
                     help="Skip cells already present in games.csv.")
+    pr.add_argument("--redo-crashed", action="store_true",
+                    help="With --resume, treat rows where crash_p0 or "
+                         "crash_p1 is True as unfinished; they're stripped "
+                         "from games.csv and re-scheduled. Useful for "
+                         "recovering from a proxy-quota or transient-"
+                         "network partial run without discarding the "
+                         "cleanly-completed cells.")
+    pr.add_argument("--skip-preflight", action="store_true",
+                    help="Skip the per-model connectivity probe that runs "
+                         "before scheduling. The probe does one short LLM "
+                         "call per model and aborts if any fail (auth, "
+                         "quota, connectivity). Skip only when you're sure "
+                         "your models work (CI, cached configs).")
+    pr.add_argument("--max-crash-rate", type=float, default=0.6,
+                    help="Auto-abort threshold on per-variant crash rate. "
+                         "If a variant's crash rate exceeds this after "
+                         "--min-cells-per-variant cells have completed, "
+                         "the run halts with an error message. Default "
+                         "0.6 (60%%). Set to 0 or negative to disable.")
+    pr.add_argument("--min-cells-per-variant", type=int, default=8,
+                    help="Cells a variant must complete before the crash-"
+                         "rate auto-abort can fire. Default 8. Prevents "
+                         "1/1 = 100%% false triggers early in a run.")
     pr.add_argument("--dry-run", action="store_true",
                     help="Print the cell count and exit.")
     pr.add_argument("--out", default="ablation_results",


### PR DESCRIPTION
Based on feedback from working on #1301. The main problem I had while doing this experiment was that quota got exhausted quickly but wasn't caught until many hours into the test. After resolving that, there were still some variant failures that weren't caught until late in the game because all variants ran sequentially rather than interleaved. 

A quick summary of the changes: 
- Add per-model probing before doing anything expensive
- Better instructions around nudging users of the skill to set their expectations and check for the right things
- Early abort on a high crash rate (and add failure reasons)
- Round robin scheduling
- New items in common pitfalls

A lot of this is more about _how_ the ablation experiment happens rather than the actual _content_ of the experiment itself.