### PR TITLE
Snake: respawn food when board is empty or interval elapses

### DIFF
--- a/kaggle_environments/envs/open_spiel_env/games/snake/harness.py
+++ b/kaggle_environments/envs/open_spiel_env/games/snake/harness.py
@@ -29,10 +29,12 @@ dies if its new head:
   - collides head-to-head with another snake (both die).
 A snake that moves onto a food cell ("*") grows by one and earns one
 point. Food spawns in 180°-rotationally-symmetric pairs (one cell and
-its mirror through the board center). Every {food_respawn_interval}
-turns a fresh pair is spawned and any uneaten food on the board is
-removed -- there is NO respawn when food is eaten. Snakes that do NOT
-eat lose their tail on the same turn. The game ends when at most one
+its mirror through the board center). A fresh pair is spawned whenever
+the board runs out of food OR when {food_respawn_interval} turns have
+elapsed since the last spawn (whichever comes first); on a timed
+respawn any uneaten food is cleared. Either trigger resets the timer
+for the next spawn. Snakes that do NOT eat lose their tail on the same
+turn. The game ends when at most one
 snake is alive, or when the board has no room left for a new food pair.
 
 Your goal is to maximize your food score (1 point per food eaten).

--- a/kaggle_environments/envs/open_spiel_env/games/snake/snake_game.py
+++ b/kaggle_environments/envs/open_spiel_env/games/snake/snake_game.py
@@ -124,8 +124,9 @@ class SnakeState(pyspiel.State):
             self.snakes.append([(start_r, start_c)])
 
         self.foods: List[Tuple[int, int]] = []
-        self._place_foods()
         self._steps = 0
+        self._last_food_spawn_step = 0
+        self._place_foods()
         self._next_player = 0
         self._move_buffer = [None] * self.num_players
         # Per-round log of applied actions (one inner list per simultaneous
@@ -172,6 +173,7 @@ class SnakeState(pyspiel.State):
 
         a, b = random.choice(candidates)
         self.foods = [a, b]
+        self._last_food_spawn_step = self._steps
 
     def current_player(self):
         """Returns id of the next player to move."""
@@ -335,10 +337,16 @@ class SnakeState(pyspiel.State):
             else:
                 self.snakes[i] = []  # Remove dead snakes
 
-        # Timed food respawn: every food_respawn_interval turns, clear any
-        # uneaten food and place a fresh symmetric pair.
-        if self.food_respawn_interval > 0 and self._steps % self.food_respawn_interval == 0:
-            self._place_foods()
+        # Food respawn: place a fresh symmetric pair (clearing any uneaten
+        # food) whenever the board is empty, OR whenever food_respawn_interval
+        # turns have elapsed since the last spawn. Either trigger resets the
+        # timer for the next spawn.
+        if self.food_respawn_interval > 0:
+            interval_elapsed = (
+                self._steps - self._last_food_spawn_step >= self.food_respawn_interval
+            )
+            if not self.foods or interval_elapsed:
+                self._place_foods()
 
         # Check termination
         # Game ends if 0 or 1 player alive (if started with >1)

--- a/kaggle_environments/envs/open_spiel_env/games/snake/snake_proxy.py
+++ b/kaggle_environments/envs/open_spiel_env/games/snake/snake_proxy.py
@@ -60,7 +60,10 @@ class SnakeState(proxy.State):
         food_respawn_interval = int(getattr(wrapped, "food_respawn_interval", 0))
         turn = int(getattr(wrapped, "_steps", 0))
         if food_respawn_interval > 0:
-            turns_until_respawn = food_respawn_interval - (turn % food_respawn_interval)
+            last_spawn = int(getattr(wrapped, "_last_food_spawn_step", 0))
+            turns_until_respawn = max(
+                0, food_respawn_interval - (turn - last_spawn)
+            )
         else:
             turns_until_respawn = None
 

--- a/tests/envs/open_spiel_env/games/snake/snake_game_test.py
+++ b/tests/envs/open_spiel_env/games/snake/snake_game_test.py
@@ -131,6 +131,63 @@ class SnakeGameTest(absltest.TestCase):
     self.assertNotIn((0, 0), state.foods)
     self.assertNotIn((9, 9), state.foods)
 
+  def test_food_respawns_immediately_when_board_empty(self):
+    game = pyspiel.load_game(
+        "snake",
+        {"rows": 10, "columns": 10, "players": 2, "food_respawn_interval": 10},
+    )
+    state = game.new_initial_state()
+
+    # Pin food where P0 will eat it on step 1 (and its symmetric partner
+    # where P1 will eat it on step 1).
+    state.snakes[0] = [(1, 1)]
+    state.snakes[1] = [(8, 8)]
+    state.foods = [(2, 1), (7, 8)]
+
+    state.apply_action(1)  # P0 DOWN -> eats (2,1)
+    state.apply_action(0)  # P1 UP   -> eats (7,8)
+
+    # Both eaten in one turn: new pair should be placed immediately (not
+    # wait 10 turns for the timer).
+    self.assertLen(state.foods, 2)
+    self.assertNotIn((2, 1), state.foods)
+    self.assertNotIn((7, 8), state.foods)
+
+  def test_immediate_respawn_resets_timer(self):
+    game = pyspiel.load_game(
+        "snake",
+        {"rows": 10, "columns": 10, "players": 2, "food_respawn_interval": 5},
+    )
+    state = game.new_initial_state()
+    state.snakes[0] = [(1, 1)]
+    state.snakes[1] = [(8, 8)]
+    state.foods = [(2, 1), (7, 8)]
+
+    # Turn 1: both foods eaten -> immediate respawn resets the timer.
+    state.apply_action(1)  # P0 DOWN
+    state.apply_action(0)  # P1 UP
+    respawned = list(state.foods)
+
+    # Pin the fresh pair somewhere unreachable so it survives 4 more turns.
+    state.foods = [(0, 4), (9, 5)]
+
+    # 4 more safe turns: timer must NOT have fired yet (5 turns since the
+    # last spawn haven't elapsed).
+    for _ in range(4):
+      state.apply_action(1)  # P0 DOWN
+      state.apply_action(0)  # P1 UP
+    self.assertIn((0, 4), state.foods)
+    self.assertIn((9, 5), state.foods)
+
+    # 5th turn since the immediate respawn: timer fires, uneaten food is
+    # cleared, fresh pair placed.
+    state.apply_action(1)
+    state.apply_action(0)
+    self.assertNotIn((0, 4), state.foods)
+    self.assertNotIn((9, 5), state.foods)
+    self.assertLen(state.foods, 2)
+    del respawned
+
   def test_simultaneous_movement(self):
     game = pyspiel.load_game(
         "snake", {"rows": 5, "columns": 5, "players": 2}


### PR DESCRIPTION
Previously food only respawned every N turns on a fixed timer, leaving the board foodless when both foods were eaten mid-interval. Now a fresh symmetric pair is placed whenever the board runs out of food OR when the interval has elapsed since the last spawn, whichever comes first. Either trigger resets the timer.