### PR TITLE
Ship visualizer dist/index.html files in the wheel

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "kaggle-environments"
-version = "1.31.1"
+version = "1.32.0"
 description = "Kaggle Environments"
 authors = [
     {name = "Kaggle", email = "support@kaggle.com"},
@@ -62,19 +62,18 @@ name = "kaggle_environments"
 # If using another build backend (setuptools, poetry), you can remove this
 # section.
 #
-# NOTE: these patterns only apply to the sdist. flit_core's wheel builder
-# ignores them and ships everything under the module directory. The CI
-# `publish-to-pypi` step (docker/cicd-publish-to-pypi.sh) prunes each
-# `visualizer/<variant>/` to just `dist/index.html` before `flit publish`
-# so that the wheel ships the self-contained bundle without node_modules
-# or build sources. The shipped `dist/index.html` is what `html_renderer()`
-# returns in notebook / iframe srcdoc contexts.
+# NOTE: `flit publish` builds the wheel by unpacking the sdist and building
+# from that copy, so these excludes apply to both the sdist and the wheel.
+# The CI `publish-to-pypi` step (docker/cicd-publish-to-pypi.sh) prunes each
+# `visualizer/<variant>/` to just `dist/index.html` before publishing — that
+# HTML is what `html_renderer()` returns in notebook / iframe srcdoc contexts
+# and must survive to the wheel. Do NOT re-add `**/visualizer/` here without
+# also switching the CI publish command away from `flit publish`.
 [tool.flit.sdist]
 exclude = [
   # Do not release tests files on PyPI
   "**/*_test.py",
   "**/node_modules/",
-  "**/visualizer/",
   ".pnpm-store/",
   "web/core/.npmrc",
 ]


### PR DESCRIPTION
The 1.31.0 / 1.31.1 wheels on PyPI (and every wheel since the vite refactor) contain zero visualizer/*/dist/index.html files. As a result html_renderer() returns "" in every env, get_player() falls back to the legacy static/player.html splice with an empty renderer string, and env.render(mode="ipython") produces a JS syntax error inside the iframe srcdoc — the "hangs then blank" symptom users see in Jupyter notebooks.

Root cause: `flit publish` builds the wheel by first building the sdist, then unpacking it and building the wheel from the unpacked copy. The sdist respects `[tool.flit.sdist] exclude = ["**/visualizer/"]`, so the whole visualizer tree is gone before the wheel builder ever runs. The prune script that PR #1152 added does its work on the working tree, but the working tree is not what flit ships.

Drop `**/visualizer/` from the exclude list. The CI prune loop already reduces each `visualizer/<variant>/` to just `dist/index.html` before publish, so removing the exclude lets exactly those files reach the sdist (and therefore the wheel), without dragging node_modules / src / e2e in.

Rewrite the misleading comment above the exclude list. It used to say flit_core's wheel builder ignores sdist excludes, which is true for `flit build --format wheel` but not for `flit publish` — which is what CI actually runs.