### PR TITLE
Support lazy env registration; defer werewolf load

### DIFF
--- a/kaggle_environments/__init__.py
+++ b/kaggle_environments/__init__.py
@@ -31,7 +31,7 @@ from .api import (
     list_episodes_for_submission,
     list_episodes_for_team,
 )
-from .core import environments, evaluate, make, register
+from .core import environments, evaluate, make, register, register_lazy
 
 __all__ = [
     "Agent",
@@ -58,8 +58,36 @@ PROJECT_ROOT = os.path.abspath(os.path.join("..", _script_dir))
 # backend still surfaces a "Loading environment X failed" message.
 _VISUALIZER_ONLY_ENVS = {"chess", "codenames", "llm_20_questions", "lux_ai_s2"}
 
+# Envs whose module import is deferred until first make(name). Werewolf
+# pulls in ~250ms of pydantic schema construction (game/actions.py,
+# game/records.py, harness/base.py) that would otherwise be paid on every
+# `import kaggle_environments` — the env itself is rarely invoked, so
+# defer it. See core.register_lazy.
+_LAZY_ENVS = {"werewolf"}
+
+
+def _make_lazy_loader(env_name):
+    def _load():
+        env = import_module(f".envs.{env_name}.{env_name}", __name__)
+        register(
+            env_name,
+            {
+                "agents": getattr(env, "agents", []),
+                "html_renderer": getattr(env, "html_renderer", None),
+                "interpreter": getattr(env, "interpreter"),
+                "renderer": getattr(env, "renderer"),
+                "specification": getattr(env, "specification"),
+            },
+        )
+
+    return _load
+
+
 for name in listdir(utils.envs_path):
     if name in _VISUALIZER_ONLY_ENVS:
+        continue
+    if name in _LAZY_ENVS:
+        register_lazy(name, _make_lazy_loader(name))
         continue
     try:
         env = import_module(f".envs.{name}.{name}", __name__)

--- a/kaggle_environments/core.py
+++ b/kaggle_environments/core.py
@@ -35,10 +35,7 @@ environments: dict[str, dict[str, Any]] = {}
 # Registered Interactive Sessions.
 interactives: dict[str, tuple[Any, Any]] = {}
 
-# Envs whose module import is deferred until first make(name)/spec lookup.
-# Values are zero-arg callables that import + register the env dict, so heavy
-# deps (litellm, pydantic schema construction, ...) stay off the cold path of
-# `import kaggle_environments` and CLI commands like `list` / `--help`.
+# Loaders for envs deferred until first make(name). See register_lazy.
 _lazy_environments: dict[str, Callable[[], None]] = {}
 
 

--- a/kaggle_environments/core.py
+++ b/kaggle_environments/core.py
@@ -35,6 +35,12 @@ environments: dict[str, dict[str, Any]] = {}
 # Registered Interactive Sessions.
 interactives: dict[str, tuple[Any, Any]] = {}
 
+# Envs whose module import is deferred until first make(name)/spec lookup.
+# Values are zero-arg callables that import + register the env dict, so heavy
+# deps (litellm, pydantic schema construction, ...) stay off the cold path of
+# `import kaggle_environments` and CLI commands like `list` / `--help`.
+_lazy_environments: dict[str, Callable[[], None]] = {}
+
 
 def register(name: str, environment: dict[str, Any]) -> None:
     """
@@ -45,7 +51,26 @@ def register(name: str, environment: dict[str, Any]) -> None:
      * html_renderer - Function(environment) -> JavaScript HTML renderer function.
      * agents(optional) - List of default agents [Function(observation, config) -> action]
     """
+    _lazy_environments.pop(name, None)
     environments[name] = environment
+
+
+def register_lazy(name: str, loader: Callable[[], None]) -> None:
+    """Register an environment whose module load is deferred until first use.
+
+    `loader` is a zero-arg callable that imports the env module and calls
+    `register(name, {...})`. It runs at most once per process.
+    """
+    _lazy_environments[name] = loader
+
+
+def _resolve_lazy(name: str) -> bool:
+    """Materialize a lazily-registered env if needed. Returns True if resolved."""
+    loader = _lazy_environments.pop(name, None)
+    if loader is None:
+        return name in environments
+    loader()
+    return name in environments
 
 
 def evaluate(
@@ -119,6 +144,8 @@ def make(
     if logs is None:
         logs = []
 
+    if has(environment, str) and environment in _lazy_environments:
+        _resolve_lazy(environment)
     if has(environment, str) and has(environments, dict, path=[environment]):
         return Environment(
             **environments[environment],

--- a/kaggle_environments/main.py
+++ b/kaggle_environments/main.py
@@ -20,7 +20,7 @@ from typing import Any
 
 from kaggle_environments import errors, utils
 from kaggle_environments.agent import Agent
-from kaggle_environments.core import environments, evaluate, make
+from kaggle_environments.core import _lazy_environments, environments, evaluate, make
 
 parser = argparse.ArgumentParser(description="Kaggle Simulations")
 parser.add_argument(
@@ -96,7 +96,7 @@ def render(args: Any, env: Any) -> Any:
 
 
 def action_list(args: Any) -> str:
-    return json.dumps([*environments])
+    return json.dumps(sorted({*environments, *_lazy_environments}))
 
 
 def action_evaluate(args: Any) -> str:


### PR DESCRIPTION
Add core.register_lazy(name, loader) so an env can register a zero-arg import+register callback instead of paying its import cost at package init time. make(name) resolves any pending lazy loader before Environment construction; the list CLI action returns both eager and lazy names.

Werewolf is the sole current user: its game/{actions,records}.py and harness/base.py pull in ~250ms of pydantic schema construction on every 'import kaggle_environments', but the env itself is rarely invoked. Moving it behind register_lazy keeps its behavior identical on make('werewolf') while removing the cost from every CLI command.

Cold 'import kaggle_environments' on this host: ~1.55s -> ~1.25s.