### PR TITLE
Extract OpenSpiel visualizer helpers from Nine Men's Morris

### DIFF
--- a/kaggle_environments/envs/open_spiel_env/games/nine_mens_morris/visualizer/default/src/transformers/nineMensMorrisTransformer.ts
+++ b/kaggle_environments/envs/open_spiel_env/games/nine_mens_morris/visualizer/default/src/transformers/nineMensMorrisTransformer.ts
@@ -8,41 +8,17 @@
 // action in a step; the inactive player submits -1. The env also emits two
 // setup steps at the start with both submissions == -1, which we drop.
 //
-// Forfeits (illegal-move / TIMEOUT / ERROR) end the game without OpenSpiel
-// reaching a terminal state. We detect them here so the renderer can label
-// the ending explicitly instead of falling back to a stale "Turn: X" line.
+// Forfeit handling (illegal-move / TIMEOUT / ERROR) is delegated to the
+// shared helpers in @kaggle-environments/core so that every OpenSpiel game
+// labels early terminations the same way.
 
-// Reasons the env sets on a player's top-level status when they fail to
-// produce a legal action. The illegal-move path additionally routes through
-// action.submission === -1 with a non-null action.status, because in that
-// branch open_spiel_env normalizes both top-level statuses to DONE.
-const FORFEIT_STATUSES = new Set(['TIMEOUT', 'ERROR', 'INVALID']);
-
-const FORFEIT_REASONS: Record<string, string> = {
-  TIMEOUT: 'ran out of time',
-  INVALID: 'submitted an illegal move',
-  ERROR: 'failed to produce valid input',
-};
-
-interface NineMensMorrisAction {
-  submission?: number;
-  actionString?: string | null;
-  thoughts?: string | null;
-  status?: string | null;
-  generate_returns?: string[] | null;
-}
-
-interface NineMensMorrisObservation {
-  observationString?: string;
-  isTerminal?: boolean;
-}
-
-interface NineMensMorrisReplayPlayer {
-  action?: NineMensMorrisAction;
-  reward: number;
-  observation: NineMensMorrisObservation;
-  status?: string;
-}
+import {
+  detectForfeit,
+  buildForfeitReason,
+  deriveWinnerFromRewards,
+  parseThoughts,
+  OpenSpielRawPlayer,
+} from '@kaggle-environments/core';
 
 interface NineMensMorrisPlayer {
   id: number;
@@ -82,25 +58,7 @@ export interface NineMensMorrisStep {
   forfeitReason: string | null;
 }
 
-// action.thoughts is the harness-curated summary and the preferred source.
-// generate_returns[0].main_response_and_thoughts is the raw LLM output;
-// use it only when the harness didn't populate thoughts.
-function parseThoughts(action?: NineMensMorrisAction): string {
-  if (action?.thoughts) return action.thoughts;
-  if (action?.generate_returns?.[0]) {
-    try {
-      const parsed = JSON.parse(action.generate_returns[0]);
-      if (parsed.main_response_and_thoughts) {
-        return parsed.main_response_and_thoughts;
-      }
-    } catch {
-      // fall through
-    }
-  }
-  return '';
-}
-
-function parseBoardState(step: NineMensMorrisReplayPlayer[]): NineMensMorrisBoardState | null {
+function parseBoardState(step: OpenSpielRawPlayer[]): NineMensMorrisBoardState | null {
   const raw = step?.[0]?.observation?.observationString ?? step?.[1]?.observation?.observationString;
   if (!raw) return null;
   try {
@@ -110,40 +68,9 @@ function parseBoardState(step: NineMensMorrisReplayPlayer[]): NineMensMorrisBoar
   }
 }
 
-function deriveWinner(step: NineMensMorrisReplayPlayer[], teamNames: string[]): string | null {
-  if (step.length < 2) return null;
-  const r0 = step[0].reward ?? 0;
-  const r1 = step[1].reward ?? 0;
-  if (r0 === r1) return 'Draw';
-  return r0 > r1 ? `${teamNames[0]} wins!` : `${teamNames[1]} wins!`;
-}
-
-// Detect if this raw step is a forfeit by a single player. Returns the index
-// of the forfeiter and the reason category (TIMEOUT / ERROR / INVALID), or
-// null if not a forfeit / ambiguous.
-function detectForfeit(step: NineMensMorrisReplayPlayer[]): { index: number; reasonKey: string } | null {
-  if (step.length < 2) return null;
-
-  const statusForfeiters = step.map((p, i) => ({ p, i })).filter(({ p }) => p.status && FORFEIT_STATUSES.has(p.status));
-  if (statusForfeiters.length === 1) {
-    return { index: statusForfeiters[0].i, reasonKey: statusForfeiters[0].p.status! };
-  }
-  if (statusForfeiters.length > 1) return null;
-
-  // illegalMoveForfeit path: env sets both top-level statuses to DONE, but
-  // the offender's action carries submission=-1 with a self-reported status.
-  const actionForfeiters = step
-    .map((p, i) => ({ p, i }))
-    .filter(({ p }) => p.action?.submission === -1 && !!p.action?.status);
-  if (actionForfeiters.length === 1) {
-    return { index: actionForfeiters[0].i, reasonKey: 'INVALID' };
-  }
-  return null;
-}
-
 export const nineMensMorrisTransformer = (environment: any): NineMensMorrisStep[] => {
   const teamNames: string[] = environment?.info?.TeamNames ?? ['Player W', 'Player B'];
-  const rawSteps: NineMensMorrisReplayPlayer[][] = environment?.steps ?? [];
+  const rawSteps: OpenSpielRawPlayer[][] = environment?.steps ?? [];
   const out: NineMensMorrisStep[] = [];
 
   rawSteps.forEach((step, index) => {
@@ -155,7 +82,7 @@ export const nineMensMorrisTransformer = (environment: any): NineMensMorrisStep[
       // A forfeit step's offender has submission === -1 but should still be
       // treated as "acting" so the step is retained and their thoughts /
       // last-attempt render in the side panel.
-      const isTurn = (submission !== undefined && submission !== -1) || isForfeiter;
+      const isTurn = (submission !== undefined && submission !== null && submission !== -1) || isForfeiter;
       return {
         id: i,
         name: teamNames[i] ?? (i === 0 ? 'Player W' : 'Player B'),
@@ -179,21 +106,13 @@ export const nineMensMorrisTransformer = (environment: any): NineMensMorrisStep[
     // terminal; treat it as terminal so downstream UI shows the end state.
     const isTerminal = observationTerminal || forfeit !== null;
 
-    let forfeitReason: string | null = null;
-    if (forfeit) {
-      const loser = teamNames[forfeit.index] ?? `Player ${forfeit.index + 1}`;
-      const winner = teamNames[1 - forfeit.index] ?? `Player ${2 - forfeit.index}`;
-      const reason = FORFEIT_REASONS[forfeit.reasonKey] ?? 'forfeited';
-      forfeitReason = `${loser} ${reason}. ${winner} wins by default.`;
-    }
-
     out.push({
       step: index,
       players,
       boardState: parseBoardState(step),
       isTerminal,
-      winner: isTerminal ? deriveWinner(step, teamNames) : null,
-      forfeitReason,
+      winner: isTerminal ? deriveWinnerFromRewards(step, teamNames) : null,
+      forfeitReason: forfeit ? buildForfeitReason(forfeit, teamNames) : null,
     });
   });
 

--- a/web/core/src/index.ts
+++ b/web/core/src/index.ts
@@ -12,6 +12,11 @@ export * from './replay-visualizer-factory/replay-visualizer-factory';
 export * from './timing/timing';
 export * from './transformers/transformers';
 
+// OpenSpiel-specific transformer helpers
+export * from './openSpiel/types';
+export * from './openSpiel/forfeit';
+export * from './openSpiel/transformer';
+
 // Components
 export * from './components';
 

--- a/web/core/src/openSpiel/forfeit.test.ts
+++ b/web/core/src/openSpiel/forfeit.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect } from 'vitest';
+import { detectForfeit, buildForfeitReason, FORFEIT_STATUSES, FORFEIT_REASONS } from './forfeit';
+import { OpenSpielRawPlayer } from './types';
+
+const activePlayer = (opts: Partial<OpenSpielRawPlayer> = {}): OpenSpielRawPlayer => ({
+  action: { submission: 0, actionString: 'move' },
+  observation: {},
+  reward: 0,
+  status: 'DONE',
+  ...opts,
+});
+
+describe('detectForfeit', () => {
+  it('returns null for invalid input', () => {
+    expect(detectForfeit(null)).toBeNull();
+    expect(detectForfeit(undefined)).toBeNull();
+    expect(detectForfeit([])).toBeNull();
+    expect(detectForfeit([activePlayer()])).toBeNull();
+  });
+
+  it('returns null for a normal step', () => {
+    expect(detectForfeit([activePlayer(), activePlayer({ action: { submission: -1 } })])).toBeNull();
+  });
+
+  for (const key of ['TIMEOUT', 'ERROR', 'INVALID']) {
+    it(`detects top-level status ${key}`, () => {
+      const result = detectForfeit([activePlayer({ status: key }), activePlayer()]);
+      expect(result).toEqual({ index: 0, reasonKey: key });
+    });
+  }
+
+  it('detects illegalMoveForfeit path (submission=-1 + action.status, both DONE)', () => {
+    const result = detectForfeit([
+      activePlayer(),
+      activePlayer({ action: { submission: -1, status: 'failed to parse' } }),
+    ]);
+    expect(result).toEqual({ index: 1, reasonKey: 'INVALID' });
+  });
+
+  it('returns null when both players carry a forfeit top-level status', () => {
+    expect(detectForfeit([activePlayer({ status: 'TIMEOUT' }), activePlayer({ status: 'ERROR' })])).toBeNull();
+  });
+
+  it('does not fire on action.submission=-1 without an action.status', () => {
+    expect(detectForfeit([activePlayer(), activePlayer({ action: { submission: -1 } })])).toBeNull();
+  });
+
+  it('prefers top-level status over action-status signal', () => {
+    const result = detectForfeit([
+      activePlayer({ status: 'TIMEOUT' }),
+      activePlayer({ action: { submission: -1, status: 'illegal' } }),
+    ]);
+    expect(result).toEqual({ index: 0, reasonKey: 'TIMEOUT' });
+  });
+});
+
+describe('buildForfeitReason', () => {
+  it('names loser and winner with the standard reason phrase', () => {
+    expect(buildForfeitReason({ index: 0, reasonKey: 'TIMEOUT' }, ['Alice', 'Bob'])).toBe(
+      'Alice ran out of time. Bob wins by default.'
+    );
+    expect(buildForfeitReason({ index: 1, reasonKey: 'INVALID' }, ['Alice', 'Bob'])).toBe(
+      'Bob submitted an illegal move. Alice wins by default.'
+    );
+  });
+
+  it('falls back to Player N labels when team names missing', () => {
+    expect(buildForfeitReason({ index: 1, reasonKey: 'ERROR' }, [])).toBe(
+      'Player 2 failed to produce valid input. Player 1 wins by default.'
+    );
+  });
+
+  it('falls back to a generic verb for unknown reason keys', () => {
+    expect(buildForfeitReason({ index: 0, reasonKey: 'MYSTERY' }, ['A', 'B'])).toBe('A forfeited. B wins by default.');
+  });
+});
+
+describe('exported constants', () => {
+  it('FORFEIT_STATUSES contains the three canonical keys', () => {
+    expect(FORFEIT_STATUSES.has('TIMEOUT')).toBe(true);
+    expect(FORFEIT_STATUSES.has('ERROR')).toBe(true);
+    expect(FORFEIT_STATUSES.has('INVALID')).toBe(true);
+    expect(FORFEIT_STATUSES.has('DONE')).toBe(false);
+  });
+
+  it('FORFEIT_REASONS maps each status key', () => {
+    expect(FORFEIT_REASONS.TIMEOUT).toBeTruthy();
+    expect(FORFEIT_REASONS.INVALID).toBeTruthy();
+    expect(FORFEIT_REASONS.ERROR).toBeTruthy();
+  });
+});

--- a/web/core/src/openSpiel/forfeit.ts
+++ b/web/core/src/openSpiel/forfeit.ts
@@ -1,0 +1,58 @@
+// Forfeit-detection helpers for OpenSpiel game visualizers.
+//
+// `open_spiel_env` can end an episode without OpenSpiel itself reaching a
+// terminal state -- when a player exhausts their illegal-move retries, times
+// out, or crashes. Renderers that only look at `observation.isTerminal` /
+// `observation.winner` will freeze on the last mid-game frame with a stale
+// "Turn: X" line. These helpers give per-game transformers a uniform way to
+// spot the three forfeit signals and label the ending explicitly.
+
+import { OpenSpielRawPlayer } from './types';
+
+// Reasons the env sets on a player's top-level status when they fail to
+// produce a legal action. The illegal-move path additionally routes through
+// action.submission === -1 with a non-null action.status, because in that
+// branch open_spiel_env normalizes both top-level statuses to DONE.
+export const FORFEIT_STATUSES: ReadonlySet<string> = new Set(['TIMEOUT', 'ERROR', 'INVALID']);
+
+export const FORFEIT_REASONS: Readonly<Record<string, string>> = {
+  TIMEOUT: 'ran out of time',
+  INVALID: 'submitted an illegal move',
+  ERROR: 'failed to produce valid input',
+};
+
+export interface ForfeitInfo {
+  index: number;
+  reasonKey: string;
+}
+
+// Detect if this raw step is a forfeit by a single player. Returns the index
+// of the forfeiter and the reason category (TIMEOUT / ERROR / INVALID), or
+// null if not a forfeit / ambiguous (e.g. both players forfeited).
+export function detectForfeit(step: OpenSpielRawPlayer[] | undefined | null): ForfeitInfo | null {
+  if (!Array.isArray(step) || step.length < 2) return null;
+
+  const statusForfeiters = step.map((p, i) => ({ p, i })).filter(({ p }) => p.status && FORFEIT_STATUSES.has(p.status));
+  if (statusForfeiters.length === 1) {
+    return { index: statusForfeiters[0].i, reasonKey: statusForfeiters[0].p.status! };
+  }
+  if (statusForfeiters.length > 1) return null;
+
+  // illegalMoveForfeit path: env sets both top-level statuses to DONE, but
+  // the offender's action carries submission=-1 with a self-reported status.
+  const actionForfeiters = step
+    .map((p, i) => ({ p, i }))
+    .filter(({ p }) => p.action?.submission === -1 && !!p.action?.status);
+  if (actionForfeiters.length === 1) {
+    return { index: actionForfeiters[0].i, reasonKey: 'INVALID' };
+  }
+  return null;
+}
+
+// Compose the human-readable "X forfeited. Y wins by default." line.
+export function buildForfeitReason(forfeit: ForfeitInfo, teamNames: string[]): string {
+  const loser = teamNames[forfeit.index] ?? `Player ${forfeit.index + 1}`;
+  const winner = teamNames[1 - forfeit.index] ?? `Player ${2 - forfeit.index}`;
+  const reason = FORFEIT_REASONS[forfeit.reasonKey] ?? 'forfeited';
+  return `${loser} ${reason}. ${winner} wins by default.`;
+}

--- a/web/core/src/openSpiel/transformer.test.ts
+++ b/web/core/src/openSpiel/transformer.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from 'vitest';
+import { parseThoughts, deriveWinnerFromRewards } from './transformer';
+import { OpenSpielRawPlayer } from './types';
+
+describe('parseThoughts', () => {
+  it('returns empty string when no action', () => {
+    expect(parseThoughts(undefined)).toBe('');
+    expect(parseThoughts({})).toBe('');
+  });
+
+  it('prefers action.thoughts over generate_returns', () => {
+    expect(
+      parseThoughts({
+        thoughts: 'from harness',
+        generate_returns: [JSON.stringify({ main_response_and_thoughts: 'from raw' })],
+      })
+    ).toBe('from harness');
+  });
+
+  it('falls back to generate_returns[0].main_response_and_thoughts', () => {
+    expect(
+      parseThoughts({
+        generate_returns: [JSON.stringify({ main_response_and_thoughts: 'from raw' })],
+      })
+    ).toBe('from raw');
+  });
+
+  it('returns empty string on invalid JSON fallback', () => {
+    expect(parseThoughts({ generate_returns: ['not json'] })).toBe('');
+  });
+});
+
+describe('deriveWinnerFromRewards', () => {
+  const p = (reward: number): OpenSpielRawPlayer => ({ reward, observation: {} });
+
+  it('returns null for degenerate step', () => {
+    expect(deriveWinnerFromRewards([], ['A', 'B'])).toBeNull();
+    expect(deriveWinnerFromRewards([p(1)], ['A', 'B'])).toBeNull();
+  });
+
+  it('returns Draw on equal rewards', () => {
+    expect(deriveWinnerFromRewards([p(0), p(0)], ['A', 'B'])).toBe('Draw');
+    expect(deriveWinnerFromRewards([p(1), p(1)], ['A', 'B'])).toBe('Draw');
+  });
+
+  it('picks the higher-reward player', () => {
+    expect(deriveWinnerFromRewards([p(1), p(-1)], ['Alice', 'Bob'])).toBe('Alice wins!');
+    expect(deriveWinnerFromRewards([p(-1), p(1)], ['Alice', 'Bob'])).toBe('Bob wins!');
+  });
+
+  it('honors the custom suffix', () => {
+    expect(deriveWinnerFromRewards([p(1), p(-1)], ['Alice', 'Bob'], 'takes it.')).toBe('Alice takes it.');
+  });
+});

--- a/web/core/src/openSpiel/transformer.ts
+++ b/web/core/src/openSpiel/transformer.ts
@@ -1,0 +1,39 @@
+// Generic transformer helpers for OpenSpiel game visualizers -- pulling
+// model thoughts out of harness output, deriving a winner from reward
+// signs on a terminal step, etc.
+
+import { OpenSpielRawAction, OpenSpielRawPlayer } from './types';
+
+// action.thoughts is the harness-curated summary and the preferred source.
+// generate_returns[0].main_response_and_thoughts is the raw LLM output;
+// use it only when the harness didn't populate thoughts.
+export function parseThoughts(action?: OpenSpielRawAction): string {
+  if (action?.thoughts) return action.thoughts;
+  if (action?.generate_returns?.[0]) {
+    try {
+      const parsed = JSON.parse(action.generate_returns[0]);
+      if (parsed.main_response_and_thoughts) {
+        return parsed.main_response_and_thoughts;
+      }
+    } catch {
+      // fall through
+    }
+  }
+  return '';
+}
+
+// Reward-sign winner derivation. Works for any 2-player terminal, and is
+// the fallback path when a forfeit ends the game before OpenSpiel's own
+// winner field is set. Returns "Draw" on equal rewards.
+export function deriveWinnerFromRewards(
+  step: OpenSpielRawPlayer[],
+  teamNames: string[],
+  winnerSuffix = 'wins!'
+): string | null {
+  if (!Array.isArray(step) || step.length < 2) return null;
+  const r0 = step[0].reward ?? 0;
+  const r1 = step[1].reward ?? 0;
+  if (r0 === r1) return 'Draw';
+  const winnerName = r0 > r1 ? teamNames[0] : teamNames[1];
+  return `${winnerName} ${winnerSuffix}`;
+}

--- a/web/core/src/openSpiel/types.ts
+++ b/web/core/src/openSpiel/types.ts
@@ -1,0 +1,24 @@
+// Raw step shape produced by `open_spiel_env` and consumed by every
+// OpenSpiel-game visualizer transformer. Kept intentionally loose (all
+// fields optional) because the env fills different subsets depending on
+// the phase (setup steps, active turns, forfeit / terminal steps).
+
+export interface OpenSpielRawAction {
+  submission?: number | null;
+  actionString?: string | null;
+  thoughts?: string | null;
+  status?: string | null;
+  generate_returns?: string[] | null;
+}
+
+export interface OpenSpielRawObservation {
+  observationString?: string;
+  isTerminal?: boolean;
+}
+
+export interface OpenSpielRawPlayer {
+  action?: OpenSpielRawAction;
+  observation?: OpenSpielRawObservation;
+  reward?: number;
+  status?: string;
+}


### PR DESCRIPTION
Most importantly, extract common forfeit parsing logic. If this looks good and Nine Men's Morris behaves as expected, I will take a pass to use it in all open Spiel visualizers that are not handling forfeits yet.