### PR TITLE
Fix env.render(mode="ipython") in Jupyter after Vite refactor

### DIFF
--- a/kaggle_environments/utils.py
+++ b/kaggle_environments/utils.py
@@ -241,6 +241,22 @@ window.kaggle = {json.dumps(window_kaggle, indent=2)};\n\n
         """
         return read_file(renderer[1]).replace(key, value)
 
+    # Vite-built visualizers return a self-contained HTML document. Inject the
+    # window.kaggle payload directly so the visualizer picks it up on load —
+    # notebook iframes are srcdoc'd with no parent to postMessage from.
+    if isinstance(renderer, str) and renderer.lstrip().startswith("<"):
+        snippet = f"<script>window.kaggle = {json.dumps(window_kaggle)};</script>"
+        lower = renderer.lower()
+        head_close = lower.find("</head>")
+        if head_close != -1:
+            return renderer[:head_close] + snippet + renderer[head_close:]
+        body_open = lower.find("<body")
+        if body_open != -1:
+            body_end = renderer.find(">", body_open)
+            if body_end != -1:
+                return renderer[: body_end + 1] + snippet + renderer[body_end + 1 :]
+        return snippet + renderer
+
     key = "/*window.kaggle*/"
     value = f"""
 window.kaggle = {json.dumps(window_kaggle, indent=2)};\n\n

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "kaggle-environments"
-version = "1.30.2"
+version = "1.31.0"
 description = "Kaggle Environments"
 authors = [
     {name = "Kaggle", email = "support@kaggle.com"},

--- a/web/core/src/player/player.ts
+++ b/web/core/src/player/player.ts
@@ -91,8 +91,26 @@ export class ReplayVisualizer<TSteps extends BaseGameStep[] = BaseGameStep[]> {
     }
 
     // 3. (PRIORITY 3) Production build (or not DEV) and no HMR data.
+    //    Check for a Python-injected window.kaggle payload (notebook iframe
+    //    srcdoc path from kaggle_environments.utils.get_player).
     else {
-      this.viewer.innerHTML = '<div>Loading...</div>';
+      const initial = (window as unknown as { kaggle?: any }).kaggle;
+      if (initial?.environment) {
+        const data = initial.environment;
+        let agents = data.info?.Agents;
+        if (!agents && data.steps?.[0]) {
+          const playerCount = Array.isArray(data.steps[0]) ? data.steps[0].length : 0;
+          const teamNames = data.info?.TeamNames || [];
+          agents = Array.from({ length: playerCount }, (_, i) => ({
+            index: i,
+            name: teamNames[i] || `Player ${i + 1}`,
+          }));
+        }
+        if (typeof initial.step === 'number') this.step = initial.step;
+        this.setData(data, agents);
+      } else {
+        this.viewer.innerHTML = '<div>Loading...</div>';
+      }
     }
 
     // 4. Add listener (always)


### PR DESCRIPTION
PR #1152 wired vite-built visualizers into html_renderer() but the notebook render path still didn't work — env.render(mode="ipython") produced a blank iframe.

Two things were broken:

1. get_player() in kaggle_environments/utils.py treated the full HTML document returned by html_renderer() as a JS snippet and spliced it into static/player.html via renderer.strip(), producing a garbage page. Add a third branch that detects a full HTML document (leading "<") and injects `<script>window.kaggle = {...};</script>` before </head> instead.

2. web/core/src/player/player.ts::loadData() only accepted initial replay data from HMR state, VITE_REPLAY_FILE, or postMessage. A notebook iframe uses srcdoc with no parent script, so nothing ever posted → visualizer sat at "Loading..." forever. Add a window.kaggle initial-data source alongside the existing tiers, reusing the same agent-derivation as the VITE_REPLAY_FILE branch.

The static/player.html fallback path is untouched — envs that still ship a single-file JS renderer (orbit_wars) continue to work exactly as before. GCS-served visualizers are unaffected: window.kaggle is only injected in the Python get_player() call path.

Verified end-to-end: rebuilt connectx, rendered via env.render(mode="html"), embedded via srcdoc in a browser — the board renders, the yellow chip appears on step 2, playback controls populate 1/10 steps.

Bump version to 1.31.0.