### PR TITLE
Demote OpenSpiel per-game load list to DEBUG

### DIFF
--- a/kaggle_environments/envs/open_spiel_env/open_spiel_env.py
+++ b/kaggle_environments/envs/open_spiel_env/open_spiel_env.py
@@ -972,10 +972,10 @@ def _register_game_envs(games_list: list[str]) -> dict[str, Any]:
 
     _log.info(f"Successfully loaded OpenSpiel environments: {len(registered_envs)}.")
     for env_name in registered_envs:
-        _log.info(f"   {env_name}")
+        _log.debug(f"   {env_name}")
     _log.info(f"OpenSpiel games skipped: {len(skipped_games)}.")
     for game_string in skipped_games:
-        _log.info(f"   {game_string}")
+        _log.debug(f"   {game_string}")
 
     return registered_envs
 


### PR DESCRIPTION
The per-game success/skip enumeration in _register_game_envs prints ~44 lines on every import of kaggle_environments. Move the individual entries to DEBUG so only the two summary lines ('Successfully loaded ... N', 'OpenSpiel games skipped: M') show at INFO. Set LOG_LEVEL=DEBUG on the open_spiel_env logger to see the full list.