### PR TITLE
Publish wheel directly instead of via flit publish

### DIFF
--- a/docker/cicd-publish-to-pypi.sh
+++ b/docker/cicd-publish-to-pypi.sh
@@ -43,11 +43,10 @@ if [ "$VERSION_EXISTS" = "true" ]; then
 else
   echo "🚀 Version $VERSION_FROM_PYPROJECT not found on PyPI. Publishing..."
 
-  # Prune visualizer trees to keep only `dist/index.html` (the self-contained
-  # bundle produced by vite-plugin-singlefile). flit_core's wheel builder does
-  # not apply [tool.flit.sdist] excludes, so we have to physically remove
-  # node_modules / src / e2e / etc. before `flit publish` or they end up in
-  # the wheel. The `build-all-visualizers` step must run before this.
+  # Prune each visualizer variant to just `dist/index.html` (the self-contained
+  # bundle produced by vite-plugin-singlefile) so node_modules / src / e2e /
+  # etc. don't end up in the shipped wheel. The `build-all-visualizers` step
+  # must run before this.
   echo "Pruning visualizer trees to dist/index.html only..."
   find kaggle_environments -type d -name visualizer | while read -r viz_dir; do
     find "$viz_dir" -mindepth 1 -maxdepth 1 -type d | while read -r variant; do
@@ -69,7 +68,16 @@ else
   export FLIT_USERNAME=__token__
   export FLIT_PASSWORD=$PYPI_TOKEN
 
-  flit publish
+  # Build and upload the wheel directly, skipping the sdist. `flit publish`
+  # would build the sdist first (which runs a `git status` check) and refuse
+  # because the prune loop above leaves the working tree dirty vs. git
+  # (visualizer sources deleted, dist/index.html untracked). `flit build
+  # --format wheel` copies the module directory from disk with no VCS check
+  # and no exclude-list filtering, so the pruned dist/index.html files
+  # reach the wheel unchanged.
+  rm -rf dist
+  flit build --format wheel
+  flit publish --repository pypi dist/*.whl
   
   # It takes a bit for the package to show up on PyPI. Make sure it's visible through Pip before proceeding.
   # --- RETRY LOGIC START ---

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,13 +62,12 @@ name = "kaggle_environments"
 # If using another build backend (setuptools, poetry), you can remove this
 # section.
 #
-# NOTE: `flit publish` builds the wheel by unpacking the sdist and building
-# from that copy, so these excludes apply to both the sdist and the wheel.
-# The CI `publish-to-pypi` step (docker/cicd-publish-to-pypi.sh) prunes each
-# `visualizer/<variant>/` to just `dist/index.html` before publishing — that
-# HTML is what `html_renderer()` returns in notebook / iframe srcdoc contexts
-# and must survive to the wheel. Do NOT re-add `**/visualizer/` here without
-# also switching the CI publish command away from `flit publish`.
+# NOTE: only the sdist is affected by these excludes. The CI publish step
+# (docker/cicd-publish-to-pypi.sh) uses `flit build --format wheel` — which
+# copies the module directory from disk and ignores this list — and does
+# NOT ship the sdist. The `visualizer/*/dist/index.html` files that
+# `html_renderer()` needs are shaped for the wheel by the prune loop in
+# that script, not by any pattern here.
 [tool.flit.sdist]
 exclude = [
   # Do not release tests files on PyPI


### PR DESCRIPTION
PR #1308 dropped `**/visualizer/` from the sdist excludes so the shipped wheel would include `visualizer/*/dist/index.html`. That works for `flit build`, but `flit publish` runs a `git status` check while building its sdist and refuses on a dirty tree — and the prune loop in the publish script leaves the tree dirty (visualizer sources deleted, dist/index.html untracked). CI hit `flit_core.common.VCSError: Untracked or deleted files in the source directory.` and the release failed.

Split the publish into `flit build --format wheel` + `flit publish --repository pypi dist/*.whl`. `flit build --format wheel` copies the module directory from disk with no VCS check and no sdist-exclude filtering, so the pruned dist/index.html files reach the wheel unchanged. The sdist is not built or uploaded (pip prefers the universal wheel for pure-Python packages).

Update the pyproject comment to describe the actual publish shape. verified the wheel builds and looks correct locally. 