### PR TITLE
Restructure Word Art responses and parsing + fix nits

### DIFF
--- a/kaggle_environments/core_harness.py
+++ b/kaggle_environments/core_harness.py
@@ -147,6 +147,69 @@ _JSON_FENCE_RE = re.compile(
 _JSON_DECODER = json.JSONDecoder(strict=False)
 
 
+def extract_last_json_object_with_position(
+    response: str,
+    *,
+    required_keys: Sequence[str] | None = None,
+) -> tuple[dict[str, Any] | None, int]:
+    """Find the LAST parseable JSON object in an LLM response AND return
+    its start position.
+
+    Same two-strategy scan and last-wins semantics as
+    :func:`extract_last_json_object` (see that function for the model-
+    behaviour rationale). The extra return value is the character index
+    at which the winning object starts in ``response`` -- useful for
+    callers that want to slice out the prose reasoning that precedes
+    the JSON answer for a ``ParseResult.thoughts`` field.
+
+    Args:
+        response: The full LLM response text.
+        required_keys: If given, candidates lacking every one of these keys
+            at the top level are skipped. Lets callers ignore JSON-shaped
+            content in the model's reasoning that isn't an action object.
+
+    Returns:
+        ``(dict, start)`` for the winning object, or ``(None, -1)`` if no
+        candidate parses. ``start`` is the index of the opening ``{`` (bare
+        strategy) or the opening ``` ``` ``` fence (fenced strategy) --
+        i.e., everything at ``response[:start]`` is prose that preceded
+        the answer.
+    """
+
+    def _passes_filter(d: dict[str, Any]) -> bool:
+        if required_keys is None:
+            return True
+        return any(k in d for k in required_keys)
+
+    winner: dict[str, Any] | None = None
+    winner_start = -1
+
+    for match in _JSON_FENCE_RE.finditer(response):
+        try:
+            obj = json.loads(match.group(1), strict=False)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(obj, dict) and _passes_filter(obj):
+            winner, winner_start = obj, match.start()
+    if winner is not None:
+        return winner, winner_start
+
+    i = 0
+    while True:
+        i = response.find("{", i)
+        if i < 0:
+            break
+        try:
+            obj, end = _JSON_DECODER.raw_decode(response, i)
+        except json.JSONDecodeError:
+            i += 1
+            continue
+        if isinstance(obj, dict) and _passes_filter(obj):
+            winner, winner_start = obj, i
+        i = end
+    return winner, winner_start
+
+
 def extract_last_json_object(
     response: str,
     *,
@@ -168,6 +231,10 @@ def extract_last_json_object(
     2. Balanced top-level ``{...}`` substrings, parsed with
        ``json.JSONDecoder.raw_decode`` so nested objects work correctly.
 
+    Thin wrapper over :func:`extract_last_json_object_with_position` that
+    drops the position -- callers that need to slice prose reasoning out
+    should use that variant directly.
+
     Args:
         response: The full LLM response text.
         required_keys: If given, candidates lacking every one of these keys
@@ -177,41 +244,10 @@ def extract_last_json_object(
     Returns:
         The matching dict, or ``None`` if no candidate parses.
     """
-
-    def _passes_filter(d: dict[str, Any]) -> bool:
-        if required_keys is None:
-            return True
-        return any(k in d for k in required_keys)
-
-    fenced: list[dict[str, Any]] = []
-    for match in _JSON_FENCE_RE.finditer(response):
-        try:
-            obj = json.loads(match.group(1), strict=False)
-        except json.JSONDecodeError:
-            continue
-        if isinstance(obj, dict) and _passes_filter(obj):
-            fenced.append(obj)
-    if fenced:
-        return fenced[-1]
-
-    bare: list[dict[str, Any]] = []
-    i = 0
-    while True:
-        i = response.find("{", i)
-        if i < 0:
-            break
-        try:
-            obj, end = _JSON_DECODER.raw_decode(response, i)
-        except json.JSONDecodeError:
-            i += 1
-            continue
-        if isinstance(obj, dict) and _passes_filter(obj):
-            bare.append(obj)
-        i = end
-    if bare:
-        return bare[-1]
-
-    return None
+    parsed, _ = extract_last_json_object_with_position(
+        response, required_keys=required_keys,
+    )
+    return parsed
 
 
 # ---------------------------------------------------------------------------

--- a/kaggle_environments/envs/word_art/harness.py
+++ b/kaggle_environments/envs/word_art/harness.py
@@ -407,9 +407,8 @@ Rules:
 - The engine mechanically disqualifies art that contains either the
   target word or any run of 3+ letters with 2+ distinct characters
   (labels, captions, headings). When that happens you'll see a
-  placeholder marker instead of a picture -- the marker text tells you
-  which check fired. Past rounds in the history below are likewise
-  labelled "DISQUALIFIED" when this happened.
+  placeholder marker instead of a picture. Past rounds in the history
+  below are likewise labelled "DISQUALIFIED" when this happened.
 
 {scoring}
 

--- a/kaggle_environments/envs/word_art/harness.py
+++ b/kaggle_environments/envs/word_art/harness.py
@@ -9,8 +9,21 @@ Implements the ``GameHarness`` protocol:
 - ``generate_prompt(observation, move_history, ...)`` -- dispatches on
   ``observation.role`` (``"artist"`` vs ``"guesser"``).
 - ``parse_response(response, legal_action_strings, *, observation=None)``
-  -- pulls ``"art"`` or ``"guess"`` from the last JSON object in the model
-  response and returns it as a free-form ``submission``.
+  -- extracts the answer from the last role-appropriate answer marker in
+  the model response and returns it as a free-form ``submission``.
+
+Output formats differ by role:
+
+- **Artist** writes prose reasoning, then wraps the drawing in
+  ``<art>...</art>`` tags. Tags -- not JSON -- because ASCII art is
+  full of newlines, backslashes, and quotes that would need escaping
+  inside a JSON string. In practice models routinely forget to escape
+  those, which forced ~1% of turns into an avoidable retry when this
+  harness used JSON for the art payload.
+- **Guesser** writes prose reasoning, then a JSON object
+  ``{"guess": "..."}``. Single-word answers don't have the escaping
+  problem, and JSON keeps the guesser consistent with the rest of the
+  repo's harnesses.
 
 Word Art is 2v2: agents 0/1 are Team Blue, agents 2/3 are Team Yellow.
 Each round, one teammate on each team draws ASCII art for a secret word
@@ -26,34 +39,31 @@ import json
 import re
 from typing import Any, Mapping, Sequence
 
-from kaggle_environments.core_harness import ParseResult, extract_last_json_object
+from kaggle_environments.core_harness import (
+    ParseResult,
+    extract_last_json_object_with_position,
+)
 
-# Standard JSON permits only \", \\, \/, \b, \f, \n, \r, \t, \uXXXX after a
-# backslash; any other bare `\` inside a string is an invalid escape and
-# json.loads rejects the whole object. In word_art specifically, models
-# routinely write ASCII-art snippets like `\ | /`, `/\`, `\_/`, `\-`
-# inside the `thinking` field (guessers describing what they see) or the
-# `art` field (artists drawing) without doubling the backslash. Against
-# a 624-episode / 35.5k-turn replay archive this bug rejected ~1.1% of
-# first-attempt responses and forced a retry. Recovery rate of the
-# repair fallback on that dataset: 421/449 (93.8%).
-#
-# We keep this in the word_art harness rather than pushing it into
-# core_harness because ASCII-art-in-string is a word_art-shaped problem;
-# other games don't have prose about `/\` in their reasoning nearly as
-# often, and touching the shared helper would risk changing behaviour
-# for every harness in the repo.
-#
-# The scan matches valid JSON escapes atomically (leaving them alone --
-# crucial, because `\\` is already valid and must not be split into two
-# lone `\`s) OR a truly lone `\`. Only the lone case gets doubled.
-_JSON_ESCAPE_SCAN_RE = re.compile(r'\\(?:["\\/bfnrtu]|u[0-9a-fA-F]{4})|\\')
+# Matches every <art>...</art> block. Case-insensitive and tolerant of
+# whitespace around the tag names so `<Art>`, `< art >`, `</ART >` all
+# match. DOTALL so the tag contents can span newlines -- essential for
+# multi-line ASCII art. Last-wins: if the model rethinks and emits a
+# second <art> block, the trailing one is the intent.
+_ART_TAG_RE = re.compile(
+    r"<\s*art\s*>(.*?)<\s*/\s*art\s*>",
+    re.DOTALL | re.IGNORECASE,
+)
 
 
-def _repair_lone_backslashes(text: str) -> str:
-    def _sub(m: re.Match[str]) -> str:
-        return "\\\\" if m.group(0) == "\\" else m.group(0)
-    return _JSON_ESCAPE_SCAN_RE.sub(_sub, text)
+def _slice_thoughts(response: str, answer_start: int) -> str | None:
+    """Return the prose reasoning that precedes the answer marker, or
+    ``None`` if there's nothing meaningful before it (in which case
+    core_harness falls back to storing the full raw response, which is
+    still the useful thing to log)."""
+    if answer_start <= 0:
+        return None
+    prose = response[:answer_start].strip()
+    return prose or None
 
 # --- Helpers ----------------------------------------------------------------
 
@@ -151,37 +161,56 @@ def _round_status_block(observation: Mapping[str, Any]) -> str:
 
 
 # Free-form means there's no "illegal action" case (any string is a legal
-# submission), but parse failure comes in two flavours that need different
-# corrections:
-#   NO_JSON    -> the response had no parseable JSON object with the right key
-#                 at all. Show the last 500 chars of the response so the model
-#                 can see how its answer trailed off.
-#   BAD_VALUE  -> a JSON object with the required key was found, but the value
-#                 was missing / non-string / empty / whitespace-only. Quote the
-#                 offending object back so the model sees exactly what got
-#                 rejected instead of guessing what tripped the parser.
-RETHINK_NO_JSON = """
+# submission), but parse failure comes in two flavours per role that need
+# different corrections:
+#   NO_ANSWER  -> the response had no answer marker at all (no <art> tag
+#                 for artists, no JSON with a "guess" key for guessers).
+#                 Show the last 500 chars of the response so the model can
+#                 see how its answer trailed off, and restate the format.
+#   EMPTY      -> a marker was present but its value was missing / empty /
+#                 whitespace-only. Show the offending marker back so the
+#                 model sees exactly what got rejected instead of guessing.
+RETHINK_ARTIST_NO_ANSWER = """
 
-Your previous response did not contain a parseable JSON object with the
-required key ('art' for artists, 'guess' for guessers). Last 500 characters
-of your previous response:
+Your previous response did not contain a parseable <art>...</art> block.
+Last 500 characters of your previous response:
 {previous_response}
 
-Re-read the output format above and respond again. The JSON must include the
-required key and be parseable (no comments, no trailing commas, no surrounding
-prose inside the JSON itself)."""
+Re-read the output format above and respond again. Wrap your drawing in a
+single <art>...</art> block; anything outside the block is treated as
+reasoning and ignored."""
 
 
-RETHINK_BAD_VALUE = """
+RETHINK_ARTIST_EMPTY = """
 
-Your previous response included a JSON object but the required key was
-missing or had an invalid value (must be a non-empty string). Your submitted
-JSON was:
+Your previous response included an <art>...</art> block but its contents
+were empty or whitespace-only. Your submitted block was:
 {previous_action}
 
-Re-read the output format above and respond again. The JSON must include the
-required key ('art' for artists, 'guess' for guessers) with a non-empty
-string value."""
+Re-read the output format above and respond again. The <art>...</art>
+block must contain the actual ASCII drawing."""
+
+
+RETHINK_GUESSER_NO_ANSWER = """
+
+Your previous response did not contain a parseable JSON object with a
+"guess" key. Last 500 characters of your previous response:
+{previous_response}
+
+Re-read the output format above and respond again. End your response with
+a JSON object of the form {{"guess": "SINGLEWORD"}} (parseable: no
+comments, no trailing commas)."""
+
+
+RETHINK_GUESSER_BAD_VALUE = """
+
+Your previous response included a JSON object but the "guess" key was
+missing or had an invalid value (must be a non-empty string). Your
+submitted JSON was:
+{previous_action}
+
+Re-read the output format above and respond again. The JSON must include a
+"guess" key with a non-empty single-word string value."""
 
 
 # --- Public functions (GameHarness protocol) --------------------------------
@@ -239,13 +268,19 @@ def generate_prompt(
         prompt = "Word Art has not started this round yet. Wait for your role (artist or guesser) to be assigned."
 
     # core_harness sets previous_action to the parser's raw_action on failure:
-    # None when no JSON was found, populated when JSON was found but the value
-    # was missing/non-string/empty. Branch on that so the model sees a
-    # correction tailored to what actually broke.
-    if previous_action is not None:
-        prompt += RETHINK_BAD_VALUE.format(previous_action=previous_action)
-    elif previous_response is not None:
-        prompt += RETHINK_NO_JSON.format(previous_response=previous_response[-500:])
+    # None when no answer marker was found, populated when a marker was found
+    # but its value was missing/empty. Branch on role AND on that flag so the
+    # model sees a correction tailored to what actually broke.
+    if role == "artist":
+        if previous_action is not None:
+            prompt += RETHINK_ARTIST_EMPTY.format(previous_action=previous_action)
+        elif previous_response is not None:
+            prompt += RETHINK_ARTIST_NO_ANSWER.format(previous_response=previous_response[-500:])
+    elif role == "guesser":
+        if previous_action is not None:
+            prompt += RETHINK_GUESSER_BAD_VALUE.format(previous_action=previous_action)
+        elif previous_response is not None:
+            prompt += RETHINK_GUESSER_NO_ANSWER.format(previous_response=previous_response[-500:])
 
     return prompt
 
@@ -269,8 +304,9 @@ Rules:
   drawing, never the word. The opposing team sees neither. Roles swap
   each round.
 - The guesser has up to {max_attempts} attempts. Matching is
-  case-insensitive and whitespace-trimmed; only the exact word counts
-  (no plurals, synonyms, partial matches, or other spelling variants).
+  case-insensitive with leading/trailing whitespace trimmed; only the
+  exact word counts (no plurals, synonyms, partial matches, or other
+  spelling variants).
 
 {scoring}
 
@@ -311,14 +347,22 @@ The secret word you must depict is: '{target_word}'.
 Past rounds in this game so far:
 {history_text}
 
-Think step by step about how to depict the word visually, then return
-your reasoning in 'thinking' and the art string in 'art' (escape
-newlines as '\\n'). No text or markdown outside the JSON block. Example:
+Think step by step about how to depict the word visually, writing
+your reasoning as ordinary prose. Then end your response with your
+final drawing wrapped in a single <art>...</art> block. Everything
+inside the block is taken verbatim -- literal newlines are fine, no
+escaping, no markdown -- and everything outside is treated as
+reasoning and ignored. Example:
 
-```json
-{{"thinking": "I'll draw a cat face using basic ASCII characters...",
-  "art": " /\\\\_/\\\\\\n( o.o )\\n > ^ <"}}
-```"""
+I'll draw a cat face using basic ASCII characters -- pointy ears with
+slashes, round eyes, a nose. Keeping runs of letters to 2 or fewer to
+stay clear of the any-word check.
+
+<art>
+ /\\_/\\
+( o.o )
+ > ^ <
+</art>"""
 
 
 def _build_guesser_prompt(
@@ -356,8 +400,8 @@ Rules:
 - Your teammate (the artist) saw a secret word and drew the ASCII art
   below; you don't see the word. Roles swap each round.
 - You have up to {max_attempts} guesses. Matching is case-insensitive
-  and whitespace-trimmed; only the exact word counts (no plurals,
-  synonyms, partial matches, or other spelling variants).
+  with leading/trailing whitespace trimmed; only the exact word counts
+  (no plurals, synonyms, partial matches, or other spelling variants).
 - The opposing team plays the same secret word each round in parallel
   and cannot see your art or guesses.
 - The engine mechanically disqualifies art that contains either the
@@ -366,6 +410,11 @@ Rules:
   placeholder marker instead of a picture -- the marker text tells you
   which check fired. Past rounds in the history below are likewise
   labelled "DISQUALIFIED" when this happened.
+- The engine also silently strips combining marks, wide characters
+  (CJK, most emoji), and other non-single-cell Unicode from the art
+  before you see it, so monospace alignment holds. If the drawing
+  looks oddly truncated or a glyph is missing where one seems intended,
+  that's why.
 
 {scoring}
 
@@ -379,14 +428,14 @@ Your teammate's drawing (be aware that monospace alignment matters):
 {teammate_art if teammate_art else "(your teammate submitted nothing)"}
 
 Think step by step about what the art depicts (letter shapes, spatial
-layout, any annotations), then return your reasoning in 'thinking' and
-a SINGLE WORD (no spaces, no punctuation, no articles) in 'guess'. No
-text or markdown outside the JSON block. Example:
+layout, any annotations), writing your reasoning as ordinary prose.
+Then end your response with a JSON object containing your final answer
+as a SINGLE WORD (no spaces, no punctuation, no articles). Example:
 
-```json
-{{"thinking": "Four-legged animal with a tail and pointy ears; the 'meow'-like whiskers suggest CAT.",
-  "guess": "CAT"}}
-```"""
+Four-legged animal with a tail and pointy ears; the 'meow'-like
+whiskers suggest CAT.
+
+{{"guess": "CAT"}}"""
 
 
 def parse_response(
@@ -398,46 +447,61 @@ def parse_response(
     """Extract the artist's art or the guesser's word from the LLM response.
 
     Both phases are free-form, so ``legal_action_strings`` is always
-    ``None``. We look for the LAST JSON object in the response that
-    contains either ``"art"`` or ``"guess"`` (the helper does the
-    multi-block / fenced / bare-JSON disambiguation for us).
+    ``None``. Dispatch is role-strict:
 
-    Dispatch is role-strict: routes on ``observation.role`` and requires
-    the matching key with a non-empty string value. Anything else --
-    wrong key, non-string value, empty or whitespace-only string, or a
-    missing role -- returns ``ParseResult(raw_action=...)`` without a
-    submission so the rethink loop can correct the model rather than
-    silently burning an attempt on garbage the model didn't meaningfully
-    submit. In production ``core_harness`` always forwards
-    ``observation``, so the missing-role branch only fires from ad-hoc
-    test callers.
+    - **Artist**: extracts the contents of the LAST ``<art>...</art>``
+      block (case-insensitive, tolerant of whitespace inside the tag
+      names). If no block matches, returns ``ParseResult(raw_action=None)``
+      -- categorized as UNPARSABLE in telemetry. If a block matches but
+      its contents are empty/whitespace-only, returns
+      ``ParseResult(raw_action=<the empty tag>)`` so the rethink prompt
+      can quote it back.
+
+    - **Guesser**: extracts the LAST parseable JSON object containing a
+      ``"guess"`` key. Same two failure modes (no JSON vs. present but
+      bad value) map to the same two ``raw_action`` outcomes.
+
+    Missing / unrecognized role: returns ``ParseResult(raw_action=None)``
+    without submitting. In production ``core_harness`` always forwards
+    ``observation``, so this branch only fires from ad-hoc test callers.
+
+    ``thoughts`` carries the prose reasoning that precedes the answer
+    marker in the response -- everything before the last ``<art>`` /
+    JSON block, whitespace-stripped. When the model wrote no prose (or
+    the parser found no answer marker at all) ``thoughts`` is left
+    ``None`` and ``core_harness`` falls back to logging the full raw
+    response, which is still the useful thing to keep in the replay.
     """
-    parsed = extract_last_json_object(response, required_keys=("art", "guess"))
-    if parsed is None:
-        # Retry once against a copy with lone backslashes doubled --
-        # otherwise-usable answers where the model wrote `\ | /` etc. in a
-        # string get through. See _repair_lone_backslashes above.
-        repaired = _repair_lone_backslashes(response)
-        if repaired != response:
-            parsed = extract_last_json_object(repaired, required_keys=("art", "guess"))
-    if parsed is None:
-        # No JSON object found at all -- raw_action=None so core_harness
-        # categorizes this as UNPARSABLE (not ILLEGAL) in telemetry. The
-        # rethink loop still has the full response via `previous_response`.
-        return ParseResult(raw_action=None)
-
-    thinking = parsed.get("thinking")
     role = (observation or {}).get("role", "")
-    key = "art" if role == "artist" else "guess" if role == "guesser" else None
-    if key is None:
-        return ParseResult(raw_action=json.dumps(parsed)[:500], thoughts=thinking)
 
-    value = parsed.get(key)
-    if not isinstance(value, str) or value.strip() == "":
-        return ParseResult(raw_action=json.dumps(parsed)[:500], thoughts=thinking)
+    if role == "artist":
+        matches = list(_ART_TAG_RE.finditer(response))
+        if not matches:
+            return ParseResult(raw_action=None)
+        last = matches[-1]
+        raw = last.group(1)
+        thoughts = _slice_thoughts(response, last.start())
+        if raw.strip() == "":
+            # Empty <art> block -- record the (empty) tag for the rethink
+            # prompt to quote back so the model sees what got rejected.
+            return ParseResult(raw_action="<art></art>", thoughts=thoughts)
+        return ParseResult(submission=raw, raw_action=raw, thoughts=thoughts)
 
-    return ParseResult(
-        submission=value,
-        raw_action=value[:200],
-        thoughts=thinking,
-    )
+    if role == "guesser":
+        parsed, start = extract_last_json_object_with_position(
+            response, required_keys=("guess",),
+        )
+        if parsed is None:
+            return ParseResult(raw_action=None)
+        thoughts = _slice_thoughts(response, start)
+        value = parsed.get("guess")
+        if not isinstance(value, str) or value.strip() == "":
+            # Cap the dumped-JSON preview so a runaway payload can't bloat
+            # telemetry or the rethink prompt; the answer we tried to
+            # extract is what matters here.
+            return ParseResult(raw_action=json.dumps(parsed)[:500], thoughts=thoughts)
+        return ParseResult(submission=value, raw_action=value, thoughts=thoughts)
+
+    # Unknown / missing role -- refuse to submit; test-only path in
+    # practice since core_harness forwards `observation`.
+    return ParseResult(raw_action=None)

--- a/kaggle_environments/envs/word_art/harness.py
+++ b/kaggle_environments/envs/word_art/harness.py
@@ -23,9 +23,37 @@ rounds the higher score wins. Roles within each team swap every round.
 from __future__ import annotations
 
 import json
+import re
 from typing import Any, Mapping, Sequence
 
 from kaggle_environments.core_harness import ParseResult, extract_last_json_object
+
+# Standard JSON permits only \", \\, \/, \b, \f, \n, \r, \t, \uXXXX after a
+# backslash; any other bare `\` inside a string is an invalid escape and
+# json.loads rejects the whole object. In word_art specifically, models
+# routinely write ASCII-art snippets like `\ | /`, `/\`, `\_/`, `\-`
+# inside the `thinking` field (guessers describing what they see) or the
+# `art` field (artists drawing) without doubling the backslash. Against
+# a 624-episode / 35.5k-turn replay archive this bug rejected ~1.1% of
+# first-attempt responses and forced a retry. Recovery rate of the
+# repair fallback on that dataset: 421/449 (93.8%).
+#
+# We keep this in the word_art harness rather than pushing it into
+# core_harness because ASCII-art-in-string is a word_art-shaped problem;
+# other games don't have prose about `/\` in their reasoning nearly as
+# often, and touching the shared helper would risk changing behaviour
+# for every harness in the repo.
+#
+# The scan matches valid JSON escapes atomically (leaving them alone --
+# crucial, because `\\` is already valid and must not be split into two
+# lone `\`s) OR a truly lone `\`. Only the lone case gets doubled.
+_JSON_ESCAPE_SCAN_RE = re.compile(r'\\(?:["\\/bfnrtu]|u[0-9a-fA-F]{4})|\\')
+
+
+def _repair_lone_backslashes(text: str) -> str:
+    def _sub(m: re.Match[str]) -> str:
+        return "\\\\" if m.group(0) == "\\" else m.group(0)
+    return _JSON_ESCAPE_SCAN_RE.sub(_sub, text)
 
 # --- Helpers ----------------------------------------------------------------
 
@@ -104,8 +132,10 @@ def _scoring_block(max_attempts: int, first_try_bonus: int) -> str:
         f"(1 base + {first_try_bonus} first-try bonus)\n"
         f"  - Correct on attempt 2 through {max_attempts}: 1 point\n"
         f"  - No correct guess within {max_attempts} attempts: 0 points\n"
-        "Both teams play in parallel; your score is independent of the "
-        "other team's outcome for the round."
+        "Both teams play the same secret word each round in parallel; your "
+        "score is independent of the other team's outcome for the round. "
+        "After all rounds are played, the team with the higher total wins; "
+        "equal totals are a tie."
     )
 
 
@@ -240,7 +270,7 @@ Rules:
   each round.
 - The guesser has up to {max_attempts} attempts. Matching is
   case-insensitive and whitespace-trimmed; only the exact word counts
-  (no spelling variants).
+  (no plurals, synonyms, partial matches, or other spelling variants).
 
 {scoring}
 
@@ -327,8 +357,9 @@ Rules:
   below; you don't see the word. Roles swap each round.
 - You have up to {max_attempts} guesses. Matching is case-insensitive
   and whitespace-trimmed; only the exact word counts (no plurals,
-  synonyms, or partial matches).
-- The opposing team plays in parallel and cannot see your art or guesses.
+  synonyms, partial matches, or other spelling variants).
+- The opposing team plays the same secret word each round in parallel
+  and cannot see your art or guesses.
 - The engine mechanically disqualifies art that contains either the
   target word or any run of 3+ letters with 2+ distinct characters
   (labels, captions, headings). When that happens you'll see a
@@ -382,6 +413,13 @@ def parse_response(
     test callers.
     """
     parsed = extract_last_json_object(response, required_keys=("art", "guess"))
+    if parsed is None:
+        # Retry once against a copy with lone backslashes doubled --
+        # otherwise-usable answers where the model wrote `\ | /` etc. in a
+        # string get through. See _repair_lone_backslashes above.
+        repaired = _repair_lone_backslashes(response)
+        if repaired != response:
+            parsed = extract_last_json_object(repaired, required_keys=("art", "guess"))
     if parsed is None:
         # No JSON object found at all -- raw_action=None so core_harness
         # categorizes this as UNPARSABLE (not ILLEGAL) in telemetry. The

--- a/kaggle_environments/envs/word_art/harness.py
+++ b/kaggle_environments/envs/word_art/harness.py
@@ -410,11 +410,6 @@ Rules:
   placeholder marker instead of a picture -- the marker text tells you
   which check fired. Past rounds in the history below are likewise
   labelled "DISQUALIFIED" when this happened.
-- The engine also silently strips combining marks, wide characters
-  (CJK, most emoji), and other non-single-cell Unicode from the art
-  before you see it, so monospace alignment holds. If the drawing
-  looks oddly truncated or a glyph is missing where one seems intended,
-  that's why.
 
 {scoring}
 

--- a/tests/core_harness_test.py
+++ b/tests/core_harness_test.py
@@ -10,6 +10,7 @@ from kaggle_environments.core_harness import (
     ParseResult,
     create_agent_fn,
     extract_last_json_object,
+    extract_last_json_object_with_position,
     render_rethink_suffix,
     set_telemetry_exporter,
 )
@@ -995,6 +996,63 @@ class ExtractLastJsonObjectTest(absltest.TestCase):
             extract_last_json_object(response),
             {"move": "e5"},
         )
+
+
+class ExtractLastJsonObjectWithPositionTest(absltest.TestCase):
+    """Position-tracking sibling of ``extract_last_json_object``. Used by
+    harnesses that want to slice out the prose reasoning preceding the
+    JSON answer for a ``ParseResult.thoughts`` field."""
+
+    def test_returns_none_and_negative_when_no_match(self):
+        parsed, start = extract_last_json_object_with_position("no json here")
+        self.assertIsNone(parsed)
+        self.assertEqual(start, -1)
+
+    def test_bare_json_start_is_opening_brace(self):
+        response = "reasoning prose here " + '{"move": "e5"}'
+        parsed, start = extract_last_json_object_with_position(response)
+        self.assertEqual(parsed, {"move": "e5"})
+        self.assertEqual(response[start], "{")
+        self.assertEqual(response[:start], "reasoning prose here ")
+
+    def test_fenced_json_start_is_opening_fence(self):
+        response = "prose\n```json\n{\"move\": \"e5\"}\n```"
+        parsed, start = extract_last_json_object_with_position(response)
+        self.assertEqual(parsed, {"move": "e5"})
+        # start indexes the opening ``` fence, not the {
+        self.assertTrue(response[start:].startswith("```"))
+        self.assertEqual(response[:start].strip(), "prose")
+
+    def test_picks_last_of_multiple_matches(self):
+        response = 'first {"move":"a1"} then {"move":"e5"}'
+        parsed, start = extract_last_json_object_with_position(response)
+        self.assertEqual(parsed, {"move": "e5"})
+        # Position points at the SECOND {, not the first.
+        self.assertGreater(start, response.find('{"move":"a1"}'))
+
+    def test_required_keys_filter_is_respected(self):
+        response = '{"other": 1} then {"move": "e5"}'
+        parsed, start = extract_last_json_object_with_position(
+            response, required_keys=("move",),
+        )
+        self.assertEqual(parsed, {"move": "e5"})
+        # Should skip the earlier {"other": 1} despite it being first.
+        self.assertGreater(start, response.find('{"other"'))
+
+    def test_agrees_with_extract_last_json_object(self):
+        """The dict returned by the position variant must match the plain
+        variant on every input -- they share the same scan."""
+        cases = [
+            '```json\n{"move": "e5"}\n```',
+            'prose {"move":"a1"} more {"move":"e5"}',
+            '{"other": 1}',
+            "no json",
+            '```\n{"move": "e5"}\n```',
+        ]
+        for r in cases:
+            plain = extract_last_json_object(r)
+            with_pos, _ = extract_last_json_object_with_position(r)
+            self.assertEqual(plain, with_pos, msg=repr(r))
 
 
 if __name__ == "__main__":

--- a/tests/envs/word_art/test_harness.py
+++ b/tests/envs/word_art/test_harness.py
@@ -464,6 +464,45 @@ class GeneratePromptTest(absltest.TestCase):
         self.assertIn("2500", prompt)
         self.assertIn("truncated", prompt.lower())
 
+    def test_scoring_block_states_win_and_tie_conditions(self):
+        # Prior gap: scoring block explained per-round points but never told
+        # the model how the game as a whole ends. 12% of episodes in the
+        # 624-replay archive were ties -- if the model doesn't know ties are
+        # possible it can't strategize around a close score.
+        for obs in (_artist_obs(), _guesser_obs()):
+            prompt = generate_prompt(obs, [])
+            lower = prompt.lower()
+            self.assertIn("higher total wins", lower)
+            self.assertIn("tie", lower)
+
+    def test_scoring_block_states_teams_share_secret_word(self):
+        # Prior gap: nothing in the prompt said both teams got the SAME
+        # secret word each round. Implicit from history (both teams' entries
+        # share `word`) but never disclosed upfront.
+        for obs in (_artist_obs(), _guesser_obs()):
+            prompt = generate_prompt(obs, [])
+            self.assertIn("same secret word", prompt)
+
+    def test_match_rule_wording_is_consistent_across_roles(self):
+        # Prior gap: artist said "no spelling variants" and guesser said
+        # "no plurals, synonyms, or partial matches" -- same rule, different
+        # phrasing. Both prompts should now use the same fuller list.
+        artist = " ".join(generate_prompt(_artist_obs(), []).split())
+        guesser = " ".join(generate_prompt(_guesser_obs(), []).split())
+        phrase = "no plurals, synonyms, partial matches, or other spelling variants"
+        self.assertIn(phrase, artist)
+        self.assertIn(phrase, guesser)
+
+    def test_guesser_prompt_discloses_sanitization(self):
+        # Prior gap: artist prompt described the silent sanitization pass
+        # (combining marks / CJK / wide chars dropped) but the guesser
+        # prompt didn't, leaving the guesser confused if art rendered oddly.
+        prompt = generate_prompt(_guesser_obs(), [])
+        lower = prompt.lower()
+        self.assertIn("silently strip", lower)
+        self.assertIn("cjk", lower)
+        self.assertIn("monospace", lower)
+
     def test_guesser_prompt_explains_disqualification_marker(self):
         """Guesser must be told what the placeholder string means when their
         teammate's art gets disqualified for containing the target word."""
@@ -630,6 +669,68 @@ class AgentIntegrationTest(absltest.TestCase):
         ):
             with self.assertRaises(ValueError):
                 agent(obs, {"freeForm": True})
+
+
+# --- Parser regression: lone-backslash repair fallback ---------------------
+
+
+class LoneBackslashRepairTest(absltest.TestCase):
+    """Models discussing / drawing ASCII art routinely write `\\ | /`,
+    `/\\`, `\\_/` etc. in JSON string values without doubling the
+    backslash. Strict json.loads rejects the whole object; the harness
+    tries once more against a repaired copy where lone backslashes are
+    doubled. In a 624-episode replay archive this recovered ~94% of
+    otherwise-forced retries."""
+
+    def test_guesser_thoughts_contain_lone_backslashes(self):
+        obs = _guesser_obs()
+        response = (
+            '```json\n'
+            '{"thinking": "The drawing shows \\ | / on top and \\_ _/ below",'
+            ' "guess": "FISHBOWL"}\n'
+            '```'
+        )
+        result = parse_response(response, None, observation=obs)
+        self.assertEqual(result.submission, "FISHBOWL")
+
+    def test_bare_json_guess_with_lone_backslashes(self):
+        obs = _guesser_obs()
+        response = (
+            'Reasoning: {"thinking":"peaked /\\ shapes suggest mountain",'
+            '"guess":"MOUNTAIN"}'
+        )
+        result = parse_response(response, None, observation=obs)
+        self.assertEqual(result.submission, "MOUNTAIN")
+
+    def test_artist_art_with_lone_backslashes(self):
+        obs = _artist_obs()
+        # Model wrote "/\" and "\_/" inside `art` without doubling.
+        response = '{"thinking": "cat", "art": "/\\_/\\\n( o.o )"}'
+        # First loads: `\_` inside `art` is invalid; repair should recover.
+        # (Note: the `\n` after `\\_/\\` is a real Python `\n` in this
+        # source, not an escape in the JSON text, so json.loads would fail
+        # even without the `\_`. Repair fixes both.)
+        result = parse_response(response, None, observation=obs)
+        self.assertIsNotNone(result.submission)
+        self.assertIn("_/", result.submission)
+
+    def test_repair_preserves_real_escapes(self):
+        """Response with legitimate `\\n`, `\\"`, `\\\\` escapes must parse
+        the same before/after the repair path -- no double-escaping."""
+        obs = _artist_obs()
+        response = '```json\n{"art": "line1\\nline2\\n\\\\end"}\n```'
+        result = parse_response(response, None, observation=obs)
+        self.assertEqual(result.submission, "line1\nline2\n\\end")
+
+    def test_repair_does_not_fire_on_valid_json(self):
+        """When strict parse succeeds on the first try, the repair path
+        is skipped -- confirmed indirectly: a response whose lone `\\`
+        appears OUTSIDE the JSON object shouldn't have to trigger the
+        fallback for the primary block to parse."""
+        obs = _guesser_obs()
+        response = 'Some prose with a lone \\ here\n```json\n{"guess": "CAT"}\n```'
+        result = parse_response(response, None, observation=obs)
+        self.assertEqual(result.submission, "CAT")
 
 
 # --- Parser regression: no ghost-substitution for guess responses -----------

--- a/tests/envs/word_art/test_harness.py
+++ b/tests/envs/word_art/test_harness.py
@@ -1,4 +1,14 @@
-"""Tests for the Word Art harness (core_harness integration)."""
+"""Tests for the Word Art harness (core_harness integration).
+
+Output-format contract exercised by these tests:
+
+- Artist writes prose reasoning, then wraps the drawing in ``<art>...</art>``
+  tags. Tags -- not JSON -- because ASCII art is full of newlines /
+  backslashes / quotes that models routinely forget to escape.
+- Guesser writes prose reasoning, then a ``{"guess": "..."}`` JSON object.
+  Single-word answers don't have the escaping problem, and JSON keeps the
+  guesser consistent with the rest of the repo's harnesses.
+"""
 
 from unittest.mock import patch
 
@@ -142,75 +152,99 @@ class GetLegalMovesTest(absltest.TestCase):
         self.assertIsNone(get_legal_moves({}))
 
 
-# --- parse_response ---------------------------------------------------------
+# --- parse_response: artist (<art>...</art> tags) ---------------------------
 
 
-class ParseResponseTest(absltest.TestCase):
-    # --- Artist ---
-
-    def test_artist_extracts_art_fenced_json(self):
+class ParseResponseArtistTest(absltest.TestCase):
+    def test_extracts_verbatim_art(self):
+        """No JSON-escape gymnastics -- literal newlines / backslashes / quotes
+        inside the tag pass through unchanged."""
         obs = _artist_obs()
-        response = '```json\n{"thinking": "a cat", "art": " /\\\\_/\\\\\\n( o.o )"}\n```'
+        response = 'Reasoning: a cat.\n<art>\n /\\_/\\\n( o.o )\n > ^ <\n</art>'
         result = parse_response(response, None, observation=obs)
-        self.assertEqual(result.submission, " /\\_/\\\n( o.o )")
-        self.assertEqual(result.thoughts, "a cat")
+        self.assertEqual(result.submission, "\n /\\_/\\\n( o.o )\n > ^ <\n")
 
-    def test_artist_extracts_art_bare_json(self):
+    def test_picks_last_of_multiple_art_blocks(self):
+        """Model self-corrects: the earlier block is the rejected draft,
+        the trailing block is the intent."""
         obs = _artist_obs()
-        response = '{"thinking": "x", "art": "BANANA-banner"}'
-        result = parse_response(response, None, observation=obs)
-        self.assertEqual(result.submission, "BANANA-banner")
-
-    def test_artist_picks_last_json_block(self):
-        obs = _artist_obs()
-        response = 'Draft: {"art": "DRAFT_DRAWING"}\nFinal: {"thinking": "revised", "art": "FINAL_DRAWING"}'
+        response = 'Draft:\n<art>DRAFT_DRAWING</art>\nActually, revised:\n<art>FINAL_DRAWING</art>'
         result = parse_response(response, None, observation=obs)
         self.assertEqual(result.submission, "FINAL_DRAWING")
 
-    def test_artist_missing_art_key_returns_no_submission(self):
-        # JSON emitted but neither "art" nor "guess" is present →
-        # extract_last_json_object returns None → telemetry UNPARSABLE.
+    def test_tolerates_tag_case_and_whitespace_variants(self):
+        for opener, closer in [
+            ("<art>", "</art>"),
+            ("<Art>", "</Art>"),
+            ("<ART>", "</ART>"),
+            ("< art >", "< / art >"),
+            ("<art >", "</ art>"),
+        ]:
+            obs = _artist_obs()
+            response = f"Prose.\n{opener}MEOW{closer}"
+            result = parse_response(response, None, observation=obs)
+            self.assertEqual(
+                result.submission, "MEOW",
+                msg=f"Failed on {opener!r}/{closer!r}",
+            )
+
+    def test_no_tag_returns_no_submission(self):
         obs = _artist_obs()
-        response = '{"thinking": "I forgot the art key"}'
+        response = "Here's a drawing of a cat: ^.^"
         result = parse_response(response, None, observation=obs)
         self.assertIsNone(result.submission)
+        # No answer marker at all -> raw_action=None -> UNPARSABLE telemetry.
         self.assertIsNone(result.raw_action)
 
-    def test_artist_wrong_role_key_returns_no_submission_but_surfaces_raw(self):
-        # JSON with the OTHER role's key (a guess on an artist turn) -- the
-        # model did emit structured output; it just answered the wrong
-        # question. Surfaces raw_action so the rethink prompt can quote it
-        # back and the telemetry categorizes as ILLEGAL.
+    def test_empty_tag_surfaces_raw_action(self):
+        """Model wrote the tag but left it empty -- the rethink prompt should
+        be able to quote it back."""
+        obs = _artist_obs()
+        for response in (
+            "<art></art>",
+            "<art>   </art>",
+            "<art>\n\n</art>",
+        ):
+            result = parse_response(response, None, observation=obs)
+            self.assertIsNone(result.submission, msg=repr(response))
+            self.assertIsNotNone(result.raw_action, msg=repr(response))
+
+    def test_wrong_role_marker_returns_no_submission(self):
+        """Artist emitted a guesser-style JSON instead of an <art> tag -- no
+        submission, raw_action=None (no <art> tag exists to quote)."""
         obs = _artist_obs()
         response = '{"guess": "ELEPHANT"}'
         result = parse_response(response, None, observation=obs)
         self.assertIsNone(result.submission)
-        self.assertIsNotNone(result.raw_action)
-        self.assertIn("guess", result.raw_action)
-
-    def test_artist_prose_only_returns_no_submission(self):
-        obs = _artist_obs()
-        response = "Here is a drawing of a cat: ^.^"
-        result = parse_response(response, None, observation=obs)
-        self.assertIsNone(result.submission)
-        # No JSON at all → raw_action=None → telemetry UNPARSABLE.
         self.assertIsNone(result.raw_action)
 
-    # --- Guesser ---
 
-    def test_guesser_extracts_guess(self):
+# --- parse_response: guesser (JSON with "guess" key) ------------------------
+
+
+class ParseResponseGuesserTest(absltest.TestCase):
+    def test_extracts_guess_fenced_json(self):
         obs = _guesser_obs()
-        response = '```json\n{"thinking": "looks like a cat", "guess": "CAT"}\n```'
+        response = 'Prose reasoning here.\n```json\n{"guess": "CAT"}\n```'
         result = parse_response(response, None, observation=obs)
         self.assertEqual(result.submission, "CAT")
-        self.assertEqual(result.thoughts, "looks like a cat")
 
-    def test_guesser_rejects_non_string_guess(self):
+    def test_extracts_guess_bare_json(self):
+        obs = _guesser_obs()
+        response = 'Reasoning: whiskers suggest cat. {"guess": "CAT"}'
+        result = parse_response(response, None, observation=obs)
+        self.assertEqual(result.submission, "CAT")
+
+    def test_picks_last_json_block(self):
+        obs = _guesser_obs()
+        response = 'Maybe {"guess": "DOG"} but actually {"guess": "CAT"}'
+        result = parse_response(response, None, observation=obs)
+        self.assertEqual(result.submission, "CAT")
+
+    def test_rejects_non_string_guess(self):
         # A number (or any non-string) in the guess slot is not a submission.
         # The parser deliberately does NOT coerce -- the model said something
-        # structurally wrong and should get a rethink, not have the harness
-        # silently invent a string on its behalf. raw_action is set so the
-        # rethink can quote the offending JSON back.
+        # structurally wrong and should get a rethink.
         obs = _guesser_obs()
         response = '{"guess": 42}'
         result = parse_response(response, None, observation=obs)
@@ -218,65 +252,247 @@ class ParseResponseTest(absltest.TestCase):
         self.assertIsNotNone(result.raw_action)
         self.assertIn("42", result.raw_action)
 
-    def test_guesser_rejects_empty_guess(self):
+    def test_rejects_empty_guess(self):
         obs = _guesser_obs()
         response = '{"guess": ""}'
         result = parse_response(response, None, observation=obs)
         self.assertIsNone(result.submission)
         self.assertIsNotNone(result.raw_action)
 
-    def test_guesser_rejects_whitespace_only_guess(self):
+    def test_rejects_whitespace_only_guess(self):
         obs = _guesser_obs()
         response = '{"guess": "   "}'
         result = parse_response(response, None, observation=obs)
         self.assertIsNone(result.submission)
         self.assertIsNotNone(result.raw_action)
 
-    def test_artist_rejects_empty_art(self):
-        obs = _artist_obs()
-        response = '{"art": ""}'
-        result = parse_response(response, None, observation=obs)
-        self.assertIsNone(result.submission)
-        self.assertIsNotNone(result.raw_action)
-
-    def test_artist_rejects_non_string_art(self):
-        # e.g. model returned art as a list of lines instead of a string.
-        obs = _artist_obs()
-        response = '{"art": ["line1", "line2"]}'
-        result = parse_response(response, None, observation=obs)
-        self.assertIsNone(result.submission)
-        self.assertIsNotNone(result.raw_action)
-
-    def test_guesser_missing_guess_key_returns_no_submission(self):
+    def test_missing_guess_key_returns_no_submission(self):
         obs = _guesser_obs()
-        response = '{"thinking": "no idea", "art": "still"}'
+        response = '{"note": "no idea", "other": "still"}'
         result = parse_response(response, None, observation=obs)
         self.assertIsNone(result.submission)
+        # No JSON with "guess" key -> raw_action=None -> UNPARSABLE.
+        self.assertIsNone(result.raw_action)
 
-    def test_guesser_picks_last_json_block(self):
+    def test_no_json_returns_no_submission(self):
         obs = _guesser_obs()
-        response = 'Maybe {"guess": "DOG"} but actually\n{"thinking": "wait, whiskers", "guess": "CAT"}'
+        response = "The art clearly shows a CAT. My answer is CAT."
         result = parse_response(response, None, observation=obs)
-        self.assertEqual(result.submission, "CAT")
-
-    # --- No-role dispatch (e.g. obs not forwarded) ---
-
-    def test_no_observation_rejects_both_keys(self):
-        # Parser is role-strict. Without a role we can't tell whether a
-        # response containing "guess" on an artist turn is the model
-        # answering the wrong question, so we refuse to submit. raw_action
-        # is still set for the rethink to quote back. In production
-        # core_harness always forwards `observation`; this only fires from
-        # ad-hoc test callers.
-        for response in ('{"art": "X"}', '{"guess": "CAT"}'):
-            result = parse_response(response, None)
-            self.assertIsNone(result.submission)
-            self.assertIsNotNone(result.raw_action)
-
-    def test_prose_returns_no_submission(self):
-        result = parse_response("Just some text", None)
         self.assertIsNone(result.submission)
         self.assertIsNone(result.raw_action)
+
+
+# --- parse_response: dispatch / no-role -------------------------------------
+
+
+class ParseResponseDispatchTest(absltest.TestCase):
+    def test_no_observation_refuses_to_submit(self):
+        # Parser is role-strict. Without a role we can't tell which marker
+        # format to look for, so we refuse. In production core_harness
+        # always forwards `observation`; this only fires from ad-hoc test
+        # callers.
+        for response in ("<art>X</art>", '{"guess": "CAT"}'):
+            result = parse_response(response, None)
+            self.assertIsNone(result.submission)
+            self.assertIsNone(result.raw_action)
+
+    def test_prose_returns_no_submission(self):
+        result = parse_response("Just some text", None, observation=_guesser_obs())
+        self.assertIsNone(result.submission)
+        self.assertIsNone(result.raw_action)
+
+
+# --- Thoughts extraction ---------------------------------------------------
+
+
+class ThoughtsExtractionTest(absltest.TestCase):
+    """Prose reasoning that precedes the answer marker must be captured in
+    ``ParseResult.thoughts`` so the replay records reasoning separately
+    from the submitted answer. Without this, core_harness falls back to
+    logging the full raw response and post-hoc analysis has to re-parse
+    it to separate reasoning from action."""
+
+    def test_artist_captures_prose_before_art_tag(self):
+        obs = _artist_obs()
+        response = (
+            "I'll draw a cat face: pointy ears with slashes, round eyes.\n"
+            "<art>\n /\\_/\\\n( o.o )\n</art>"
+        )
+        result = parse_response(response, None, observation=obs)
+        self.assertIsNotNone(result.thoughts)
+        self.assertIn("cat face", result.thoughts)
+        self.assertIn("pointy ears", result.thoughts)
+        # Answer content must NOT leak into thoughts.
+        self.assertNotIn("<art>", result.thoughts)
+        self.assertNotIn("/\\_/\\", result.thoughts)
+
+    def test_artist_thoughts_stop_at_last_art_tag_on_rethink(self):
+        """When the model self-corrects with a second <art> block, thoughts
+        should include the earlier draft (it IS reasoning) but not the
+        final block itself."""
+        obs = _artist_obs()
+        response = (
+            "Draft:\n<art>DRAFT</art>\n"
+            "Actually, revised approach:\n<art>FINAL</art>"
+        )
+        result = parse_response(response, None, observation=obs)
+        self.assertEqual(result.submission, "FINAL")
+        self.assertIsNotNone(result.thoughts)
+        self.assertIn("Draft", result.thoughts)
+        self.assertIn("<art>DRAFT</art>", result.thoughts)
+        self.assertIn("revised", result.thoughts)
+        # The winning block itself must NOT be in thoughts.
+        self.assertNotIn("FINAL", result.thoughts)
+
+    def test_artist_no_prose_leaves_thoughts_none(self):
+        """Model wrote only the answer -- fallback to logging the full
+        raw response (core_harness handles that when thoughts=None)."""
+        obs = _artist_obs()
+        response = "<art>MEOW</art>"
+        result = parse_response(response, None, observation=obs)
+        self.assertEqual(result.submission, "MEOW")
+        self.assertIsNone(result.thoughts)
+
+    def test_artist_whitespace_only_prose_leaves_thoughts_none(self):
+        obs = _artist_obs()
+        response = "   \n\n  <art>MEOW</art>"
+        result = parse_response(response, None, observation=obs)
+        self.assertIsNone(result.thoughts)
+
+    def test_guesser_captures_prose_before_json(self):
+        obs = _guesser_obs()
+        response = (
+            'Looks like a four-legged animal with whiskers. My guess: cat.\n'
+            '{"guess": "CAT"}'
+        )
+        result = parse_response(response, None, observation=obs)
+        self.assertIsNotNone(result.thoughts)
+        self.assertIn("four-legged", result.thoughts)
+        self.assertIn("whiskers", result.thoughts)
+        # Answer JSON must NOT leak into thoughts.
+        self.assertNotIn('"guess"', result.thoughts)
+
+    def test_guesser_thoughts_stop_at_last_json_on_rethink(self):
+        obs = _guesser_obs()
+        response = (
+            'Maybe {"guess": "DOG"}\n'
+            'Wait -- the whiskers point to a cat instead.\n'
+            '{"guess": "CAT"}'
+        )
+        result = parse_response(response, None, observation=obs)
+        self.assertEqual(result.submission, "CAT")
+        self.assertIsNotNone(result.thoughts)
+        self.assertIn("DOG", result.thoughts)
+        self.assertIn("Wait", result.thoughts)
+        # The winning JSON block itself must NOT be in thoughts.
+        self.assertNotIn('"CAT"', result.thoughts)
+
+    def test_guesser_fenced_json_captures_prose(self):
+        obs = _guesser_obs()
+        response = (
+            'Reasoning about the drawing.\n'
+            '```json\n{"guess": "CAT"}\n```'
+        )
+        result = parse_response(response, None, observation=obs)
+        self.assertIsNotNone(result.thoughts)
+        self.assertIn("Reasoning", result.thoughts)
+        self.assertNotIn("```", result.thoughts)
+
+    def test_guesser_no_prose_leaves_thoughts_none(self):
+        obs = _guesser_obs()
+        response = '{"guess": "CAT"}'
+        result = parse_response(response, None, observation=obs)
+        self.assertEqual(result.submission, "CAT")
+        self.assertIsNone(result.thoughts)
+
+    def test_thoughts_preserved_when_answer_is_rejected(self):
+        """Even on bad-value failures (empty tag, non-string guess), the
+        prose reasoning should still make it into thoughts -- the model
+        DID reason, we just couldn't extract a submission."""
+        # Artist: empty tag.
+        obs_a = _artist_obs()
+        result = parse_response(
+            "My drawing is coming up next.\n<art></art>",
+            None,
+            observation=obs_a,
+        )
+        self.assertIsNone(result.submission)
+        self.assertIsNotNone(result.thoughts)
+        self.assertIn("drawing", result.thoughts)
+
+        # Guesser: non-string guess.
+        obs_g = _guesser_obs()
+        result = parse_response(
+            'I think it might be a number.\n{"guess": 42}',
+            None,
+            observation=obs_g,
+        )
+        self.assertIsNone(result.submission)
+        self.assertIsNotNone(result.thoughts)
+        self.assertIn("number", result.thoughts)
+
+
+# --- Parser regression: no ghost-substitution -------------------------------
+
+
+class NoGhostFallbackTest(absltest.TestCase):
+    """The free-form parser intentionally has NO prose fallback. If the
+    model writes 'CAT' in prose but its JSON is missing/wrong, we MUST NOT
+    silently submit CAT -- let the rethink loop handle it."""
+
+    def test_guesser_prose_with_no_json_returns_nothing(self):
+        obs = _guesser_obs()
+        response = "The art clearly shows a CAT. My answer is CAT."
+        result = parse_response(response, None, observation=obs)
+        self.assertIsNone(result.submission)
+
+    def test_guesser_prose_with_json_lacking_guess_returns_nothing(self):
+        obs = _guesser_obs()
+        response = 'I see a cat: CAT. {"note": "CAT"}'
+        result = parse_response(response, None, observation=obs)
+        self.assertIsNone(result.submission)
+
+    def test_artist_prose_containing_ascii_art_but_no_tag(self):
+        # Model drew something readable in prose but forgot the tag -- we
+        # do NOT submit prose, forcing a rethink to comply with the format.
+        obs = _artist_obs()
+        response = "Here you go:\n /\\_/\\\n( o.o )"
+        result = parse_response(response, None, observation=obs)
+        self.assertIsNone(result.submission)
+
+
+# --- ParseResult shape ------------------------------------------------------
+
+
+class ParseResultShapeTest(absltest.TestCase):
+    def test_artist_submission_is_str(self):
+        result = parse_response(
+            "<art>x</art>",
+            None,
+            observation=_artist_obs(),
+        )
+        self.assertIsInstance(result, ParseResult)
+        self.assertIsInstance(result.submission, str)
+
+    def test_guesser_submission_is_str(self):
+        result = parse_response(
+            '{"guess": "CAT"}',
+            None,
+            observation=_guesser_obs(),
+        )
+        self.assertIsInstance(result.submission, str)
+
+    def test_success_raw_action_equals_submission_untruncated(self):
+        """On a successful parse we set raw_action == submission verbatim
+        (matches core_harness's parse_json_action convention). Prior
+        versions capped this at [:200], which truncated most of an
+        artist's drawing in telemetry for no clear benefit."""
+        obs = _artist_obs()
+        big_art = "X" * 3000  # well over the old 200 cap
+        response = f"<art>{big_art}</art>"
+        result = parse_response(response, None, observation=obs)
+        self.assertEqual(result.submission, big_art)
+        self.assertEqual(result.raw_action, big_art)
 
 
 # --- generate_prompt --------------------------------------------------------
@@ -303,51 +519,50 @@ class GeneratePromptTest(absltest.TestCase):
         self.assertIn("0 points", prompt)
 
     def test_artist_prompt_warns_about_writing_word_verbatim(self):
-        # Critical mechanic: the engine catches the target word verbatim,
-        # obfuscated, or reversed. The prompt must spell out the rule, the
-        # normalization that powers it, and the consequence.
         prompt = generate_prompt(_artist_obs(target="ELEPHANT"), [])
-        # Accept either the hyphenated check name ("target-word check")
-        # or the plain phrase.
         lower = prompt.lower()
         self.assertTrue("target-word" in lower or "target word" in lower)
         self.assertIn("engine-enforced", lower)
-        # The prompt MUST describe the normalization so the model understands
-        # what's actually caught (not just a vague "don't do it").
         self.assertIn("strips every non-alphanumeric", prompt)
         self.assertIn("reversed", prompt)
-        # Consequence (placeholder shown to teammate).
         self.assertIn("placeholder", prompt)
 
     def test_artist_prompt_broad_no_words_rule(self):
-        # Beyond the engine-enforced target-word check, the prompt must
-        # explain the ANY-WORD mechanical check, enumerate examples of what
-        # counts as a "word" (synonyms, labels, NATO, translations, rhymes),
-        # and state the broad rule ("do not include any words") in
-        # unambiguous language so the model doesn't get lost in the
-        # mechanical details.
         prompt = generate_prompt(_artist_obs(), [])
-        # Normalise whitespace: the prose paragraph flow-wraps and can put
-        # a newline between adjacent words we care about matching.
         squished = " ".join(prompt.lower().split())
         self.assertIn("do not include any words", squished)
         self.assertIn("any-word check", squished)
         for kw in ("synonym", "label", "nato", "translation", "rhyme"):
             self.assertIn(kw, squished)
-        # And the prompt must clarify that letters as visual elements are
-        # fine -- otherwise the rule reads as "no letters at all".
         self.assertIn("visual element", squished)
 
-    def test_artist_prompt_requests_thinking_before_json(self):
-        # Memory contract: every prompt asks for reasoning BEFORE JSON.
+    def test_artist_prompt_requests_reasoning_before_art_tag(self):
+        # Memory contract: every prompt asks for reasoning BEFORE the answer.
+        # Now the answer is <art>...</art>; reasoning is prose above it.
+        # The instruction must explicitly ask the model to WRITE the
+        # reasoning out (not just "think" internally) so a reader can see
+        # the chain of thought in the response.
         prompt = generate_prompt(_artist_obs(), [])
         lower = prompt.lower()
-        self.assertIn("think step by step", lower)
-        self.assertIn("thinking", lower)
-        # Thinking instruction must precede the JSON example.
-        json_block = prompt.find("```json")
-        self.assertGreater(json_block, 0)
-        self.assertLess(lower.find("think step by step"), json_block)
+        squished = " ".join(lower.split())
+        self.assertIn("think step by step", squished)
+        # Parallel to the guesser prompt: "writing your reasoning as
+        # ordinary prose" is what makes the CoT observable.
+        self.assertIn("writing your reasoning as ordinary prose", squished)
+        # And the reasoning instruction must precede the concrete example.
+        instruct_pos = lower.find("<art>")
+        self.assertGreater(instruct_pos, 0)
+        self.assertLess(lower.find("think step by step"), instruct_pos)
+
+    def test_artist_prompt_documents_art_tag_format(self):
+        prompt = generate_prompt(_artist_obs(), [])
+        # The instruction and the worked example must both be present so
+        # the model knows the exact format expected.
+        self.assertIn("<art>", prompt)
+        self.assertIn("</art>", prompt)
+        # And the prompt must call out that no escaping is needed (this is
+        # the whole reason for using tags over JSON).
+        self.assertIn("verbatim", prompt.lower())
 
     def test_guesser_prompt_shows_teammate_art(self):
         art = "  /\\_/\\\n ( o.o )\n  > ^ <"
@@ -368,13 +583,20 @@ class GeneratePromptTest(absltest.TestCase):
         self.assertIn("all wrong", prompt)
         self.assertIn("attempt 2 of 3", prompt)
 
-    def test_guesser_prompt_requests_thinking_before_json(self):
+    def test_guesser_prompt_requests_reasoning_before_json(self):
         prompt = generate_prompt(_guesser_obs(), [])
         lower = prompt.lower()
         self.assertIn("think step by step", lower)
-        json_block = prompt.find("```json")
-        self.assertGreater(json_block, 0)
-        self.assertLess(lower.find("think step by step"), json_block)
+        # Reasoning instruction must precede the JSON example.
+        json_pos = prompt.find('{"guess"')
+        self.assertGreater(json_pos, 0)
+        self.assertLess(lower.find("think step by step"), json_pos)
+
+    def test_guesser_prompt_example_shows_json_format(self):
+        prompt = generate_prompt(_guesser_obs(), [])
+        # Example must include a minimal valid JSON showing only the
+        # required key -- reasoning is prose now, no "thinking" field.
+        self.assertIn('{"guess": "CAT"}', prompt)
 
     def test_history_block_renders_completed_rounds(self):
         hist = [
@@ -403,10 +625,13 @@ class GeneratePromptTest(absltest.TestCase):
         self.assertIn("Blue 4", prompt)
         self.assertIn("Yellow 2", prompt)
 
-    def test_rethink_no_json_branch(self):
-        # When previous_action is None the parser found no JSON; the rethink
-        # should quote back the tail of the response so the model can see
-        # how its answer trailed off.
+    def test_rethink_not_appended_on_first_attempt(self):
+        prompt = generate_prompt(_artist_obs(), [])
+        self.assertNotIn("Last 500 characters", prompt)
+        self.assertNotIn("Your submitted", prompt)
+
+    def test_artist_rethink_no_answer_branch(self):
+        # No <art> tag found -> quote back the tail of the response.
         prompt = generate_prompt(
             _artist_obs(),
             [],
@@ -414,42 +639,65 @@ class GeneratePromptTest(absltest.TestCase):
         )
         self.assertIn("Last 500 characters", prompt)
         self.assertIn("my last try was junk text", prompt)
-        # Must NOT use the bad-value template's phrasing.
-        self.assertNotIn("Your submitted JSON was", prompt)
+        self.assertIn("<art>", prompt)
+        # Must NOT use the empty-tag branch's phrasing.
+        self.assertNotIn("were empty", prompt)
 
-    def test_rethink_bad_value_branch(self):
-        # When previous_action is set the parser DID find a JSON object but
-        # the required key was missing / non-string / empty. The rethink
-        # should quote the offending JSON back verbatim rather than telling
-        # the model "you didn't include the key" when it did.
+    def test_artist_rethink_empty_tag_branch(self):
+        # <art> tag present but empty -> quote it back verbatim.
         prompt = generate_prompt(
             _artist_obs(),
             [],
-            previous_response='thinking ... {"guess": "CAT"}',
-            previous_action='{"guess": "CAT"}',
+            previous_response="here you go: <art></art>",
+            previous_action="<art></art>",
         )
-        self.assertIn("required key was\nmissing or had an invalid value", prompt)
-        self.assertIn('{"guess": "CAT"}', prompt)
-        # Must NOT use the no-JSON template's phrasing.
+        self.assertIn("empty or whitespace-only", prompt)
+        self.assertIn("<art></art>", prompt)
+        # Must NOT use the no-answer branch's phrasing.
         self.assertNotIn("Last 500 characters", prompt)
 
-    def test_rethink_not_appended_on_first_attempt(self):
-        prompt = generate_prompt(_artist_obs(), [])
-        self.assertNotIn("Last 500 characters", prompt)
+    def test_guesser_rethink_no_json_branch(self):
+        prompt = generate_prompt(
+            _guesser_obs(),
+            [],
+            previous_response="I think it's a cat but I'm not sure",
+        )
+        self.assertIn("Last 500 characters", prompt)
+        self.assertIn("I think it's a cat", prompt)
+        self.assertIn('"guess"', prompt)
+        # Must NOT use the bad-value branch's phrasing.
         self.assertNotIn("Your submitted JSON was", prompt)
 
+    def test_guesser_rethink_bad_value_branch(self):
+        prompt = generate_prompt(
+            _guesser_obs(),
+            [],
+            previous_response='reasoning ... {"guess": 42}',
+            previous_action='{"guess": 42}',
+        )
+        squished = " ".join(prompt.split())
+        self.assertIn("Your submitted JSON was", squished)
+        self.assertIn('{"guess": 42}', prompt)
+        # Must NOT use the no-json branch's phrasing.
+        self.assertNotIn("Last 500 characters", prompt)
+
+    def test_rethink_dispatch_respects_role(self):
+        # An artist and a guesser with the same previous_response should
+        # get role-specific rethink text (different format hints).
+        artist = generate_prompt(_artist_obs(), [], previous_response="junk")
+        guesser = generate_prompt(_guesser_obs(), [], previous_response="junk")
+        self.assertIn("<art>", artist)
+        self.assertNotIn('"guess"', artist.split("Rules:")[-1].split("Past rounds")[-1])
+        # (Guesser rethink specifically mentions the JSON format.)
+        self.assertIn('"guess"', guesser)
+
     def test_max_attempts_propagates_to_prompt(self):
-        # Env supports configurable max_attempts; prompt must reflect it.
         prompt = generate_prompt(_artist_obs(max_attempts=5), [])
         self.assertIn("attempt 2 through 5", prompt)
         self.assertIn("within 5 attempts", prompt)
 
     def test_first_try_bonus_propagates_from_observation(self):
-        """The scoring text must reflect the env's first_try_bonus, not a
-        hardcoded value. Previously the harness hardcoded 1, silently lying
-        to the model whenever the env was configured differently."""
         prompt = generate_prompt(_artist_obs(first_try_bonus=5), [])
-        # Base 1 + bonus 5 = 6 points on attempt 1.
         self.assertIn("Correct on attempt 1: 6 points", prompt)
         self.assertIn("1 base + 5 first-try bonus", prompt)
 
@@ -459,16 +707,11 @@ class GeneratePromptTest(absltest.TestCase):
         self.assertIn("1 base + 0 first-try bonus", prompt)
 
     def test_artist_prompt_mentions_max_art_chars_truncation(self):
-        """Artist must know the env will silently truncate over-long art."""
         prompt = generate_prompt(_artist_obs(max_art_chars=2500), [])
         self.assertIn("2500", prompt)
         self.assertIn("truncated", prompt.lower())
 
     def test_scoring_block_states_win_and_tie_conditions(self):
-        # Prior gap: scoring block explained per-round points but never told
-        # the model how the game as a whole ends. 12% of episodes in the
-        # 624-replay archive were ties -- if the model doesn't know ties are
-        # possible it can't strategize around a close score.
         for obs in (_artist_obs(), _guesser_obs()):
             prompt = generate_prompt(obs, [])
             lower = prompt.lower()
@@ -476,17 +719,11 @@ class GeneratePromptTest(absltest.TestCase):
             self.assertIn("tie", lower)
 
     def test_scoring_block_states_teams_share_secret_word(self):
-        # Prior gap: nothing in the prompt said both teams got the SAME
-        # secret word each round. Implicit from history (both teams' entries
-        # share `word`) but never disclosed upfront.
         for obs in (_artist_obs(), _guesser_obs()):
             prompt = generate_prompt(obs, [])
             self.assertIn("same secret word", prompt)
 
     def test_match_rule_wording_is_consistent_across_roles(self):
-        # Prior gap: artist said "no spelling variants" and guesser said
-        # "no plurals, synonyms, or partial matches" -- same rule, different
-        # phrasing. Both prompts should now use the same fuller list.
         artist = " ".join(generate_prompt(_artist_obs(), []).split())
         guesser = " ".join(generate_prompt(_guesser_obs(), []).split())
         phrase = "no plurals, synonyms, partial matches, or other spelling variants"
@@ -494,9 +731,6 @@ class GeneratePromptTest(absltest.TestCase):
         self.assertIn(phrase, guesser)
 
     def test_guesser_prompt_discloses_sanitization(self):
-        # Prior gap: artist prompt described the silent sanitization pass
-        # (combining marks / CJK / wide chars dropped) but the guesser
-        # prompt didn't, leaving the guesser confused if art rendered oddly.
         prompt = generate_prompt(_guesser_obs(), [])
         lower = prompt.lower()
         self.assertIn("silently strip", lower)
@@ -504,25 +738,16 @@ class GeneratePromptTest(absltest.TestCase):
         self.assertIn("monospace", lower)
 
     def test_guesser_prompt_explains_disqualification_marker(self):
-        """Guesser must be told what the placeholder string means when their
-        teammate's art gets disqualified for containing the target word."""
         prompt = generate_prompt(_guesser_obs(), [])
-        # The rule statement must call out the placeholder mechanic (so the
-        # model isn't surprised by the marker text). Match a stem so we
-        # accept "disqualifies" / "disqualified" / "disqualification".
         self.assertIn("disqualif", prompt.lower())
         self.assertIn("placeholder", prompt.lower())
-        # And the wording must mention WHY (target word in the art).
         self.assertIn("target word", prompt.lower())
 
     def test_history_marks_disqualified_blue_entry(self):
-        """When a past round's blue art was disqualified, _format_history
-        must label it so the model doesn't read the raw art as something
-        the guesser actually saw."""
         hist = [
             {
                 "word": "CAT",
-                "blue_art": "C A T",  # was disqualified
+                "blue_art": "C A T",
                 "blue_art_disqualified": True,
                 "blue_art_disqualification_reason": "target_word",
                 "blue_guesses": ["DOG", "BEAR", "LION"],
@@ -535,12 +760,9 @@ class GeneratePromptTest(absltest.TestCase):
             }
         ]
         prompt = generate_prompt(_guesser_obs(history=hist, current_round=1), [])
-        # Blue art line must carry the disqualification label with a
-        # human-readable reason (target-word check fired here).
         self.assertIn("Blue art: (DISQUALIFIED", prompt)
         self.assertIn("contained the target word", prompt)
         self.assertIn("placeholder", prompt.lower())
-        # Yellow art line must NOT carry the label.
         self.assertIn("Yellow art:", prompt)
         self.assertNotIn("Yellow art: (DISQUALIFIED", prompt)
 
@@ -553,7 +775,7 @@ class GeneratePromptTest(absltest.TestCase):
                 "blue_art_disqualification_reason": None,
                 "blue_guesses": ["DOG"],
                 "blue_points": 2,
-                "yellow_art": "the dog runs",  # disqualified by any-word check
+                "yellow_art": "the dog runs",
                 "yellow_art_disqualified": True,
                 "yellow_art_disqualification_reason": "contains_words",
                 "yellow_guesses": ["WOLF", "FOX"],
@@ -562,7 +784,6 @@ class GeneratePromptTest(absltest.TestCase):
         ]
         prompt = generate_prompt(_artist_obs(history=hist, current_round=1), [])
         self.assertIn("Yellow art: (DISQUALIFIED", prompt)
-        # any-word rejection should surface its specific reason text.
         self.assertIn("contained text", prompt)
         self.assertNotIn("Blue art: (DISQUALIFIED", prompt)
 
@@ -583,7 +804,7 @@ class AgentIntegrationTest(absltest.TestCase):
     def test_artist_successful_submission(self):
         agent = create_agent_fn(_WordArtHarness())
         obs = _artist_obs(target="CAT")
-        llm = '{"thinking": "a cat face", "art": " /\\\\_/\\\\\\n( o.o )"}'
+        llm = "A cat face.\n<art>\n /\\_/\\\n( o.o )\n</art>"
         with (
             patch.dict("os.environ", _ENV, clear=False),
             patch.object(
@@ -593,13 +814,13 @@ class AgentIntegrationTest(absltest.TestCase):
             ),
         ):
             result = agent(obs, {"freeForm": True})
-        self.assertEqual(result["submission"], " /\\_/\\\n( o.o )")
+        self.assertEqual(result["submission"], "\n /\\_/\\\n( o.o )\n")
         self.assertEqual(result["status"], "OK")
 
     def test_guesser_successful_submission(self):
         agent = create_agent_fn(_WordArtHarness())
         obs = _guesser_obs(art="MEOW")
-        llm = '{"thinking": "cat", "guess": "CAT"}'
+        llm = 'Looks like a cat.\n{"guess": "CAT"}'
         with (
             patch.dict("os.environ", _ENV, clear=False),
             patch.object(
@@ -617,7 +838,7 @@ class AgentIntegrationTest(absltest.TestCase):
         obs = _guesser_obs()
         responses = [
             _fake_completion("I think it might be a cat"),  # no JSON
-            _fake_completion('{"thinking": "cat", "guess": "CAT"}'),
+            _fake_completion('Looks like a cat.\n{"guess": "CAT"}'),
         ]
         with (
             patch.dict("os.environ", _ENV, clear=False),
@@ -631,15 +852,12 @@ class AgentIntegrationTest(absltest.TestCase):
         self.assertEqual(result["submission"], "CAT")
         self.assertEqual(mock_call.call_count, 2)
 
-    def test_artist_wrong_key_triggers_rethink(self):
-        """Artist who emits a 'guess' instead of 'art' should trigger the
-        rethink loop. With a single retry budget the agent raises; with
-        more, it gets a chance to fix and submits the art."""
+    def test_artist_missing_tag_triggers_rethink(self):
         agent = create_agent_fn(_WordArtHarness(), max_retries=2)
         obs = _artist_obs()
         responses = [
-            _fake_completion('{"guess": "CAT"}'),  # wrong key
-            _fake_completion('{"thinking": "fix", "art": "MEOW"}'),
+            _fake_completion("Here's my drawing:\n /\\_/\\"),  # no <art> tag
+            _fake_completion("Retry.\n<art>MEOW</art>"),
         ]
         with (
             patch.dict("os.environ", _ENV, clear=False),
@@ -654,11 +872,9 @@ class AgentIntegrationTest(absltest.TestCase):
         self.assertEqual(mock_call.call_count, 2)
 
     def test_artist_no_valid_response_raises_after_retries(self):
-        """When the artist never produces a valid 'art' key, the agent
-        raises ValueError after exhausting retries (core_harness behaviour)."""
         agent = create_agent_fn(_WordArtHarness(), max_retries=1)
         obs = _artist_obs()
-        responses = [_fake_completion('{"guess": "CAT"}')]
+        responses = [_fake_completion("Just prose, no tag.")]
         with (
             patch.dict("os.environ", _ENV, clear=False),
             patch.object(
@@ -669,112 +885,6 @@ class AgentIntegrationTest(absltest.TestCase):
         ):
             with self.assertRaises(ValueError):
                 agent(obs, {"freeForm": True})
-
-
-# --- Parser regression: lone-backslash repair fallback ---------------------
-
-
-class LoneBackslashRepairTest(absltest.TestCase):
-    """Models discussing / drawing ASCII art routinely write `\\ | /`,
-    `/\\`, `\\_/` etc. in JSON string values without doubling the
-    backslash. Strict json.loads rejects the whole object; the harness
-    tries once more against a repaired copy where lone backslashes are
-    doubled. In a 624-episode replay archive this recovered ~94% of
-    otherwise-forced retries."""
-
-    def test_guesser_thoughts_contain_lone_backslashes(self):
-        obs = _guesser_obs()
-        response = (
-            '```json\n'
-            '{"thinking": "The drawing shows \\ | / on top and \\_ _/ below",'
-            ' "guess": "FISHBOWL"}\n'
-            '```'
-        )
-        result = parse_response(response, None, observation=obs)
-        self.assertEqual(result.submission, "FISHBOWL")
-
-    def test_bare_json_guess_with_lone_backslashes(self):
-        obs = _guesser_obs()
-        response = (
-            'Reasoning: {"thinking":"peaked /\\ shapes suggest mountain",'
-            '"guess":"MOUNTAIN"}'
-        )
-        result = parse_response(response, None, observation=obs)
-        self.assertEqual(result.submission, "MOUNTAIN")
-
-    def test_artist_art_with_lone_backslashes(self):
-        obs = _artist_obs()
-        # Model wrote "/\" and "\_/" inside `art` without doubling.
-        response = '{"thinking": "cat", "art": "/\\_/\\\n( o.o )"}'
-        # First loads: `\_` inside `art` is invalid; repair should recover.
-        # (Note: the `\n` after `\\_/\\` is a real Python `\n` in this
-        # source, not an escape in the JSON text, so json.loads would fail
-        # even without the `\_`. Repair fixes both.)
-        result = parse_response(response, None, observation=obs)
-        self.assertIsNotNone(result.submission)
-        self.assertIn("_/", result.submission)
-
-    def test_repair_preserves_real_escapes(self):
-        """Response with legitimate `\\n`, `\\"`, `\\\\` escapes must parse
-        the same before/after the repair path -- no double-escaping."""
-        obs = _artist_obs()
-        response = '```json\n{"art": "line1\\nline2\\n\\\\end"}\n```'
-        result = parse_response(response, None, observation=obs)
-        self.assertEqual(result.submission, "line1\nline2\n\\end")
-
-    def test_repair_does_not_fire_on_valid_json(self):
-        """When strict parse succeeds on the first try, the repair path
-        is skipped -- confirmed indirectly: a response whose lone `\\`
-        appears OUTSIDE the JSON object shouldn't have to trigger the
-        fallback for the primary block to parse."""
-        obs = _guesser_obs()
-        response = 'Some prose with a lone \\ here\n```json\n{"guess": "CAT"}\n```'
-        result = parse_response(response, None, observation=obs)
-        self.assertEqual(result.submission, "CAT")
-
-
-# --- Parser regression: no ghost-substitution for guess responses -----------
-
-
-class NoGhostFallbackTest(absltest.TestCase):
-    """The free-form parser intentionally has NO prose fallback. If the
-    model writes 'CAT' in prose but its JSON is missing/wrong, we MUST NOT
-    silently submit CAT — let the rethink loop handle it."""
-
-    def test_prose_with_no_json_returns_nothing(self):
-        obs = _guesser_obs()
-        response = "The art clearly shows a CAT. My answer is CAT."
-        result = parse_response(response, None, observation=obs)
-        self.assertIsNone(result.submission)
-
-    def test_prose_with_json_lacking_guess_returns_nothing(self):
-        obs = _guesser_obs()
-        response = 'I see a cat: CAT. {"thinking": "CAT"}'
-        result = parse_response(response, None, observation=obs)
-        # No "guess" key → no submission, even though CAT is in the prose
-        self.assertIsNone(result.submission)
-
-
-# --- ParseResult shape (defensive: make sure we never return weird types) ---
-
-
-class ParseResultShapeTest(absltest.TestCase):
-    def test_artist_submission_is_str(self):
-        result = parse_response(
-            '{"art": "x"}',
-            None,
-            observation=_artist_obs(),
-        )
-        self.assertIsInstance(result, ParseResult)
-        self.assertIsInstance(result.submission, str)
-
-    def test_guesser_submission_is_str(self):
-        result = parse_response(
-            '{"guess": "CAT"}',
-            None,
-            observation=_guesser_obs(),
-        )
-        self.assertIsInstance(result.submission, str)
 
 
 if __name__ == "__main__":

--- a/tests/envs/word_art/test_harness.py
+++ b/tests/envs/word_art/test_harness.py
@@ -730,13 +730,6 @@ class GeneratePromptTest(absltest.TestCase):
         self.assertIn(phrase, artist)
         self.assertIn(phrase, guesser)
 
-    def test_guesser_prompt_discloses_sanitization(self):
-        prompt = generate_prompt(_guesser_obs(), [])
-        lower = prompt.lower()
-        self.assertIn("silently strip", lower)
-        self.assertIn("cjk", lower)
-        self.assertIn("monospace", lower)
-
     def test_guesser_prompt_explains_disqualification_marker(self):
         prompt = generate_prompt(_guesser_obs(), [])
         self.assertIn("disqualif", prompt.lower())


### PR DESCRIPTION
Parsing:
* Restructure the required model response format to include raw thoughts _before_ the final block containing the action, consistent with most other harnesses in the repo
* On the artist's turn, parse the art out of a `<art>...</art>` section instead of a JSON value. JSON formatting likely trips models up because they have to escape a lot of characters that are used legitimately in the drawing.
    * Still requires a final JSON section for guessers, like most harnesses
* Add a core_harness helper for extracting the last JSON object *and* its start position, to separate thoughts from the action

Prompt:
* Mention the win and draw conditions
* Make some statements consistent for both artist and guesser