### PR TITLE
Publish with --no-use-vcs to include pruned dist files

### DIFF
--- a/docker/cicd-publish-to-pypi.sh
+++ b/docker/cicd-publish-to-pypi.sh
@@ -68,16 +68,12 @@ else
   export FLIT_USERNAME=__token__
   export FLIT_PASSWORD=$PYPI_TOKEN
 
-  # Build and upload the wheel directly, skipping the sdist. `flit publish`
-  # would build the sdist first (which runs a `git status` check) and refuse
-  # because the prune loop above leaves the working tree dirty vs. git
-  # (visualizer sources deleted, dist/index.html untracked). `flit build
-  # --format wheel` copies the module directory from disk with no VCS check
-  # and no exclude-list filtering, so the pruned dist/index.html files
-  # reach the wheel unchanged.
-  rm -rf dist
-  flit build --format wheel
-  flit publish --repository pypi dist/*.whl
+  # `--no-use-vcs` tells flit's sdist builder to walk the filesystem
+  # instead of `git ls-files`, so it (a) picks up the pruned, untracked
+  # `dist/index.html` files, and (b) skips the git-cleanliness check that
+  # would otherwise reject the pruned tree. Slated to become flit's
+  # default in a future release.
+  flit publish --no-use-vcs
   
   # It takes a bit for the package to show up on PyPI. Make sure it's visible through Pip before proceeding.
   # --- RETRY LOGIC START ---

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,12 +62,14 @@ name = "kaggle_environments"
 # If using another build backend (setuptools, poetry), you can remove this
 # section.
 #
-# NOTE: only the sdist is affected by these excludes. The CI publish step
-# (docker/cicd-publish-to-pypi.sh) uses `flit build --format wheel` — which
-# copies the module directory from disk and ignores this list — and does
-# NOT ship the sdist. The `visualizer/*/dist/index.html` files that
-# `html_renderer()` needs are shaped for the wheel by the prune loop in
-# that script, not by any pattern here.
+# NOTE: `flit publish` applies these excludes when building the sdist, and
+# then builds the wheel from the sdist — so anything listed here is stripped
+# from both. The CI publish step (docker/cicd-publish-to-pypi.sh) prunes
+# each `visualizer/<variant>/` down to just `dist/index.html` before
+# publishing (with `--no-use-vcs` so the untracked pruned files are
+# included), and `**/visualizer/` is deliberately NOT in this list so those
+# files survive to the wheel. That HTML is what `html_renderer()` returns
+# in notebook / iframe srcdoc contexts.
 [tool.flit.sdist]
 exclude = [
   # Do not release tests files on PyPI


### PR DESCRIPTION
4th time is the charm.

PR #1308 removed `**/visualizer/` from the sdist excludes so the pruned `dist/index.html` files would reach the wheel, but publish then failed because `flit publish`'s sdist builder defaults to enumerating files via `git ls-files` and (a) doesn't see untracked files like the built dist/index.html and (b) rejects a dirty tree.

Pass `--no-use-vcs` so flit walks the filesystem instead. That one-flag change picks up the pruned dist files and skips the git cleanliness check in one go. Slated to become flit's default in a future release.

Approaches considered:
1. Excludes-only (PR #1308): removed `**/visualizer/` so the pruned dist files would ship. Failed — flit's default sdist selector uses `git ls-files`, which ignores untracked files regardless of excludes.
2. `flit build --format wheel` + `flit publish dist/*.whl` (PR #1311): built the wheel directly. Failed — `flit publish` doesn't accept file arguments; it always rebuilds from pyproject.toml.
3. `flit publish --no-use-vcs` (this change): tells the sdist builder to walk the filesystem instead of git, picking up the untracked dist/index.html files.