### PR TITLE
Add LLM harness for Lux AI 2021

### DIFF
--- a/kaggle_environments/envs/lux_ai_2021/harness.py
+++ b/kaggle_environments/envs/lux_ai_2021/harness.py
@@ -1,0 +1,512 @@
+"""LLM harness for the Lux AI 2021 environment.
+
+Implements the three module-level functions of the ``GameHarness`` protocol:
+``get_legal_moves``, ``generate_prompt``, ``parse_response``. The action space
+is free-form (per-unit command strings are combinatorial), so
+``get_legal_moves`` always returns ``None`` and ``freeForm: true`` in the env
+spec routes the parser's ``submission`` list through as ``state[team].action``.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any, Mapping, Sequence
+
+from kaggle_environments.core_harness import (
+    ParseResult,
+    extract_last_json_object,
+    get_telemetry_logger,
+    render_rethink_suffix,
+)
+
+from kaggle_environments.envs.lux_ai_2021.test_agents.python.lux.game import Game
+from kaggle_environments.envs.lux_ai_2021.test_agents.python.lux.game_map import GameMap
+from kaggle_environments.envs.lux_ai_2021.test_agents.python.lux.game_objects import Player
+
+_TELEMETRY = get_telemetry_logger(__name__)
+
+# Fraction of malformed commands above which we reject the whole turn and
+# ask the model to rethink. At/below this fraction, valid commands are
+# submitted and the invalid ones are silently dropped (the Node engine
+# ignores unrecognized commands anyway).
+_INVALID_COMMAND_THRESHOLD = 0.5
+
+# Lux command grammar. Each pattern anchors the full string; ``re.fullmatch``
+# is used against the head-keyed matcher below.
+_DIR = r"[nsewc]"
+_INT = r"\d+"
+_UNIT_ID = r"u_\d+"
+_RESOURCE = r"(?:wood|coal|uranium)"
+
+# The engine's wire protocol uses "uranium" as one of the resource types. To
+# avoid tripping LLM safety filters that flag nuclear-material references, the
+# prompt talks about "crystal" instead; the harness rewrites crystal→uranium
+# in the outgoing action list and uranium→crystal when rendering the incoming
+# observation summary. Nothing else changes -- the on-wire keyword is still
+# "uranium" as far as the Node engine and the game_constants file are
+# concerned.
+_DISPLAY_URANIUM = "crystal"
+
+_COMMAND_VALIDATORS: dict[str, re.Pattern[str]] = {
+    "m": re.compile(rf"m {_UNIT_ID} {_DIR}"),  # move
+    "bcity": re.compile(rf"bcity {_UNIT_ID}"),  # build city
+    "p": re.compile(rf"p {_UNIT_ID}"),  # pillage
+    "t": re.compile(rf"t {_UNIT_ID} {_UNIT_ID} {_RESOURCE} {_INT}"),  # transfer
+    "r": re.compile(rf"r {_INT} {_INT}"),  # research
+    "bw": re.compile(rf"bw {_INT} {_INT}"),  # build worker
+    "bc": re.compile(rf"bc {_INT} {_INT}"),  # build cart
+}
+
+
+# --- Prompt templates -------------------------------------------------------
+
+
+LUX_PROMPT_TEMPLATE = """Let's play Lux AI 2021.
+
+Rules: {width}x{width} square map. Two players simultaneously issue actions
+for their workers, carts, and city tiles. The game runs 360 turns split into
+day/night cycles (30 day turns then 10 night turns).
+
+Resources and fuel. Workers can mine wood (always), coal (requires >= 50
+research points), and crystal (requires >= 200 research points). Each `r`
+command issued from a city tile adds 1 research point (subject to the
+city tile's cooldown), and unlocks tiers apply immediately once the
+thresholds are crossed. Once burned by a city, each unit of wood yields
+1 fuel, coal 10 fuel, crystal 40 fuel -- so fuel-per-city and
+resource-units-carried-by-a-worker are DIFFERENT quantities. Only WOOD
+regenerates (~1.025x per turn, capped at 500 per tile); coal and crystal
+tiles do not replenish once mined.
+
+Building units and cities.
+  - `bw` / `bc` at a city tile SPAWN a new worker / cart on that tile.
+    Spawning is FREE (no resources consumed), but the total number of
+    friendly units may not exceed the total number of friendly city
+    tiles -- spawn commands over that cap are rejected by the engine.
+  - `bcity` from a worker creates a new city tile on the worker's
+    current cell. It consumes 100 resource units total from the worker's
+    cargo, drawn in the order wood -> coal -> crystal until 100 units are
+    spent (any mix works). The cell MUST be empty (no resource on it,
+    see the command list below).
+
+Carts have larger cargo and can transfer resources to workers.
+
+Movement and stacking.
+  - Moves resolve simultaneously across both players. Direction `c` (stay)
+    is always safe.
+  - You may NOT move onto an opponent city tile (the engine rejects that
+    command outright).
+  - CITY TILES allow UNLIMITED stacking of FRIENDLY units. Any number of
+    your workers/carts may occupy the same friendly city tile (and any
+    friendly city tile they stand on at night shields them from the
+    per-unit fuel burn).
+  - Outside city tiles, at most ONE unit may occupy a cell after the
+    move. If two or more of your units try to enter the same non-city
+    cell, ALL of them are cancelled back to their starting cells. That
+    cancellation can cascade (a bounced-back unit may in turn collide
+    with someone who was trying to move into ITS old cell), so lining
+    up two moves into the same empty square typically loses both units'
+    turns rather than picking one.
+  - You cannot enter a non-city cell that is already held by any unit
+    (friend or foe) that stayed put or was cancelled -- your move gets
+    cancelled too.
+
+Night survival. At NIGHT (turns 30-39, 70-79, ...):
+  - Each city tile burns fuel from its city's shared pool. A city's
+    per-night-turn upkeep is `23 * num_tiles - 10 * num_adjacent_pairs`
+    (i.e. base 23 per tile, minus 10 for each orthogonal (N/S/E/W) pair
+    of tiles that both belong to the same city). If a city's fuel drops
+    below its upkeep on any night turn, the whole city collapses. The
+    player-state section below shows each city's already-computed net
+    upkeep so you don't have to recompute the adjacency bonus by hand.
+  - A worker OUTSIDE a city tile burns 4 of its own cargo per night turn
+    (wood first, then coal, then crystal, each converted using the
+    fuel-yield rates above); a cart outside a city burns 10. If a
+    worker/cart can't cover its upkeep it dies. A worker or cart STANDING
+    ON a friendly city tile at night pays nothing personally.
+
+The game ends at turn 360, or earlier if a team has no units AND no city
+tiles (elimination). Winner: more city tiles at end, tiebreak more units;
+if both are still tied it is a draw.
+
+Commands (one per line in your JSON response):
+  m <unit_id> <direction>          -- move unit (direction: n, s, e, w, c=stay)
+  bcity <unit_id>                  -- worker builds a city tile at its position
+                                      (worker must be on an empty cell -- not
+                                      on a wood/coal/crystal resource tile and
+                                      not on an existing city tile)
+  p <unit_id>                      -- worker pillages road at its position
+  t <from_id> <to_id> <res> <amt>  -- transfer resources between adjacent units
+                                      (res: wood, coal, or crystal)
+  r <x> <y>                        -- city tile at (x,y) researches
+  bw <x> <y>                       -- city tile at (x,y) builds a worker
+  bc <x> <y>                       -- city tile at (x,y) builds a cart
+
+A unit or city tile can only act when its cooldown is < 1. Each unit and
+each city tile may perform AT MOST ONE command per turn -- any second
+command for the same id in the same turn is silently dropped by the
+engine. Across the fleet you may issue zero or more commands per turn.
+Every command you emit must exactly match one of the forms above -- a
+small amount of leeway is applied (leading bullets, uppercase directions
+and unit ids, extra whitespace, `[u_1]`/`<u_2>` brackets, trailing `#`
+or `//` comments) but arbitrary syntax is NOT accepted. If more than
+half of your commands are malformed the whole turn is rejected and you
+are asked to try again; otherwise the malformed ones are dropped and
+the valid ones are submitted.
+
+Coordinates are (x, y) with x=0 on the left and y=0 at the top.
+
+You are player {player_id}. Turn {turn} of 360 ({phase}).
+
+Map (uppercase = your units/cities, lowercase = opponent's):
+  legend: `.` empty, `w` wood, `k` coal, `x` crystal,
+          `U/u` worker, `A/a` cart, `T/t` city tile
+{ascii_map}
+
+Your state:
+{your_summary}
+
+Opponent state:
+{opponent_summary}
+
+{recent_moves_block}
+Reply with a JSON object of the form:
+
+```json
+{{"actions": ["m u_1 n", "bcity u_2", "r 5 7"]}}
+```
+
+An empty list (`{{"actions": []}}`) is legal and means "do nothing this turn".
+"""
+
+
+_THRESHOLD_PCT = int(_INVALID_COMMAND_THRESHOLD * 100)
+
+RETHINK_ILLEGAL = (
+    "\n\nMore than "
+    + str(_THRESHOLD_PCT)
+    + "% of your previous commands were malformed:\n"
+    + "{previous_action}\n\n"
+    + "Re-read the command grammar above and reply again with a JSON object "
+    + 'of the form `{{"actions": [...]}}`. Every command must match one of '
+    + "the listed forms exactly.\n"
+)
+
+RETHINK_UNPARSABLE = (
+    "\n\nYour previous response ended with:\n"
+    + "{previous_response}\n\n"
+    + "No JSON `actions` object could be parsed from that. Conclude your "
+    + "response with a JSON object in a fenced code block, exactly like:\n\n"
+    + "```json\n"
+    + '{{"actions": ["m u_1 n"]}}\n'
+    + "```\n"
+)
+
+
+# --- Helpers ----------------------------------------------------------------
+
+
+def _rebuild_game(observation: Mapping[str, Any]) -> Game:
+    """Reconstruct a fully-populated ``Game`` from a single turn's observation.
+
+    ``lux.game.Game._update`` fully rebuilds the map and both players from
+    the update messages, so one call per turn is enough as long as we seed
+    the width/height/players ourselves. At step 0 the engine's frame carries
+    a two-line header (game id + "W H") that ``_initialize`` consumes;
+    ``_update`` doesn't handle it, so we strip it there. From step 1 on
+    every frame is turn-shaped.
+    """
+    width = int(observation["width"])
+    height = int(observation.get("height", width))
+    updates = list(observation.get("updates") or [])
+    step = int(observation.get("step", 0))
+
+    game = Game()
+    game.id = 0
+    game.map_width = width
+    game.map_height = height
+    game.map = GameMap(width, height)
+    game.players = [Player(0), Player(1)]
+    # ``_update`` increments ``turn`` before consuming messages, so the value
+    # after N cumulative ``_update`` calls is N-1. Step 0 has the header
+    # (which ``_update`` treats as no-ops) but no turn has been applied yet;
+    # step 1 is the first real turn.
+    game.turn = step - 2
+
+    if step == 0 and len(updates) >= 2:
+        # Step-0 header: drop game id + "W H" lines before ``_update``.
+        updates = updates[2:]
+    game._update(updates)
+    return game
+
+
+def _phase(turn: int) -> str:
+    """Return ``"day"`` or ``"night"`` for the current turn."""
+    return "night" if (turn % 40) >= 30 else "day"
+
+
+def _render_ascii_map(game: Game, player_id: int) -> str:
+    """Render the game map as an ASCII grid, uppercase = ``player_id``'s side.
+
+    Precedence per cell (last write wins visually): resources → carts →
+    workers → city tiles. Coordinate axes are printed above and to the
+    left so the model can read positions off the grid.
+    """
+    width, height = game.map.width, game.map.height
+    grid = [["."] * width for _ in range(height)]
+
+    for y in range(height):
+        for x in range(width):
+            cell = game.map.get_cell(x, y)
+            if cell.has_resource():
+                r = cell.resource.type
+                # Glyphs chosen to not collide with unit/city letters.
+                # "coal" → "k" (c is stay-in-place direction), "uranium" → "x"
+                # (also avoids the "u" that opponent workers use).
+                grid[y][x] = "w" if r == "wood" else ("k" if r == "coal" else "x")
+
+    def _place(char_you: str, char_them: str, team: int, x: int, y: int) -> None:
+        if 0 <= x < width and 0 <= y < height:
+            grid[y][x] = char_you if team == player_id else char_them
+
+    for team, player in enumerate(game.players):
+        for unit in player.units:
+            char_you, char_them = ("A", "a") if unit.is_cart() else ("U", "u")
+            _place(char_you, char_them, team, unit.pos.x, unit.pos.y)
+        for city in player.cities.values():
+            for tile in city.citytiles:
+                _place("T", "t", team, tile.pos.x, tile.pos.y)
+
+    # Header: two-digit column indices, top row is tens, second row is units.
+    tens = "   " + "".join(str(x // 10) if x >= 10 else " " for x in range(width))
+    ones = "   " + "".join(str(x % 10) for x in range(width))
+    body = [f"{y:2d} " + "".join(row) for y, row in enumerate(grid)]
+    return "\n".join([tens, ones, *body])
+
+
+def _render_player(game: Game, player_id: int) -> str:
+    """Render a structured per-player summary (research, units, cities)."""
+    player = game.players[player_id]
+    rp = player.research_points
+    # Distance to the next unlock is what the model needs to plan research
+    # investment; surface it explicitly.
+    if not player.researched_coal():
+        next_unlock = f"coal in {max(0, 50 - rp)} more points"
+    elif not player.researched_uranium():
+        next_unlock = f"{_DISPLAY_URANIUM} in {max(0, 200 - rp)} more points"
+    else:
+        next_unlock = "all resources unlocked"
+    lines = [
+        f"  research points: {rp} (coal @ 50, {_DISPLAY_URANIUM} @ 200; next: {next_unlock})",
+        f"    coal researched: {player.researched_coal()}, "
+        f"{_DISPLAY_URANIUM} researched: {player.researched_uranium()}",
+    ]
+
+    if player.units:
+        lines.append(f"  units ({len(player.units)}):")
+        for u in player.units:
+            kind = "worker" if u.is_worker() else "cart"
+            cargo = f"wood={u.cargo.wood} coal={u.cargo.coal} {_DISPLAY_URANIUM}={u.cargo.uranium}"
+            lines.append(f"    {u.id} {kind} at ({u.pos.x},{u.pos.y}) cooldown={u.cooldown:g} cargo=[{cargo}]")
+    else:
+        lines.append("  units: (none)")
+
+    if player.cities:
+        total_tiles = sum(len(c.citytiles) for c in player.cities.values())
+        # Aggregate net upkeep across all cities so the model can see the
+        # total per-night fuel drain without having to sum by hand.
+        total_upkeep = sum(c.light_upkeep for c in player.cities.values())
+        lines.append(
+            f"  cities ({len(player.cities)}, {total_tiles} tiles, "
+            f"total night upkeep {total_upkeep:g}/turn):"
+        )
+        for city in player.cities.values():
+            tiles = ", ".join(f"({t.pos.x},{t.pos.y})" for t in city.citytiles)
+            lines.append(f"    {city.cityid} fuel={city.fuel:g} upkeep={city.light_upkeep:g} tiles=[{tiles}]")
+    else:
+        lines.append("  cities: (none)")
+
+    return "\n".join(lines)
+
+
+def _render_recent_moves(move_history: Sequence[str]) -> str:
+    """Render the previous turn's action summary if we have one."""
+    if not move_history:
+        return ""
+    return f"Your previous turn's commands: {move_history[-1]}\n\n"
+
+
+# Full-word direction aliases the parser accepts and folds to the single-letter
+# form the engine expects.
+_DIRECTION_ALIASES = {
+    "north": "n",
+    "south": "s",
+    "east": "e",
+    "west": "w",
+    "center": "c",
+}
+
+_LEADING_JUNK_RE = re.compile(r"^[\s\-*•]+|^\d+[.)]\s*")
+_TRAILING_JUNK_RE = re.compile(r"[\s.,;:!?]+$")
+_TRAILING_COMMENT_RE = re.compile(r"\s*(?:#|//).*$")
+_ID_TOKEN_RE = re.compile(r"[uUcC]_\d+")
+
+
+def _normalize_command(cmd: str) -> str:
+    """Fold common LLM variants into the engine's canonical command form.
+
+    - Strips surrounding whitespace and list-marker leaders (``-``, ``*``,
+      ``1.``, bullets) and trailing punctuation (``.``, ``,``, ``;``).
+    - Strips trailing line-comments (``# ...`` and ``// ...``).
+    - Strips ``[]``, ``()``, and ``<>`` wrappers around any token.
+    - Collapses runs of internal whitespace to a single space.
+    - Lowercases command head, unit/city id tokens (``U_1`` -> ``u_1``),
+      and full direction names for the ``m`` command.
+    - Rewrites the display resource name (``crystal``) back to the engine's
+      wire keyword (``uranium``) in ``t`` transfer commands.
+    """
+    if not cmd:
+        return ""
+    cmd = _TRAILING_COMMENT_RE.sub("", cmd)
+    cmd = _LEADING_JUNK_RE.sub("", cmd)
+    cmd = _TRAILING_JUNK_RE.sub("", cmd)
+    # Strip bracket/angle/paren wrappers around any token
+    # (e.g. ``[u_1]`` -> ``u_1``, ``<u_2>`` -> ``u_2``, ``(u_3)`` -> ``u_3``).
+    cmd = cmd.translate(str.maketrans("", "", "[]<>()"))
+    cmd = " ".join(cmd.split())  # collapse internal whitespace
+    if not cmd:
+        return ""
+    parts = cmd.split(" ")
+    # All command heads (``m``, ``bcity``, ``p``, ``t``, ``r``, ``bw``, ``bc``)
+    # are lowercase in the engine's grammar.
+    parts[0] = parts[0].lower()
+    # Unit and city ids are exclusively lowercase in the engine's wire
+    # protocol (``u_N`` / ``c_N``). Models routinely uppercase them to match
+    # the ASCII map letters (``U``/``T``), so fold every id-shaped token.
+    parts = [p.lower() if _ID_TOKEN_RE.fullmatch(p) else p for p in parts]
+    if parts[0] == "m" and len(parts) == 3:
+        # direction lowercased and folded from full-word aliases.
+        d = parts[2].lower()
+        parts[2] = _DIRECTION_ALIASES.get(d, d)
+    elif parts[0] == "t" and len(parts) == 5:
+        # Resource keyword is always lowercase in the engine grammar.
+        # Fold case, then map the display name (``crystal``) to the wire
+        # keyword (``uranium``).
+        parts[3] = parts[3].lower()
+        if parts[3] == _DISPLAY_URANIUM:
+            parts[3] = "uranium"
+    return " ".join(parts)
+
+
+def _validate_command(cmd: str) -> bool:
+    """True iff ``cmd`` matches one of the Lux command patterns exactly."""
+    if not cmd:
+        return False
+    head = cmd.split(" ", 1)[0]
+    matcher = _COMMAND_VALIDATORS.get(head)
+    return matcher is not None and matcher.fullmatch(cmd) is not None
+
+
+# --- Public functions (GameHarness protocol) --------------------------------
+
+
+def get_legal_moves(observation: Mapping[str, Any]) -> dict[int, str] | None:
+    """Free-form action space. ``freeForm: true`` in the env spec is required."""
+    del observation
+    return None
+
+
+def generate_prompt(
+    observation: Mapping[str, Any],
+    move_history: list[str],
+    previous_response: str | None = None,
+    previous_action: str | None = None,
+) -> str:
+    """Build the LLM prompt for the current Lux turn."""
+    if not observation.get("updates"):
+        return "Lux AI has not started this turn yet. Waiting for the game to initialize."
+
+    player_id = int(observation.get("player", 0))
+    game = _rebuild_game(observation)
+    # On step 0 (before any turn has been played), ``game.turn`` is -1;
+    # clamp to 0 so the prompt reads "Turn 0 (day)" rather than the
+    # nonsensical "Turn -1 (night)".
+    turn = max(game.turn, 0)
+    width = game.map.width
+
+    ascii_map = _render_ascii_map(game, player_id)
+    your_summary = _render_player(game, player_id)
+    opponent_summary = _render_player(game, 1 - player_id)
+    recent_moves_block = _render_recent_moves(move_history)
+
+    prompt = LUX_PROMPT_TEMPLATE.format(
+        width=width,
+        player_id=player_id,
+        turn=turn,
+        phase=_phase(turn),
+        ascii_map=ascii_map,
+        your_summary=your_summary,
+        opponent_summary=opponent_summary,
+        recent_moves_block=recent_moves_block,
+    )
+
+    prompt += render_rethink_suffix(
+        RETHINK_ILLEGAL,
+        RETHINK_UNPARSABLE,
+        previous_response,
+        previous_action,
+    )
+
+    return prompt
+
+
+def parse_response(
+    response: str,
+    legal_action_strings: Sequence[str] | None,
+    *,
+    observation: Mapping[str, Any] | None = None,
+) -> ParseResult:
+    """Extract a JSON ``{"actions": [...]}`` list of Lux command strings.
+
+    Malformed commands are dropped and valid ones submitted, unless more
+    than ``_INVALID_COMMAND_THRESHOLD`` of the list is malformed -- in that
+    case the whole turn is rejected and ``core_harness`` triggers a rethink.
+    An empty ``actions`` list is legal ("do nothing this turn").
+    """
+    del legal_action_strings, observation  # free-form; not used
+
+    obj = extract_last_json_object(response, required_keys=("actions",))
+    if obj is None:
+        return ParseResult(raw_action=None)
+    actions_raw = obj.get("actions")
+    if not isinstance(actions_raw, list):
+        # ``actions`` is present but not a list (string, null, dict). The
+        # failure is structural, not command-level, so route to the
+        # unparseable rethink ("send an array") rather than the malformed
+        # rethink ("fix your commands"). raw_action=None triggers that path.
+        _TELEMETRY(actions_not_a_list={"got": str(actions_raw)[:200]})
+        return ParseResult(raw_action=None)
+
+    actions = [_normalize_command(str(a)) for a in actions_raw]
+    valid = [a for a in actions if _validate_command(a)]
+    invalid = [a for a in actions if not _validate_command(a)]
+    summary = "[" + ", ".join(actions) + "]"
+
+    if actions and (len(invalid) / len(actions)) > _INVALID_COMMAND_THRESHOLD:
+        _TELEMETRY(
+            too_many_invalid_commands={
+                "valid": len(valid),
+                "invalid": len(invalid),
+                "invalid_commands": invalid,
+            },
+        )
+        return ParseResult(raw_action=summary)
+
+    if invalid:
+        _TELEMETRY(
+            some_invalid_commands={
+                "valid": len(valid),
+                "invalid": len(invalid),
+                "invalid_commands": invalid,
+            },
+        )
+    return ParseResult(submission=valid, raw_action=summary)

--- a/kaggle_environments/envs/lux_ai_2021/lux_ai_2021.json
+++ b/kaggle_environments/envs/lux_ai_2021/lux_ai_2021.json
@@ -21,8 +21,14 @@
       "default": "random"
     },
     "width": {
-      "description": "Width of map to generate",
-      "type": "integer"
+      "description": "Width of map to generate.",
+      "type": "integer",
+      "default": 12
+    },
+    "height": {
+      "description": "Height of map to generate.",
+      "type": "integer",
+      "default": 12
     },
     "seed": {
       "description": "Seed to use for episodes",
@@ -38,6 +44,11 @@
       "description": "Logging level of the game. 2 for warnings (e.g unit collisions, malformed actions), 1 for errors, 0 for none",
       "type": "integer",
       "default": 0
+    },
+    "freeForm": {
+      "description": "If true, the core harness allows free-form actions. Always true for lux_ai_2021 since per-unit command strings are not enumerable.",
+      "type": "boolean",
+      "default": true
     }
   },
   "reward": {

--- a/tests/envs/lux_ai_2021/test_harness.py
+++ b/tests/envs/lux_ai_2021/test_harness.py
@@ -1,0 +1,630 @@
+"""Tests for the Lux AI 2021 harness."""
+
+from __future__ import annotations
+
+import json
+
+from absl.testing import absltest
+
+from kaggle_environments.envs.lux_ai_2021.harness import (
+    _INVALID_COMMAND_THRESHOLD,
+    _normalize_command,
+    _phase,
+    _rebuild_game,
+    _render_ascii_map,
+    _validate_command,
+    generate_prompt,
+    get_legal_moves,
+    parse_response,
+)
+
+# --- Fixtures ---------------------------------------------------------------
+
+
+def _turn_updates(
+    width: int = 12,
+    *,
+    p0_units: list[tuple[str, int, int]] | None = None,
+    p1_units: list[tuple[str, int, int]] | None = None,
+    p0_cities: list[tuple[str, list[tuple[int, int]]]] | None = None,
+    resources: list[tuple[str, int, int, int]] | None = None,
+    p0_rp: int = 0,
+    p1_rp: int = 0,
+) -> list[str]:
+    """Build a minimal turn-frame update list.
+
+    Unit tuples: ``(unit_id, x, y)`` -- always workers, cooldown 0, empty cargo.
+    City tuples: ``(city_id, [(x, y), ...])`` -- fuel 100, upkeep 5.
+    Resource tuples: ``(type, x, y, amount)``.
+    """
+    lines = [f"rp 0 {p0_rp}", f"rp 1 {p1_rp}"]
+    for r_type, x, y, amt in resources or []:
+        lines.append(f"r {r_type} {x} {y} {amt}")
+    for uid, x, y in p0_units or []:
+        # unit type 0 = worker; team 0
+        lines.append(f"u 0 0 {uid} {x} {y} 0 0 0 0")
+    for uid, x, y in p1_units or []:
+        lines.append(f"u 0 1 {uid} {x} {y} 0 0 0 0")
+    for cid, tiles in p0_cities or []:
+        lines.append(f"c 0 {cid} 100 5")
+        for x, y in tiles:
+            lines.append(f"ct 0 {cid} {x} {y} 0")
+    return lines
+
+
+def _observation(
+    step: int = 2,
+    player: int = 0,
+    width: int = 12,
+    updates: list[str] | None = None,
+) -> dict:
+    """Build a turn-shaped observation. ``step`` defaults to 2 so
+    ``_rebuild_game`` computes ``game.turn == 0`` (the first playable turn).
+    Pass ``step=0`` with header-prefixed ``updates`` to exercise the
+    step-0 stripping branch.
+    """
+    if updates is None:
+        updates = _turn_updates(width=width, p0_units=[("u_1", 3, 4)])
+    return {
+        "player": player,
+        "step": step,
+        "width": width,
+        "height": width,
+        "updates": updates,
+        "isTerminal": False,
+    }
+
+
+# --- get_legal_moves --------------------------------------------------------
+
+
+class GetLegalMovesTest(absltest.TestCase):
+    def test_always_none(self):
+        self.assertIsNone(get_legal_moves(_observation()))
+        self.assertIsNone(get_legal_moves({}))
+
+
+# --- _validate_command ------------------------------------------------------
+
+
+class ValidateCommandTest(absltest.TestCase):
+    def test_move_directions(self):
+        for d in ("n", "s", "e", "w", "c"):
+            self.assertTrue(_validate_command(f"m u_1 {d}"))
+
+    def test_move_bad_direction(self):
+        self.assertFalse(_validate_command("m u_1 north"))
+        self.assertFalse(_validate_command("m u_1 x"))
+
+    def test_move_bad_unit_id(self):
+        self.assertFalse(_validate_command("m unit_1 n"))
+        self.assertFalse(_validate_command("m u1 n"))
+        self.assertFalse(_validate_command("m u_ n"))
+
+    def test_bcity(self):
+        self.assertTrue(_validate_command("bcity u_2"))
+        self.assertFalse(_validate_command("bcity"))
+        self.assertFalse(_validate_command("bcity 5 5"))
+
+    def test_pillage(self):
+        self.assertTrue(_validate_command("p u_1"))
+        self.assertFalse(_validate_command("p 3 5"))
+
+    def test_transfer(self):
+        self.assertTrue(_validate_command("t u_1 u_2 wood 100"))
+        self.assertTrue(_validate_command("t u_1 u_2 coal 0"))
+        self.assertTrue(_validate_command("t u_1 u_2 uranium 500"))
+        self.assertFalse(_validate_command("t u_1 u_2 gold 100"))
+        self.assertFalse(_validate_command("t u_1 u_2 wood -1"))
+        self.assertFalse(_validate_command("t u_1 wood 100"))
+
+    def test_city_tile_commands(self):
+        self.assertTrue(_validate_command("r 3 5"))
+        self.assertTrue(_validate_command("bw 0 0"))
+        self.assertTrue(_validate_command("bc 11 11"))
+        self.assertFalse(_validate_command("r 3"))
+        self.assertFalse(_validate_command("r 3 5 7"))
+
+    def test_empty_and_junk(self):
+        self.assertFalse(_validate_command(""))
+        self.assertFalse(_validate_command("do stuff"))
+        self.assertFalse(_validate_command("annotate 1 2"))  # dc/annotations off
+
+    def test_trailing_whitespace_rejected(self):
+        # Fullmatch: no leading/trailing whitespace allowed.
+        self.assertFalse(_validate_command("m u_1 n "))
+        self.assertFalse(_validate_command(" m u_1 n"))
+
+
+# --- _normalize_command -----------------------------------------------------
+
+
+class NormalizeCommandTest(absltest.TestCase):
+    def test_passthrough(self):
+        self.assertEqual(_normalize_command("m u_1 n"), "m u_1 n")
+        self.assertEqual(_normalize_command("bcity u_2"), "bcity u_2")
+
+    def test_uppercase_direction(self):
+        self.assertEqual(_normalize_command("m u_1 N"), "m u_1 n")
+        self.assertEqual(_normalize_command("M u_1 South"), "m u_1 s")
+
+    def test_full_direction_names(self):
+        for full, short in [("north", "n"), ("south", "s"), ("east", "e"), ("west", "w"), ("center", "c")]:
+            self.assertEqual(_normalize_command(f"m u_1 {full}"), f"m u_1 {short}")
+
+    def test_extra_internal_whitespace_collapsed(self):
+        self.assertEqual(_normalize_command("m  u_1  n"), "m u_1 n")
+        self.assertEqual(_normalize_command("t  u_1  u_2  wood  100"), "t u_1 u_2 wood 100")
+
+    def test_leading_bullets_stripped(self):
+        self.assertEqual(_normalize_command("- m u_1 n"), "m u_1 n")
+        self.assertEqual(_normalize_command("* bcity u_2"), "bcity u_2")
+        self.assertEqual(_normalize_command("1. m u_1 n"), "m u_1 n")
+        self.assertEqual(_normalize_command("2) bcity u_2"), "bcity u_2")
+
+    def test_trailing_punctuation_stripped(self):
+        self.assertEqual(_normalize_command("m u_1 n."), "m u_1 n")
+        self.assertEqual(_normalize_command("bcity u_2,"), "bcity u_2")
+        self.assertEqual(_normalize_command("r 5 7;"), "r 5 7")
+
+    def test_normalization_composes_with_validator(self):
+        # After normalization every one of these must be a valid command.
+        for raw in [
+            "M u_1 N",
+            "  m u_1 n  ",
+            "- m u_1 north",
+            "1. bcity u_2.",
+            "t  u_1  u_2  wood  50",
+        ]:
+            normalized = _normalize_command(raw)
+            self.assertTrue(_validate_command(normalized), f"{raw!r} -> {normalized!r}")
+
+    def test_unit_id_case_folded(self):
+        # The engine's unit ids are exclusively lowercase (u_N / c_N); models
+        # frequently uppercase them to match the ASCII map letters. Fold so
+        # the validator accepts.
+        self.assertEqual(_normalize_command("m U_1 n"), "m u_1 n")
+        self.assertTrue(_validate_command("m u_1 n"))
+        self.assertEqual(_normalize_command("bcity U_2"), "bcity u_2")
+        self.assertEqual(_normalize_command("t U_1 U_2 wood 40"), "t u_1 u_2 wood 40")
+        # Non-id tokens are untouched (e.g. resource keyword case is
+        # already handled elsewhere; the fold is scoped to [uUcC]_\\d+).
+        self.assertEqual(_normalize_command("m U_1 N"), "m u_1 n")
+
+    def test_strips_bracket_wrappers(self):
+        for raw in ["m [u_1] n", "bcity <u_2>", "t (u_1) (u_2) wood 40"]:
+            normalized = _normalize_command(raw)
+            self.assertTrue(_validate_command(normalized), f"{raw!r} -> {normalized!r}")
+
+    def test_strips_trailing_line_comments(self):
+        self.assertEqual(_normalize_command("m u_1 n # go north"), "m u_1 n")
+        self.assertEqual(_normalize_command("bcity u_2 // build"), "bcity u_2")
+        self.assertEqual(_normalize_command("r 5 7  #  research"), "r 5 7")
+
+    def test_crystal_rewritten_to_uranium_in_transfer(self):
+        # The prompt uses "crystal" for the third resource type; the engine's
+        # wire keyword is "uranium". Normalization must rewrite it.
+        self.assertEqual(
+            _normalize_command("t u_1 u_2 crystal 100"),
+            "t u_1 u_2 uranium 100",
+        )
+        # Uppercase variant folds too.
+        self.assertEqual(
+            _normalize_command("T u_1 u_2 Crystal 100"),
+            "t u_1 u_2 uranium 100",
+        )
+
+    def test_uppercase_command_head_folded(self):
+        # All command heads are lowercase in the engine grammar. Models
+        # frequently emit uppercase or title-case variants; normalization
+        # should fold the head and let the validator pass.
+        for raw, want in [
+            ("BCITY u_1", "bcity u_1"),
+            ("Bcity u_2", "bcity u_2"),
+            ("R 5 7", "r 5 7"),
+            ("BW 0 0", "bw 0 0"),
+            ("BC 3 4", "bc 3 4"),
+            ("P u_1", "p u_1"),
+        ]:
+            normalized = _normalize_command(raw)
+            self.assertEqual(normalized, want, f"{raw!r} -> {normalized!r}")
+            self.assertTrue(_validate_command(normalized))
+
+    def test_resource_case_folded_in_transfer(self):
+        # Resource names are lowercase in the engine grammar. Fold uppercase
+        # and title-case variants so the validator accepts them.
+        for raw, want in [
+            ("t u_1 u_2 Wood 50", "t u_1 u_2 wood 50"),
+            ("t u_1 u_2 COAL 5", "t u_1 u_2 coal 5"),
+            ("t u_1 u_2 URANIUM 50", "t u_1 u_2 uranium 50"),
+            ("t u_1 u_2 CRYSTAL 50", "t u_1 u_2 uranium 50"),
+        ]:
+            normalized = _normalize_command(raw)
+            self.assertEqual(normalized, want, f"{raw!r} -> {normalized!r}")
+            self.assertTrue(_validate_command(normalized))
+
+    def test_uranium_still_accepted(self):
+        # If the model uses the wire keyword directly, don't break it.
+        self.assertEqual(
+            _normalize_command("t u_1 u_2 uranium 100"),
+            "t u_1 u_2 uranium 100",
+        )
+
+
+# --- parse_response ---------------------------------------------------------
+
+
+class ParseResponseTest(absltest.TestCase):
+    def _parse(self, response: str):
+        return parse_response(response, None)
+
+    def test_all_valid(self):
+        payload = {"actions": ["m u_1 n", "bcity u_2", "r 5 7"]}
+        result = self._parse(f"```json\n{json.dumps(payload)}\n```")
+        self.assertEqual(result.submission, ["m u_1 n", "bcity u_2", "r 5 7"])
+
+    def test_empty_list_is_legal(self):
+        result = self._parse('```json\n{"actions": []}\n```')
+        self.assertEqual(result.submission, [])
+        self.assertEqual(result.raw_action, "[]")
+
+    def test_mixed_below_threshold_drops_invalid(self):
+        # 3 valid, 1 invalid = 25% invalid, below 50% threshold → submit valid.
+        payload = {
+            "actions": ["m u_1 n", "m u_2 s", "bcity u_3", "junk"],
+        }
+        result = self._parse(f"```json\n{json.dumps(payload)}\n```")
+        self.assertEqual(result.submission, ["m u_1 n", "m u_2 s", "bcity u_3"])
+
+    def test_mixed_above_threshold_triggers_rethink(self):
+        # 1 valid, 3 invalid = 75% invalid → whole turn rejected.
+        payload = {"actions": ["m u_1 n", "junk1", "junk2", "junk3"]}
+        result = self._parse(f"```json\n{json.dumps(payload)}\n```")
+        self.assertIsNone(result.submission)
+        self.assertIsNotNone(result.raw_action)
+
+    def test_exactly_at_threshold_submits(self):
+        # 2 valid, 2 invalid = 50% invalid, at threshold (>0.5 rejects) → submit.
+        payload = {"actions": ["m u_1 n", "m u_2 s", "junk1", "junk2"]}
+        result = self._parse(f"```json\n{json.dumps(payload)}\n```")
+        self.assertEqual(result.submission, ["m u_1 n", "m u_2 s"])
+        # Sanity-check the constant so this test stays meaningful.
+        self.assertEqual(_INVALID_COMMAND_THRESHOLD, 0.5)
+
+    def test_all_invalid_triggers_rethink(self):
+        payload = {"actions": ["junk1", "junk2"]}
+        result = self._parse(f"```json\n{json.dumps(payload)}\n```")
+        self.assertIsNone(result.submission)
+
+    def test_no_json_returns_unparsable(self):
+        result = self._parse("I have no idea what to do here.")
+        self.assertIsNone(result.submission)
+        self.assertIsNone(result.raw_action)
+
+    def test_json_without_actions_key_returns_unparsable(self):
+        result = self._parse('```json\n{"move": "north"}\n```')
+        self.assertIsNone(result.submission)
+        self.assertIsNone(result.raw_action)
+
+    def test_actions_not_a_list_routes_to_unparseable(self):
+        # Scalar / null actions is a structural failure ("send an array"),
+        # not a command-level failure ("fix your commands"). Route to the
+        # UNPARSABLE rethink by returning raw_action=None so core_harness
+        # picks that template.
+        for payload in ['{"actions": "m u_1 n"}', '{"actions": null}', '{"actions": {"m": "u_1"}}']:
+            result = self._parse(f"```json\n{payload}\n```")
+            self.assertIsNone(result.submission, payload)
+            self.assertIsNone(result.raw_action, payload)
+
+    def test_normalizes_uppercase_directions(self):
+        # Model uses full-word directions; parser should still accept them.
+        payload = {"actions": ["m u_1 North", "m u_2 SOUTH"]}
+        result = self._parse(f"```json\n{json.dumps(payload)}\n```")
+        self.assertEqual(result.submission, ["m u_1 n", "m u_2 s"])
+
+    def test_normalizes_extra_whitespace(self):
+        payload = {"actions": ["m  u_1  n", "bcity  u_2"]}
+        result = self._parse(f"```json\n{json.dumps(payload)}\n```")
+        self.assertEqual(result.submission, ["m u_1 n", "bcity u_2"])
+
+    def test_crystal_in_transfer_rewritten_to_uranium(self):
+        # End-to-end: the model uses "crystal" (matching the prompt), the
+        # submission must go to the engine as "uranium" (the wire keyword).
+        payload = {"actions": ["t u_1 u_2 crystal 40"]}
+        result = self._parse(f"```json\n{json.dumps(payload)}\n```")
+        self.assertEqual(result.submission, ["t u_1 u_2 uranium 40"])
+
+    def test_last_json_wins(self):
+        # Model writes a draft then revises. Last one wins.
+        response = 'Draft: ```json\n{"actions": ["junk"]}\n```\nFinal: ```json\n{"actions": ["m u_1 n"]}\n```'
+        result = self._parse(response)
+        self.assertEqual(result.submission, ["m u_1 n"])
+
+
+# --- _rebuild_game & _render_ascii_map --------------------------------------
+
+
+class RebuildGameTest(absltest.TestCase):
+    def test_step_0_strips_header(self):
+        # Step 0's engine frame carries `[game_id, "W H", ...]`; the harness
+        # must drop those before feeding `_update`, or the first two data
+        # lines (research points) get silently swallowed.
+        header = ["0", "8 8"]
+        body = _turn_updates(width=8, p0_units=[("u_1", 2, 2)], p0_rp=7)
+        obs = _observation(step=0, width=8, updates=header + body)
+        game = _rebuild_game(obs)
+        self.assertEqual(game.map.width, 8)
+        self.assertEqual(game.map.height, 8)
+        self.assertEqual(len(game.players[0].units), 1)
+        # Research points must survive -- this is the regression from the
+        # header-stripping bug where turn==0 dropped the first two lines.
+        self.assertEqual(game.players[0].research_points, 7)
+
+    def test_step_1_no_header_stripped(self):
+        # Step 1 is the first turn-shaped frame -- no header, so the
+        # research-point lines at the start of `updates` must be preserved.
+        updates = _turn_updates(width=6, p0_units=[("u_1", 1, 1)], p0_rp=42)
+        obs = _observation(step=1, width=6, updates=updates)
+        game = _rebuild_game(obs)
+        self.assertEqual(game.players[0].research_points, 42)
+
+    def test_turn_number_derived_from_step(self):
+        # step 0 = init (before any update), step 1 = first turn, so
+        # game.turn should equal step - 1 for step >= 1.
+        for step in [1, 5, 42, 359]:
+            obs = _observation(step=step, updates=_turn_updates(p0_units=[("u_1", 0, 0)]))
+            game = _rebuild_game(obs)
+            self.assertEqual(game.turn, step - 1, f"step={step}")
+
+    def test_resources_and_cities(self):
+        updates = _turn_updates(
+            width=6,
+            p0_units=[("u_1", 1, 1)],
+            p1_units=[("u_2", 4, 4)],
+            p0_cities=[("c_1", [(2, 2), (2, 3)])],
+            resources=[("wood", 3, 3, 500), ("coal", 5, 0, 100)],
+        )
+        obs = _observation(step=5, width=6, updates=updates)
+        game = _rebuild_game(obs)
+        self.assertEqual(len(game.players[0].units), 1)
+        self.assertEqual(len(game.players[1].units), 1)
+        self.assertEqual(len(game.players[0].cities), 1)
+        self.assertEqual(game.players[0].city_tile_count, 2)
+        self.assertTrue(game.map.get_cell(3, 3).has_resource())
+        self.assertEqual(game.map.get_cell(3, 3).resource.type, "wood")
+
+
+class RenderAsciiMapTest(absltest.TestCase):
+    def test_uppercase_for_current_player(self):
+        updates = _turn_updates(
+            width=6,
+            p0_units=[("u_1", 1, 1)],
+            p1_units=[("u_2", 4, 4)],
+            p0_cities=[("c_1", [(2, 2)])],
+            resources=[
+                ("wood", 0, 0, 500),
+                ("coal", 0, 5, 100),
+                ("uranium", 5, 5, 50),
+            ],
+        )
+        obs = _observation(step=2, player=0, width=6, updates=updates)
+        game = _rebuild_game(obs)
+
+        rendered_p0 = _render_ascii_map(game, player_id=0)
+        self.assertIn("U", rendered_p0)  # own worker uppercase
+        self.assertIn("u", rendered_p0)  # opponent worker lowercase
+        self.assertIn("T", rendered_p0)  # own city tile uppercase
+        self.assertIn("w", rendered_p0)  # wood glyph
+        self.assertIn("k", rendered_p0)  # coal glyph
+        self.assertIn("x", rendered_p0)  # crystal glyph (rebranded uranium)
+
+        rendered_p1 = _render_ascii_map(game, player_id=1)
+        # From p1's perspective the letters flip.
+        self.assertIn("U", rendered_p1)
+        self.assertIn("u", rendered_p1)
+        self.assertIn("t", rendered_p1)  # p0's city is now opponent's
+
+
+# --- _phase -----------------------------------------------------------------
+
+
+class PhaseTest(absltest.TestCase):
+    def test_day_night_boundaries(self):
+        self.assertEqual(_phase(0), "day")
+        self.assertEqual(_phase(29), "day")
+        self.assertEqual(_phase(30), "night")
+        self.assertEqual(_phase(39), "night")
+        self.assertEqual(_phase(40), "day")  # next cycle starts
+        self.assertEqual(_phase(70), "night")
+
+
+# --- generate_prompt --------------------------------------------------------
+
+
+class GeneratePromptTest(absltest.TestCase):
+    def test_renders_key_sections(self):
+        updates = _turn_updates(
+            width=8,
+            p0_units=[("u_1", 2, 2)],
+            p0_cities=[("c_1", [(3, 3)])],
+            resources=[("wood", 5, 5, 500)],
+            p0_rp=42,
+        )
+        obs = _observation(step=16, player=0, width=8, updates=updates)
+        prompt = generate_prompt(obs, move_history=[])
+
+        # Board dimensions surface from the observation, not hardcoded.
+        self.assertIn("8x8", prompt)
+        # Turn + phase.
+        self.assertIn("Turn 15", prompt)
+        self.assertIn("day", prompt)
+        # Player id.
+        self.assertIn("player 0", prompt)
+        # Structured summary carries unit + city + research info.
+        self.assertIn("u_1", prompt)
+        self.assertIn("c_1", prompt)
+        self.assertIn("42", prompt)
+        # Command grammar is documented.
+        self.assertIn("bcity", prompt)
+        # JSON response format is documented.
+        self.assertIn('"actions"', prompt)
+        # Rebrand: the prose talks about "crystal", not "uranium".
+        self.assertIn("crystal", prompt)
+        self.assertNotIn("uranium", prompt)
+
+    def test_recent_moves_included_when_history_nonempty(self):
+        obs = _observation()
+        prompt = generate_prompt(obs, move_history=["[m u_1 n, bcity u_2]"])
+        self.assertIn("previous turn", prompt.lower())
+        self.assertIn("[m u_1 n, bcity u_2]", prompt)
+
+    def test_no_history_block_when_empty(self):
+        obs = _observation()
+        prompt = generate_prompt(obs, move_history=[])
+        self.assertNotIn("previous turn", prompt.lower())
+
+    def test_rethink_illegal_appended_when_previous_action_set(self):
+        obs = _observation()
+        prompt = generate_prompt(
+            obs,
+            move_history=[],
+            previous_response="whatever",
+            previous_action="[junk1, junk2]",
+        )
+        self.assertIn("malformed", prompt)
+        self.assertIn("[junk1, junk2]", prompt)
+
+    def test_rethink_unparsable_appended_when_no_previous_action(self):
+        obs = _observation()
+        prompt = generate_prompt(
+            obs,
+            move_history=[],
+            previous_response="I ate a sandwich.",
+            previous_action=None,
+        )
+        self.assertIn("No JSON `actions` object could be parsed", prompt)
+        self.assertIn("I ate a sandwich.", prompt)
+
+    def test_empty_observation_returns_placeholder(self):
+        prompt = generate_prompt({}, move_history=[])
+        self.assertIn("has not started", prompt)
+
+    def test_terminal_conditions_include_elimination_and_draw(self):
+        obs = _observation()
+        prompt = generate_prompt(obs, move_history=[])
+        self.assertIn("elimination", prompt)
+        self.assertIn("draw", prompt)
+        self.assertIn("360", prompt)
+
+    def test_adjacency_formula_uses_10_per_pair(self):
+        # Engine double-counts adjacentCityTiles so the coefficient in the
+        # net-upkeep formula is 10 per pair, not 5.
+        obs = _observation()
+        prompt = generate_prompt(obs, move_history=[])
+        self.assertIn("23 * num_tiles - 10 * num_adjacent_pairs", prompt)
+
+    def test_one_command_per_unit_per_turn_disclosed(self):
+        obs = _observation()
+        prompt = generate_prompt(obs, move_history=[])
+        self.assertIn("AT MOST ONE command", prompt)
+
+    def test_bcity_disallows_existing_city_tile(self):
+        obs = _observation()
+        prompt = generate_prompt(obs, move_history=[])
+        self.assertIn("not on an existing city tile", prompt)
+
+    def test_movement_stacking_rules_disclosed(self):
+        obs = _observation()
+        prompt = generate_prompt(obs, move_history=[])
+        # Unlimited stacking on friendly city tiles.
+        self.assertIn("UNLIMITED stacking", prompt)
+        # Outside cities: at most one unit per cell.
+        self.assertIn("at most ONE unit", prompt)
+        # Colliding movers cancel (bounce back), and cascade.
+        self.assertIn("cancelled", prompt)
+        self.assertIn("cascade", prompt)
+        # Cannot enter opponent city tile.
+        self.assertIn("opponent city tile", prompt)
+
+    def test_spawn_cost_and_unit_cap_disclosed(self):
+        obs = _observation()
+        prompt = generate_prompt(obs, move_history=[])
+        # Spawning is free; unit count is capped by number of city tiles.
+        self.assertIn("FREE", prompt)
+        self.assertIn("total number of friendly city", prompt.lower().replace("tiles", "tile"))
+
+    def test_bcity_cost_and_consumption_order_disclosed(self):
+        obs = _observation()
+        prompt = generate_prompt(obs, move_history=[])
+        # bcity costs 100 resource units; consumed wood -> coal -> crystal.
+        self.assertIn("100 resource units", prompt)
+        self.assertIn("wood -> coal -> crystal", prompt)
+
+    def test_wood_regeneration_disclosed(self):
+        obs = _observation()
+        prompt = generate_prompt(obs, move_history=[])
+        # Only wood regenerates; coal and crystal do not.
+        self.assertIn("Only WOOD", prompt)
+        self.assertIn("do not replenish", prompt)
+
+    def test_research_thresholds_disclosed(self):
+        obs = _observation()
+        prompt = generate_prompt(obs, move_history=[])
+        # Numeric thresholds from game_constants: coal=50, uranium=200.
+        self.assertIn("50", prompt)
+        self.assertIn("200", prompt)
+        # Explanation that `r` adds a point.
+        self.assertIn("research point", prompt)
+
+    def test_night_upkeep_rules_disclosed(self):
+        obs = _observation()
+        prompt = generate_prompt(obs, move_history=[])
+        # City tile upkeep + adjacency bonus formula are surfaced.
+        self.assertIn("23", prompt)  # per-tile base
+        # Worker/cart night-consumption numbers and the "in a city is safe" carve-out.
+        self.assertIn("4", prompt)   # worker night burn
+        self.assertIn("10", prompt)  # cart night burn
+        self.assertIn("city tile at night", prompt.lower().replace("standing on a friendly ", ""))
+
+    def test_player_summary_shows_total_upkeep(self):
+        updates = _turn_updates(
+            width=6,
+            p0_units=[("u_1", 0, 0)],
+            p0_cities=[("c_1", [(2, 2), (2, 3)])],  # single city, 2 tiles
+        )
+        obs = _observation(step=5, player=0, width=6, updates=updates)
+        prompt = generate_prompt(obs, move_history=[])
+        # Test fixture emits `c 0 c_1 100 5` → per-city light_upkeep=5 in
+        # the reconstructed Game. Sum across cities must appear.
+        self.assertIn("total night upkeep 5/turn", prompt)
+
+    def test_player_summary_shows_research_next_unlock(self):
+        updates = _turn_updates(width=6, p0_units=[("u_1", 0, 0)], p0_rp=17)
+        obs = _observation(step=5, player=0, width=6, updates=updates)
+        prompt = generate_prompt(obs, move_history=[])
+        # 17 points → coal in 33 more.
+        self.assertIn("coal in 33 more points", prompt)
+
+    def test_bcity_empty_tile_requirement_disclosed(self):
+        # Engine's Unit.can_build requires the worker's cell to have no
+        # resource. Prompt must say so or models issue silently-ignored
+        # bcity commands while standing on wood.
+        obs = _observation()
+        prompt = generate_prompt(obs, move_history=[])
+        # Both the "empty" language and the specific resource names appear
+        # in the bcity line -- verify the bcity clause is present.
+        self.assertIn("empty cell", prompt)
+
+    def test_step_0_reports_turn_0_day(self):
+        # At step 0, game.turn == -1 pre-update; the prompt must clamp so
+        # it doesn't read "Turn -1 (night)".
+        header = ["0", "6 6"]
+        body = _turn_updates(width=6, p0_units=[("u_1", 1, 1)])
+        obs = _observation(step=0, player=0, width=6, updates=header + body)
+        prompt = generate_prompt(obs, move_history=[])
+        self.assertIn("Turn 0 of 360 (day)", prompt)
+        self.assertNotIn("Turn -1", prompt)
+
+
+if __name__ == "__main__":
+    absltest.main()


### PR DESCRIPTION
Adds `harness.py` implementing the GameHarness protocol (`get_legal_moves`, `generate_prompt`, `parse_response`) with a full ASCII map + structured summary prompt, free-form JSON action list parsing, and a 50%-invalid rethink threshold. Includes unit tests.

Prompt rebrands the "uranium" resource as "crystal" to avoid tripping LLM safety filters; the harness rewrites crystal→uranium in outgoing transfer commands and displays uranium→crystal in the observation summary. The on-wire engine keyword is unchanged.

Spec: default `width` to 12 (was random 12/16/24/32) and add `freeForm: true` so the core harness accepts free-form submissions.

Interpreter: populate `observation.updates` and `isTerminal` on both players in the init and per-turn branches, and drop the redundant `height` config (Lux maps are square).