### PR TITLE
Add transformers to visualizers that are missing them

### DIFF
--- a/kaggle_environments/envs/open_spiel_env/games/bargaining/visualizer/default/src/transformers/bargainingTransformer.ts
+++ b/kaggle_environments/envs/open_spiel_env/games/bargaining/visualizer/default/src/transformers/bargainingTransformer.ts
@@ -9,6 +9,22 @@ function parseObs(raw?: string): BargainingObs | null {
   }
 }
 
+// action.thoughts is the harness-curated summary and the preferred source.
+// generate_returns[0].main_response_and_thoughts is the raw LLM output;
+// use it only when the harness didn't populate thoughts.
+function parseThoughts(action?: { thoughts?: string | null; generate_returns?: string[] | null }): string {
+  if (action?.thoughts) return action.thoughts;
+  if (action?.generate_returns?.[0]) {
+    try {
+      const parsed = JSON.parse(action.generate_returns[0]);
+      if (parsed.main_response_and_thoughts) return parsed.main_response_and_thoughts;
+    } catch {
+      // fall through
+    }
+  }
+  return '';
+}
+
 // Submission is -1 (or null) on setup/inactive turns; treat anything else as a real move.
 const isRealMove = (submission: unknown): boolean =>
   submission !== undefined && submission !== null && submission !== -1;
@@ -30,7 +46,7 @@ export const bargainingTransformer = (environment: any): BargainingStep[] => {
         thumbnail: '',
         isTurn: isRealMove(sub),
         actionDisplayText: p.action?.actionString ?? '',
-        thoughts: p.action?.thoughts ?? '',
+        thoughts: parseThoughts(p.action),
         reward: p.reward,
       };
     });

--- a/kaggle_environments/envs/open_spiel_env/games/bridge_arena/visualizer/default/src/main.ts
+++ b/kaggle_environments/envs/open_spiel_env/games/bridge_arena/visualizer/default/src/main.ts
@@ -1,5 +1,6 @@
 import { createReplayVisualizer, ReplayAdapter } from '@kaggle-environments/core';
 import { renderer } from './renderer';
+import { bridgeArenaTransformer } from './transformers/bridgeArenaTransformer';
 import './style.css';
 
 const app = document.getElementById('app');
@@ -17,5 +18,10 @@ createReplayVisualizer(
     gameName: 'open_spiel_bridge_arena',
     renderer: renderer as any,
     ui: 'side-panel',
+    transformer: (replay) => ({
+      ...replay,
+      steps: bridgeArenaTransformer(replay),
+      isTransformed: true,
+    }),
   })
 );

--- a/kaggle_environments/envs/open_spiel_env/games/bridge_arena/visualizer/default/src/main.ts
+++ b/kaggle_environments/envs/open_spiel_env/games/bridge_arena/visualizer/default/src/main.ts
@@ -21,7 +21,6 @@ createReplayVisualizer(
     transformer: (replay) => ({
       ...replay,
       steps: bridgeArenaTransformer(replay),
-      isTransformed: true,
     }),
   })
 );

--- a/kaggle_environments/envs/open_spiel_env/games/bridge_arena/visualizer/default/src/renderer.ts
+++ b/kaggle_environments/envs/open_spiel_env/games/bridge_arena/visualizer/default/src/renderer.ts
@@ -1,4 +1,5 @@
 import type { RendererOptions } from '@kaggle-environments/core';
+import type { BridgeStep } from './transformers/bridgeArenaTransformer';
 
 // External AABB ids: 0,1 = team A (N,S); 2,3 = team B (E,W).
 const TEAM_A_PIDS = [0, 1] as const;
@@ -37,23 +38,8 @@ type Observation = {
   winning_team?: number | string;
 };
 
-function getObservation(step: any, playerIdx: number): Observation | null {
-  const raw = step?.[playerIdx]?.observation?.observationString;
-  if (!raw) return null;
-  try {
-    return JSON.parse(raw);
-  } catch {
-    return null;
-  }
-}
-
-function getSharedObservation(step: any): Observation | null {
-  if (!Array.isArray(step)) return null;
-  for (let i = 0; i < step.length; i++) {
-    const obs = getObservation(step, i);
-    if (obs) return obs;
-  }
-  return null;
+function getSharedObservation(step: BridgeStep | undefined | null): Observation | null {
+  return (step?.boardState as Observation | null) ?? null;
 }
 
 function getPlayerName(replay: any, idx: number): string {
@@ -280,9 +266,9 @@ function renderStatus(obs: Observation, activePid: number | null, playerNames: s
   return `<span>Setting up...</span><span class="annotation">phase: ${obs.phase ?? '?'}</span>`;
 }
 
-export function renderer(options: RendererOptions) {
+export function renderer(options: RendererOptions<BridgeStep[]>) {
   const { parent, replay, step } = options;
-  const steps = (replay?.steps ?? []) as any[];
+  const steps = (replay?.steps ?? []) as BridgeStep[];
   if (!steps.length) {
     parent.innerHTML = '';
     return;

--- a/kaggle_environments/envs/open_spiel_env/games/bridge_arena/visualizer/default/src/transformers/bridgeArenaTransformer.ts
+++ b/kaggle_environments/envs/open_spiel_env/games/bridge_arena/visualizer/default/src/transformers/bridgeArenaTransformer.ts
@@ -1,0 +1,112 @@
+// Bridge Arena replay transformer.
+//
+// Populates `players[]` (4 seats) so the side-panel sidebar can show each
+// mover's thoughts and call/play. Pre-parses the shared observation JSON
+// (whichever player has it populated) into `boardState`.
+
+interface BridgeAction {
+  submission?: number;
+  actionString?: string | null;
+  thoughts?: string | null;
+  generate_returns?: string[] | null;
+}
+
+interface BridgeReplayPlayer {
+  action?: BridgeAction;
+  reward: number;
+  observation: { observationString?: string };
+  status?: string;
+}
+
+interface BridgePlayer {
+  id: number;
+  name: string;
+  thumbnail: string;
+  isTurn: boolean;
+  actionDisplayText: string;
+  thoughts: string;
+  reward: number;
+}
+
+export interface BridgeBoardState {
+  phase?: string;
+  is_terminal?: boolean;
+  dealer_table_position?: string;
+  dealer_player_id?: number;
+  current_player_id?: number | null;
+  current_table_position?: string | null;
+  current_team_id?: number | null;
+  auction?: unknown[];
+  plays?: unknown[];
+  table_seating?: Record<string, string>;
+  teams?: Record<string, number[]>;
+  returns?: number[];
+  team_totals?: number[];
+  winning_team?: number | string;
+}
+
+export interface BridgeStep {
+  step: number;
+  players: BridgePlayer[];
+  boardState: BridgeBoardState | null;
+}
+
+// action.thoughts is the harness-curated summary and the preferred source.
+// generate_returns[0].main_response_and_thoughts is the raw LLM output;
+// use it only when the harness didn't populate thoughts.
+function parseThoughts(action?: BridgeAction): string {
+  if (action?.thoughts) return action.thoughts;
+  if (action?.generate_returns?.[0]) {
+    try {
+      const parsed = JSON.parse(action.generate_returns[0]);
+      if (parsed.main_response_and_thoughts) return parsed.main_response_and_thoughts;
+    } catch {
+      // fall through
+    }
+  }
+  return '';
+}
+
+// Bridge observations are per-player (hidden information), but the renderer
+// only uses the shared/public parts, and takes them from whichever seat has
+// a non-empty observationString.
+function parseBoardState(step: BridgeReplayPlayer[]): BridgeBoardState | null {
+  for (const p of step) {
+    const raw = p?.observation?.observationString;
+    if (!raw) continue;
+    try {
+      return JSON.parse(raw) as BridgeBoardState;
+    } catch {
+      // try the next seat
+    }
+  }
+  return null;
+}
+
+const isRealMove = (submission: unknown): boolean =>
+  submission !== undefined && submission !== null && submission !== -1;
+
+export const bridgeArenaTransformer = (environment: any): BridgeStep[] => {
+  const teamNames: string[] = environment?.info?.TeamNames ?? [];
+  const rawSteps: BridgeReplayPlayer[][] = environment?.steps ?? [];
+
+  return rawSteps.map((step, index): BridgeStep => {
+    const players: BridgePlayer[] = step.map(
+      (p, i): BridgePlayer => ({
+        id: i,
+        name: teamNames[i] || `Player ${i}`,
+        thumbnail: '',
+        isTurn: isRealMove(p.action?.submission),
+        actionDisplayText: p.action?.actionString ?? '',
+        thoughts: parseThoughts(p.action),
+        reward: p.reward ?? 0,
+      })
+    );
+
+    return {
+      step: index,
+      players,
+      boardState: parseBoardState(step),
+    };
+  });
+};

--- a/kaggle_environments/envs/open_spiel_env/games/mancala/visualizer/default/src/App.tsx
+++ b/kaggle_environments/envs/open_spiel_env/games/mancala/visualizer/default/src/App.tsx
@@ -1,6 +1,7 @@
 import { useCallback } from 'react';
 import { createReplayVisualizer, ReplayAdapter } from '@kaggle-environments/core';
 import GameRenderer from './components/GameRenderer';
+import { mancalaTransformer } from './transformers/mancalaTransformer';
 
 export default function App() {
   const init = useCallback((element: HTMLDivElement | null) => {
@@ -9,6 +10,11 @@ export default function App() {
       gameName: 'open_spiel_mancala',
       GameRenderer: GameRenderer as any,
       ui: 'side-panel',
+      transformer: (replay) => ({
+        ...replay,
+        steps: mancalaTransformer(replay),
+        isTransformed: true,
+      }),
     });
     createReplayVisualizer(element, adapter);
   }, []);

--- a/kaggle_environments/envs/open_spiel_env/games/mancala/visualizer/default/src/App.tsx
+++ b/kaggle_environments/envs/open_spiel_env/games/mancala/visualizer/default/src/App.tsx
@@ -13,7 +13,6 @@ export default function App() {
       transformer: (replay) => ({
         ...replay,
         steps: mancalaTransformer(replay),
-        isTransformed: true,
       }),
     });
     createReplayVisualizer(element, adapter);

--- a/kaggle_environments/envs/open_spiel_env/games/mancala/visualizer/default/src/components/GameRenderer.tsx
+++ b/kaggle_environments/envs/open_spiel_env/games/mancala/visualizer/default/src/components/GameRenderer.tsx
@@ -4,6 +4,7 @@ import type { GameRendererProps } from '@kaggle-environments/core';
 import Pit from './Pit';
 import MancalaStore from './MancalaStore';
 import { BOTTOM_ROW, MancalaObservation, STORE_LEFT, STORE_RIGHT, TOP_ROW } from '../types';
+import type { MancalaStep } from '../transformers/mancalaTransformer';
 
 import goose1Idle from '../assets/goose_1_idle.png';
 import goose1Pensive from '../assets/goose_1_pensive.png';
@@ -22,17 +23,11 @@ const GOOSE_SPRITES: Record<0 | 1, Record<'idle' | 'pensive' | 'elated' | 'sad',
   1: { idle: goose2Idle, pensive: goose2Pensive, elated: goose2Elated, sad: goose2Sad },
 };
 
-function parseObservation(step: any): MancalaObservation | null {
-  const raw = step?.[0]?.observation?.observationString;
-  if (typeof raw !== 'string') return null;
-  try {
-    return JSON.parse(raw) as MancalaObservation;
-  } catch {
-    return null;
-  }
+function parseObservation(step: MancalaStep | undefined | null): MancalaObservation | null {
+  return step?.boardState ?? null;
 }
 
-function findObservation(steps: any[], idx: number): MancalaObservation | null {
+function findObservation(steps: MancalaStep[], idx: number): MancalaObservation | null {
   for (let i = idx; i < steps.length; i++) {
     const obs = parseObservation(steps[i]);
     if (obs) return obs;
@@ -65,7 +60,7 @@ function gooseSprite(player: 0 | 1, state: MancalaObservation) {
 }
 
 function GameRenderer({ replay, step }: GameRendererProps) {
-  const steps = (replay.steps as any[]) ?? [];
+  const steps = (replay.steps as unknown as MancalaStep[]) ?? [];
   const state = useMemo(() => findObservation(steps, step), [steps, step]);
   const prevState = useMemo(() => findObservation(steps, Math.max(0, step - 1)), [steps, step]);
 

--- a/kaggle_environments/envs/open_spiel_env/games/mancala/visualizer/default/src/transformers/mancalaTransformer.ts
+++ b/kaggle_environments/envs/open_spiel_env/games/mancala/visualizer/default/src/transformers/mancalaTransformer.ts
@@ -1,0 +1,90 @@
+// Mancala replay transformer.
+//
+// Populates `players[]` so the side-panel can show each mover's thoughts
+// and pit choice, and pre-parses the observation JSON into `boardState`.
+
+import type { MancalaObservation } from '../types';
+
+interface MancalaAction {
+  submission?: number;
+  actionString?: string | null;
+  thoughts?: string | null;
+  generate_returns?: string[] | null;
+}
+
+interface MancalaReplayPlayer {
+  action?: MancalaAction;
+  reward: number;
+  observation: { observationString?: string };
+  status?: string;
+}
+
+interface MancalaPlayer {
+  id: number;
+  name: string;
+  thumbnail: string;
+  isTurn: boolean;
+  actionDisplayText: string;
+  thoughts: string;
+  reward: number;
+}
+
+export interface MancalaStep {
+  step: number;
+  players: MancalaPlayer[];
+  boardState: MancalaObservation | null;
+}
+
+// action.thoughts is the harness-curated summary and the preferred source.
+// generate_returns[0].main_response_and_thoughts is the raw LLM output;
+// use it only when the harness didn't populate thoughts.
+function parseThoughts(action?: MancalaAction): string {
+  if (action?.thoughts) return action.thoughts;
+  if (action?.generate_returns?.[0]) {
+    try {
+      const parsed = JSON.parse(action.generate_returns[0]);
+      if (parsed.main_response_and_thoughts) return parsed.main_response_and_thoughts;
+    } catch {
+      // fall through
+    }
+  }
+  return '';
+}
+
+function parseBoardState(step: MancalaReplayPlayer[]): MancalaObservation | null {
+  const raw = step?.[0]?.observation?.observationString;
+  if (typeof raw !== 'string') return null;
+  try {
+    return JSON.parse(raw) as MancalaObservation;
+  } catch {
+    return null;
+  }
+}
+
+const isRealMove = (submission: unknown): boolean =>
+  submission !== undefined && submission !== null && submission !== -1;
+
+export const mancalaTransformer = (environment: any): MancalaStep[] => {
+  const teamNames: string[] = environment?.info?.TeamNames ?? [];
+  const rawSteps: MancalaReplayPlayer[][] = environment?.steps ?? [];
+
+  return rawSteps.map((step, index): MancalaStep => {
+    const players: MancalaPlayer[] = step.map(
+      (p, i): MancalaPlayer => ({
+        id: i,
+        name: teamNames[i] || `Player ${i + 1}`,
+        thumbnail: '',
+        isTurn: isRealMove(p.action?.submission),
+        actionDisplayText: p.action?.actionString ?? '',
+        thoughts: parseThoughts(p.action),
+        reward: p.reward ?? 0,
+      })
+    );
+
+    return {
+      step: index,
+      players,
+      boardState: parseBoardState(step),
+    };
+  });
+};

--- a/kaggle_environments/envs/open_spiel_env/games/markov_soccer/visualizer/default/src/main.ts
+++ b/kaggle_environments/envs/open_spiel_env/games/markov_soccer/visualizer/default/src/main.ts
@@ -1,5 +1,6 @@
 import { createReplayVisualizer, ReplayAdapter } from '@kaggle-environments/core';
 import { renderer } from './renderer';
+import { markovSoccerTransformer } from './transformers/markovSoccerTransformer';
 import './style.css';
 
 const app = document.getElementById('app');
@@ -17,5 +18,10 @@ createReplayVisualizer(
     gameName: 'open_spiel_markov_soccer',
     renderer: renderer as any,
     ui: 'side-panel',
+    transformer: (replay) => ({
+      ...replay,
+      steps: markovSoccerTransformer(replay),
+      isTransformed: true,
+    }),
   })
 );

--- a/kaggle_environments/envs/open_spiel_env/games/markov_soccer/visualizer/default/src/main.ts
+++ b/kaggle_environments/envs/open_spiel_env/games/markov_soccer/visualizer/default/src/main.ts
@@ -21,7 +21,6 @@ createReplayVisualizer(
     transformer: (replay) => ({
       ...replay,
       steps: markovSoccerTransformer(replay),
-      isTransformed: true,
     }),
   })
 );

--- a/kaggle_environments/envs/open_spiel_env/games/markov_soccer/visualizer/default/src/renderer.ts
+++ b/kaggle_environments/envs/open_spiel_env/games/markov_soccer/visualizer/default/src/renderer.ts
@@ -1,4 +1,5 @@
 import type { RendererOptions } from '@kaggle-environments/core';
+import type { SoccerStep } from './transformers/markovSoccerTransformer';
 
 const COLOR_A = '#1f77b4';
 const COLOR_B = '#d62728';
@@ -26,19 +27,12 @@ interface SoccerState {
   ball_owner: 'A' | 'B' | null;
 }
 
-function parseObservation(step: any): SoccerState | null {
-  const raw = step?.[0]?.observation?.observationString;
-  if (!raw) return null;
-  try {
-    return JSON.parse(raw) as SoccerState;
-  } catch {
-    return null;
-  }
+function parseObservation(step: SoccerStep | undefined | null): SoccerState | null {
+  return (step?.boardState as SoccerState | null) ?? null;
 }
 
-function getLastAction(step: any, playerIdx: number): string | null {
-  const info = step?.[playerIdx]?.info;
-  const str = info?.actionSubmittedToString;
+function getLastAction(step: SoccerStep | undefined | null, playerIdx: number): string | null {
+  const str = step?.players?.[playerIdx]?.actionDisplayText;
   if (typeof str === 'string' && str !== '') return str;
   return null;
 }
@@ -306,9 +300,9 @@ function drawBoard(
   }
 }
 
-export function renderer(options: RendererOptions) {
+export function renderer(options: RendererOptions<SoccerStep[]>) {
   const { parent, replay, step } = options;
-  const steps = (replay?.steps ?? []) as any[];
+  const steps = (replay?.steps ?? []) as SoccerStep[];
   if (!steps.length) return;
 
   parent.innerHTML = `

--- a/kaggle_environments/envs/open_spiel_env/games/markov_soccer/visualizer/default/src/transformers/markovSoccerTransformer.ts
+++ b/kaggle_environments/envs/open_spiel_env/games/markov_soccer/visualizer/default/src/transformers/markovSoccerTransformer.ts
@@ -1,0 +1,106 @@
+// Markov Soccer replay transformer.
+//
+// Populates `players[]` so the side-panel can show each mover's thoughts
+// and last action, and pre-parses the observation JSON into `boardState`.
+// Markov Soccer is a simultaneous-move game — both seats submit a real
+// action every round, so both players are `isTurn: true` on played steps.
+
+interface SoccerAction {
+  submission?: number;
+  actionString?: string | null;
+  thoughts?: string | null;
+  generate_returns?: string[] | null;
+}
+
+interface SoccerReplayPlayer {
+  action?: SoccerAction;
+  info?: { actionSubmittedToString?: string | null };
+  reward: number;
+  observation: { observationString?: string };
+  status?: string;
+}
+
+interface SoccerPlayer {
+  id: number;
+  name: string;
+  thumbnail: string;
+  isTurn: boolean;
+  actionDisplayText: string;
+  thoughts: string;
+  reward: number;
+}
+
+type Pos = [number, number] | null;
+
+export interface SoccerBoardState {
+  board: string[][];
+  current_player: string;
+  is_terminal: boolean;
+  winner: 'A' | 'B' | 'draw' | null;
+  player_a_pos: Pos;
+  player_b_pos: Pos;
+  ball_pos: Pos;
+  ball_owner: 'A' | 'B' | null;
+}
+
+export interface SoccerStep {
+  step: number;
+  players: SoccerPlayer[];
+  boardState: SoccerBoardState | null;
+}
+
+// action.thoughts is the harness-curated summary and the preferred source.
+// generate_returns[0].main_response_and_thoughts is the raw LLM output;
+// use it only when the harness didn't populate thoughts.
+function parseThoughts(action?: SoccerAction): string {
+  if (action?.thoughts) return action.thoughts;
+  if (action?.generate_returns?.[0]) {
+    try {
+      const parsed = JSON.parse(action.generate_returns[0]);
+      if (parsed.main_response_and_thoughts) return parsed.main_response_and_thoughts;
+    } catch {
+      // fall through
+    }
+  }
+  return '';
+}
+
+function parseBoardState(step: SoccerReplayPlayer[]): SoccerBoardState | null {
+  const raw = step?.[0]?.observation?.observationString;
+  if (!raw) return null;
+  try {
+    return JSON.parse(raw) as SoccerBoardState;
+  } catch {
+    return null;
+  }
+}
+
+const isRealMove = (submission: unknown): boolean =>
+  submission !== undefined && submission !== null && submission !== -1;
+
+export const markovSoccerTransformer = (environment: any): SoccerStep[] => {
+  const teamNames: string[] = environment?.info?.TeamNames ?? [];
+  const rawSteps: SoccerReplayPlayer[][] = environment?.steps ?? [];
+
+  return rawSteps.map((step, index): SoccerStep => {
+    const players: SoccerPlayer[] = step.map(
+      (p, i): SoccerPlayer => ({
+        id: i,
+        name: teamNames[i] || (i === 0 ? 'Player A' : 'Player B'),
+        thumbnail: '',
+        isTurn: isRealMove(p.action?.submission),
+        // info.actionSubmittedToString is what the renderer historically
+        // displayed. Fall back to action.actionString when info is absent.
+        actionDisplayText: p.info?.actionSubmittedToString ?? p.action?.actionString ?? '',
+        thoughts: parseThoughts(p.action),
+        reward: p.reward ?? 0,
+      })
+    );
+
+    return {
+      step: index,
+      players,
+      boardState: parseBoardState(step),
+    };
+  });
+};

--- a/kaggle_environments/envs/open_spiel_env/games/negotiation/visualizer/default/src/main.ts
+++ b/kaggle_environments/envs/open_spiel_env/games/negotiation/visualizer/default/src/main.ts
@@ -1,5 +1,6 @@
 import { createReplayVisualizer, ReplayAdapter } from '@kaggle-environments/core';
 import { renderer } from './renderer';
+import { negotiationTransformer } from './transformers/negotiationTransformer';
 import './style.css';
 
 const app = document.getElementById('app');
@@ -17,5 +18,10 @@ createReplayVisualizer(
     gameName: 'open_spiel_negotiation',
     renderer: renderer as any,
     ui: 'side-panel',
+    transformer: (replay) => ({
+      ...replay,
+      steps: negotiationTransformer(replay),
+      isTransformed: true,
+    }),
   })
 );

--- a/kaggle_environments/envs/open_spiel_env/games/negotiation/visualizer/default/src/main.ts
+++ b/kaggle_environments/envs/open_spiel_env/games/negotiation/visualizer/default/src/main.ts
@@ -21,7 +21,6 @@ createReplayVisualizer(
     transformer: (replay) => ({
       ...replay,
       steps: negotiationTransformer(replay),
-      isTransformed: true,
     }),
   })
 );

--- a/kaggle_environments/envs/open_spiel_env/games/negotiation/visualizer/default/src/renderer.ts
+++ b/kaggle_environments/envs/open_spiel_env/games/negotiation/visualizer/default/src/renderer.ts
@@ -1,4 +1,5 @@
 import type { RendererOptions } from '@kaggle-environments/core';
+import type { NegotiationStep } from './transformers/negotiationTransformer';
 
 const ITEM_COLORS = ['#1f4f8b', '#9a3324', '#3c6e3c', '#7a5a1f', '#5c3a73', '#b6862c'];
 const ITEM_NAMES = ['apples', 'pears', 'grapes', 'plums', 'figs', 'limes'];
@@ -26,14 +27,8 @@ interface NegotiationObs {
   };
 }
 
-function parseObservation(step: any, playerIdx: number): NegotiationObs | null {
-  const raw = step?.[playerIdx]?.observation?.observationString;
-  if (!raw) return null;
-  try {
-    return JSON.parse(raw) as NegotiationObs;
-  } catch {
-    return null;
-  }
+function parseObservation(step: NegotiationStep | undefined | null, playerIdx: number): NegotiationObs | null {
+  return (step?.boardState?.perPlayer?.[playerIdx as 0 | 1] as NegotiationObs | null) ?? null;
 }
 
 function itemSwatch(itemIdx: number, size: number): string {
@@ -168,9 +163,9 @@ function statusText(obs: NegotiationObs): string {
     <div class="neg-status-sub">final utility: Player 1 = ${r[0]} · Player 2 = ${r[1]}</div>`;
 }
 
-export function renderer(options: RendererOptions) {
+export function renderer(options: RendererOptions<NegotiationStep[]>) {
   const { step, replay, parent } = options;
-  const steps = (replay.steps as unknown as any[]) ?? [];
+  const steps = (replay.steps as unknown as NegotiationStep[]) ?? [];
   const safeStep = Math.max(0, Math.min(step, steps.length - 1));
   const current = steps[safeStep];
 

--- a/kaggle_environments/envs/open_spiel_env/games/negotiation/visualizer/default/src/transformers/negotiationTransformer.ts
+++ b/kaggle_environments/envs/open_spiel_env/games/negotiation/visualizer/default/src/transformers/negotiationTransformer.ts
@@ -1,0 +1,118 @@
+// Negotiation replay transformer.
+//
+// Populates `players[]` so the sidebar can show each mover's thoughts and
+// their proposal/utterance action. Negotiation is a private-information
+// game — each seat's observation shows different utilities, so `boardState`
+// keeps both players' pre-parsed observations side by side.
+
+interface NegotiationAction {
+  submission?: number;
+  actionString?: string | null;
+  thoughts?: string | null;
+  generate_returns?: string[] | null;
+}
+
+interface NegotiationReplayPlayer {
+  action?: NegotiationAction;
+  reward: number;
+  observation: { observationString?: string };
+  status?: string;
+}
+
+interface NegotiationPlayer {
+  id: number;
+  name: string;
+  thumbnail: string;
+  isTurn: boolean;
+  actionDisplayText: string;
+  thoughts: string;
+  reward: number;
+}
+
+export interface NegotiationObs {
+  current_player: number;
+  viewing_player: number;
+  turn_type: 'proposal' | 'utterance' | null;
+  max_steps: number;
+  item_pool: number[];
+  my_utilities: number[];
+  proposals: Array<{ player: number; items?: number[]; accept: boolean }>;
+  utterances: Array<{ player: number; symbols: number[] }>;
+  most_recent_proposal: number[] | null;
+  most_recent_utterance: number[] | null;
+  agreement_reached: boolean;
+  is_terminal: boolean;
+  winner: number | 'draw' | null;
+  rewards: number[] | null;
+  params: {
+    num_items: number;
+    num_symbols: number;
+    utterance_dim: number;
+    enable_utterances: boolean;
+  };
+}
+
+export interface NegotiationStep {
+  step: number;
+  players: NegotiationPlayer[];
+  // Per-seat observations — both are needed because utilities are private.
+  boardState: {
+    perPlayer: [NegotiationObs | null, NegotiationObs | null];
+  } | null;
+}
+
+// action.thoughts is the harness-curated summary and the preferred source.
+// generate_returns[0].main_response_and_thoughts is the raw LLM output;
+// use it only when the harness didn't populate thoughts.
+function parseThoughts(action?: NegotiationAction): string {
+  if (action?.thoughts) return action.thoughts;
+  if (action?.generate_returns?.[0]) {
+    try {
+      const parsed = JSON.parse(action.generate_returns[0]);
+      if (parsed.main_response_and_thoughts) return parsed.main_response_and_thoughts;
+    } catch {
+      // fall through
+    }
+  }
+  return '';
+}
+
+function parseObs(raw?: string): NegotiationObs | null {
+  if (!raw) return null;
+  try {
+    return JSON.parse(raw) as NegotiationObs;
+  } catch {
+    return null;
+  }
+}
+
+const isRealMove = (submission: unknown): boolean =>
+  submission !== undefined && submission !== null && submission !== -1;
+
+export const negotiationTransformer = (environment: any): NegotiationStep[] => {
+  const teamNames: string[] = environment?.info?.TeamNames ?? [];
+  const rawSteps: NegotiationReplayPlayer[][] = environment?.steps ?? [];
+
+  return rawSteps.map((step, index): NegotiationStep => {
+    const players: NegotiationPlayer[] = step.map(
+      (p, i): NegotiationPlayer => ({
+        id: i,
+        name: teamNames[i] || `Player ${i + 1}`,
+        thumbnail: '',
+        isTurn: isRealMove(p.action?.submission),
+        actionDisplayText: p.action?.actionString ?? '',
+        thoughts: parseThoughts(p.action),
+        reward: p.reward ?? 0,
+      })
+    );
+
+    const obs0 = parseObs(step?.[0]?.observation?.observationString);
+    const obs1 = parseObs(step?.[1]?.observation?.observationString);
+
+    return {
+      step: index,
+      players,
+      boardState: obs0 || obs1 ? { perPlayer: [obs0, obs1] } : null,
+    };
+  });
+};

--- a/kaggle_environments/envs/open_spiel_env/games/python_ant_foraging/visualizer/default/src/main.ts
+++ b/kaggle_environments/envs/open_spiel_env/games/python_ant_foraging/visualizer/default/src/main.ts
@@ -1,5 +1,6 @@
 import { createReplayVisualizer, ReplayAdapter } from '@kaggle-environments/core';
 import { renderer } from './renderer';
+import { pythonAntForagingTransformer } from './transformers/pythonAntForagingTransformer';
 import './style.css';
 
 const app = document.getElementById('app');
@@ -17,5 +18,10 @@ createReplayVisualizer(
     gameName: 'open_spiel_python_ant_foraging',
     renderer: renderer as any,
     ui: 'side-panel',
+    transformer: (replay) => ({
+      ...replay,
+      steps: pythonAntForagingTransformer(replay),
+      isTransformed: true,
+    }),
   })
 );

--- a/kaggle_environments/envs/open_spiel_env/games/python_ant_foraging/visualizer/default/src/main.ts
+++ b/kaggle_environments/envs/open_spiel_env/games/python_ant_foraging/visualizer/default/src/main.ts
@@ -21,7 +21,6 @@ createReplayVisualizer(
     transformer: (replay) => ({
       ...replay,
       steps: pythonAntForagingTransformer(replay),
-      isTransformed: true,
     }),
   })
 );

--- a/kaggle_environments/envs/open_spiel_env/games/python_ant_foraging/visualizer/default/src/renderer.ts
+++ b/kaggle_environments/envs/open_spiel_env/games/python_ant_foraging/visualizer/default/src/renderer.ts
@@ -1,25 +1,7 @@
 import type { RendererOptions } from '@kaggle-environments/core';
+import type { AntStep, AntBoardState } from './transformers/pythonAntForagingTransformer';
 
-type AntForagingObservation = {
-  grid: string[][];
-  grid_size: number;
-  num_ants: number;
-  num_food: number;
-  nest_position: [number, number];
-  food_positions: [number, number][];
-  ant_positions: [number, number][];
-  carrying_food: boolean[];
-  pheromone_to_food: number[][];
-  pheromone_to_nest: number[][];
-  food_collected: number;
-  score: number;
-  turn: number;
-  max_turns: number;
-  current_player: number;
-  legal_actions: number[];
-  action_names: Record<string, string>;
-  is_terminal: boolean;
-};
+type AntForagingObservation = AntBoardState;
 
 const ANT_COLORS = ['#9a3324', '#1f4f8b', '#2e7d32', '#7b1fa2'];
 const INK = '#050001';
@@ -38,31 +20,23 @@ function getPlayerName(replay: any, idx: number): string {
   return `Ant ${idx}`;
 }
 
-function parseObservation(step: any): AntForagingObservation | null {
-  const raw = step?.[0]?.observation?.observationString;
-  if (!raw) return null;
-  try {
-    return JSON.parse(raw) as AntForagingObservation;
-  } catch {
-    return null;
-  }
+function parseObservation(step: AntStep | undefined | null): AntForagingObservation | null {
+  return step?.boardState ?? null;
 }
 
 function getLastAction(
-  replay: any,
+  steps: AntStep[],
   step: number,
   obs: AntForagingObservation
 ): { antIdx: number; name: string } | null {
   if (step <= 0) return null;
-  const steps = replay?.steps ?? [];
   const prev = steps[step - 1];
   if (!prev) return null;
-  // Find the player whose action.submission is a valid play action (not -1).
-  for (let i = 0; i < prev.length; i++) {
-    const submission = prev[i]?.action?.submission;
+  for (const player of prev.players) {
+    const submission = player.submission;
     if (typeof submission === 'number' && submission >= 0 && submission <= 4) {
       const name = obs.action_names?.[String(submission)] ?? `action ${submission}`;
-      return { antIdx: i, name };
+      return { antIdx: player.id, name };
     }
   }
   return null;
@@ -239,9 +213,9 @@ function drawBoard(
   }
 }
 
-export function renderer(options: RendererOptions) {
+export function renderer(options: RendererOptions<AntStep[]>) {
   const { parent, replay, step } = options;
-  const steps = (replay?.steps ?? []) as any[];
+  const steps = (replay?.steps ?? []) as AntStep[];
   if (!steps.length) {
     parent.innerHTML = '<div>No replay data.</div>';
     return;
@@ -253,7 +227,7 @@ export function renderer(options: RendererOptions) {
   }
   const prev = step > 0 ? parseObservation(steps[step - 1]) : null;
   const prevAntPositions = prev?.ant_positions ?? null;
-  const lastAction = getLastAction(replay, step, obs);
+  const lastAction = getLastAction(steps, step, obs);
 
   parent.innerHTML = `
     <div class="renderer-container">

--- a/kaggle_environments/envs/open_spiel_env/games/python_ant_foraging/visualizer/default/src/transformers/pythonAntForagingTransformer.ts
+++ b/kaggle_environments/envs/open_spiel_env/games/python_ant_foraging/visualizer/default/src/transformers/pythonAntForagingTransformer.ts
@@ -1,0 +1,114 @@
+// Python Ant Foraging replay transformer.
+//
+// Populates `players[]` so the sidebar shows each mover's thoughts, and
+// pre-parses the observation JSON into `boardState`.
+
+interface AntAction {
+  submission?: number;
+  actionString?: string | null;
+  thoughts?: string | null;
+  generate_returns?: string[] | null;
+}
+
+interface AntReplayPlayer {
+  action?: AntAction;
+  reward: number;
+  observation: { observationString?: string };
+  status?: string;
+}
+
+interface AntPlayer {
+  id: number;
+  name: string;
+  thumbnail: string;
+  isTurn: boolean;
+  actionDisplayText: string;
+  thoughts: string;
+  reward: number;
+  // Preserved so the renderer's `getLastAction` can look up the semantic
+  // name via boardState.action_names[submission] like before.
+  submission: number | null;
+}
+
+export interface AntBoardState {
+  grid: string[][];
+  grid_size: number;
+  num_ants: number;
+  num_food: number;
+  nest_position: [number, number];
+  food_positions: [number, number][];
+  ant_positions: [number, number][];
+  carrying_food: boolean[];
+  pheromone_to_food: number[][];
+  pheromone_to_nest: number[][];
+  food_collected: number;
+  score: number;
+  turn: number;
+  max_turns: number;
+  current_player: number;
+  legal_actions: number[];
+  action_names: Record<string, string>;
+  is_terminal: boolean;
+}
+
+export interface AntStep {
+  step: number;
+  players: AntPlayer[];
+  boardState: AntBoardState | null;
+}
+
+// action.thoughts is the harness-curated summary and the preferred source.
+// generate_returns[0].main_response_and_thoughts is the raw LLM output;
+// use it only when the harness didn't populate thoughts.
+function parseThoughts(action?: AntAction): string {
+  if (action?.thoughts) return action.thoughts;
+  if (action?.generate_returns?.[0]) {
+    try {
+      const parsed = JSON.parse(action.generate_returns[0]);
+      if (parsed.main_response_and_thoughts) return parsed.main_response_and_thoughts;
+    } catch {
+      // fall through
+    }
+  }
+  return '';
+}
+
+function parseBoardState(step: AntReplayPlayer[]): AntBoardState | null {
+  const raw = step?.[0]?.observation?.observationString;
+  if (!raw) return null;
+  try {
+    return JSON.parse(raw) as AntBoardState;
+  } catch {
+    return null;
+  }
+}
+
+const isRealMove = (submission: unknown): boolean =>
+  submission !== undefined && submission !== null && submission !== -1;
+
+export const pythonAntForagingTransformer = (environment: any): AntStep[] => {
+  const teamNames: string[] = environment?.info?.TeamNames ?? [];
+  const rawSteps: AntReplayPlayer[][] = environment?.steps ?? [];
+
+  return rawSteps.map((step, index): AntStep => {
+    const players: AntPlayer[] = step.map((p, i): AntPlayer => {
+      const sub = p.action?.submission;
+      return {
+        id: i,
+        name: teamNames[i] || `Ant ${i}`,
+        thumbnail: '',
+        isTurn: isRealMove(sub),
+        actionDisplayText: p.action?.actionString ?? '',
+        thoughts: parseThoughts(p.action),
+        reward: p.reward ?? 0,
+        submission: typeof sub === 'number' ? sub : null,
+      };
+    });
+
+    return {
+      step: index,
+      players,
+      boardState: parseBoardState(step),
+    };
+  });
+};

--- a/kaggle_environments/envs/open_spiel_env/games/snake/visualizer/default/src/main.ts
+++ b/kaggle_environments/envs/open_spiel_env/games/snake/visualizer/default/src/main.ts
@@ -21,7 +21,6 @@ createReplayVisualizer(
     transformer: (replay) => ({
       ...replay,
       steps: snakeTransformer(replay),
-      isTransformed: true,
     }),
   })
 );

--- a/kaggle_environments/envs/open_spiel_env/games/snake/visualizer/default/src/main.ts
+++ b/kaggle_environments/envs/open_spiel_env/games/snake/visualizer/default/src/main.ts
@@ -1,5 +1,6 @@
 import { createReplayVisualizer, ReplayAdapter } from '@kaggle-environments/core';
 import { renderer } from './renderer';
+import { snakeTransformer } from './transformers/snakeTransformer';
 import './style.css';
 
 const app = document.getElementById('app');
@@ -17,5 +18,10 @@ createReplayVisualizer(
     gameName: 'open_spiel_snake',
     renderer: renderer as any,
     ui: 'side-panel',
+    transformer: (replay) => ({
+      ...replay,
+      steps: snakeTransformer(replay),
+      isTransformed: true,
+    }),
   })
 );

--- a/kaggle_environments/envs/open_spiel_env/games/snake/visualizer/default/src/renderer.ts
+++ b/kaggle_environments/envs/open_spiel_env/games/snake/visualizer/default/src/renderer.ts
@@ -1,4 +1,5 @@
 import type { RendererOptions } from '@kaggle-environments/core';
+import type { SnakeStep, SnakeBoardState } from './transformers/snakeTransformer';
 
 const PLAYER_COLORS = ['#1f4f8b', '#9a3324', '#2e7d32', '#7b1fa2'];
 const HEAD_COLORS = ['#4a90e2', '#e74c3c', '#4caf50', '#ab47bc'];
@@ -7,28 +8,7 @@ const GRID_LINE = '#d6cfb0';
 const CELL_FILL = '#fbf7e8';
 const INK = '#050001';
 
-type SnakeObservation = {
-  board: string[][];
-  num_rows: number;
-  num_columns: number;
-  num_players: number;
-  foods?: [number, number][];
-  food?: [number, number] | null;
-  snakes: {
-    player: number;
-    body: [number, number][];
-    alive: boolean;
-    score: number;
-  }[];
-  scores: number[];
-  is_alive: boolean[];
-  current_player: number;
-  pending_this_turn: number[];
-  turn: number;
-  is_terminal: boolean;
-  winner: number | string | null;
-  game_over_reason: string | null;
-};
+type SnakeObservation = SnakeBoardState;
 
 function getPlayerName(replay: any, idx: number): string {
   const team = replay?.info?.TeamNames?.[idx];
@@ -38,14 +18,8 @@ function getPlayerName(replay: any, idx: number): string {
   return `Player ${idx}`;
 }
 
-function parseObservation(step: any): SnakeObservation | null {
-  const raw = step?.[0]?.observation?.observationString;
-  if (!raw) return null;
-  try {
-    return JSON.parse(raw) as SnakeObservation;
-  } catch {
-    return null;
-  }
+function parseObservation(step: SnakeStep | undefined | null): SnakeObservation | null {
+  return step?.boardState ?? null;
 }
 
 function drawBoard(ctx: CanvasRenderingContext2D, width: number, height: number, obs: SnakeObservation) {
@@ -117,9 +91,9 @@ function drawBoard(ctx: CanvasRenderingContext2D, width: number, height: number,
   }
 }
 
-export function renderer(options: RendererOptions) {
+export function renderer(options: RendererOptions<SnakeStep[]>) {
   const { parent, replay, step } = options;
-  const steps = replay?.steps ?? [];
+  const steps = (replay?.steps ?? []) as SnakeStep[];
   if (!steps.length) {
     parent.innerHTML = '<div>No replay data.</div>';
     return;

--- a/kaggle_environments/envs/open_spiel_env/games/snake/visualizer/default/src/transformers/snakeTransformer.ts
+++ b/kaggle_environments/envs/open_spiel_env/games/snake/visualizer/default/src/transformers/snakeTransformer.ts
@@ -1,0 +1,112 @@
+// Snake replay transformer.
+//
+// Populates `players[]` so the side-panel sidebar can render each mover's
+// thoughts / action label, and pre-parses the observation JSON into
+// `boardState` for the renderer.
+
+interface SnakeAction {
+  submission?: number;
+  actionString?: string | null;
+  thoughts?: string | null;
+  generate_returns?: string[] | null;
+}
+
+interface SnakeReplayPlayer {
+  action?: SnakeAction;
+  reward: number;
+  observation: { observationString?: string };
+  status?: string;
+}
+
+interface SnakePlayer {
+  id: number;
+  name: string;
+  thumbnail: string;
+  isTurn: boolean;
+  actionDisplayText: string;
+  thoughts: string;
+  reward: number;
+}
+
+export interface SnakeBoardState {
+  board: string[][];
+  num_rows: number;
+  num_columns: number;
+  num_players: number;
+  foods?: [number, number][];
+  food?: [number, number] | null;
+  snakes: {
+    player: number;
+    body: [number, number][];
+    alive: boolean;
+    score: number;
+  }[];
+  scores: number[];
+  is_alive: boolean[];
+  current_player: number;
+  pending_this_turn: number[];
+  turn: number;
+  is_terminal: boolean;
+  winner: number | string | null;
+  game_over_reason: string | null;
+}
+
+export interface SnakeStep {
+  step: number;
+  players: SnakePlayer[];
+  boardState: SnakeBoardState | null;
+}
+
+// action.thoughts is the harness-curated summary and the preferred source.
+// generate_returns[0].main_response_and_thoughts is the raw LLM output;
+// use it only when the harness didn't populate thoughts.
+function parseThoughts(action?: SnakeAction): string {
+  if (action?.thoughts) return action.thoughts;
+  if (action?.generate_returns?.[0]) {
+    try {
+      const parsed = JSON.parse(action.generate_returns[0]);
+      if (parsed.main_response_and_thoughts) return parsed.main_response_and_thoughts;
+    } catch {
+      // fall through
+    }
+  }
+  return '';
+}
+
+function parseBoardState(step: SnakeReplayPlayer[]): SnakeBoardState | null {
+  const raw = step?.[0]?.observation?.observationString;
+  if (!raw) return null;
+  try {
+    return JSON.parse(raw) as SnakeBoardState;
+  } catch {
+    return null;
+  }
+}
+
+const isRealMove = (submission: unknown): boolean =>
+  submission !== undefined && submission !== null && submission !== -1;
+
+export const snakeTransformer = (environment: any): SnakeStep[] => {
+  const teamNames: string[] = environment?.info?.TeamNames ?? [];
+  const rawSteps: SnakeReplayPlayer[][] = environment?.steps ?? [];
+
+  return rawSteps.map((step, index): SnakeStep => {
+    const players: SnakePlayer[] = step.map(
+      (p, i): SnakePlayer => ({
+        id: i,
+        name: teamNames[i] || `Player ${i}`,
+        thumbnail: '',
+        isTurn: isRealMove(p.action?.submission),
+        actionDisplayText: p.action?.actionString ?? '',
+        thoughts: parseThoughts(p.action),
+        reward: p.reward ?? 0,
+      })
+    );
+
+    return {
+      step: index,
+      players,
+      boardState: parseBoardState(step),
+    };
+  });
+};


### PR DESCRIPTION
The presence of a transformer is what causes steps and thoughts to be rendered on the sidebar.

ACK most of these are abandoned games, but https://github.com/Kaggle/kaggle-environments/pull/1328 updates the `create-visualizer` skill to always create a transformer and we may as well backfill.