### PR TITLE
Make snake env use SIMULTANEOUS dynamics

### DIFF
--- a/kaggle_environments/envs/open_spiel_env/games/snake/snake_game.py
+++ b/kaggle_environments/envs/open_spiel_env/games/snake/snake_game.py
@@ -16,7 +16,7 @@ _FOOD_RESPAWN_INTERVAL = 10
 _GAME_TYPE = pyspiel.GameType(
     short_name="snake",
     long_name="Snake",
-    dynamics=pyspiel.GameType.Dynamics.SEQUENTIAL,
+    dynamics=pyspiel.GameType.Dynamics.SIMULTANEOUS,
     chance_mode=pyspiel.GameType.ChanceMode.DETERMINISTIC,
     information=pyspiel.GameType.Information.PERFECT_INFORMATION,
     utility=pyspiel.GameType.Utility.GENERAL_SUM,
@@ -61,9 +61,7 @@ class SnakeGame(pyspiel.Game):
         self.cols = params.get("columns", _NUM_COLS) if params else _NUM_COLS
         self._num_players = params.get("players", _NUM_PLAYERS) if params else _NUM_PLAYERS
         self.food_respawn_interval = (
-            params.get("food_respawn_interval", _FOOD_RESPAWN_INTERVAL)
-            if params
-            else _FOOD_RESPAWN_INTERVAL
+            params.get("food_respawn_interval", _FOOD_RESPAWN_INTERVAL) if params else _FOOD_RESPAWN_INTERVAL
         )
 
         # Update game info with dynamic player count
@@ -127,8 +125,6 @@ class SnakeState(pyspiel.State):
         self._steps = 0
         self._last_food_spawn_step = 0
         self._place_foods()
-        self._next_player = 0
-        self._move_buffer = [None] * self.num_players
         # Per-round log of applied actions (one inner list per simultaneous
         # round). Lets the harness expose opponent moves to each player; in
         # simultaneous-move snake this is otherwise invisible.
@@ -179,36 +175,33 @@ class SnakeState(pyspiel.State):
         """Returns id of the next player to move."""
         if self._is_terminal:
             return pyspiel.PlayerId.TERMINAL
-        return self._next_player
+        return pyspiel.PlayerId.SIMULTANEOUS
 
-    def _legal_actions(self, player=None):
-        """Returns a list of legal actions."""
-        del player
+    def _legal_actions(self, player):
+        """Returns a list of legal actions for the given player.
+
+        Dead players return an empty list, which the interpreter uses to
+        mark them INACTIVE at simultaneous nodes.
+        """
         if self._is_terminal:
             return []
-        # If player is dead, their only action is pass/nothing,
-        # but OpenSpiel doesn't have PASS for simultaneous easily wrapped in
-        # sequential.
-        # We'll just allow any action and ignore it if dead.
+        if 0 <= player < self.num_players and not self.is_alive[player]:
+            return []
         return [a.value for a in Action]
 
-    def _apply_action(self, action):
-        """Applies the specified action to the state."""
-        # Store move
-        self._move_buffer[self._next_player] = action
+    def _apply_actions(self, actions):
+        """Applies one action per player at a simultaneous node."""
+        # Dead players are passed pyspiel.INVALID_ACTION by the interpreter;
+        # normalize to None so downstream code doesn't have to special-case it.
+        move_buffer = [
+            actions[i] if (0 <= i < len(actions) and actions[i] != pyspiel.INVALID_ACTION) else None
+            for i in range(self.num_players)
+        ]
+        self._process_simultaneous_turn(move_buffer)
 
-        # Move to next player
-        self._next_player += 1
-
-        # If all players have moved, process the turn
-        if self._next_player >= self.num_players:
-            self._process_simultaneous_turn()
-            self._next_player = 0
-            self._move_buffer = [None] * self.num_players
-
-    def _process_simultaneous_turn(self):
+    def _process_simultaneous_turn(self, move_buffer):
         self._steps += 1
-        self._round_history.append(list(self._move_buffer))
+        self._round_history.append(list(move_buffer))
 
         # Calculate new heads
         new_heads = []
@@ -217,7 +210,7 @@ class SnakeState(pyspiel.State):
                 new_heads.append(None)
                 continue
 
-            action = self._move_buffer[i]
+            action = move_buffer[i]
             if not self.snakes[i]:
                 new_heads.append(None)
                 continue
@@ -342,9 +335,7 @@ class SnakeState(pyspiel.State):
         # turns have elapsed since the last spawn. Either trigger resets the
         # timer for the next spawn.
         if self.food_respawn_interval > 0:
-            interval_elapsed = (
-                self._steps - self._last_food_spawn_step >= self.food_respawn_interval
-            )
+            interval_elapsed = self._steps - self._last_food_spawn_step >= self.food_respawn_interval
             if not self.foods or interval_elapsed:
                 self._place_foods()
 

--- a/kaggle_environments/envs/open_spiel_env/games/snake/snake_proxy.py
+++ b/kaggle_environments/envs/open_spiel_env/games/snake/snake_proxy.py
@@ -1,9 +1,8 @@
 """Structured JSON observations for the custom Snake game.
 
 The Snake game (see ``snake_game.py``) is a multi-snake grid game with
-simultaneous-move semantics implemented sequentially: each turn cycles
-through players 0..N-1, buffering their actions, and on player N-1's
-move the buffered actions are applied together. Actions are
+simultaneous-move dynamics: every turn all snakes submit an action and
+the moves are applied together. Actions are
 ``0=UP, 1=DOWN, 2=LEFT, 3=RIGHT``.
 
 This proxy exposes the state as structured JSON so agents and the
@@ -30,6 +29,16 @@ _EMPTY_CHAR = "."
 
 class SnakeState(proxy.State):
     """Snake state proxy with JSON observations."""
+
+    def _apply_actions(self, actions: list[int]) -> None:
+        # Override for simultaneous-move games; the proxy base class only
+        # forwards the sequential _apply_action.
+        return self.__wrapped__.apply_actions(actions)
+
+    def _player_label(self, player: int) -> int | str:
+        if player < 0:
+            return pyspiel.PlayerId(player).name.lower()
+        return player
 
     def _board(self, snakes: list[list[list[int]]], is_alive: list[bool], foods: list[list[int]]) -> list[list[str]]:
         rows = self.__wrapped__.rows
@@ -61,9 +70,7 @@ class SnakeState(proxy.State):
         turn = int(getattr(wrapped, "_steps", 0))
         if food_respawn_interval > 0:
             last_spawn = int(getattr(wrapped, "_last_food_spawn_step", 0))
-            turns_until_respawn = max(
-                0, food_respawn_interval - (turn - last_spawn)
-            )
+            turns_until_respawn = max(0, food_respawn_interval - (turn - last_spawn))
         else:
             turns_until_respawn = None
 
@@ -83,17 +90,8 @@ class SnakeState(proxy.State):
             for i in range(wrapped.num_players)
         ]
 
-        # While players are buffering moves for the current turn (sequential
-        # implementation of simultaneous play), expose who is acting next and
-        # which players have already submitted this turn.
-        buffer = [a for a in getattr(wrapped, "_move_buffer", [])]
-        pending = [i for i, a in enumerate(buffer) if a is not None]
-
         round_history = [
-            [
-                _Action(a).name if a is not None and 0 <= a < len(_Action) else None
-                for a in round_moves
-            ]
+            [_Action(a).name if a is not None and 0 <= a < len(_Action) else None for a in round_moves]
             for round_moves in getattr(wrapped, "_round_history", [])
         ]
 
@@ -109,8 +107,7 @@ class SnakeState(proxy.State):
             "snakes": snake_objs,
             "scores": scores,
             "is_alive": is_alive,
-            "current_player": self.current_player(),
-            "pending_this_turn": pending,
+            "current_player": self._player_label(self.current_player()),
             "round_history": round_history,
             "turn": turn,
             "is_terminal": is_terminal,

--- a/kaggle_environments/envs/open_spiel_env/games/snake/visualizer/default/replays/test-replay.json
+++ b/kaggle_environments/envs/open_spiel_env/games/snake/visualizer/default/replays/test-replay.json
@@ -1,19 +1,20 @@
 {
-  "id": "b93ea0ce-552d-11f1-8652-bae7cb43ed0b",
+  "id": "2e64a06e-8559-11f1-90b3-ca9d63c29872",
   "name": "open_spiel_snake",
   "title": "Open Spiel: snake",
   "description": "Kaggle environment wrapper for OpenSpiel games.\nFor game implementation details see:\nhttps://github.com/google-deepmind/open_spiel/tree/master/open_spiel/games",
   "version": "0.1.0",
-  "module_version": "1.18.0",
+  "module_version": "1.30.1",
   "configuration": {
     "includeLegalActions": true,
-    "episodeSteps": 300,
+    "episodeSteps": 500,
     "actTimeout": 3600,
     "runTimeout": 172800,
-    "openSpielGameString": "snake_proxy(columns=10,players=2,rows=10)",
+    "openSpielGameString": "snake_proxy(columns=10,food_respawn_interval=10,players=2,rows=10)",
     "openSpielGameName": "snake",
     "openSpielGameParameters": {
       "columns": 10,
+      "food_respawn_interval": 10,
       "players": 2,
       "rows": 10
     },
@@ -24,6 +25,7 @@
     "metadata": {},
     "strictMode": false,
     "savePrompt": true,
+    "saveResponse": true,
     "freeForm": false,
     "includeGenerateReturns": false,
     "illegalMoveForfeit": true
@@ -36,13 +38,15 @@
         "submission": -1
       }
     },
-    "agents": [2],
+    "agents": [
+      2
+    ],
     "configuration": {
       "episodeSteps": {
         "description": "Maximum number of steps in the episode.",
         "type": "integer",
         "minimum": 1,
-        "default": 300
+        "default": 500
       },
       "actTimeout": {
         "description": "Maximum runtime (seconds) to obtain an action from an agent.",
@@ -59,7 +63,7 @@
       "openSpielGameString": {
         "description": "The full game string including parameters.",
         "type": "string",
-        "default": "snake_proxy(columns=10,players=2,rows=10)"
+        "default": "snake_proxy(columns=10,food_respawn_interval=10,players=2,rows=10)"
       },
       "openSpielGameName": {
         "description": "The short_name of the OpenSpiel game to load.",
@@ -71,6 +75,7 @@
         "type": "object",
         "default": {
           "columns": 10,
+          "food_respawn_interval": 10,
           "players": 2,
           "rows": 10
         },
@@ -129,6 +134,11 @@
         "type": "boolean",
         "default": true
       },
+      "saveResponse": {
+        "description": "If disabled, skip logging raw LLM responses in the replay file. Extracted thoughts (which typically contain everything but the final move tag) are still logged on the action, so the legal response is effectively preserved.",
+        "type": "boolean",
+        "default": true
+      },
       "freeForm": {
         "description": "If true, the core harness allows free-form actions (get_legal_moves may return None) on turns where the action space is not enumerable. Defaults to false for OpenSpiel games.",
         "type": "boolean",
@@ -165,7 +175,7 @@
         "openSpielGameString": {
           "description": "Full game string including parameters.",
           "type": "string",
-          "default": "snake_proxy(columns=10,players=2,rows=10)"
+          "default": "snake_proxy(columns=10,food_respawn_interval=10,players=2,rows=10)"
         },
         "openSpielGameName": {
           "description": "Short name of the OpenSpiel game.",
@@ -206,7 +216,10 @@
       "default": {}
     },
     "reward": {
-      "type": ["number", "null"],
+      "type": [
+        "number",
+        "null"
+      ],
       "default": 0.0
     }
   },
@@ -252,13 +265,23 @@
         "observation": {
           "remainingOverageTime": 12,
           "step": 1,
-          "observationString": "{\"board\": [[\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \"A\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \"*\", \".\", \".\", \".\", \".\", \".\", \"B\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"]], \"num_rows\": 10, \"num_columns\": 10, \"num_players\": 2, \"food\": [8, 2], \"snakes\": [{\"player\": 0, \"body\": [[1, 1]], \"alive\": true, \"score\": 0.0}, {\"player\": 1, \"body\": [[8, 8]], \"alive\": true, \"score\": 0.0}], \"scores\": [0.0, 0.0], \"is_alive\": [true, true], \"current_player\": 0, \"pending_this_turn\": [], \"turn\": 0, \"is_terminal\": false, \"winner\": null, \"game_over_reason\": null}",
-          "currentPlayer": 0,
+          "observationString": "{\"board\": [[\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \"A\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \"*\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \"*\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \"B\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"]], \"num_rows\": 10, \"num_columns\": 10, \"num_players\": 2, \"foods\": [[2, 6], [7, 3]], \"food\": [2, 6], \"food_respawn_interval\": 10, \"turns_until_respawn\": 10, \"snakes\": [{\"player\": 0, \"body\": [[1, 1]], \"alive\": true, \"score\": 0.0}, {\"player\": 1, \"body\": [[8, 8]], \"alive\": true, \"score\": 0.0}], \"scores\": [0.0, 0.0], \"is_alive\": [true, true], \"current_player\": \"simultaneous\", \"round_history\": [], \"turn\": 0, \"is_terminal\": false, \"winner\": null, \"game_over_reason\": null}",
+          "currentPlayer": -2,
           "playerId": 0,
           "isTerminal": false,
-          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nsnake_proxy(columns=10,players=2,rows=10)\n[State]\nhistory=\nmove_number=0\n__dict__=gASV7AIAAAAAAAB9lIwLX193cmFwcGVkX1+UjD5rYWdnbGVfZW52aXJvbm1lbnRzLmVudnMub3Blbl9zcGllbF9lbnYuZ2FtZXMuc25ha2Uuc25ha2VfZ2FtZZSMClNuYWtlU3RhdGWUk5QpgZRYgAIAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCnNuYWtlKGNvbHVtbnM9MTAscGxheWVycz0yLHJvd3M9MTApCltTdGF0ZV0KaGlzdG9yeT0KbW92ZV9udW1iZXI9MApfX2RpY3RfXz1nQVNWV2dFQUFBQUFBQUI5bENpTUJWOW5ZVzFsbEl3K2EyRm5aMnhsWDJWdWRtbHliMjV0Wlc1MGN5NWxiblp6TG05d1pXNWZjM0JwWld4ZlpXNTJMbWRoYldWekxuTnVZV3RsTG5OdVlXdGxYMmRoYldXVWpBbFRibUZyWlVkaGJXV1VrNVFwZ1pTTUkzTnVZV3RsS0dOdmJIVnRibk05TVRBc2NHeGhlV1Z5Y3oweUxISnZkM005TVRBcGxHS01CSEp2ZDNPVVN3cU1CR052YkhPVVN3cU1DMjUxYlY5d2JHRjVaWEp6bEVzQ2pBeGZhWE5mZEdWeWJXbHVZV3lVaVl3UlgyZGhiV1ZmYjNabGNsOXlaV0Z6YjI2VVRvd0djMjVoYTJWemxGMlVLRjJVU3dGTEFZYVVZVjJVU3doTENJYVVZV1dNQm5OamIzSmxjNVJkbENoSEFBQUFBQUFBQUFCSEFBQUFBQUFBQUFCbGpBaHBjMTloYkdsMlpaUmRsQ2lJaUdXTUJHWnZiMlNVU3doTEFvYVVqQVpmYzNSbGNIT1VTd0NNREY5dVpYaDBYM0JzWVhsbGNwUkxBSXdNWDIxdmRtVmZZblZtWm1WeWxGMlVLRTVPWlhVdQqUYnMu\n",
-          "legalActions": [0, 1, 2, 3],
-          "legalActionStrings": ["UP", "DOWN", "LEFT", "RIGHT"]
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nsnake_proxy(columns=10,food_respawn_interval=10,players=2,rows=10)\n[State]\nhistory=\nmove_number=0\n__dict__=gASVQQMAAAAAAAB9lIwLX193cmFwcGVkX1+UjD5rYWdnbGVfZW52aXJvbm1lbnRzLmVudnMub3Blbl9zcGllbF9lbnYuZ2FtZXMuc25ha2Uuc25ha2VfZ2FtZZSMClNuYWtlU3RhdGWUk5QpgZRY1QIAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCnNuYWtlKGNvbHVtbnM9MTAsZm9vZF9yZXNwYXduX2ludGVydmFsPTEwLHBsYXllcnM9Mixyb3dzPTEwKQpbU3RhdGVdCmhpc3Rvcnk9Cm1vdmVfbnVtYmVyPTAKX19kaWN0X189Z0FTVmhRRUFBQUFBQUFCOWxDaU1CVjluWVcxbGxJdythMkZuWjJ4bFgyVnVkbWx5YjI1dFpXNTBjeTVsYm5aekxtOXdaVzVmYzNCcFpXeGZaVzUyTG1kaGJXVnpMbk51WVd0bExuTnVZV3RsWDJkaGJXV1VqQWxUYm1GclpVZGhiV1dVazVRcGdaU01QSE51WVd0bEtHTnZiSFZ0Ym5NOU1UQXNabTl2WkY5eVpYTndZWGR1WDJsdWRHVnlkbUZzUFRFd0xIQnNZWGxsY25NOU1peHliM2R6UFRFd0taUmlqQVJ5YjNkemxFc0tqQVJqYjJ4emxFc0tqQXR1ZFcxZmNHeGhlV1Z5YzVSTEFvd1ZabTl2WkY5eVpYTndZWGR1WDJsdWRHVnlkbUZzbEVzS2pBeGZhWE5mZEdWeWJXbHVZV3lVaVl3UlgyZGhiV1ZmYjNabGNsOXlaV0Z6YjI2VVRvd0djMjVoYTJWemxGMlVLRjJVU3dGTEFZYVVZVjJVU3doTENJYVVZV1dNQm5OamIzSmxjNVJkbENoSEFBQUFBQUFBQUFCSEFBQUFBQUFBQUFCbGpBaHBjMTloYkdsMlpaUmRsQ2lJaUdXTUJXWnZiMlJ6bEYyVUtFc0NTd2FHbEVzSFN3T0dsR1dNQmw5emRHVndjNVJMQUl3T1gzSnZkVzVrWDJocGMzUnZjbm1VWFpSMUxnPT0KlGJzLg==\n",
+          "legalActions": [
+            0,
+            1,
+            2,
+            3
+          ],
+          "legalActionStrings": [
+            "UP",
+            "DOWN",
+            "LEFT",
+            "RIGHT"
+          ]
         },
         "status": "ACTIVE"
       },
@@ -267,91 +290,78 @@
           "submission": -1
         },
         "reward": null,
-        "info": {},
+        "info": {
+          "actionSubmitted": null,
+          "actionSubmittedToString": null,
+          "actionApplied": null,
+          "timeTaken": null,
+          "agentSelfReportedStatus": null
+        },
         "observation": {
           "remainingOverageTime": 12,
-          "observationString": "{\"board\": [[\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \"A\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \"*\", \".\", \".\", \".\", \".\", \".\", \"B\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"]], \"num_rows\": 10, \"num_columns\": 10, \"num_players\": 2, \"food\": [8, 2], \"snakes\": [{\"player\": 0, \"body\": [[1, 1]], \"alive\": true, \"score\": 0.0}, {\"player\": 1, \"body\": [[8, 8]], \"alive\": true, \"score\": 0.0}], \"scores\": [0.0, 0.0], \"is_alive\": [true, true], \"current_player\": 0, \"pending_this_turn\": [], \"turn\": 0, \"is_terminal\": false, \"winner\": null, \"game_over_reason\": null}",
-          "currentPlayer": 0,
+          "observationString": "{\"board\": [[\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \"A\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \"*\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \"*\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \"B\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"]], \"num_rows\": 10, \"num_columns\": 10, \"num_players\": 2, \"foods\": [[2, 6], [7, 3]], \"food\": [2, 6], \"food_respawn_interval\": 10, \"turns_until_respawn\": 10, \"snakes\": [{\"player\": 0, \"body\": [[1, 1]], \"alive\": true, \"score\": 0.0}, {\"player\": 1, \"body\": [[8, 8]], \"alive\": true, \"score\": 0.0}], \"scores\": [0.0, 0.0], \"is_alive\": [true, true], \"current_player\": \"simultaneous\", \"round_history\": [], \"turn\": 0, \"is_terminal\": false, \"winner\": null, \"game_over_reason\": null}",
+          "currentPlayer": -2,
           "playerId": 1,
           "isTerminal": false,
-          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nsnake_proxy(columns=10,players=2,rows=10)\n[State]\nhistory=\nmove_number=0\n__dict__=gASV7AIAAAAAAAB9lIwLX193cmFwcGVkX1+UjD5rYWdnbGVfZW52aXJvbm1lbnRzLmVudnMub3Blbl9zcGllbF9lbnYuZ2FtZXMuc25ha2Uuc25ha2VfZ2FtZZSMClNuYWtlU3RhdGWUk5QpgZRYgAIAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCnNuYWtlKGNvbHVtbnM9MTAscGxheWVycz0yLHJvd3M9MTApCltTdGF0ZV0KaGlzdG9yeT0KbW92ZV9udW1iZXI9MApfX2RpY3RfXz1nQVNWV2dFQUFBQUFBQUI5bENpTUJWOW5ZVzFsbEl3K2EyRm5aMnhsWDJWdWRtbHliMjV0Wlc1MGN5NWxiblp6TG05d1pXNWZjM0JwWld4ZlpXNTJMbWRoYldWekxuTnVZV3RsTG5OdVlXdGxYMmRoYldXVWpBbFRibUZyWlVkaGJXV1VrNVFwZ1pTTUkzTnVZV3RsS0dOdmJIVnRibk05TVRBc2NHeGhlV1Z5Y3oweUxISnZkM005TVRBcGxHS01CSEp2ZDNPVVN3cU1CR052YkhPVVN3cU1DMjUxYlY5d2JHRjVaWEp6bEVzQ2pBeGZhWE5mZEdWeWJXbHVZV3lVaVl3UlgyZGhiV1ZmYjNabGNsOXlaV0Z6YjI2VVRvd0djMjVoYTJWemxGMlVLRjJVU3dGTEFZYVVZVjJVU3doTENJYVVZV1dNQm5OamIzSmxjNVJkbENoSEFBQUFBQUFBQUFCSEFBQUFBQUFBQUFCbGpBaHBjMTloYkdsMlpaUmRsQ2lJaUdXTUJHWnZiMlNVU3doTEFvYVVqQVpmYzNSbGNIT1VTd0NNREY5dVpYaDBYM0JzWVhsbGNwUkxBSXdNWDIxdmRtVmZZblZtWm1WeWxGMlVLRTVPWlhVdQqUYnMu\n",
-          "legalActions": [],
-          "legalActionStrings": []
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nsnake_proxy(columns=10,food_respawn_interval=10,players=2,rows=10)\n[State]\nhistory=\nmove_number=0\n__dict__=gASVQQMAAAAAAAB9lIwLX193cmFwcGVkX1+UjD5rYWdnbGVfZW52aXJvbm1lbnRzLmVudnMub3Blbl9zcGllbF9lbnYuZ2FtZXMuc25ha2Uuc25ha2VfZ2FtZZSMClNuYWtlU3RhdGWUk5QpgZRY1QIAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCnNuYWtlKGNvbHVtbnM9MTAsZm9vZF9yZXNwYXduX2ludGVydmFsPTEwLHBsYXllcnM9Mixyb3dzPTEwKQpbU3RhdGVdCmhpc3Rvcnk9Cm1vdmVfbnVtYmVyPTAKX19kaWN0X189Z0FTVmhRRUFBQUFBQUFCOWxDaU1CVjluWVcxbGxJdythMkZuWjJ4bFgyVnVkbWx5YjI1dFpXNTBjeTVsYm5aekxtOXdaVzVmYzNCcFpXeGZaVzUyTG1kaGJXVnpMbk51WVd0bExuTnVZV3RsWDJkaGJXV1VqQWxUYm1GclpVZGhiV1dVazVRcGdaU01QSE51WVd0bEtHTnZiSFZ0Ym5NOU1UQXNabTl2WkY5eVpYTndZWGR1WDJsdWRHVnlkbUZzUFRFd0xIQnNZWGxsY25NOU1peHliM2R6UFRFd0taUmlqQVJ5YjNkemxFc0tqQVJqYjJ4emxFc0tqQXR1ZFcxZmNHeGhlV1Z5YzVSTEFvd1ZabTl2WkY5eVpYTndZWGR1WDJsdWRHVnlkbUZzbEVzS2pBeGZhWE5mZEdWeWJXbHVZV3lVaVl3UlgyZGhiV1ZmYjNabGNsOXlaV0Z6YjI2VVRvd0djMjVoYTJWemxGMlVLRjJVU3dGTEFZYVVZVjJVU3doTENJYVVZV1dNQm5OamIzSmxjNVJkbENoSEFBQUFBQUFBQUFCSEFBQUFBQUFBQUFCbGpBaHBjMTloYkdsMlpaUmRsQ2lJaUdXTUJXWnZiMlJ6bEYyVUtFc0NTd2FHbEVzSFN3T0dsR1dNQmw5emRHVndjNVJMQUl3T1gzSnZkVzVrWDJocGMzUnZjbm1VWFpSMUxnPT0KlGJzLg==\n",
+          "legalActions": [
+            0,
+            1,
+            2,
+            3
+          ],
+          "legalActionStrings": [
+            "UP",
+            "DOWN",
+            "LEFT",
+            "RIGHT"
+          ]
         },
-        "status": "INACTIVE"
+        "status": "ACTIVE"
       }
     ],
     [
       {
         "action": {
-          "submission": 0,
-          "thoughts": "beta mu iota imagine consider shadow delta rho",
-          "actionString": "UP"
+          "submission": 1,
+          "thoughts": "ember rho ponder phi eta cascade zeta xi",
+          "actionString": "DOWN"
         },
         "reward": null,
         "info": {
-          "actionSubmitted": 0,
-          "actionSubmittedToString": "UP",
-          "actionApplied": 0,
+          "actionSubmitted": 1,
+          "actionSubmittedToString": "DOWN",
+          "actionApplied": 1,
           "timeTaken": 0.0,
           "agentSelfReportedStatus": null
         },
         "observation": {
           "remainingOverageTime": 12,
           "step": 2,
-          "observationString": "{\"board\": [[\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \"A\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \"*\", \".\", \".\", \".\", \".\", \".\", \"B\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"]], \"num_rows\": 10, \"num_columns\": 10, \"num_players\": 2, \"food\": [8, 2], \"snakes\": [{\"player\": 0, \"body\": [[1, 1]], \"alive\": true, \"score\": 0.0}, {\"player\": 1, \"body\": [[8, 8]], \"alive\": true, \"score\": 0.0}], \"scores\": [0.0, 0.0], \"is_alive\": [true, true], \"current_player\": 1, \"pending_this_turn\": [0], \"turn\": 0, \"is_terminal\": false, \"winner\": null, \"game_over_reason\": null}",
-          "currentPlayer": 1,
+          "observationString": "{\"board\": [[\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \"A\", \".\", \".\", \".\", \".\", \"*\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \"*\", \".\", \".\", \".\", \".\", \"B\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"]], \"num_rows\": 10, \"num_columns\": 10, \"num_players\": 2, \"foods\": [[2, 6], [7, 3]], \"food\": [2, 6], \"food_respawn_interval\": 10, \"turns_until_respawn\": 9, \"snakes\": [{\"player\": 0, \"body\": [[2, 1]], \"alive\": true, \"score\": 0.0}, {\"player\": 1, \"body\": [[7, 8]], \"alive\": true, \"score\": 0.0}], \"scores\": [0.0, 0.0], \"is_alive\": [true, true], \"current_player\": \"simultaneous\", \"round_history\": [[\"DOWN\", \"UP\"]], \"turn\": 1, \"is_terminal\": false, \"winner\": null, \"game_over_reason\": null}",
+          "currentPlayer": -2,
           "playerId": 0,
           "isTerminal": false,
-          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nsnake_proxy(columns=10,players=2,rows=10)\n[State]\nhistory=0:0\nmove_number=1\n__dict__=gASV8wIAAAAAAAB9lIwLX193cmFwcGVkX1+UjD5rYWdnbGVfZW52aXJvbm1lbnRzLmVudnMub3Blbl9zcGllbF9lbnYuZ2FtZXMuc25ha2Uuc25ha2VfZ2FtZZSMClNuYWtlU3RhdGWUk5QpgZRYhwIAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCnNuYWtlKGNvbHVtbnM9MTAscGxheWVycz0yLHJvd3M9MTApCltTdGF0ZV0KaGlzdG9yeT0wOjAKbW92ZV9udW1iZXI9MQpfX2RpY3RfXz1nQVNWV3dFQUFBQUFBQUI5bENpTUJWOW5ZVzFsbEl3K2EyRm5aMnhsWDJWdWRtbHliMjV0Wlc1MGN5NWxiblp6TG05d1pXNWZjM0JwWld4ZlpXNTJMbWRoYldWekxuTnVZV3RsTG5OdVlXdGxYMmRoYldXVWpBbFRibUZyWlVkaGJXV1VrNVFwZ1pTTUkzTnVZV3RsS0dOdmJIVnRibk05TVRBc2NHeGhlV1Z5Y3oweUxISnZkM005TVRBcGxHS01CSEp2ZDNPVVN3cU1CR052YkhPVVN3cU1DMjUxYlY5d2JHRjVaWEp6bEVzQ2pBeGZhWE5mZEdWeWJXbHVZV3lVaVl3UlgyZGhiV1ZmYjNabGNsOXlaV0Z6YjI2VVRvd0djMjVoYTJWemxGMlVLRjJVU3dGTEFZYVVZVjJVU3doTENJYVVZV1dNQm5OamIzSmxjNVJkbENoSEFBQUFBQUFBQUFCSEFBQUFBQUFBQUFCbGpBaHBjMTloYkdsMlpaUmRsQ2lJaUdXTUJHWnZiMlNVU3doTEFvYVVqQVpmYzNSbGNIT1VTd0NNREY5dVpYaDBYM0JzWVhsbGNwUkxBWXdNWDIxdmRtVmZZblZtWm1WeWxGMlVLRXNBVG1WMUxnPT0KlGJzLg==\n",
-          "legalActions": [],
-          "legalActionStrings": []
-        },
-        "status": "INACTIVE"
-      },
-      {
-        "action": {
-          "submission": -1
-        },
-        "reward": null,
-        "info": {},
-        "observation": {
-          "remainingOverageTime": 12,
-          "observationString": "{\"board\": [[\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \"A\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \"*\", \".\", \".\", \".\", \".\", \".\", \"B\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"]], \"num_rows\": 10, \"num_columns\": 10, \"num_players\": 2, \"food\": [8, 2], \"snakes\": [{\"player\": 0, \"body\": [[1, 1]], \"alive\": true, \"score\": 0.0}, {\"player\": 1, \"body\": [[8, 8]], \"alive\": true, \"score\": 0.0}], \"scores\": [0.0, 0.0], \"is_alive\": [true, true], \"current_player\": 1, \"pending_this_turn\": [0], \"turn\": 0, \"is_terminal\": false, \"winner\": null, \"game_over_reason\": null}",
-          "currentPlayer": 1,
-          "playerId": 1,
-          "isTerminal": false,
-          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nsnake_proxy(columns=10,players=2,rows=10)\n[State]\nhistory=0:0\nmove_number=1\n__dict__=gASV8wIAAAAAAAB9lIwLX193cmFwcGVkX1+UjD5rYWdnbGVfZW52aXJvbm1lbnRzLmVudnMub3Blbl9zcGllbF9lbnYuZ2FtZXMuc25ha2Uuc25ha2VfZ2FtZZSMClNuYWtlU3RhdGWUk5QpgZRYhwIAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCnNuYWtlKGNvbHVtbnM9MTAscGxheWVycz0yLHJvd3M9MTApCltTdGF0ZV0KaGlzdG9yeT0wOjAKbW92ZV9udW1iZXI9MQpfX2RpY3RfXz1nQVNWV3dFQUFBQUFBQUI5bENpTUJWOW5ZVzFsbEl3K2EyRm5aMnhsWDJWdWRtbHliMjV0Wlc1MGN5NWxiblp6TG05d1pXNWZjM0JwWld4ZlpXNTJMbWRoYldWekxuTnVZV3RsTG5OdVlXdGxYMmRoYldXVWpBbFRibUZyWlVkaGJXV1VrNVFwZ1pTTUkzTnVZV3RsS0dOdmJIVnRibk05TVRBc2NHeGhlV1Z5Y3oweUxISnZkM005TVRBcGxHS01CSEp2ZDNPVVN3cU1CR052YkhPVVN3cU1DMjUxYlY5d2JHRjVaWEp6bEVzQ2pBeGZhWE5mZEdWeWJXbHVZV3lVaVl3UlgyZGhiV1ZmYjNabGNsOXlaV0Z6YjI2VVRvd0djMjVoYTJWemxGMlVLRjJVU3dGTEFZYVVZVjJVU3doTENJYVVZV1dNQm5OamIzSmxjNVJkbENoSEFBQUFBQUFBQUFCSEFBQUFBQUFBQUFCbGpBaHBjMTloYkdsMlpaUmRsQ2lJaUdXTUJHWnZiMlNVU3doTEFvYVVqQVpmYzNSbGNIT1VTd0NNREY5dVpYaDBYM0JzWVhsbGNwUkxBWXdNWDIxdmRtVmZZblZtWm1WeWxGMlVLRXNBVG1WMUxnPT0KlGJzLg==\n",
-          "legalActions": [0, 1, 2, 3],
-          "legalActionStrings": ["UP", "DOWN", "LEFT", "RIGHT"]
-        },
-        "status": "ACTIVE"
-      }
-    ],
-    [
-      {
-        "action": {
-          "submission": -1
-        },
-        "reward": null,
-        "info": {},
-        "observation": {
-          "remainingOverageTime": 12,
-          "step": 3,
-          "observationString": "{\"board\": [[\".\", \"A\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \"B\", \".\"], [\".\", \".\", \"*\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"]], \"num_rows\": 10, \"num_columns\": 10, \"num_players\": 2, \"food\": [8, 2], \"snakes\": [{\"player\": 0, \"body\": [[0, 1]], \"alive\": true, \"score\": 0.0}, {\"player\": 1, \"body\": [[7, 8]], \"alive\": true, \"score\": 0.0}], \"scores\": [0.0, 0.0], \"is_alive\": [true, true], \"current_player\": 0, \"pending_this_turn\": [], \"turn\": 1, \"is_terminal\": false, \"winner\": null, \"game_over_reason\": null}",
-          "currentPlayer": 0,
-          "playerId": 0,
-          "isTerminal": false,
-          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nsnake_proxy(columns=10,players=2,rows=10)\n[State]\nhistory=0:0,1:0\nmove_number=2\n__dict__=gASV8wIAAAAAAAB9lIwLX193cmFwcGVkX1+UjD5rYWdnbGVfZW52aXJvbm1lbnRzLmVudnMub3Blbl9zcGllbF9lbnYuZ2FtZXMuc25ha2Uuc25ha2VfZ2FtZZSMClNuYWtlU3RhdGWUk5QpgZRYhwIAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCnNuYWtlKGNvbHVtbnM9MTAscGxheWVycz0yLHJvd3M9MTApCltTdGF0ZV0KaGlzdG9yeT0wOjAsMTowCm1vdmVfbnVtYmVyPTIKX19kaWN0X189Z0FTVldnRUFBQUFBQUFCOWxDaU1CVjluWVcxbGxJdythMkZuWjJ4bFgyVnVkbWx5YjI1dFpXNTBjeTVsYm5aekxtOXdaVzVmYzNCcFpXeGZaVzUyTG1kaGJXVnpMbk51WVd0bExuTnVZV3RsWDJkaGJXV1VqQWxUYm1GclpVZGhiV1dVazVRcGdaU01JM051WVd0bEtHTnZiSFZ0Ym5NOU1UQXNjR3hoZVdWeWN6MHlMSEp2ZDNNOU1UQXBsR0tNQkhKdmQzT1VTd3FNQkdOdmJIT1VTd3FNQzI1MWJWOXdiR0Y1WlhKemxFc0NqQXhmYVhOZmRHVnliV2x1WVd5VWlZd1JYMmRoYldWZmIzWmxjbDl5WldGemIyNlVUb3dHYzI1aGEyVnpsRjJVS0YyVVN3QkxBWWFVWVYyVVN3ZExDSWFVWVdXTUJuTmpiM0psYzVSZGxDaEhBQUFBQUFBQUFBQkhBQUFBQUFBQUFBQmxqQWhwYzE5aGJHbDJaWlJkbENpSWlHV01CR1p2YjJTVVN3aExBb2FVakFaZmMzUmxjSE9VU3dHTURGOXVaWGgwWDNCc1lYbGxjcFJMQUl3TVgyMXZkbVZmWW5WbVptVnlsRjJVS0U1T1pYVXUKlGJzLg==\n",
-          "legalActions": [0, 1, 2, 3],
-          "legalActionStrings": ["UP", "DOWN", "LEFT", "RIGHT"]
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nsnake_proxy(columns=10,food_respawn_interval=10,players=2,rows=10)\n[State]\nhistory=0:1,1:0\nmove_number=1\n__dict__=gASVVAMAAAAAAAB9lIwLX193cmFwcGVkX1+UjD5rYWdnbGVfZW52aXJvbm1lbnRzLmVudnMub3Blbl9zcGllbF9lbnYuZ2FtZXMuc25ha2Uuc25ha2VfZ2FtZZSMClNuYWtlU3RhdGWUk5QpgZRY6AIAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCnNuYWtlKGNvbHVtbnM9MTAsZm9vZF9yZXNwYXduX2ludGVydmFsPTEwLHBsYXllcnM9Mixyb3dzPTEwKQpbU3RhdGVdCmhpc3Rvcnk9MDoxLDE6MAptb3ZlX251bWJlcj0xCl9fZGljdF9fPWdBU1ZqZ0VBQUFBQUFBQjlsQ2lNQlY5bllXMWxsSXcrYTJGbloyeGxYMlZ1ZG1seWIyNXRaVzUwY3k1bGJuWnpMbTl3Wlc1ZmMzQnBaV3hmWlc1MkxtZGhiV1Z6TG5OdVlXdGxMbk51WVd0bFgyZGhiV1dVakFsVGJtRnJaVWRoYldXVWs1UXBnWlNNUEhOdVlXdGxLR052YkhWdGJuTTlNVEFzWm05dlpGOXlaWE53WVhkdVgybHVkR1Z5ZG1Gc1BURXdMSEJzWVhsbGNuTTlNaXh5YjNkelBURXdLWlJpakFSeWIzZHpsRXNLakFSamIyeHpsRXNLakF0dWRXMWZjR3hoZVdWeWM1UkxBb3dWWm05dlpGOXlaWE53WVhkdVgybHVkR1Z5ZG1Gc2xFc0tqQXhmYVhOZmRHVnliV2x1WVd5VWlZd1JYMmRoYldWZmIzWmxjbDl5WldGemIyNlVUb3dHYzI1aGEyVnpsRjJVS0YyVVN3SkxBWWFVWVYyVVN3ZExDSWFVWVdXTUJuTmpiM0psYzVSZGxDaEhBQUFBQUFBQUFBQkhBQUFBQUFBQUFBQmxqQWhwYzE5aGJHbDJaWlJkbENpSWlHV01CV1p2YjJSemxGMlVLRXNDU3dhR2xFc0hTd09HbEdXTUJsOXpkR1Z3YzVSTEFZd09YM0p2ZFc1a1gyaHBjM1J2Y25tVVhaUmRsQ2hMQVVzQVpXRjFMZz09CpRicy4=\n",
+          "legalActions": [
+            0,
+            1,
+            2,
+            3
+          ],
+          "legalActionStrings": [
+            "UP",
+            "DOWN",
+            "LEFT",
+            "RIGHT"
+          ]
         },
         "status": "ACTIVE"
       },
       {
         "action": {
           "submission": 0,
-          "thoughts": "delta kappa ponder psi reflect reflect rho sigma",
+          "thoughts": "spark echo cascade cascade reflect mu psi echo",
           "actionString": "UP"
         },
         "reward": null,
@@ -364,22 +374,107 @@
         },
         "observation": {
           "remainingOverageTime": 12,
-          "observationString": "{\"board\": [[\".\", \"A\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \"B\", \".\"], [\".\", \".\", \"*\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"]], \"num_rows\": 10, \"num_columns\": 10, \"num_players\": 2, \"food\": [8, 2], \"snakes\": [{\"player\": 0, \"body\": [[0, 1]], \"alive\": true, \"score\": 0.0}, {\"player\": 1, \"body\": [[7, 8]], \"alive\": true, \"score\": 0.0}], \"scores\": [0.0, 0.0], \"is_alive\": [true, true], \"current_player\": 0, \"pending_this_turn\": [], \"turn\": 1, \"is_terminal\": false, \"winner\": null, \"game_over_reason\": null}",
-          "currentPlayer": 0,
+          "observationString": "{\"board\": [[\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \"A\", \".\", \".\", \".\", \".\", \"*\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \"*\", \".\", \".\", \".\", \".\", \"B\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"]], \"num_rows\": 10, \"num_columns\": 10, \"num_players\": 2, \"foods\": [[2, 6], [7, 3]], \"food\": [2, 6], \"food_respawn_interval\": 10, \"turns_until_respawn\": 9, \"snakes\": [{\"player\": 0, \"body\": [[2, 1]], \"alive\": true, \"score\": 0.0}, {\"player\": 1, \"body\": [[7, 8]], \"alive\": true, \"score\": 0.0}], \"scores\": [0.0, 0.0], \"is_alive\": [true, true], \"current_player\": \"simultaneous\", \"round_history\": [[\"DOWN\", \"UP\"]], \"turn\": 1, \"is_terminal\": false, \"winner\": null, \"game_over_reason\": null}",
+          "currentPlayer": -2,
           "playerId": 1,
           "isTerminal": false,
-          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nsnake_proxy(columns=10,players=2,rows=10)\n[State]\nhistory=0:0,1:0\nmove_number=2\n__dict__=gASV8wIAAAAAAAB9lIwLX193cmFwcGVkX1+UjD5rYWdnbGVfZW52aXJvbm1lbnRzLmVudnMub3Blbl9zcGllbF9lbnYuZ2FtZXMuc25ha2Uuc25ha2VfZ2FtZZSMClNuYWtlU3RhdGWUk5QpgZRYhwIAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCnNuYWtlKGNvbHVtbnM9MTAscGxheWVycz0yLHJvd3M9MTApCltTdGF0ZV0KaGlzdG9yeT0wOjAsMTowCm1vdmVfbnVtYmVyPTIKX19kaWN0X189Z0FTVldnRUFBQUFBQUFCOWxDaU1CVjluWVcxbGxJdythMkZuWjJ4bFgyVnVkbWx5YjI1dFpXNTBjeTVsYm5aekxtOXdaVzVmYzNCcFpXeGZaVzUyTG1kaGJXVnpMbk51WVd0bExuTnVZV3RsWDJkaGJXV1VqQWxUYm1GclpVZGhiV1dVazVRcGdaU01JM051WVd0bEtHTnZiSFZ0Ym5NOU1UQXNjR3hoZVdWeWN6MHlMSEp2ZDNNOU1UQXBsR0tNQkhKdmQzT1VTd3FNQkdOdmJIT1VTd3FNQzI1MWJWOXdiR0Y1WlhKemxFc0NqQXhmYVhOZmRHVnliV2x1WVd5VWlZd1JYMmRoYldWZmIzWmxjbDl5WldGemIyNlVUb3dHYzI1aGEyVnpsRjJVS0YyVVN3QkxBWWFVWVYyVVN3ZExDSWFVWVdXTUJuTmpiM0psYzVSZGxDaEhBQUFBQUFBQUFBQkhBQUFBQUFBQUFBQmxqQWhwYzE5aGJHbDJaWlJkbENpSWlHV01CR1p2YjJTVVN3aExBb2FVakFaZmMzUmxjSE9VU3dHTURGOXVaWGgwWDNCc1lYbGxjcFJMQUl3TVgyMXZkbVZmWW5WbVptVnlsRjJVS0U1T1pYVXUKlGJzLg==\n",
-          "legalActions": [],
-          "legalActionStrings": []
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nsnake_proxy(columns=10,food_respawn_interval=10,players=2,rows=10)\n[State]\nhistory=0:1,1:0\nmove_number=1\n__dict__=gASVVAMAAAAAAAB9lIwLX193cmFwcGVkX1+UjD5rYWdnbGVfZW52aXJvbm1lbnRzLmVudnMub3Blbl9zcGllbF9lbnYuZ2FtZXMuc25ha2Uuc25ha2VfZ2FtZZSMClNuYWtlU3RhdGWUk5QpgZRY6AIAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCnNuYWtlKGNvbHVtbnM9MTAsZm9vZF9yZXNwYXduX2ludGVydmFsPTEwLHBsYXllcnM9Mixyb3dzPTEwKQpbU3RhdGVdCmhpc3Rvcnk9MDoxLDE6MAptb3ZlX251bWJlcj0xCl9fZGljdF9fPWdBU1ZqZ0VBQUFBQUFBQjlsQ2lNQlY5bllXMWxsSXcrYTJGbloyeGxYMlZ1ZG1seWIyNXRaVzUwY3k1bGJuWnpMbTl3Wlc1ZmMzQnBaV3hmWlc1MkxtZGhiV1Z6TG5OdVlXdGxMbk51WVd0bFgyZGhiV1dVakFsVGJtRnJaVWRoYldXVWs1UXBnWlNNUEhOdVlXdGxLR052YkhWdGJuTTlNVEFzWm05dlpGOXlaWE53WVhkdVgybHVkR1Z5ZG1Gc1BURXdMSEJzWVhsbGNuTTlNaXh5YjNkelBURXdLWlJpakFSeWIzZHpsRXNLakFSamIyeHpsRXNLakF0dWRXMWZjR3hoZVdWeWM1UkxBb3dWWm05dlpGOXlaWE53WVhkdVgybHVkR1Z5ZG1Gc2xFc0tqQXhmYVhOZmRHVnliV2x1WVd5VWlZd1JYMmRoYldWZmIzWmxjbDl5WldGemIyNlVUb3dHYzI1aGEyVnpsRjJVS0YyVVN3SkxBWWFVWVYyVVN3ZExDSWFVWVdXTUJuTmpiM0psYzVSZGxDaEhBQUFBQUFBQUFBQkhBQUFBQUFBQUFBQmxqQWhwYzE5aGJHbDJaWlJkbENpSWlHV01CV1p2YjJSemxGMlVLRXNDU3dhR2xFc0hTd09HbEdXTUJsOXpkR1Z3YzVSTEFZd09YM0p2ZFc1a1gyaHBjM1J2Y25tVVhaUmRsQ2hMQVVzQVpXRjFMZz09CpRicy4=\n",
+          "legalActions": [
+            0,
+            1,
+            2,
+            3
+          ],
+          "legalActionStrings": [
+            "UP",
+            "DOWN",
+            "LEFT",
+            "RIGHT"
+          ]
         },
-        "status": "INACTIVE"
+        "status": "ACTIVE"
+      }
+    ],
+    [
+      {
+        "action": {
+          "submission": 0,
+          "thoughts": "wonder horizon epsilon omega epsilon alpha shadow rho",
+          "actionString": "UP"
+        },
+        "reward": null,
+        "info": {
+          "actionSubmitted": 0,
+          "actionSubmittedToString": "UP",
+          "actionApplied": 0,
+          "timeTaken": 0.0,
+          "agentSelfReportedStatus": null
+        },
+        "observation": {
+          "remainingOverageTime": 12,
+          "step": 3,
+          "observationString": "{\"board\": [[\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \"A\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \"*\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \"B\", \".\"], [\".\", \".\", \".\", \"*\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"]], \"num_rows\": 10, \"num_columns\": 10, \"num_players\": 2, \"foods\": [[2, 6], [7, 3]], \"food\": [2, 6], \"food_respawn_interval\": 10, \"turns_until_respawn\": 8, \"snakes\": [{\"player\": 0, \"body\": [[1, 1]], \"alive\": true, \"score\": 0.0}, {\"player\": 1, \"body\": [[6, 8]], \"alive\": true, \"score\": 0.0}], \"scores\": [0.0, 0.0], \"is_alive\": [true, true], \"current_player\": \"simultaneous\", \"round_history\": [[\"DOWN\", \"UP\"], [\"UP\", \"UP\"]], \"turn\": 2, \"is_terminal\": false, \"winner\": null, \"game_over_reason\": null}",
+          "currentPlayer": -2,
+          "playerId": 0,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nsnake_proxy(columns=10,food_respawn_interval=10,players=2,rows=10)\n[State]\nhistory=0:1,1:0,0:0,1:0\nmove_number=2\n__dict__=gASVaAMAAAAAAAB9lIwLX193cmFwcGVkX1+UjD5rYWdnbGVfZW52aXJvbm1lbnRzLmVudnMub3Blbl9zcGllbF9lbnYuZ2FtZXMuc25ha2Uuc25ha2VfZ2FtZZSMClNuYWtlU3RhdGWUk5QpgZRY/AIAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCnNuYWtlKGNvbHVtbnM9MTAsZm9vZF9yZXNwYXduX2ludGVydmFsPTEwLHBsYXllcnM9Mixyb3dzPTEwKQpbU3RhdGVdCmhpc3Rvcnk9MDoxLDE6MCwwOjAsMTowCm1vdmVfbnVtYmVyPTIKX19kaWN0X189Z0FTVmx3RUFBQUFBQUFCOWxDaU1CVjluWVcxbGxJdythMkZuWjJ4bFgyVnVkbWx5YjI1dFpXNTBjeTVsYm5aekxtOXdaVzVmYzNCcFpXeGZaVzUyTG1kaGJXVnpMbk51WVd0bExuTnVZV3RsWDJkaGJXV1VqQWxUYm1GclpVZGhiV1dVazVRcGdaU01QSE51WVd0bEtHTnZiSFZ0Ym5NOU1UQXNabTl2WkY5eVpYTndZWGR1WDJsdWRHVnlkbUZzUFRFd0xIQnNZWGxsY25NOU1peHliM2R6UFRFd0taUmlqQVJ5YjNkemxFc0tqQVJqYjJ4emxFc0tqQXR1ZFcxZmNHeGhlV1Z5YzVSTEFvd1ZabTl2WkY5eVpYTndZWGR1WDJsdWRHVnlkbUZzbEVzS2pBeGZhWE5mZEdWeWJXbHVZV3lVaVl3UlgyZGhiV1ZmYjNabGNsOXlaV0Z6YjI2VVRvd0djMjVoYTJWemxGMlVLRjJVU3dGTEFZYVVZVjJVU3daTENJYVVZV1dNQm5OamIzSmxjNVJkbENoSEFBQUFBQUFBQUFCSEFBQUFBQUFBQUFCbGpBaHBjMTloYkdsMlpaUmRsQ2lJaUdXTUJXWnZiMlJ6bEYyVUtFc0NTd2FHbEVzSFN3T0dsR1dNQmw5emRHVndjNVJMQW93T1gzSnZkVzVrWDJocGMzUnZjbm1VWFpRb1haUW9Td0ZMQUdWZGxDaExBRXNBWldWMUxnPT0KlGJzLg==\n",
+          "legalActions": [
+            0,
+            1,
+            2,
+            3
+          ],
+          "legalActionStrings": [
+            "UP",
+            "DOWN",
+            "LEFT",
+            "RIGHT"
+          ]
+        },
+        "status": "ACTIVE"
+      },
+      {
+        "action": {
+          "submission": 0,
+          "thoughts": "wonder nu reflect iota sigma muse spark tau",
+          "actionString": "UP"
+        },
+        "reward": null,
+        "info": {
+          "actionSubmitted": 0,
+          "actionSubmittedToString": "UP",
+          "actionApplied": 0,
+          "timeTaken": 0.0,
+          "agentSelfReportedStatus": null
+        },
+        "observation": {
+          "remainingOverageTime": 12,
+          "observationString": "{\"board\": [[\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \"A\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \"*\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \"B\", \".\"], [\".\", \".\", \".\", \"*\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"]], \"num_rows\": 10, \"num_columns\": 10, \"num_players\": 2, \"foods\": [[2, 6], [7, 3]], \"food\": [2, 6], \"food_respawn_interval\": 10, \"turns_until_respawn\": 8, \"snakes\": [{\"player\": 0, \"body\": [[1, 1]], \"alive\": true, \"score\": 0.0}, {\"player\": 1, \"body\": [[6, 8]], \"alive\": true, \"score\": 0.0}], \"scores\": [0.0, 0.0], \"is_alive\": [true, true], \"current_player\": \"simultaneous\", \"round_history\": [[\"DOWN\", \"UP\"], [\"UP\", \"UP\"]], \"turn\": 2, \"is_terminal\": false, \"winner\": null, \"game_over_reason\": null}",
+          "currentPlayer": -2,
+          "playerId": 1,
+          "isTerminal": false,
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nsnake_proxy(columns=10,food_respawn_interval=10,players=2,rows=10)\n[State]\nhistory=0:1,1:0,0:0,1:0\nmove_number=2\n__dict__=gASVaAMAAAAAAAB9lIwLX193cmFwcGVkX1+UjD5rYWdnbGVfZW52aXJvbm1lbnRzLmVudnMub3Blbl9zcGllbF9lbnYuZ2FtZXMuc25ha2Uuc25ha2VfZ2FtZZSMClNuYWtlU3RhdGWUk5QpgZRY/AIAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCnNuYWtlKGNvbHVtbnM9MTAsZm9vZF9yZXNwYXduX2ludGVydmFsPTEwLHBsYXllcnM9Mixyb3dzPTEwKQpbU3RhdGVdCmhpc3Rvcnk9MDoxLDE6MCwwOjAsMTowCm1vdmVfbnVtYmVyPTIKX19kaWN0X189Z0FTVmx3RUFBQUFBQUFCOWxDaU1CVjluWVcxbGxJdythMkZuWjJ4bFgyVnVkbWx5YjI1dFpXNTBjeTVsYm5aekxtOXdaVzVmYzNCcFpXeGZaVzUyTG1kaGJXVnpMbk51WVd0bExuTnVZV3RsWDJkaGJXV1VqQWxUYm1GclpVZGhiV1dVazVRcGdaU01QSE51WVd0bEtHTnZiSFZ0Ym5NOU1UQXNabTl2WkY5eVpYTndZWGR1WDJsdWRHVnlkbUZzUFRFd0xIQnNZWGxsY25NOU1peHliM2R6UFRFd0taUmlqQVJ5YjNkemxFc0tqQVJqYjJ4emxFc0tqQXR1ZFcxZmNHeGhlV1Z5YzVSTEFvd1ZabTl2WkY5eVpYTndZWGR1WDJsdWRHVnlkbUZzbEVzS2pBeGZhWE5mZEdWeWJXbHVZV3lVaVl3UlgyZGhiV1ZmYjNabGNsOXlaV0Z6YjI2VVRvd0djMjVoYTJWemxGMlVLRjJVU3dGTEFZYVVZVjJVU3daTENJYVVZV1dNQm5OamIzSmxjNVJkbENoSEFBQUFBQUFBQUFCSEFBQUFBQUFBQUFCbGpBaHBjMTloYkdsMlpaUmRsQ2lJaUdXTUJXWnZiMlJ6bEYyVUtFc0NTd2FHbEVzSFN3T0dsR1dNQmw5emRHVndjNVJMQW93T1gzSnZkVzVrWDJocGMzUnZjbm1VWFpRb1haUW9Td0ZMQUdWZGxDaExBRXNBWldWMUxnPT0KlGJzLg==\n",
+          "legalActions": [
+            0,
+            1,
+            2,
+            3
+          ],
+          "legalActionStrings": [
+            "UP",
+            "DOWN",
+            "LEFT",
+            "RIGHT"
+          ]
+        },
+        "status": "ACTIVE"
       }
     ],
     [
       {
         "action": {
           "submission": 2,
-          "thoughts": "spark alpha spark consider xi eta cascade xi",
+          "thoughts": "nu chi cascade reflect explore theta omega xi",
           "actionString": "LEFT"
         },
         "reward": null,
@@ -393,31 +488,59 @@
         "observation": {
           "remainingOverageTime": 12,
           "step": 4,
-          "observationString": "{\"board\": [[\".\", \"A\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \"B\", \".\"], [\".\", \".\", \"*\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"]], \"num_rows\": 10, \"num_columns\": 10, \"num_players\": 2, \"food\": [8, 2], \"snakes\": [{\"player\": 0, \"body\": [[0, 1]], \"alive\": true, \"score\": 0.0}, {\"player\": 1, \"body\": [[7, 8]], \"alive\": true, \"score\": 0.0}], \"scores\": [0.0, 0.0], \"is_alive\": [true, true], \"current_player\": 1, \"pending_this_turn\": [0], \"turn\": 1, \"is_terminal\": false, \"winner\": null, \"game_over_reason\": null}",
-          "currentPlayer": 1,
+          "observationString": "{\"board\": [[\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\"A\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \"*\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \"B\"], [\".\", \".\", \".\", \"*\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"]], \"num_rows\": 10, \"num_columns\": 10, \"num_players\": 2, \"foods\": [[2, 6], [7, 3]], \"food\": [2, 6], \"food_respawn_interval\": 10, \"turns_until_respawn\": 7, \"snakes\": [{\"player\": 0, \"body\": [[1, 0]], \"alive\": true, \"score\": 0.0}, {\"player\": 1, \"body\": [[6, 9]], \"alive\": true, \"score\": 0.0}], \"scores\": [0.0, 0.0], \"is_alive\": [true, true], \"current_player\": \"simultaneous\", \"round_history\": [[\"DOWN\", \"UP\"], [\"UP\", \"UP\"], [\"LEFT\", \"RIGHT\"]], \"turn\": 3, \"is_terminal\": false, \"winner\": null, \"game_over_reason\": null}",
+          "currentPlayer": -2,
           "playerId": 0,
           "isTerminal": false,
-          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nsnake_proxy(columns=10,players=2,rows=10)\n[State]\nhistory=0:0,1:0,0:2\nmove_number=3\n__dict__=gASV+wIAAAAAAAB9lIwLX193cmFwcGVkX1+UjD5rYWdnbGVfZW52aXJvbm1lbnRzLmVudnMub3Blbl9zcGllbF9lbnYuZ2FtZXMuc25ha2Uuc25ha2VfZ2FtZZSMClNuYWtlU3RhdGWUk5QpgZRYjwIAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCnNuYWtlKGNvbHVtbnM9MTAscGxheWVycz0yLHJvd3M9MTApCltTdGF0ZV0KaGlzdG9yeT0wOjAsMTowLDA6Mgptb3ZlX251bWJlcj0zCl9fZGljdF9fPWdBU1ZXd0VBQUFBQUFBQjlsQ2lNQlY5bllXMWxsSXcrYTJGbloyeGxYMlZ1ZG1seWIyNXRaVzUwY3k1bGJuWnpMbTl3Wlc1ZmMzQnBaV3hmWlc1MkxtZGhiV1Z6TG5OdVlXdGxMbk51WVd0bFgyZGhiV1dVakFsVGJtRnJaVWRoYldXVWs1UXBnWlNNSTNOdVlXdGxLR052YkhWdGJuTTlNVEFzY0d4aGVXVnljejB5TEhKdmQzTTlNVEFwbEdLTUJISnZkM09VU3dxTUJHTnZiSE9VU3dxTUMyNTFiVjl3YkdGNVpYSnpsRXNDakF4ZmFYTmZkR1Z5YldsdVlXeVVpWXdSWDJkaGJXVmZiM1psY2w5eVpXRnpiMjZVVG93R2MyNWhhMlZ6bEYyVUtGMlVTd0JMQVlhVVlWMlVTd2RMQ0lhVVlXV01Cbk5qYjNKbGM1UmRsQ2hIQUFBQUFBQUFBQUJIQUFBQUFBQUFBQUJsakFocGMxOWhiR2wyWlpSZGxDaUlpR1dNQkdadmIyU1VTd2hMQW9hVWpBWmZjM1JsY0hPVVN3R01ERjl1WlhoMFgzQnNZWGxsY3BSTEFZd01YMjF2ZG1WZlluVm1abVZ5bEYyVUtFc0NUbVYxTGc9PQqUYnMu\n",
-          "legalActions": [],
-          "legalActionStrings": []
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nsnake_proxy(columns=10,food_respawn_interval=10,players=2,rows=10)\n[State]\nhistory=0:1,1:0,0:0,1:0,0:2,1:3\nmove_number=3\n__dict__=gASVeAMAAAAAAAB9lIwLX193cmFwcGVkX1+UjD5rYWdnbGVfZW52aXJvbm1lbnRzLmVudnMub3Blbl9zcGllbF9lbnYuZ2FtZXMuc25ha2Uuc25ha2VfZ2FtZZSMClNuYWtlU3RhdGWUk5QpgZRYDAMAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCnNuYWtlKGNvbHVtbnM9MTAsZm9vZF9yZXNwYXduX2ludGVydmFsPTEwLHBsYXllcnM9Mixyb3dzPTEwKQpbU3RhdGVdCmhpc3Rvcnk9MDoxLDE6MCwwOjAsMTowLDA6MiwxOjMKbW92ZV9udW1iZXI9MwpfX2RpY3RfXz1nQVNWbndFQUFBQUFBQUI5bENpTUJWOW5ZVzFsbEl3K2EyRm5aMnhsWDJWdWRtbHliMjV0Wlc1MGN5NWxiblp6TG05d1pXNWZjM0JwWld4ZlpXNTJMbWRoYldWekxuTnVZV3RsTG5OdVlXdGxYMmRoYldXVWpBbFRibUZyWlVkaGJXV1VrNVFwZ1pTTVBITnVZV3RsS0dOdmJIVnRibk05TVRBc1ptOXZaRjl5WlhOd1lYZHVYMmx1ZEdWeWRtRnNQVEV3TEhCc1lYbGxjbk05TWl4eWIzZHpQVEV3S1pSaWpBUnliM2R6bEVzS2pBUmpiMnh6bEVzS2pBdHVkVzFmY0d4aGVXVnljNVJMQW93VlptOXZaRjl5WlhOd1lYZHVYMmx1ZEdWeWRtRnNsRXNLakF4ZmFYTmZkR1Z5YldsdVlXeVVpWXdSWDJkaGJXVmZiM1psY2w5eVpXRnpiMjZVVG93R2MyNWhhMlZ6bEYyVUtGMlVTd0ZMQUlhVVlWMlVTd1pMQ1lhVVlXV01Cbk5qYjNKbGM1UmRsQ2hIQUFBQUFBQUFBQUJIQUFBQUFBQUFBQUJsakFocGMxOWhiR2wyWlpSZGxDaUlpR1dNQldadmIyUnpsRjJVS0VzQ1N3YUdsRXNIU3dPR2xHV01CbDl6ZEdWd2M1UkxBNHdPWDNKdmRXNWtYMmhwYzNSdmNubVVYWlFvWFpRb1N3RkxBR1ZkbENoTEFFc0FaVjJVS0VzQ1N3TmxaWFV1CpRicy4=\n",
+          "legalActions": [
+            0,
+            1,
+            2,
+            3
+          ],
+          "legalActionStrings": [
+            "UP",
+            "DOWN",
+            "LEFT",
+            "RIGHT"
+          ]
         },
-        "status": "INACTIVE"
+        "status": "ACTIVE"
       },
       {
         "action": {
-          "submission": -1
+          "submission": 3,
+          "thoughts": "horizon alpha muse explore omicron shadow wonder ripple",
+          "actionString": "RIGHT"
         },
         "reward": null,
-        "info": {},
+        "info": {
+          "actionSubmitted": 3,
+          "actionSubmittedToString": "RIGHT",
+          "actionApplied": 3,
+          "timeTaken": 0.0,
+          "agentSelfReportedStatus": null
+        },
         "observation": {
           "remainingOverageTime": 12,
-          "observationString": "{\"board\": [[\".\", \"A\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \"B\", \".\"], [\".\", \".\", \"*\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"]], \"num_rows\": 10, \"num_columns\": 10, \"num_players\": 2, \"food\": [8, 2], \"snakes\": [{\"player\": 0, \"body\": [[0, 1]], \"alive\": true, \"score\": 0.0}, {\"player\": 1, \"body\": [[7, 8]], \"alive\": true, \"score\": 0.0}], \"scores\": [0.0, 0.0], \"is_alive\": [true, true], \"current_player\": 1, \"pending_this_turn\": [0], \"turn\": 1, \"is_terminal\": false, \"winner\": null, \"game_over_reason\": null}",
-          "currentPlayer": 1,
+          "observationString": "{\"board\": [[\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\"A\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \"*\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \"B\"], [\".\", \".\", \".\", \"*\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"]], \"num_rows\": 10, \"num_columns\": 10, \"num_players\": 2, \"foods\": [[2, 6], [7, 3]], \"food\": [2, 6], \"food_respawn_interval\": 10, \"turns_until_respawn\": 7, \"snakes\": [{\"player\": 0, \"body\": [[1, 0]], \"alive\": true, \"score\": 0.0}, {\"player\": 1, \"body\": [[6, 9]], \"alive\": true, \"score\": 0.0}], \"scores\": [0.0, 0.0], \"is_alive\": [true, true], \"current_player\": \"simultaneous\", \"round_history\": [[\"DOWN\", \"UP\"], [\"UP\", \"UP\"], [\"LEFT\", \"RIGHT\"]], \"turn\": 3, \"is_terminal\": false, \"winner\": null, \"game_over_reason\": null}",
+          "currentPlayer": -2,
           "playerId": 1,
           "isTerminal": false,
-          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nsnake_proxy(columns=10,players=2,rows=10)\n[State]\nhistory=0:0,1:0,0:2\nmove_number=3\n__dict__=gASV+wIAAAAAAAB9lIwLX193cmFwcGVkX1+UjD5rYWdnbGVfZW52aXJvbm1lbnRzLmVudnMub3Blbl9zcGllbF9lbnYuZ2FtZXMuc25ha2Uuc25ha2VfZ2FtZZSMClNuYWtlU3RhdGWUk5QpgZRYjwIAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCnNuYWtlKGNvbHVtbnM9MTAscGxheWVycz0yLHJvd3M9MTApCltTdGF0ZV0KaGlzdG9yeT0wOjAsMTowLDA6Mgptb3ZlX251bWJlcj0zCl9fZGljdF9fPWdBU1ZXd0VBQUFBQUFBQjlsQ2lNQlY5bllXMWxsSXcrYTJGbloyeGxYMlZ1ZG1seWIyNXRaVzUwY3k1bGJuWnpMbTl3Wlc1ZmMzQnBaV3hmWlc1MkxtZGhiV1Z6TG5OdVlXdGxMbk51WVd0bFgyZGhiV1dVakFsVGJtRnJaVWRoYldXVWs1UXBnWlNNSTNOdVlXdGxLR052YkhWdGJuTTlNVEFzY0d4aGVXVnljejB5TEhKdmQzTTlNVEFwbEdLTUJISnZkM09VU3dxTUJHTnZiSE9VU3dxTUMyNTFiVjl3YkdGNVpYSnpsRXNDakF4ZmFYTmZkR1Z5YldsdVlXeVVpWXdSWDJkaGJXVmZiM1psY2w5eVpXRnpiMjZVVG93R2MyNWhhMlZ6bEYyVUtGMlVTd0JMQVlhVVlWMlVTd2RMQ0lhVVlXV01Cbk5qYjNKbGM1UmRsQ2hIQUFBQUFBQUFBQUJIQUFBQUFBQUFBQUJsakFocGMxOWhiR2wyWlpSZGxDaUlpR1dNQkdadmIyU1VTd2hMQW9hVWpBWmZjM1JsY0hPVVN3R01ERjl1WlhoMFgzQnNZWGxsY3BSTEFZd01YMjF2ZG1WZlluVm1abVZ5bEYyVUtFc0NUbVYxTGc9PQqUYnMu\n",
-          "legalActions": [0, 1, 2, 3],
-          "legalActionStrings": ["UP", "DOWN", "LEFT", "RIGHT"]
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nsnake_proxy(columns=10,food_respawn_interval=10,players=2,rows=10)\n[State]\nhistory=0:1,1:0,0:0,1:0,0:2,1:3\nmove_number=3\n__dict__=gASVeAMAAAAAAAB9lIwLX193cmFwcGVkX1+UjD5rYWdnbGVfZW52aXJvbm1lbnRzLmVudnMub3Blbl9zcGllbF9lbnYuZ2FtZXMuc25ha2Uuc25ha2VfZ2FtZZSMClNuYWtlU3RhdGWUk5QpgZRYDAMAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCnNuYWtlKGNvbHVtbnM9MTAsZm9vZF9yZXNwYXduX2ludGVydmFsPTEwLHBsYXllcnM9Mixyb3dzPTEwKQpbU3RhdGVdCmhpc3Rvcnk9MDoxLDE6MCwwOjAsMTowLDA6MiwxOjMKbW92ZV9udW1iZXI9MwpfX2RpY3RfXz1nQVNWbndFQUFBQUFBQUI5bENpTUJWOW5ZVzFsbEl3K2EyRm5aMnhsWDJWdWRtbHliMjV0Wlc1MGN5NWxiblp6TG05d1pXNWZjM0JwWld4ZlpXNTJMbWRoYldWekxuTnVZV3RsTG5OdVlXdGxYMmRoYldXVWpBbFRibUZyWlVkaGJXV1VrNVFwZ1pTTVBITnVZV3RsS0dOdmJIVnRibk05TVRBc1ptOXZaRjl5WlhOd1lYZHVYMmx1ZEdWeWRtRnNQVEV3TEhCc1lYbGxjbk05TWl4eWIzZHpQVEV3S1pSaWpBUnliM2R6bEVzS2pBUmpiMnh6bEVzS2pBdHVkVzFmY0d4aGVXVnljNVJMQW93VlptOXZaRjl5WlhOd1lYZHVYMmx1ZEdWeWRtRnNsRXNLakF4ZmFYTmZkR1Z5YldsdVlXeVVpWXdSWDJkaGJXVmZiM1psY2w5eVpXRnpiMjZVVG93R2MyNWhhMlZ6bEYyVUtGMlVTd0ZMQUlhVVlWMlVTd1pMQ1lhVVlXV01Cbk5qYjNKbGM1UmRsQ2hIQUFBQUFBQUFBQUJIQUFBQUFBQUFBQUJsakFocGMxOWhiR2wyWlpSZGxDaUlpR1dNQldadmIyUnpsRjJVS0VzQ1N3YUdsRXNIU3dPR2xHV01CbDl6ZEdWd2M1UkxBNHdPWDNKdmRXNWtYMmhwYzNSdmNubVVYWlFvWFpRb1N3RkxBR1ZkbENoTEFFc0FaVjJVS0VzQ1N3TmxaWFV1CpRicy4=\n",
+          "legalActions": [
+            0,
+            1,
+            2,
+            3
+          ],
+          "legalActionStrings": [
+            "UP",
+            "DOWN",
+            "LEFT",
+            "RIGHT"
+          ]
         },
         "status": "ACTIVE"
       }
@@ -425,112 +548,26 @@
     [
       {
         "action": {
-          "submission": -1
+          "submission": 3,
+          "thoughts": "iota ripple ponder horizon upsilon cascade iota wonder",
+          "actionString": "RIGHT"
         },
-        "reward": null,
-        "info": {},
+        "reward": 0.0,
+        "info": {
+          "actionSubmitted": 3,
+          "actionSubmittedToString": "RIGHT",
+          "actionApplied": 3,
+          "timeTaken": 0.0,
+          "agentSelfReportedStatus": null
+        },
         "observation": {
           "remainingOverageTime": 12,
           "step": 5,
-          "observationString": "{\"board\": [[\"A\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \"B\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \"*\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"]], \"num_rows\": 10, \"num_columns\": 10, \"num_players\": 2, \"food\": [8, 2], \"snakes\": [{\"player\": 0, \"body\": [[0, 0]], \"alive\": true, \"score\": 0.0}, {\"player\": 1, \"body\": [[6, 8]], \"alive\": true, \"score\": 0.0}], \"scores\": [0.0, 0.0], \"is_alive\": [true, true], \"current_player\": 0, \"pending_this_turn\": [], \"turn\": 2, \"is_terminal\": false, \"winner\": null, \"game_over_reason\": null}",
-          "currentPlayer": 0,
-          "playerId": 0,
-          "isTerminal": false,
-          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nsnake_proxy(columns=10,players=2,rows=10)\n[State]\nhistory=0:0,1:0,0:2,1:0\nmove_number=4\n__dict__=gASV+wIAAAAAAAB9lIwLX193cmFwcGVkX1+UjD5rYWdnbGVfZW52aXJvbm1lbnRzLmVudnMub3Blbl9zcGllbF9lbnYuZ2FtZXMuc25ha2Uuc25ha2VfZ2FtZZSMClNuYWtlU3RhdGWUk5QpgZRYjwIAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCnNuYWtlKGNvbHVtbnM9MTAscGxheWVycz0yLHJvd3M9MTApCltTdGF0ZV0KaGlzdG9yeT0wOjAsMTowLDA6MiwxOjAKbW92ZV9udW1iZXI9NApfX2RpY3RfXz1nQVNWV2dFQUFBQUFBQUI5bENpTUJWOW5ZVzFsbEl3K2EyRm5aMnhsWDJWdWRtbHliMjV0Wlc1MGN5NWxiblp6TG05d1pXNWZjM0JwWld4ZlpXNTJMbWRoYldWekxuTnVZV3RsTG5OdVlXdGxYMmRoYldXVWpBbFRibUZyWlVkaGJXV1VrNVFwZ1pTTUkzTnVZV3RsS0dOdmJIVnRibk05TVRBc2NHeGhlV1Z5Y3oweUxISnZkM005TVRBcGxHS01CSEp2ZDNPVVN3cU1CR052YkhPVVN3cU1DMjUxYlY5d2JHRjVaWEp6bEVzQ2pBeGZhWE5mZEdWeWJXbHVZV3lVaVl3UlgyZGhiV1ZmYjNabGNsOXlaV0Z6YjI2VVRvd0djMjVoYTJWemxGMlVLRjJVU3dCTEFJYVVZVjJVU3daTENJYVVZV1dNQm5OamIzSmxjNVJkbENoSEFBQUFBQUFBQUFCSEFBQUFBQUFBQUFCbGpBaHBjMTloYkdsMlpaUmRsQ2lJaUdXTUJHWnZiMlNVU3doTEFvYVVqQVpmYzNSbGNIT1VTd0tNREY5dVpYaDBYM0JzWVhsbGNwUkxBSXdNWDIxdmRtVmZZblZtWm1WeWxGMlVLRTVPWlhVdQqUYnMu\n",
-          "legalActions": [0, 1, 2, 3],
-          "legalActionStrings": ["UP", "DOWN", "LEFT", "RIGHT"]
-        },
-        "status": "ACTIVE"
-      },
-      {
-        "action": {
-          "submission": 0,
-          "thoughts": "pi omicron xi lambda beta tau epsilon horizon",
-          "actionString": "UP"
-        },
-        "reward": null,
-        "info": {
-          "actionSubmitted": 0,
-          "actionSubmittedToString": "UP",
-          "actionApplied": 0,
-          "timeTaken": 0.0,
-          "agentSelfReportedStatus": null
-        },
-        "observation": {
-          "remainingOverageTime": 12,
-          "observationString": "{\"board\": [[\"A\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \"B\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \"*\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"]], \"num_rows\": 10, \"num_columns\": 10, \"num_players\": 2, \"food\": [8, 2], \"snakes\": [{\"player\": 0, \"body\": [[0, 0]], \"alive\": true, \"score\": 0.0}, {\"player\": 1, \"body\": [[6, 8]], \"alive\": true, \"score\": 0.0}], \"scores\": [0.0, 0.0], \"is_alive\": [true, true], \"current_player\": 0, \"pending_this_turn\": [], \"turn\": 2, \"is_terminal\": false, \"winner\": null, \"game_over_reason\": null}",
-          "currentPlayer": 0,
-          "playerId": 1,
-          "isTerminal": false,
-          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nsnake_proxy(columns=10,players=2,rows=10)\n[State]\nhistory=0:0,1:0,0:2,1:0\nmove_number=4\n__dict__=gASV+wIAAAAAAAB9lIwLX193cmFwcGVkX1+UjD5rYWdnbGVfZW52aXJvbm1lbnRzLmVudnMub3Blbl9zcGllbF9lbnYuZ2FtZXMuc25ha2Uuc25ha2VfZ2FtZZSMClNuYWtlU3RhdGWUk5QpgZRYjwIAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCnNuYWtlKGNvbHVtbnM9MTAscGxheWVycz0yLHJvd3M9MTApCltTdGF0ZV0KaGlzdG9yeT0wOjAsMTowLDA6MiwxOjAKbW92ZV9udW1iZXI9NApfX2RpY3RfXz1nQVNWV2dFQUFBQUFBQUI5bENpTUJWOW5ZVzFsbEl3K2EyRm5aMnhsWDJWdWRtbHliMjV0Wlc1MGN5NWxiblp6TG05d1pXNWZjM0JwWld4ZlpXNTJMbWRoYldWekxuTnVZV3RsTG5OdVlXdGxYMmRoYldXVWpBbFRibUZyWlVkaGJXV1VrNVFwZ1pTTUkzTnVZV3RsS0dOdmJIVnRibk05TVRBc2NHeGhlV1Z5Y3oweUxISnZkM005TVRBcGxHS01CSEp2ZDNPVVN3cU1CR052YkhPVVN3cU1DMjUxYlY5d2JHRjVaWEp6bEVzQ2pBeGZhWE5mZEdWeWJXbHVZV3lVaVl3UlgyZGhiV1ZmYjNabGNsOXlaV0Z6YjI2VVRvd0djMjVoYTJWemxGMlVLRjJVU3dCTEFJYVVZVjJVU3daTENJYVVZV1dNQm5OamIzSmxjNVJkbENoSEFBQUFBQUFBQUFCSEFBQUFBQUFBQUFCbGpBaHBjMTloYkdsMlpaUmRsQ2lJaUdXTUJHWnZiMlNVU3doTEFvYVVqQVpmYzNSbGNIT1VTd0tNREY5dVpYaDBYM0JzWVhsbGNwUkxBSXdNWDIxdmRtVmZZblZtWm1WeWxGMlVLRTVPWlhVdQqUYnMu\n",
-          "legalActions": [],
-          "legalActionStrings": []
-        },
-        "status": "INACTIVE"
-      }
-    ],
-    [
-      {
-        "action": {
-          "submission": 0,
-          "thoughts": "psi ripple ponder echo omega reflect beta kappa",
-          "actionString": "UP"
-        },
-        "reward": null,
-        "info": {
-          "actionSubmitted": 0,
-          "actionSubmittedToString": "UP",
-          "actionApplied": 0,
-          "timeTaken": 0.0,
-          "agentSelfReportedStatus": null
-        },
-        "observation": {
-          "remainingOverageTime": 12,
-          "step": 6,
-          "observationString": "{\"board\": [[\"A\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \"B\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \"*\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"]], \"num_rows\": 10, \"num_columns\": 10, \"num_players\": 2, \"food\": [8, 2], \"snakes\": [{\"player\": 0, \"body\": [[0, 0]], \"alive\": true, \"score\": 0.0}, {\"player\": 1, \"body\": [[6, 8]], \"alive\": true, \"score\": 0.0}], \"scores\": [0.0, 0.0], \"is_alive\": [true, true], \"current_player\": 1, \"pending_this_turn\": [0], \"turn\": 2, \"is_terminal\": false, \"winner\": null, \"game_over_reason\": null}",
-          "currentPlayer": 1,
-          "playerId": 0,
-          "isTerminal": false,
-          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nsnake_proxy(columns=10,players=2,rows=10)\n[State]\nhistory=0:0,1:0,0:2,1:0,0:0\nmove_number=5\n__dict__=gASVAwMAAAAAAAB9lIwLX193cmFwcGVkX1+UjD5rYWdnbGVfZW52aXJvbm1lbnRzLmVudnMub3Blbl9zcGllbF9lbnYuZ2FtZXMuc25ha2Uuc25ha2VfZ2FtZZSMClNuYWtlU3RhdGWUk5QpgZRYlwIAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCnNuYWtlKGNvbHVtbnM9MTAscGxheWVycz0yLHJvd3M9MTApCltTdGF0ZV0KaGlzdG9yeT0wOjAsMTowLDA6MiwxOjAsMDowCm1vdmVfbnVtYmVyPTUKX19kaWN0X189Z0FTVld3RUFBQUFBQUFCOWxDaU1CVjluWVcxbGxJdythMkZuWjJ4bFgyVnVkbWx5YjI1dFpXNTBjeTVsYm5aekxtOXdaVzVmYzNCcFpXeGZaVzUyTG1kaGJXVnpMbk51WVd0bExuTnVZV3RsWDJkaGJXV1VqQWxUYm1GclpVZGhiV1dVazVRcGdaU01JM051WVd0bEtHTnZiSFZ0Ym5NOU1UQXNjR3hoZVdWeWN6MHlMSEp2ZDNNOU1UQXBsR0tNQkhKdmQzT1VTd3FNQkdOdmJIT1VTd3FNQzI1MWJWOXdiR0Y1WlhKemxFc0NqQXhmYVhOZmRHVnliV2x1WVd5VWlZd1JYMmRoYldWZmIzWmxjbDl5WldGemIyNlVUb3dHYzI1aGEyVnpsRjJVS0YyVVN3QkxBSWFVWVYyVVN3WkxDSWFVWVdXTUJuTmpiM0psYzVSZGxDaEhBQUFBQUFBQUFBQkhBQUFBQUFBQUFBQmxqQWhwYzE5aGJHbDJaWlJkbENpSWlHV01CR1p2YjJTVVN3aExBb2FVakFaZmMzUmxjSE9VU3dLTURGOXVaWGgwWDNCc1lYbGxjcFJMQVl3TVgyMXZkbVZmWW5WbVptVnlsRjJVS0VzQVRtVjFMZz09CpRicy4=\n",
-          "legalActions": [],
-          "legalActionStrings": []
-        },
-        "status": "INACTIVE"
-      },
-      {
-        "action": {
-          "submission": -1
-        },
-        "reward": null,
-        "info": {},
-        "observation": {
-          "remainingOverageTime": 12,
-          "observationString": "{\"board\": [[\"A\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \"B\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \"*\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"]], \"num_rows\": 10, \"num_columns\": 10, \"num_players\": 2, \"food\": [8, 2], \"snakes\": [{\"player\": 0, \"body\": [[0, 0]], \"alive\": true, \"score\": 0.0}, {\"player\": 1, \"body\": [[6, 8]], \"alive\": true, \"score\": 0.0}], \"scores\": [0.0, 0.0], \"is_alive\": [true, true], \"current_player\": 1, \"pending_this_turn\": [0], \"turn\": 2, \"is_terminal\": false, \"winner\": null, \"game_over_reason\": null}",
-          "currentPlayer": 1,
-          "playerId": 1,
-          "isTerminal": false,
-          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nsnake_proxy(columns=10,players=2,rows=10)\n[State]\nhistory=0:0,1:0,0:2,1:0,0:0\nmove_number=5\n__dict__=gASVAwMAAAAAAAB9lIwLX193cmFwcGVkX1+UjD5rYWdnbGVfZW52aXJvbm1lbnRzLmVudnMub3Blbl9zcGllbF9lbnYuZ2FtZXMuc25ha2Uuc25ha2VfZ2FtZZSMClNuYWtlU3RhdGWUk5QpgZRYlwIAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCnNuYWtlKGNvbHVtbnM9MTAscGxheWVycz0yLHJvd3M9MTApCltTdGF0ZV0KaGlzdG9yeT0wOjAsMTowLDA6MiwxOjAsMDowCm1vdmVfbnVtYmVyPTUKX19kaWN0X189Z0FTVld3RUFBQUFBQUFCOWxDaU1CVjluWVcxbGxJdythMkZuWjJ4bFgyVnVkbWx5YjI1dFpXNTBjeTVsYm5aekxtOXdaVzVmYzNCcFpXeGZaVzUyTG1kaGJXVnpMbk51WVd0bExuTnVZV3RsWDJkaGJXV1VqQWxUYm1GclpVZGhiV1dVazVRcGdaU01JM051WVd0bEtHTnZiSFZ0Ym5NOU1UQXNjR3hoZVdWeWN6MHlMSEp2ZDNNOU1UQXBsR0tNQkhKdmQzT1VTd3FNQkdOdmJIT1VTd3FNQzI1MWJWOXdiR0Y1WlhKemxFc0NqQXhmYVhOZmRHVnliV2x1WVd5VWlZd1JYMmRoYldWZmIzWmxjbDl5WldGemIyNlVUb3dHYzI1aGEyVnpsRjJVS0YyVVN3QkxBSWFVWVYyVVN3WkxDSWFVWVdXTUJuTmpiM0psYzVSZGxDaEhBQUFBQUFBQUFBQkhBQUFBQUFBQUFBQmxqQWhwYzE5aGJHbDJaWlJkbENpSWlHV01CR1p2YjJTVVN3aExBb2FVakFaZmMzUmxjSE9VU3dLTURGOXVaWGgwWDNCc1lYbGxjcFJMQVl3TVgyMXZkbVZmWW5WbVptVnlsRjJVS0VzQVRtVjFMZz09CpRicy4=\n",
-          "legalActions": [0, 1, 2, 3],
-          "legalActionStrings": ["UP", "DOWN", "LEFT", "RIGHT"]
-        },
-        "status": "ACTIVE"
-      }
-    ],
-    [
-      {
-        "action": {
-          "submission": -1
-        },
-        "reward": 0.0,
-        "info": {},
-        "observation": {
-          "remainingOverageTime": 12,
-          "step": 7,
-          "observationString": "{\"board\": [[\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \"B\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \"*\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"]], \"num_rows\": 10, \"num_columns\": 10, \"num_players\": 2, \"food\": [8, 2], \"snakes\": [{\"player\": 0, \"body\": [], \"alive\": false, \"score\": 0.0}, {\"player\": 1, \"body\": [[6, 7]], \"alive\": true, \"score\": 0.0}], \"scores\": [0.0, 0.0], \"is_alive\": [false, true], \"current_player\": -4, \"pending_this_turn\": [], \"turn\": 3, \"is_terminal\": true, \"winner\": 1, \"game_over_reason\": null}",
+          "observationString": "{\"board\": [[\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \"A\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \"*\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \"*\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"]], \"num_rows\": 10, \"num_columns\": 10, \"num_players\": 2, \"foods\": [[2, 6], [7, 3]], \"food\": [2, 6], \"food_respawn_interval\": 10, \"turns_until_respawn\": 6, \"snakes\": [{\"player\": 0, \"body\": [[1, 1]], \"alive\": true, \"score\": 0.0}, {\"player\": 1, \"body\": [], \"alive\": false, \"score\": 0.0}], \"scores\": [0.0, 0.0], \"is_alive\": [true, false], \"current_player\": \"terminal\", \"round_history\": [[\"DOWN\", \"UP\"], [\"UP\", \"UP\"], [\"LEFT\", \"RIGHT\"], [\"RIGHT\", \"RIGHT\"]], \"turn\": 4, \"is_terminal\": true, \"winner\": 0, \"game_over_reason\": null}",
           "currentPlayer": -4,
           "playerId": 0,
           "isTerminal": true,
-          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nsnake_proxy(columns=10,players=2,rows=10)\n[State]\nhistory=0:0,1:0,0:2,1:0,0:0,1:2\nmove_number=6\n__dict__=gASV+wIAAAAAAAB9lIwLX193cmFwcGVkX1+UjD5rYWdnbGVfZW52aXJvbm1lbnRzLmVudnMub3Blbl9zcGllbF9lbnYuZ2FtZXMuc25ha2Uuc25ha2VfZ2FtZZSMClNuYWtlU3RhdGWUk5QpgZRYjwIAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCnNuYWtlKGNvbHVtbnM9MTAscGxheWVycz0yLHJvd3M9MTApCltTdGF0ZV0KaGlzdG9yeT0wOjAsMTowLDA6MiwxOjAsMDowLDE6Mgptb3ZlX251bWJlcj02Cl9fZGljdF9fPWdBU1ZVd0VBQUFBQUFBQjlsQ2lNQlY5bllXMWxsSXcrYTJGbloyeGxYMlZ1ZG1seWIyNXRaVzUwY3k1bGJuWnpMbTl3Wlc1ZmMzQnBaV3hmWlc1MkxtZGhiV1Z6TG5OdVlXdGxMbk51WVd0bFgyZGhiV1dVakFsVGJtRnJaVWRoYldXVWs1UXBnWlNNSTNOdVlXdGxLR052YkhWdGJuTTlNVEFzY0d4aGVXVnljejB5TEhKdmQzTTlNVEFwbEdLTUJISnZkM09VU3dxTUJHTnZiSE9VU3dxTUMyNTFiVjl3YkdGNVpYSnpsRXNDakF4ZmFYTmZkR1Z5YldsdVlXeVVpSXdSWDJkaGJXVmZiM1psY2w5eVpXRnpiMjZVVG93R2MyNWhhMlZ6bEYyVUtGMlVYWlJMQmtzSGhwUmhaWXdHYzJOdmNtVnpsRjJVS0VjQUFBQUFBQUFBQUVjQUFBQUFBQUFBQUdXTUNHbHpYMkZzYVhabGxGMlVLSW1JWll3RVptOXZaSlJMQ0VzQ2hwU01CbDl6ZEdWd2M1UkxBNHdNWDI1bGVIUmZjR3hoZVdWeWxFc0FqQXhmYlc5MlpWOWlkV1ptWlhLVVhaUW9UazVsZFM0PQqUYnMu\n",
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nsnake_proxy(columns=10,food_respawn_interval=10,players=2,rows=10)\n[State]\nhistory=0:1,1:0,0:0,1:0,0:2,1:3,0:3,1:3\nmove_number=4\n__dict__=gASVhAMAAAAAAAB9lIwLX193cmFwcGVkX1+UjD5rYWdnbGVfZW52aXJvbm1lbnRzLmVudnMub3Blbl9zcGllbF9lbnYuZ2FtZXMuc25ha2Uuc25ha2VfZ2FtZZSMClNuYWtlU3RhdGWUk5QpgZRYGAMAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCnNuYWtlKGNvbHVtbnM9MTAsZm9vZF9yZXNwYXduX2ludGVydmFsPTEwLHBsYXllcnM9Mixyb3dzPTEwKQpbU3RhdGVdCmhpc3Rvcnk9MDoxLDE6MCwwOjAsMTowLDA6MiwxOjMsMDozLDE6Mwptb3ZlX251bWJlcj00Cl9fZGljdF9fPWdBU1ZvQUVBQUFBQUFBQjlsQ2lNQlY5bllXMWxsSXcrYTJGbloyeGxYMlZ1ZG1seWIyNXRaVzUwY3k1bGJuWnpMbTl3Wlc1ZmMzQnBaV3hmWlc1MkxtZGhiV1Z6TG5OdVlXdGxMbk51WVd0bFgyZGhiV1dVakFsVGJtRnJaVWRoYldXVWs1UXBnWlNNUEhOdVlXdGxLR052YkhWdGJuTTlNVEFzWm05dlpGOXlaWE53WVhkdVgybHVkR1Z5ZG1Gc1BURXdMSEJzWVhsbGNuTTlNaXh5YjNkelBURXdLWlJpakFSeWIzZHpsRXNLakFSamIyeHpsRXNLakF0dWRXMWZjR3hoZVdWeWM1UkxBb3dWWm05dlpGOXlaWE53WVhkdVgybHVkR1Z5ZG1Gc2xFc0tqQXhmYVhOZmRHVnliV2x1WVd5VWlJd1JYMmRoYldWZmIzWmxjbDl5WldGemIyNlVUb3dHYzI1aGEyVnpsRjJVS0YyVVN3RkxBWWFVWVYyVVpZd0djMk52Y21WemxGMlVLRWNBQUFBQUFBQUFBRWNBQUFBQUFBQUFBR1dNQ0dselgyRnNhWFpsbEYyVUtJaUpaWXdGWm05dlpIT1VYWlFvU3dKTEJvYVVTd2RMQTRhVVpZd0dYM04wWlhCemxFc0VqQTVmY205MWJtUmZhR2x6ZEc5eWVaUmRsQ2hkbENoTEFVc0FaVjJVS0VzQVN3QmxYWlFvU3dKTEEyVmRsQ2hMQTBzRFpXVjFMZz09CpRicy4=\n",
           "legalActions": [],
           "legalActionStrings": []
         },
@@ -538,25 +575,25 @@
       },
       {
         "action": {
-          "submission": 2,
-          "thoughts": "ember echo echo pi tau ripple eta omicron",
-          "actionString": "LEFT"
+          "submission": 3,
+          "thoughts": "ponder ember xi psi kappa shadow zeta echo",
+          "actionString": "RIGHT"
         },
         "reward": 0.0,
         "info": {
-          "actionSubmitted": 2,
-          "actionSubmittedToString": "LEFT",
-          "actionApplied": 2,
+          "actionSubmitted": 3,
+          "actionSubmittedToString": "RIGHT",
+          "actionApplied": 3,
           "timeTaken": 0.0,
           "agentSelfReportedStatus": null
         },
         "observation": {
           "remainingOverageTime": 12,
-          "observationString": "{\"board\": [[\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \"B\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \"*\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"]], \"num_rows\": 10, \"num_columns\": 10, \"num_players\": 2, \"food\": [8, 2], \"snakes\": [{\"player\": 0, \"body\": [], \"alive\": false, \"score\": 0.0}, {\"player\": 1, \"body\": [[6, 7]], \"alive\": true, \"score\": 0.0}], \"scores\": [0.0, 0.0], \"is_alive\": [false, true], \"current_player\": -4, \"pending_this_turn\": [], \"turn\": 3, \"is_terminal\": true, \"winner\": 1, \"game_over_reason\": null}",
+          "observationString": "{\"board\": [[\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \"A\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \"*\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \"*\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"]], \"num_rows\": 10, \"num_columns\": 10, \"num_players\": 2, \"foods\": [[2, 6], [7, 3]], \"food\": [2, 6], \"food_respawn_interval\": 10, \"turns_until_respawn\": 6, \"snakes\": [{\"player\": 0, \"body\": [[1, 1]], \"alive\": true, \"score\": 0.0}, {\"player\": 1, \"body\": [], \"alive\": false, \"score\": 0.0}], \"scores\": [0.0, 0.0], \"is_alive\": [true, false], \"current_player\": \"terminal\", \"round_history\": [[\"DOWN\", \"UP\"], [\"UP\", \"UP\"], [\"LEFT\", \"RIGHT\"], [\"RIGHT\", \"RIGHT\"]], \"turn\": 4, \"is_terminal\": true, \"winner\": 0, \"game_over_reason\": null}",
           "currentPlayer": -4,
           "playerId": 1,
           "isTerminal": true,
-          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nsnake_proxy(columns=10,players=2,rows=10)\n[State]\nhistory=0:0,1:0,0:2,1:0,0:0,1:2\nmove_number=6\n__dict__=gASV+wIAAAAAAAB9lIwLX193cmFwcGVkX1+UjD5rYWdnbGVfZW52aXJvbm1lbnRzLmVudnMub3Blbl9zcGllbF9lbnYuZ2FtZXMuc25ha2Uuc25ha2VfZ2FtZZSMClNuYWtlU3RhdGWUk5QpgZRYjwIAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCnNuYWtlKGNvbHVtbnM9MTAscGxheWVycz0yLHJvd3M9MTApCltTdGF0ZV0KaGlzdG9yeT0wOjAsMTowLDA6MiwxOjAsMDowLDE6Mgptb3ZlX251bWJlcj02Cl9fZGljdF9fPWdBU1ZVd0VBQUFBQUFBQjlsQ2lNQlY5bllXMWxsSXcrYTJGbloyeGxYMlZ1ZG1seWIyNXRaVzUwY3k1bGJuWnpMbTl3Wlc1ZmMzQnBaV3hmWlc1MkxtZGhiV1Z6TG5OdVlXdGxMbk51WVd0bFgyZGhiV1dVakFsVGJtRnJaVWRoYldXVWs1UXBnWlNNSTNOdVlXdGxLR052YkhWdGJuTTlNVEFzY0d4aGVXVnljejB5TEhKdmQzTTlNVEFwbEdLTUJISnZkM09VU3dxTUJHTnZiSE9VU3dxTUMyNTFiVjl3YkdGNVpYSnpsRXNDakF4ZmFYTmZkR1Z5YldsdVlXeVVpSXdSWDJkaGJXVmZiM1psY2w5eVpXRnpiMjZVVG93R2MyNWhhMlZ6bEYyVUtGMlVYWlJMQmtzSGhwUmhaWXdHYzJOdmNtVnpsRjJVS0VjQUFBQUFBQUFBQUVjQUFBQUFBQUFBQUdXTUNHbHpYMkZzYVhabGxGMlVLSW1JWll3RVptOXZaSlJMQ0VzQ2hwU01CbDl6ZEdWd2M1UkxBNHdNWDI1bGVIUmZjR3hoZVdWeWxFc0FqQXhmYlc5MlpWOWlkV1ptWlhLVVhaUW9UazVsZFM0PQqUYnMu\n",
+          "serializedGameAndState": "# Automatically generated by OpenSpiel SerializeGameAndState\n[Meta]\nVersion: 1\n\n[Game]\nsnake_proxy(columns=10,food_respawn_interval=10,players=2,rows=10)\n[State]\nhistory=0:1,1:0,0:0,1:0,0:2,1:3,0:3,1:3\nmove_number=4\n__dict__=gASVhAMAAAAAAAB9lIwLX193cmFwcGVkX1+UjD5rYWdnbGVfZW52aXJvbm1lbnRzLmVudnMub3Blbl9zcGllbF9lbnYuZ2FtZXMuc25ha2Uuc25ha2VfZ2FtZZSMClNuYWtlU3RhdGWUk5QpgZRYGAMAACMgQXV0b21hdGljYWxseSBnZW5lcmF0ZWQgYnkgT3BlblNwaWVsIFNlcmlhbGl6ZUdhbWVBbmRTdGF0ZQpbTWV0YV0KVmVyc2lvbjogMQoKW0dhbWVdCnNuYWtlKGNvbHVtbnM9MTAsZm9vZF9yZXNwYXduX2ludGVydmFsPTEwLHBsYXllcnM9Mixyb3dzPTEwKQpbU3RhdGVdCmhpc3Rvcnk9MDoxLDE6MCwwOjAsMTowLDA6MiwxOjMsMDozLDE6Mwptb3ZlX251bWJlcj00Cl9fZGljdF9fPWdBU1ZvQUVBQUFBQUFBQjlsQ2lNQlY5bllXMWxsSXcrYTJGbloyeGxYMlZ1ZG1seWIyNXRaVzUwY3k1bGJuWnpMbTl3Wlc1ZmMzQnBaV3hmWlc1MkxtZGhiV1Z6TG5OdVlXdGxMbk51WVd0bFgyZGhiV1dVakFsVGJtRnJaVWRoYldXVWs1UXBnWlNNUEhOdVlXdGxLR052YkhWdGJuTTlNVEFzWm05dlpGOXlaWE53WVhkdVgybHVkR1Z5ZG1Gc1BURXdMSEJzWVhsbGNuTTlNaXh5YjNkelBURXdLWlJpakFSeWIzZHpsRXNLakFSamIyeHpsRXNLakF0dWRXMWZjR3hoZVdWeWM1UkxBb3dWWm05dlpGOXlaWE53WVhkdVgybHVkR1Z5ZG1Gc2xFc0tqQXhmYVhOZmRHVnliV2x1WVd5VWlJd1JYMmRoYldWZmIzWmxjbDl5WldGemIyNlVUb3dHYzI1aGEyVnpsRjJVS0YyVVN3RkxBWWFVWVYyVVpZd0djMk52Y21WemxGMlVLRWNBQUFBQUFBQUFBRWNBQUFBQUFBQUFBR1dNQ0dselgyRnNhWFpsbEYyVUtJaUpaWXdGWm05dlpIT1VYWlFvU3dKTEJvYVVTd2RMQTRhVVpZd0dYM04wWlhCemxFc0VqQTVmY205MWJtUmZhR2x6ZEc5eWVaUmRsQ2hkbENoTEFVc0FaVjJVS0VzQVN3QmxYWlFvU3dKTEEyVmRsQ2hMQTBzRFpXVjFMZz09CpRicy4=\n",
           "legalActions": [],
           "legalActionStrings": []
         },
@@ -564,21 +601,39 @@
       }
     ]
   ],
-  "rewards": [0.0, 0.0],
-  "statuses": ["DONE", "DONE"],
+  "rewards": [
+    0.0,
+    0.0
+  ],
+  "statuses": [
+    "DONE",
+    "DONE"
+  ],
   "schema_version": 1,
   "info": {
-    "openSpielGameStringResolved": "snake_proxy(columns=10,players=2,rows=10)",
+    "openSpielGameStringResolved": "snake_proxy(columns=10,food_respawn_interval=10,players=2,rows=10)",
     "stateHistory": [
-      "{\"board\": [[\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \"A\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \"*\", \".\", \".\", \".\", \".\", \".\", \"B\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"]], \"num_rows\": 10, \"num_columns\": 10, \"num_players\": 2, \"food\": [8, 2], \"snakes\": [{\"player\": 0, \"body\": [[1, 1]], \"alive\": true, \"score\": 0.0}, {\"player\": 1, \"body\": [[8, 8]], \"alive\": true, \"score\": 0.0}], \"scores\": [0.0, 0.0], \"is_alive\": [true, true], \"current_player\": 0, \"pending_this_turn\": [], \"turn\": 0, \"is_terminal\": false, \"winner\": null, \"game_over_reason\": null}",
-      "{\"board\": [[\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \"A\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \"*\", \".\", \".\", \".\", \".\", \".\", \"B\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"]], \"num_rows\": 10, \"num_columns\": 10, \"num_players\": 2, \"food\": [8, 2], \"snakes\": [{\"player\": 0, \"body\": [[1, 1]], \"alive\": true, \"score\": 0.0}, {\"player\": 1, \"body\": [[8, 8]], \"alive\": true, \"score\": 0.0}], \"scores\": [0.0, 0.0], \"is_alive\": [true, true], \"current_player\": 1, \"pending_this_turn\": [0], \"turn\": 0, \"is_terminal\": false, \"winner\": null, \"game_over_reason\": null}",
-      "{\"board\": [[\".\", \"A\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \"B\", \".\"], [\".\", \".\", \"*\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"]], \"num_rows\": 10, \"num_columns\": 10, \"num_players\": 2, \"food\": [8, 2], \"snakes\": [{\"player\": 0, \"body\": [[0, 1]], \"alive\": true, \"score\": 0.0}, {\"player\": 1, \"body\": [[7, 8]], \"alive\": true, \"score\": 0.0}], \"scores\": [0.0, 0.0], \"is_alive\": [true, true], \"current_player\": 0, \"pending_this_turn\": [], \"turn\": 1, \"is_terminal\": false, \"winner\": null, \"game_over_reason\": null}",
-      "{\"board\": [[\".\", \"A\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \"B\", \".\"], [\".\", \".\", \"*\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"]], \"num_rows\": 10, \"num_columns\": 10, \"num_players\": 2, \"food\": [8, 2], \"snakes\": [{\"player\": 0, \"body\": [[0, 1]], \"alive\": true, \"score\": 0.0}, {\"player\": 1, \"body\": [[7, 8]], \"alive\": true, \"score\": 0.0}], \"scores\": [0.0, 0.0], \"is_alive\": [true, true], \"current_player\": 1, \"pending_this_turn\": [0], \"turn\": 1, \"is_terminal\": false, \"winner\": null, \"game_over_reason\": null}",
-      "{\"board\": [[\"A\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \"B\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \"*\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"]], \"num_rows\": 10, \"num_columns\": 10, \"num_players\": 2, \"food\": [8, 2], \"snakes\": [{\"player\": 0, \"body\": [[0, 0]], \"alive\": true, \"score\": 0.0}, {\"player\": 1, \"body\": [[6, 8]], \"alive\": true, \"score\": 0.0}], \"scores\": [0.0, 0.0], \"is_alive\": [true, true], \"current_player\": 0, \"pending_this_turn\": [], \"turn\": 2, \"is_terminal\": false, \"winner\": null, \"game_over_reason\": null}",
-      "{\"board\": [[\"A\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \"B\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \"*\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"]], \"num_rows\": 10, \"num_columns\": 10, \"num_players\": 2, \"food\": [8, 2], \"snakes\": [{\"player\": 0, \"body\": [[0, 0]], \"alive\": true, \"score\": 0.0}, {\"player\": 1, \"body\": [[6, 8]], \"alive\": true, \"score\": 0.0}], \"scores\": [0.0, 0.0], \"is_alive\": [true, true], \"current_player\": 1, \"pending_this_turn\": [0], \"turn\": 2, \"is_terminal\": false, \"winner\": null, \"game_over_reason\": null}",
-      "{\"board\": [[\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \"B\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \"*\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"]], \"num_rows\": 10, \"num_columns\": 10, \"num_players\": 2, \"food\": [8, 2], \"snakes\": [{\"player\": 0, \"body\": [], \"alive\": false, \"score\": 0.0}, {\"player\": 1, \"body\": [[6, 7]], \"alive\": true, \"score\": 0.0}], \"scores\": [0.0, 0.0], \"is_alive\": [false, true], \"current_player\": -4, \"pending_this_turn\": [], \"turn\": 3, \"is_terminal\": true, \"winner\": 1, \"game_over_reason\": null}"
+      "{\"board\": [[\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \"A\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \"*\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \"*\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \"B\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"]], \"num_rows\": 10, \"num_columns\": 10, \"num_players\": 2, \"foods\": [[2, 6], [7, 3]], \"food\": [2, 6], \"food_respawn_interval\": 10, \"turns_until_respawn\": 10, \"snakes\": [{\"player\": 0, \"body\": [[1, 1]], \"alive\": true, \"score\": 0.0}, {\"player\": 1, \"body\": [[8, 8]], \"alive\": true, \"score\": 0.0}], \"scores\": [0.0, 0.0], \"is_alive\": [true, true], \"current_player\": \"simultaneous\", \"round_history\": [], \"turn\": 0, \"is_terminal\": false, \"winner\": null, \"game_over_reason\": null}",
+      "{\"board\": [[\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \"A\", \".\", \".\", \".\", \".\", \"*\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \"*\", \".\", \".\", \".\", \".\", \"B\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"]], \"num_rows\": 10, \"num_columns\": 10, \"num_players\": 2, \"foods\": [[2, 6], [7, 3]], \"food\": [2, 6], \"food_respawn_interval\": 10, \"turns_until_respawn\": 9, \"snakes\": [{\"player\": 0, \"body\": [[2, 1]], \"alive\": true, \"score\": 0.0}, {\"player\": 1, \"body\": [[7, 8]], \"alive\": true, \"score\": 0.0}], \"scores\": [0.0, 0.0], \"is_alive\": [true, true], \"current_player\": \"simultaneous\", \"round_history\": [[\"DOWN\", \"UP\"]], \"turn\": 1, \"is_terminal\": false, \"winner\": null, \"game_over_reason\": null}",
+      "{\"board\": [[\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \"A\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \"*\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \"B\", \".\"], [\".\", \".\", \".\", \"*\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"]], \"num_rows\": 10, \"num_columns\": 10, \"num_players\": 2, \"foods\": [[2, 6], [7, 3]], \"food\": [2, 6], \"food_respawn_interval\": 10, \"turns_until_respawn\": 8, \"snakes\": [{\"player\": 0, \"body\": [[1, 1]], \"alive\": true, \"score\": 0.0}, {\"player\": 1, \"body\": [[6, 8]], \"alive\": true, \"score\": 0.0}], \"scores\": [0.0, 0.0], \"is_alive\": [true, true], \"current_player\": \"simultaneous\", \"round_history\": [[\"DOWN\", \"UP\"], [\"UP\", \"UP\"]], \"turn\": 2, \"is_terminal\": false, \"winner\": null, \"game_over_reason\": null}",
+      "{\"board\": [[\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\"A\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \"*\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \"B\"], [\".\", \".\", \".\", \"*\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"]], \"num_rows\": 10, \"num_columns\": 10, \"num_players\": 2, \"foods\": [[2, 6], [7, 3]], \"food\": [2, 6], \"food_respawn_interval\": 10, \"turns_until_respawn\": 7, \"snakes\": [{\"player\": 0, \"body\": [[1, 0]], \"alive\": true, \"score\": 0.0}, {\"player\": 1, \"body\": [[6, 9]], \"alive\": true, \"score\": 0.0}], \"scores\": [0.0, 0.0], \"is_alive\": [true, true], \"current_player\": \"simultaneous\", \"round_history\": [[\"DOWN\", \"UP\"], [\"UP\", \"UP\"], [\"LEFT\", \"RIGHT\"]], \"turn\": 3, \"is_terminal\": false, \"winner\": null, \"game_over_reason\": null}",
+      "{\"board\": [[\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \"A\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \"*\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \"*\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"], [\".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\", \".\"]], \"num_rows\": 10, \"num_columns\": 10, \"num_players\": 2, \"foods\": [[2, 6], [7, 3]], \"food\": [2, 6], \"food_respawn_interval\": 10, \"turns_until_respawn\": 6, \"snakes\": [{\"player\": 0, \"body\": [[1, 1]], \"alive\": true, \"score\": 0.0}, {\"player\": 1, \"body\": [], \"alive\": false, \"score\": 0.0}], \"scores\": [0.0, 0.0], \"is_alive\": [true, false], \"current_player\": \"terminal\", \"round_history\": [[\"DOWN\", \"UP\"], [\"UP\", \"UP\"], [\"LEFT\", \"RIGHT\"], [\"RIGHT\", \"RIGHT\"]], \"turn\": 4, \"is_terminal\": true, \"winner\": 0, \"game_over_reason\": null}"
     ],
-    "actionHistory": ["0", "0", "2", "0", "0", "2"],
-    "moveDurations": [0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+    "actionHistory": [
+      "[1, 0]",
+      "[0, 0]",
+      "[2, 3]",
+      "[3, 3]"
+    ],
+    "moveDurations": [
+      0.0,
+      0.0,
+      0.0,
+      0.0,
+      0.0,
+      0.0,
+      0.0,
+      0.0
+    ]
   }
 }

--- a/kaggle_environments/envs/open_spiel_env/games/snake/visualizer/default/src/renderer.ts
+++ b/kaggle_environments/envs/open_spiel_env/games/snake/visualizer/default/src/renderer.ts
@@ -127,7 +127,8 @@ export function renderer(options: RendererOptions<SnakeStep[]>) {
     .map((snake) => {
       const name = getPlayerName(replay, snake.player);
       const color = PLAYER_COLORS[snake.player % PLAYER_COLORS.length];
-      const isActive = !obs.is_terminal && obs.current_player === snake.player;
+      // Every alive snake acts every turn under simultaneous dynamics.
+      const isActive = !obs.is_terminal && snake.alive;
       const classes = ['snake-player-card', snake.alive ? 'alive' : 'dead', isActive ? 'active' : ''].join(' ');
       return `
         <div class="${classes}" style="color: ${color};">
@@ -151,12 +152,7 @@ export function renderer(options: RendererOptions<SnakeStep[]>) {
     }
     if (obs.game_over_reason) status += ` — ${obs.game_over_reason}`;
   } else {
-    const aname = getPlayerName(replay, obs.current_player);
-    const acolor = PLAYER_COLORS[obs.current_player % PLAYER_COLORS.length];
-    status = `Turn ${obs.turn} — acting: <span style="color: ${acolor}; font-weight: 700;">${aname}</span>`;
-    if (obs.pending_this_turn.length > 0) {
-      status += ` (pending: ${obs.pending_this_turn.join(', ')})`;
-    }
+    status = `Turn ${obs.turn} — simultaneous move`;
   }
   if (forfeitReason) {
     status += ` <span class="forfeit-reason">${escapeHtml(forfeitReason)}</span>`;

--- a/kaggle_environments/envs/open_spiel_env/games/snake/visualizer/default/src/transformers/snakeTransformer.ts
+++ b/kaggle_environments/envs/open_spiel_env/games/snake/visualizer/default/src/transformers/snakeTransformer.ts
@@ -39,8 +39,7 @@ export interface SnakeBoardState {
   }[];
   scores: number[];
   is_alive: boolean[];
-  current_player: number;
-  pending_this_turn: number[];
+  current_player: number | string;
   turn: number;
   is_terminal: boolean;
   winner: number | string | null;

--- a/tests/envs/open_spiel_env/games/snake/env_test.py
+++ b/tests/envs/open_spiel_env/games/snake/env_test.py
@@ -39,7 +39,8 @@ class SnakeEnvTest(absltest.TestCase):
         self.assertTrue(obs["snakes"][0]["alive"])
         self.assertTrue(obs["snakes"][1]["alive"])
         self.assertEqual(obs["scores"], [0.0, 0.0])
-        self.assertEqual(obs["current_player"], 0)
+        # Simultaneous game: every step is a simultaneous node.
+        self.assertEqual(obs["current_player"], "simultaneous")
         self.assertFalse(obs["is_terminal"])
         self.assertIsNone(obs["winner"])
         self.assertEqual(obs["turn"], 0)
@@ -49,22 +50,16 @@ class SnakeEnvTest(absltest.TestCase):
         self.assertEqual(obs["board"][fr][fc], "*")
 
     def test_snake_manual_playthrough(self):
-        # Sequential implementation of simultaneous play: each player submits
-        # in turn, then the buffered moves are applied together. Drive both
-        # snakes off the board on the first round so both die and the game
-        # terminates immediately.
+        # Simultaneous-move play: both players submit each step and their
+        # moves are applied together. Drive both snakes off the board so
+        # both die and the game terminates.
         env = make("open_spiel_snake", debug=True)
         env.reset()
         env.step([{"submission": -1}, {"submission": -1}])  # Setup step.
-        # P0 at (1,1): UP -> (0,1)? still on board. Send LEFT (2) twice to die.
-        # First round: both submit a move; resolution moves snakes and may kill.
-        # P0 LEFT from (1,1) -> (1,0) (alive). P1 RIGHT from (8,8) -> (8,9) (alive).
-        # Second round: P0 LEFT from (1,0) -> (1,-1) (wall, dies).
-        # P1 RIGHT from (8,9) -> (8,10) (wall, dies).
-        env.step([{"submission": 2}, {"submission": -1}])  # P0 LEFT
-        env.step([{"submission": -1}, {"submission": 3}])  # P1 RIGHT
-        env.step([{"submission": 2}, {"submission": -1}])  # P0 LEFT (off board)
-        env.step([{"submission": -1}, {"submission": 3}])  # P1 RIGHT (off board)
+        # Turn 1: P0 LEFT from (1,1) -> (1,0). P1 RIGHT from (8,8) -> (8,9).
+        env.step([{"submission": 2}, {"submission": 3}])
+        # Turn 2: P0 LEFT from (1,0) -> (1,-1) wall. P1 RIGHT from (8,9) -> (8,10) wall.
+        env.step([{"submission": 2}, {"submission": 3}])
         self.assertTrue(env.done)
         obs = json.loads(env.state[0]["observation"]["observationString"])
         self.assertTrue(obs["is_terminal"])
@@ -75,7 +70,8 @@ class SnakeEnvTest(absltest.TestCase):
         env = make("open_spiel_snake", debug=True)
         env.reset()
         env.step([{"submission": -1}, {"submission": -1}])  # Setup step.
-        env.step([{"submission": 999}, {"submission": -1}])  # Invalid action.
+        # P0 submits an illegal action; P1's submission is a legal move.
+        env.step([{"submission": 999}, {"submission": 0}])
         self.assertTrue(env.done)
         json_out = env.toJSON()
         self.assertEqual(

--- a/tests/envs/open_spiel_env/games/snake/snake_game_test.py
+++ b/tests/envs/open_spiel_env/games/snake/snake_game_test.py
@@ -5,262 +5,253 @@ from absl.testing import absltest
 
 
 class SnakeGameTest(absltest.TestCase):
+    def test_game_creation(self):
+        game = pyspiel.load_game("snake")
+        self.assertIsNotNone(game)
+        state = game.new_initial_state()
+        self.assertIsNotNone(state)
+        self.assertFalse(state.is_terminal())
+        # Default 2 players
+        self.assertEqual(state.num_players, 2)
+        # Simultaneous dynamics: current player is SIMULTANEOUS, not 0.
+        self.assertTrue(state.is_simultaneous_node())
+        self.assertEqual(state.current_player(), pyspiel.PlayerId.SIMULTANEOUS)
 
-  def test_game_creation(self):
-    game = pyspiel.load_game("snake")
-    self.assertIsNotNone(game)
-    state = game.new_initial_state()
-    self.assertIsNotNone(state)
-    self.assertFalse(state.is_terminal())
-    # Default 2 players
-    self.assertEqual(state.num_players, 2)
+    def test_movement(self):
+        game = pyspiel.load_game("snake", {"rows": 10, "columns": 10, "players": 1})
+        state = game.new_initial_state()
+        # Initial snake is at center.
+        head_pos = state.snakes[0][0]
 
-  def test_movement(self):
-    game = pyspiel.load_game(
-        "snake", {"rows": 10, "columns": 10, "players": 1}
-    )
-    state = game.new_initial_state()
-    # Initial snake is at center.
-    head_pos = state.snakes[0][0]
+        # Move UP (0)
+        state.apply_actions([0])
+        new_head_pos = state.snakes[0][0]
+        self.assertEqual(new_head_pos[0], head_pos[0] - 1)
+        self.assertEqual(new_head_pos[1], head_pos[1])
 
-    # Move UP (0)
-    state.apply_action(0)
-    new_head_pos = state.snakes[0][0]
-    self.assertEqual(new_head_pos[0], head_pos[0] - 1)
-    self.assertEqual(new_head_pos[1], head_pos[1])
+    def test_wall_collision(self):
+        game = pyspiel.load_game("snake", {"rows": 3, "columns": 3, "players": 1})
+        state = game.new_initial_state()
+        # Clear foods so the test only measures wall collision (random food may
+        # otherwise land on the snake's path and grant a point).
+        state.foods = []
+        # Snake at 1, 1.
+        # Move UP to 0, 1
+        state.apply_actions([0])
+        # Move UP to -1, 1 (collision)
+        state.apply_actions([0])
+        self.assertTrue(state.is_terminal())
+        # Check returns (0 score)
+        self.assertEqual(state.returns()[0], 0)
 
-  def test_wall_collision(self):
-    game = pyspiel.load_game(
-        "snake", {"rows": 3, "columns": 3, "players": 1}
-    )
-    state = game.new_initial_state()
-    # Clear foods so the test only measures wall collision (random food may
-    # otherwise land on the snake's path and grant a point).
-    state.foods = []
-    # Snake at 1, 1.
-    # Move UP to 0, 1
-    state.apply_action(0)
-    # Move UP to -1, 1 (collision)
-    state.apply_action(0)
-    self.assertTrue(state.is_terminal())
-    # Check returns (0 score)
-    self.assertEqual(state.returns()[0], 0)
+    def test_eating_food(self):
+        game = pyspiel.load_game("snake", {"rows": 10, "columns": 10, "players": 1})
+        state = game.new_initial_state()
 
-  def test_eating_food(self):
-    game = pyspiel.load_game(
-        "snake", {"rows": 10, "columns": 10, "players": 1}
-    )
-    state = game.new_initial_state()
+        # Force food pair to known cells (one reachable, one far away).
+        head_r, head_c = state.snakes[0][0]
+        food_r, food_c = head_r - 1, head_c
+        partner = (state.rows - 1 - food_r, state.cols - 1 - food_c)
+        state.foods = [(food_r, food_c), partner]
 
-    # Force food pair to known cells (one reachable, one far away).
-    head_r, head_c = state.snakes[0][0]
-    food_r, food_c = head_r - 1, head_c
-    partner = (state.rows - 1 - food_r, state.cols - 1 - food_c)
-    state.foods = [(food_r, food_c), partner]
+        initial_len = len(state.snakes[0])
+        # Move UP to eat
+        state.apply_actions([0])
 
-    initial_len = len(state.snakes[0])
-    # Move UP to eat
-    state.apply_action(0)
+        self.assertLen(state.snakes[0], initial_len + 1)
+        self.assertEqual(state.returns()[0], 1.0)
+        # Eaten food cell should be gone.
+        self.assertNotIn((food_r, food_c), state.foods)
 
-    self.assertLen(state.snakes[0], initial_len + 1)
-    self.assertEqual(state.returns()[0], 1.0)
-    # Eaten food cell should be gone.
-    self.assertNotIn((food_r, food_c), state.foods)
+    def test_food_pair_symmetric(self):
+        game = pyspiel.load_game("snake", {"rows": 10, "columns": 10, "players": 2})
+        state = game.new_initial_state()
 
-  def test_food_pair_symmetric(self):
-    game = pyspiel.load_game(
-        "snake", {"rows": 10, "columns": 10, "players": 2}
-    )
-    state = game.new_initial_state()
+        self.assertLen(state.foods, 2)
+        (r0, c0), (r1, c1) = state.foods
+        # 180° rotation about board center.
+        self.assertEqual(r0 + r1, state.rows - 1)
+        self.assertEqual(c0 + c1, state.cols - 1)
 
-    self.assertLen(state.foods, 2)
-    (r0, c0), (r1, c1) = state.foods
-    # 180° rotation about board center.
-    self.assertEqual(r0 + r1, state.rows - 1)
-    self.assertEqual(c0 + c1, state.cols - 1)
+        # Distance from each snake start to its nearest food is equal.
+        def manhattan(a, b):
+            return abs(a[0] - b[0]) + abs(a[1] - b[1])
 
-    # Distance from each snake start to its nearest food is equal.
-    def manhattan(a, b):
-      return abs(a[0] - b[0]) + abs(a[1] - b[1])
+        p0_start = state.snakes[0][0]
+        p1_start = state.snakes[1][0]
+        d0 = min(manhattan(p0_start, f) for f in state.foods)
+        d1 = min(manhattan(p1_start, f) for f in state.foods)
+        self.assertEqual(d0, d1)
 
-    p0_start = state.snakes[0][0]
-    p1_start = state.snakes[1][0]
-    d0 = min(manhattan(p0_start, f) for f in state.foods)
-    d1 = min(manhattan(p1_start, f) for f in state.foods)
-    self.assertEqual(d0, d1)
+    def test_food_respawn_timer(self):
+        game = pyspiel.load_game(
+            "snake",
+            {"rows": 10, "columns": 10, "players": 2, "food_respawn_interval": 3},
+        )
+        state = game.new_initial_state()
 
-  def test_food_respawn_timer(self):
-    game = pyspiel.load_game(
-        "snake",
-        {"rows": 10, "columns": 10, "players": 2, "food_respawn_interval": 3},
-    )
-    state = game.new_initial_state()
+        # Pin foods to cells far from either snake so neither can eat them.
+        state.foods = [(4, 0), (5, 9)]
 
-    # Pin foods to cells far from either snake so neither can eat them.
-    state.foods = [(4, 0), (5, 9)]
+        # Step 3 turns of safe moves: P0 starts at (1,1) heads DOWN; P1 starts
+        # at (8,8) heads UP — both stay well clear of the walls and each other.
+        for _ in range(3):
+            state.apply_actions([1, 0])  # P0 DOWN, P1 UP
 
-    # Step 3 turns of safe moves: P0 starts at (1,1) heads DOWN; P1 starts
-    # at (8,8) heads UP — both stay well clear of the walls and each other.
-    for _ in range(3):
-      state.apply_action(1)  # P0 DOWN
-      state.apply_action(0)  # P1 UP
+        # Old pinned cells must be gone (replaced by a fresh symmetric pair).
+        self.assertNotIn((4, 0), state.foods)
+        self.assertNotIn((5, 9), state.foods)
+        self.assertLen(state.foods, 2)
+        (r0, c0), (r1, c1) = state.foods
+        self.assertEqual(r0 + r1, state.rows - 1)
+        self.assertEqual(c0 + c1, state.cols - 1)
 
-    # Old pinned cells must be gone (replaced by a fresh symmetric pair).
-    self.assertNotIn((4, 0), state.foods)
-    self.assertNotIn((5, 9), state.foods)
-    self.assertLen(state.foods, 2)
-    (r0, c0), (r1, c1) = state.foods
-    self.assertEqual(r0 + r1, state.rows - 1)
-    self.assertEqual(c0 + c1, state.cols - 1)
+    def test_uneaten_food_removed_on_respawn(self):
+        game = pyspiel.load_game(
+            "snake",
+            {"rows": 10, "columns": 10, "players": 2, "food_respawn_interval": 2},
+        )
+        state = game.new_initial_state()
+        state.foods = [(0, 0), (9, 9)]  # Out of reach in 2 turns.
 
-  def test_uneaten_food_removed_on_respawn(self):
-    game = pyspiel.load_game(
-        "snake",
-        {"rows": 10, "columns": 10, "players": 2, "food_respawn_interval": 2},
-    )
-    state = game.new_initial_state()
-    state.foods = [(0, 0), (9, 9)]  # Out of reach in 2 turns.
+        for _ in range(2):
+            state.apply_actions([1, 0])  # P0 DOWN, P1 UP
 
-    for _ in range(2):
-      state.apply_action(1)  # P0 DOWN
-      state.apply_action(0)  # P1 UP
+        self.assertNotIn((0, 0), state.foods)
+        self.assertNotIn((9, 9), state.foods)
 
-    self.assertNotIn((0, 0), state.foods)
-    self.assertNotIn((9, 9), state.foods)
+    def test_food_respawns_immediately_when_board_empty(self):
+        game = pyspiel.load_game(
+            "snake",
+            {"rows": 10, "columns": 10, "players": 2, "food_respawn_interval": 10},
+        )
+        state = game.new_initial_state()
 
-  def test_food_respawns_immediately_when_board_empty(self):
-    game = pyspiel.load_game(
-        "snake",
-        {"rows": 10, "columns": 10, "players": 2, "food_respawn_interval": 10},
-    )
-    state = game.new_initial_state()
+        # Pin food where P0 will eat it on step 1 (and its symmetric partner
+        # where P1 will eat it on step 1).
+        state.snakes[0] = [(1, 1)]
+        state.snakes[1] = [(8, 8)]
+        state.foods = [(2, 1), (7, 8)]
 
-    # Pin food where P0 will eat it on step 1 (and its symmetric partner
-    # where P1 will eat it on step 1).
-    state.snakes[0] = [(1, 1)]
-    state.snakes[1] = [(8, 8)]
-    state.foods = [(2, 1), (7, 8)]
+        state.apply_actions([1, 0])  # P0 DOWN eats (2,1); P1 UP eats (7,8)
 
-    state.apply_action(1)  # P0 DOWN -> eats (2,1)
-    state.apply_action(0)  # P1 UP   -> eats (7,8)
+        # Both eaten in one turn: new pair should be placed immediately (not
+        # wait 10 turns for the timer).
+        self.assertLen(state.foods, 2)
+        self.assertNotIn((2, 1), state.foods)
+        self.assertNotIn((7, 8), state.foods)
 
-    # Both eaten in one turn: new pair should be placed immediately (not
-    # wait 10 turns for the timer).
-    self.assertLen(state.foods, 2)
-    self.assertNotIn((2, 1), state.foods)
-    self.assertNotIn((7, 8), state.foods)
+    def test_immediate_respawn_resets_timer(self):
+        game = pyspiel.load_game(
+            "snake",
+            {"rows": 10, "columns": 10, "players": 2, "food_respawn_interval": 5},
+        )
+        state = game.new_initial_state()
+        state.snakes[0] = [(1, 1)]
+        state.snakes[1] = [(8, 8)]
+        state.foods = [(2, 1), (7, 8)]
 
-  def test_immediate_respawn_resets_timer(self):
-    game = pyspiel.load_game(
-        "snake",
-        {"rows": 10, "columns": 10, "players": 2, "food_respawn_interval": 5},
-    )
-    state = game.new_initial_state()
-    state.snakes[0] = [(1, 1)]
-    state.snakes[1] = [(8, 8)]
-    state.foods = [(2, 1), (7, 8)]
+        # Turn 1: both foods eaten -> immediate respawn resets the timer.
+        state.apply_actions([1, 0])
+        respawned = list(state.foods)
 
-    # Turn 1: both foods eaten -> immediate respawn resets the timer.
-    state.apply_action(1)  # P0 DOWN
-    state.apply_action(0)  # P1 UP
-    respawned = list(state.foods)
+        # Pin the fresh pair somewhere unreachable so it survives 4 more turns.
+        state.foods = [(0, 4), (9, 5)]
 
-    # Pin the fresh pair somewhere unreachable so it survives 4 more turns.
-    state.foods = [(0, 4), (9, 5)]
+        # 4 more safe turns: timer must NOT have fired yet (5 turns since the
+        # last spawn haven't elapsed).
+        for _ in range(4):
+            state.apply_actions([1, 0])
+        self.assertIn((0, 4), state.foods)
+        self.assertIn((9, 5), state.foods)
 
-    # 4 more safe turns: timer must NOT have fired yet (5 turns since the
-    # last spawn haven't elapsed).
-    for _ in range(4):
-      state.apply_action(1)  # P0 DOWN
-      state.apply_action(0)  # P1 UP
-    self.assertIn((0, 4), state.foods)
-    self.assertIn((9, 5), state.foods)
+        # 5th turn since the immediate respawn: timer fires, uneaten food is
+        # cleared, fresh pair placed. Assert the timer bumped
+        # (_last_food_spawn_step) rather than checking specific coordinates:
+        # `_place_foods` samples uniformly from all symmetric candidate pairs,
+        # so it can legitimately re-pick the pinned (0, 4)/(9, 5) pair -- a
+        # coordinate-based assertion is flaky under different RNG states.
+        prev_spawn_step = state._last_food_spawn_step
+        state.apply_actions([1, 0])
+        self.assertEqual(state._last_food_spawn_step, state._steps)
+        self.assertNotEqual(state._last_food_spawn_step, prev_spawn_step)
+        self.assertLen(state.foods, 2)
+        del respawned
 
-    # 5th turn since the immediate respawn: timer fires, uneaten food is
-    # cleared, fresh pair placed. Assert the timer bumped
-    # (_last_food_spawn_step) rather than checking specific coordinates:
-    # `_place_foods` samples uniformly from all symmetric candidate pairs,
-    # so it can legitimately re-pick the pinned (0, 4)/(9, 5) pair -- a
-    # coordinate-based assertion is flaky under different RNG states.
-    prev_spawn_step = state._last_food_spawn_step
-    state.apply_action(1)
-    state.apply_action(0)
-    self.assertEqual(state._last_food_spawn_step, state._steps)
-    self.assertNotEqual(state._last_food_spawn_step, prev_spawn_step)
-    self.assertLen(state.foods, 2)
-    del respawned
+    def test_simultaneous_movement(self):
+        game = pyspiel.load_game("snake", {"rows": 5, "columns": 5, "players": 2})
+        state = game.new_initial_state()
 
-  def test_simultaneous_movement(self):
-    game = pyspiel.load_game(
-        "snake", {"rows": 5, "columns": 5, "players": 2}
-    )
-    state = game.new_initial_state()
+        # 2 players.
+        p0_head = state.snakes[0][0]
+        p1_head = state.snakes[1][0]
 
-    # 2 players.
-    p0_head = state.snakes[0][0]
-    p1_head = state.snakes[1][0]
+        # Apply both moves at once: P0 DOWN (1), P1 UP (0).
+        state.apply_actions([1, 0])
 
-    # P0 moves DOWN (1)
-    state.apply_action(1)
+        # Both heads should have moved.
+        self.assertEqual(state.snakes[0][0], (p0_head[0] + 1, p0_head[1]))
+        self.assertEqual(state.snakes[1][0], (p1_head[0] - 1, p1_head[1]))
 
-    # State shouldn't change yet (buffered)
-    self.assertEqual(state.snakes[0][0], p0_head)
+    def test_collision_other_snake(self):
+        # Set up a small board where they collide
+        game = pyspiel.load_game("snake", {"rows": 4, "columns": 4, "players": 2})
+        state = game.new_initial_state()
 
-    # P1 moves UP (0)
-    state.apply_action(0)
+        # Force positions for collision test
+        # P0 head at (1,1)
+        # P1 head at (1,3)
+        state.snakes[0] = [(1, 1)]
+        state.snakes[1] = [(1, 3)]
 
-    # Now state update
-    self.assertEqual(state.snakes[0][0], (p0_head[0] + 1, p0_head[1]))
-    self.assertEqual(state.snakes[1][0], (p1_head[0] - 1, p1_head[1]))
+        # P0 moves RIGHT (3) -> (1,2)
+        # P1 moves LEFT (2) -> (1,2)
+        # Head to Head collision! Both should die.
+        state.apply_actions([3, 2])
 
-  def test_collision_other_snake(self):
-    # Set up a small board where they collide
-    game = pyspiel.load_game(
-        "snake", {"rows": 4, "columns": 4, "players": 2}
-    )
-    state = game.new_initial_state()
+        # Check survival
+        self.assertFalse(state.is_alive[0])
+        self.assertFalse(state.is_alive[1])
+        self.assertTrue(state.is_terminal())
 
-    # Force positions for collision test
-    # P0 head at (1,1)
-    # P1 head at (1,3)
-    state.snakes[0] = [(1, 1)]
-    state.snakes[1] = [(1, 3)]
+    def test_one_survivor_wins(self):
+        game = pyspiel.load_game("snake", {"rows": 4, "columns": 4, "players": 2})
+        state = game.new_initial_state()
 
-    # P0 moves RIGHT (3) -> (1,2)
-    # P1 moves LEFT (2) -> (1,2)
-    # Head to Head collision! Both should die.
+        # Force positions:
+        # P0 at (1,1), P1 at (3,3)
+        state.snakes[0] = [(1, 1)]
+        state.snakes[1] = [(3, 3)]
 
-    state.apply_action(3)  # P0 RIGHT
-    state.apply_action(2)  # P1 LEFT
+        # P0 hits wall: UP -> (0,1) -> UP -> (-1,1)
+        state.apply_actions([0, 0])  # P0 UP (safe), P1 UP (safe)
+        state.apply_actions([0, 0])  # P0 UP (crash), P1 UP (safe)
 
-    # Check survival
-    self.assertFalse(state.is_alive[0])
-    self.assertFalse(state.is_alive[1])
-    self.assertTrue(state.is_terminal())
+        self.assertFalse(state.is_alive[0])
+        self.assertTrue(state.is_alive[1])
+        self.assertTrue(state.is_terminal())
 
-  def test_one_survivor_wins(self):
-    game = pyspiel.load_game(
-        "snake", {"rows": 4, "columns": 4, "players": 2}
-    )
-    state = game.new_initial_state()
+    def test_dead_player_has_no_legal_actions(self):
+        """A dead player must have empty legal_actions so the interpreter
+        marks them INACTIVE at simultaneous nodes."""
+        game = pyspiel.load_game("snake", {"rows": 5, "columns": 5, "players": 3})
+        state = game.new_initial_state()
+        # Force positions so only P0 dies from a wall crash.
+        state.snakes[0] = [(0, 0)]
+        state.snakes[1] = [(4, 4)]
+        state.snakes[2] = [(0, 4)]
 
-    # Force positions:
-    # P0 at (1,1), P1 at (3,3)
-    state.snakes[0] = [(1, 1)]
-    state.snakes[1] = [(3, 3)]
+        # P0 UP -> off top edge. P1 UP (safe). P2 DOWN (safe).
+        state.apply_actions([0, 0, 1])
 
-    # P0 hits wall: UP -> (0,1) -> UP -> (-1,1)
-    state.apply_action(0)  # P0 UP
-    state.apply_action(0)  # P1 UP (safe)
-
-    # Next turn
-    state.apply_action(0)  # P0 UP (crash)
-    state.apply_action(0)  # P1 UP (safe)
-
-    self.assertFalse(state.is_alive[0])
-    self.assertTrue(state.is_alive[1])
-    self.assertTrue(state.is_terminal())
+        self.assertFalse(state.is_alive[0])
+        self.assertTrue(state.is_alive[1])
+        self.assertTrue(state.is_alive[2])
+        self.assertFalse(state.is_terminal())
+        self.assertEqual(state.legal_actions(0), [])
+        self.assertNotEqual(state.legal_actions(1), [])
+        self.assertNotEqual(state.legal_actions(2), [])
 
 
 if __name__ == "__main__":
-  absltest.main()
+    absltest.main()


### PR DESCRIPTION
Convert snake_game from SEQUENTIAL-with-buffering to native OpenSpiel SIMULTANEOUS dynamics: current_player() returns SIMULTANEOUS, dead players get empty legal_actions (marked INACTIVE), and _apply_actions processes all players' moves in one call. Update proxy, visualizer, tests, and test-replay accordingly.