### PR TITLE
Make some Word Art harness/env improvements

### DIFF
--- a/kaggle_environments/envs/word_art/harness.py
+++ b/kaggle_environments/envs/word_art/harness.py
@@ -70,7 +70,10 @@ def _slice_thoughts(response: str, answer_start: int) -> str | None:
 
 _DISQ_REASON_TEXT = {
     "target_word": "contained the target word",
-    "contains_words": "contained text (a run of 3+ letters with 2+ distinct chars)",
+    "contains_words": (
+        "contained text (a run of 3+ letters with 2+ distinct chars, "
+        "consecutive or spaced out with punctuation)"
+    ),
 }
 
 
@@ -329,13 +332,14 @@ either fires, your teammate sees a placeholder instead of your drawing
      '(scale: CAT)', arrow labels like '<- CAT', or section headers
      like 'CAT close-up:'.
 
-  2. ANY-WORD check. Any run of 3+ consecutive letters with 2+ distinct
-     characters (case-insensitive) disqualifies the drawing. Words like
-     'top', 'the', 'HOUSE', 'MINERAL', 'grid', 'axe' all trip it. Same-
-     character runs pass -- 'OOO' (eyes), 'III' (columns), 'TTT'
-     (texture) are all fine -- as are 1- and 2-letter clusters like
-     'V', 'OO', 'H2'. Break letters up with spaces, punctuation, or
-     newlines to avoid tripping this check.
+  2. ANY-WORD check. Any run of 3+ letters with 2+ distinct characters
+     (case-insensitive) disqualifies the drawing, whether the letters
+     are consecutive ('top', 'HOUSE', 'grid', 'axe') or spaced out with
+     punctuation ('T O P', 'A.R.O.U.N.D', 'H-O-U-S-E', 'grid_view').
+     Same-character clusters ('OOO' for eyes, 'III' for columns, 'TTT'
+     for texture, 'V V V' for a zigzag) always pass, as do 1- and
+     2-letter clusters ('V', 'OO', 'H2') -- so letters remain fine as
+     visual elements.
 
 Your art is silently sanitized before scoring: combining marks, wide
 characters (CJK, most emoji), and other non-single-cell Unicode are
@@ -352,16 +356,19 @@ your reasoning as ordinary prose. Then end your response with your
 final drawing wrapped in a single <art>...</art> block. Everything
 inside the block is taken verbatim -- literal newlines are fine, no
 escaping, no markdown -- and everything outside is treated as
-reasoning and ignored. Example:
+reasoning and ignored. The example below shows the OUTPUT FORMAT, not
+a template to imitate -- your drawing should depict your own word.
 
-I'll draw a cat face using basic ASCII characters -- pointy ears with
-slashes, round eyes, a nose. Keeping runs of letters to 2 or fewer to
-stay clear of the any-word check.
+I'll draw a snowflake using radial symmetry -- arms meeting at a
+central plus, with stars at the tips. All non-letter glyphs so
+nothing can trip the any-word check.
 
 <art>
- /\\_/\\
-( o.o )
- > ^ <
+   *
+ \\ | /
+---+---
+ / | \\
+   *
 </art>"""
 
 

--- a/kaggle_environments/envs/word_art/harness.py
+++ b/kaggle_environments/envs/word_art/harness.py
@@ -72,7 +72,7 @@ _DISQ_REASON_TEXT = {
     "target_word": "contained the target word",
     "contains_words": (
         "contained text (a run of 3+ letters with 2+ distinct chars, "
-        "consecutive or spaced out with punctuation)"
+        "consecutive or separated by any non-letter, non-newline chars)"
     ),
 }
 
@@ -334,12 +334,12 @@ either fires, your teammate sees a placeholder instead of your drawing
 
   2. ANY-WORD check. Any run of 3+ letters with 2+ distinct characters
      (case-insensitive) disqualifies the drawing, whether the letters
-     are consecutive ('top', 'HOUSE', 'grid', 'axe') or spaced out with
-     punctuation ('T O P', 'A.R.O.U.N.D', 'H-O-U-S-E', 'grid_view').
-     Same-character clusters ('OOO' for eyes, 'III' for columns, 'TTT'
-     for texture, 'V V V' for a zigzag) always pass, as do 1- and
-     2-letter clusters ('V', 'OO', 'H2') -- so letters remain fine as
-     visual elements.
+     are consecutive ('top', 'HOUSE', 'grid', 'axe') or separated by
+     any non-letter, non-newline characters ('T O P', 'A.R.O.U.N.D',
+     'H-O-U-S-E', 'H|O|U|S|E', 'grid_view'). Same-character clusters
+     ('OOO' for eyes, 'III' for columns, 'TTT' for texture, 'V V V'
+     for a zigzag) always pass, as do 1- and 2-letter clusters ('V',
+     'OO', 'H2') -- so letters remain fine as visual elements.
 
 Your art is silently sanitized before scoring: combining marks, wide
 characters (CJK, most emoji), and other non-single-cell Unicode are

--- a/kaggle_environments/envs/word_art/word_art.py
+++ b/kaggle_environments/envs/word_art/word_art.py
@@ -270,7 +270,8 @@ DISQUALIFIED_ART_PLACEHOLDERS = {
     ),
     "contains_words": (
         "<your teammate's drawing was disqualified for containing text "
-        "(a run of 3+ letters with 2+ distinct chars)>"
+        "(a run of 3+ letters with 2+ distinct chars, consecutive or "
+        "spaced out with punctuation)>"
     ),
 }
 
@@ -302,23 +303,37 @@ def _art_contains_word(art, word):
 
 
 _WORD_LIKE_RE = re.compile(r"[A-Za-z]{3,}")
+# Spaced-out labels: 3+ letters interleaved with same-line separators
+# (space/tab/dot/dash/underscore/middle-dot). Excludes newlines so letters
+# in different rows of the art don't chain across a 2D layout into fake
+# words. Catches evasions the consecutive-only _WORD_LIKE_RE misses --
+# 'A R O U N D', 'T.O.P.', 'H-O-U-S-E', 'grid_view'.
+_SPACED_WORD_RE = re.compile(r"[A-Za-z](?:[ \t.\-_·]+[A-Za-z]){2,}")
 
 
 def _art_contains_any_word(art):
     """Return True if `art` contains any run of 3+ letters with 2+
-    distinct characters (case-insensitive).
+    distinct characters (case-insensitive), whether the letters are
+    consecutive ('TOP', 'HOUSE') or separated by same-line punctuation
+    ('T O P', 'A.R.O.U.N.D', 'H-O-U-S-E').
 
     Same-letter clusters ('OOO' for eyes, 'III' for columns, 'TTT' for
-    texture) pass so models can still use letters as visual elements.
-    Anything else — 'top', 'the', 'HOUSE', 'grid', 'axe' — is treated as
-    a text label and rejected. Complementary to _art_contains_word; that
-    catches only the target word, this catches every OTHER word.
+    texture, 'V V V' for a zigzag) pass so models can still use letters
+    as visual elements. Complementary to _art_contains_word; that catches
+    only the target word, this catches every OTHER word.
+
+    The distinct-character count considers LETTERS only (not the
+    separators between them), so a decorative row like 'V V V' evaluates
+    as one distinct letter and passes even though the raw match string
+    contains both 'v' and ' '.
     """
     if not art:
         return False
-    for m in _WORD_LIKE_RE.finditer(art):
-        if len(set(m.group(0).lower())) > 1:
-            return True
+    for regex in (_WORD_LIKE_RE, _SPACED_WORD_RE):
+        for m in regex.finditer(art):
+            distinct_letters = {c for c in m.group(0).lower() if c.isalpha()}
+            if len(distinct_letters) > 1:
+                return True
     return False
 
 
@@ -344,7 +359,42 @@ def _score_for_attempt(attempt_num, first_try_bonus):
     return base + (first_try_bonus if attempt_num == 1 else 0)
 
 
-def initialize_game(state, config):
+class _WordArtState:
+    """Round-scoped hidden state, kept on ``env`` -- never on a player's
+    observation.
+
+    Storing the word list or in-progress guesses on ``state[i].observation``
+    (even under an underscore-prefixed key) leaks them into the replay JSON
+    and into whatever the agent process receives; a custom agent could then
+    short-circuit the art channel by reading the target word directly, and
+    any future prompt change that dumps the raw obs would silently ship
+    hidden fields to the LLM. Following the werewolf env's pattern, the
+    interpreter is passed ``env`` on every call, so authoritative state
+    lives there and each player's observation is rebuilt each step
+    containing only public + role-appropriate fields.
+    """
+
+    def __init__(self, words):
+        self.words = words
+        self.reset_round()
+
+    def reset_round(self):
+        self.blue_art = ""
+        self.yellow_art = ""
+        self.blue_art_disqualified = False
+        self.yellow_art_disqualified = False
+        self.blue_disq_reason = None
+        self.yellow_disq_reason = None
+        self.blue_guesses = []
+        self.yellow_guesses = []
+        self.blue_done = False
+        self.yellow_done = False
+        self.blue_points = 0
+        self.yellow_points = 0
+
+
+def initialize_game(state, env):
+    config = env.configuration
     seed = config.get("seed")
     rng = random.Random(seed) if seed is not None else random
 
@@ -375,29 +425,7 @@ def initialize_game(state, config):
         s.observation.yellow_attempts_used = 0
         s.observation.history = []
 
-    # Hidden round-scoped state lives on agent 0's observation: the full word
-    # list, in-progress art, accumulated guesses, and per-team done flags.
-    # Guessers must not see the words list, and the opposing team must not see
-    # in-progress art or guesses, so these fields are kept off the spec and
-    # only mirrored to the appropriate agents.
-    obs0 = state[0].observation
-    obs0._words = sampled
-    _reset_round_internals(obs0)
-
-
-def _reset_round_internals(obs0):
-    obs0._round_blue_art = ""
-    obs0._round_yellow_art = ""
-    obs0._round_blue_art_disqualified = False
-    obs0._round_yellow_art_disqualified = False
-    obs0._round_blue_disq_reason = None
-    obs0._round_yellow_disq_reason = None
-    obs0._round_blue_guesses = []
-    obs0._round_yellow_guesses = []
-    obs0._round_blue_done = False
-    obs0._round_yellow_done = False
-    obs0._round_blue_points = 0
-    obs0._round_yellow_points = 0
+    env.word_art_state = _WordArtState(sampled)
 
 
 # Statuses set by the kaggle framework when an agent fails. We must NOT
@@ -417,7 +445,7 @@ def _set_art_statuses(state, round_idx):
         state[i].status = "ACTIVE" if role == "artist" else "INACTIVE"
 
 
-def _set_guess_statuses(state, round_idx, obs0):
+def _set_guess_statuses(state, round_idx, wa_state):
     """During the guess phase: a team's guesser stays ACTIVE until they score
     or exhaust attempts; once done, they go INACTIVE. Artists are always
     INACTIVE in the guess phase. Agents in a terminal failure state
@@ -431,11 +459,11 @@ def _set_guess_statuses(state, round_idx, obs0):
             state[i].status = "INACTIVE"
             continue
         team = get_team(i)
-        done = obs0._round_blue_done if team == "blue" else obs0._round_yellow_done
+        done = wa_state.blue_done if team == "blue" else wa_state.yellow_done
         state[i].status = "INACTIVE" if done else "ACTIVE"
 
 
-def _process_team_guess(state, obs0, team, env_config, target_norm):
+def _process_team_guess(state, obs0, wa_state, team, env_config, target_norm):
     """Read the active guesser's action, append to the team's guess list, and
     return (points_awarded, is_done_now) — both 0/False if the team was already
     done or inactive this step.
@@ -444,11 +472,11 @@ def _process_team_guess(state, obs0, team, env_config, target_norm):
     first_try_bonus = env_config.get("first_try_bonus", 1)
 
     if team == "blue":
-        if obs0._round_blue_done:
+        if wa_state.blue_done:
             return 0, False
         g_idx = _blue_guesser(obs0.current_round)
     else:
-        if obs0._round_yellow_done:
+        if wa_state.yellow_done:
             return 0, False
         g_idx = _yellow_guesser(obs0.current_round)
 
@@ -456,50 +484,49 @@ def _process_team_guess(state, obs0, team, env_config, target_norm):
         # Guesser was not asked for an action this step (e.g. ERROR/TIMEOUT
         # propagated from a prior step). Treat as out of the round.
         if team == "blue":
-            obs0._round_blue_done = True
+            wa_state.blue_done = True
         else:
-            obs0._round_yellow_done = True
+            wa_state.yellow_done = True
         return 0, True
 
     raw = _unwrap(state[g_idx].action)
     guess_str = raw if isinstance(raw, str) else (str(raw) if raw is not None else "")
     if team == "blue":
-        obs0._round_blue_guesses.append(guess_str)
-        used = len(obs0._round_blue_guesses)
+        wa_state.blue_guesses.append(guess_str)
+        used = len(wa_state.blue_guesses)
     else:
-        obs0._round_yellow_guesses.append(guess_str)
-        used = len(obs0._round_yellow_guesses)
+        wa_state.yellow_guesses.append(guess_str)
+        used = len(wa_state.yellow_guesses)
 
     guess_norm = _normalize_guess(raw)
     if _matches_target(guess_norm, target_norm):
         pts = _score_for_attempt(used, first_try_bonus)
         if team == "blue":
-            obs0._round_blue_points = pts
-            obs0._round_blue_done = True
+            wa_state.blue_points = pts
+            wa_state.blue_done = True
             state[0].reward = (state[0].reward or 0) + pts
             state[1].reward = (state[1].reward or 0) + pts
         else:
-            obs0._round_yellow_points = pts
-            obs0._round_yellow_done = True
+            wa_state.yellow_points = pts
+            wa_state.yellow_done = True
             state[2].reward = (state[2].reward or 0) + pts
             state[3].reward = (state[3].reward or 0) + pts
         return pts, True
 
     if used >= max_attempts:
         if team == "blue":
-            obs0._round_blue_done = True
+            wa_state.blue_done = True
         else:
-            obs0._round_yellow_done = True
+            wa_state.yellow_done = True
         return 0, True
 
     return 0, False
 
 
-def _enter_guess_phase(state, obs0, round_idx, blue_art, yellow_art):
+def _enter_guess_phase(state, wa_state, round_idx, blue_art, yellow_art, max_attempts):
     """Mutate every agent's observation for the start of the guess phase and
     activate both guessers.
     """
-    max_attempts = obs0.max_attempts
     for i, s in enumerate(state):
         s.observation.phase = "guess"
         s.observation.target_word = ""
@@ -514,28 +541,28 @@ def _enter_guess_phase(state, obs0, round_idx, blue_art, yellow_art):
             s.observation.teammate_art = ""
             s.observation.attempts_remaining = 0
             s.observation.previous_guesses = []
-    _set_guess_statuses(state, round_idx, obs0)
+    _set_guess_statuses(state, round_idx, wa_state)
 
 
-def _advance_after_round(state, obs0, round_idx, words, target):
+def _advance_after_round(state, obs0, wa_state, round_idx, words, target):
     """Roll the per-team round state into history and advance to the next
     round's art phase (or finish the game).
     """
-    new_blue_score = obs0.blue_score + obs0._round_blue_points
-    new_yellow_score = obs0.yellow_score + obs0._round_yellow_points
+    new_blue_score = obs0.blue_score + wa_state.blue_points
+    new_yellow_score = obs0.yellow_score + wa_state.yellow_points
 
     history_entry = {
         "word": target,
-        "blue_art": obs0._round_blue_art,
-        "blue_art_disqualified": obs0._round_blue_art_disqualified,
-        "blue_art_disqualification_reason": obs0._round_blue_disq_reason,
-        "blue_guesses": list(obs0._round_blue_guesses),
-        "blue_points": obs0._round_blue_points,
-        "yellow_art": obs0._round_yellow_art,
-        "yellow_art_disqualified": obs0._round_yellow_art_disqualified,
-        "yellow_art_disqualification_reason": obs0._round_yellow_disq_reason,
-        "yellow_guesses": list(obs0._round_yellow_guesses),
-        "yellow_points": obs0._round_yellow_points,
+        "blue_art": wa_state.blue_art,
+        "blue_art_disqualified": wa_state.blue_art_disqualified,
+        "blue_art_disqualification_reason": wa_state.blue_disq_reason,
+        "blue_guesses": list(wa_state.blue_guesses),
+        "blue_points": wa_state.blue_points,
+        "yellow_art": wa_state.yellow_art,
+        "yellow_art_disqualified": wa_state.yellow_art_disqualified,
+        "yellow_art_disqualification_reason": wa_state.yellow_disq_reason,
+        "yellow_guesses": list(wa_state.yellow_guesses),
+        "yellow_points": wa_state.yellow_points,
     }
     new_history = list(obs0.history) + [history_entry]
 
@@ -559,7 +586,7 @@ def _advance_after_round(state, obs0, round_idx, words, target):
             if s.observation.role == "artist":
                 s.observation.target_word = words[next_round]
 
-    _reset_round_internals(obs0)
+    wa_state.reset_round()
 
     if is_done:
         for i in range(4):
@@ -572,9 +599,10 @@ def _advance_after_round(state, obs0, round_idx, words, target):
 
 def process_step(state, env):
     obs0 = state[0].observation
+    wa_state: _WordArtState = env.word_art_state
     phase = obs0.phase
     rnd = obs0.current_round
-    words = obs0._words
+    words = wa_state.words
     target = words[rnd]
 
     if phase == "art":
@@ -585,44 +613,47 @@ def process_step(state, env):
         yellow_art = _coerce_str(yellow_action, max_chars)
 
         # The artist's RAW (already-sanitized-and-truncated) submission is
-        # preserved in obs0._round_*_art — and then in history — so the
-        # replay shows what actually reached the engine. What the guesser
-        # sees may be replaced by a placeholder if the art smuggles the
-        # target word in or contains text-like letter clusters. Per-team
-        # disqualification reason drives both the guesser's placeholder
-        # variant and the history-entry annotation; the boolean is kept
-        # alongside so the visualizer's disqualified-label check keeps
-        # working without needing to know about reasons.
-        obs0._round_blue_art = blue_art
-        obs0._round_yellow_art = yellow_art
-        obs0._round_blue_disq_reason = _disqualification_reason(blue_art, target)
-        obs0._round_yellow_disq_reason = _disqualification_reason(yellow_art, target)
-        obs0._round_blue_art_disqualified = obs0._round_blue_disq_reason is not None
-        obs0._round_yellow_art_disqualified = obs0._round_yellow_disq_reason is not None
+        # preserved in wa_state.*_art — and then in history — so the replay
+        # shows what actually reached the engine. What the guesser sees may
+        # be replaced by a placeholder if the art smuggles the target word
+        # in or contains text-like letter clusters. Per-team disqualification
+        # reason drives both the guesser's placeholder variant and the
+        # history-entry annotation; the boolean is kept alongside so the
+        # visualizer's disqualified-label check keeps working without
+        # needing to know about reasons.
+        wa_state.blue_art = blue_art
+        wa_state.yellow_art = yellow_art
+        wa_state.blue_disq_reason = _disqualification_reason(blue_art, target)
+        wa_state.yellow_disq_reason = _disqualification_reason(yellow_art, target)
+        wa_state.blue_art_disqualified = wa_state.blue_disq_reason is not None
+        wa_state.yellow_art_disqualified = wa_state.yellow_disq_reason is not None
 
         blue_art_for_guesser = (
-            DISQUALIFIED_ART_PLACEHOLDERS[obs0._round_blue_disq_reason]
-            if obs0._round_blue_disq_reason else blue_art
+            DISQUALIFIED_ART_PLACEHOLDERS[wa_state.blue_disq_reason]
+            if wa_state.blue_disq_reason else blue_art
         )
         yellow_art_for_guesser = (
-            DISQUALIFIED_ART_PLACEHOLDERS[obs0._round_yellow_disq_reason]
-            if obs0._round_yellow_disq_reason else yellow_art
+            DISQUALIFIED_ART_PLACEHOLDERS[wa_state.yellow_disq_reason]
+            if wa_state.yellow_disq_reason else yellow_art
         )
-        _enter_guess_phase(state, obs0, rnd, blue_art_for_guesser, yellow_art_for_guesser)
+        _enter_guess_phase(
+            state, wa_state, rnd, blue_art_for_guesser, yellow_art_for_guesser,
+            obs0.max_attempts,
+        )
         return
 
     # phase == "guess" — a single sub-step. Each still-active guesser
     # contributes one attempt.
     target_norm = target.strip().upper()
-    _process_team_guess(state, obs0, "blue", env.configuration, target_norm)
-    _process_team_guess(state, obs0, "yellow", env.configuration, target_norm)
+    _process_team_guess(state, obs0, wa_state, "blue", env.configuration, target_norm)
+    _process_team_guess(state, obs0, wa_state, "yellow", env.configuration, target_norm)
 
-    blue_used = len(obs0._round_blue_guesses)
-    yellow_used = len(obs0._round_yellow_guesses)
+    blue_used = len(wa_state.blue_guesses)
+    yellow_used = len(wa_state.yellow_guesses)
     max_attempts = obs0.max_attempts
 
-    if obs0._round_blue_done and obs0._round_yellow_done:
-        _advance_after_round(state, obs0, rnd, words, target)
+    if wa_state.blue_done and wa_state.yellow_done:
+        _advance_after_round(state, obs0, wa_state, rnd, words, target)
         return
 
     # Round still in progress: update per-team counters on every agent's view
@@ -635,26 +666,26 @@ def process_step(state, env):
         s.observation.blue_attempts_used = blue_used
         s.observation.yellow_attempts_used = yellow_used
 
-    if not obs0._round_blue_done:
+    if not wa_state.blue_done:
         state[blue_g_idx].observation.attempts_remaining = max_attempts - blue_used
-        state[blue_g_idx].observation.previous_guesses = list(obs0._round_blue_guesses)
+        state[blue_g_idx].observation.previous_guesses = list(wa_state.blue_guesses)
     else:
         state[blue_g_idx].observation.attempts_remaining = 0
-        state[blue_g_idx].observation.previous_guesses = list(obs0._round_blue_guesses)
+        state[blue_g_idx].observation.previous_guesses = list(wa_state.blue_guesses)
 
-    if not obs0._round_yellow_done:
+    if not wa_state.yellow_done:
         state[yellow_g_idx].observation.attempts_remaining = max_attempts - yellow_used
-        state[yellow_g_idx].observation.previous_guesses = list(obs0._round_yellow_guesses)
+        state[yellow_g_idx].observation.previous_guesses = list(wa_state.yellow_guesses)
     else:
         state[yellow_g_idx].observation.attempts_remaining = 0
-        state[yellow_g_idx].observation.previous_guesses = list(obs0._round_yellow_guesses)
+        state[yellow_g_idx].observation.previous_guesses = list(wa_state.yellow_guesses)
 
-    _set_guess_statuses(state, rnd, obs0)
+    _set_guess_statuses(state, rnd, wa_state)
 
 
 def interpreter(state, env):
     if state[0].observation.phase == "":
-        initialize_game(state, env.configuration)
+        initialize_game(state, env)
         _set_art_statuses(state, 0)
         return state
 

--- a/kaggle_environments/envs/word_art/word_art.py
+++ b/kaggle_environments/envs/word_art/word_art.py
@@ -271,7 +271,7 @@ DISQUALIFIED_ART_PLACEHOLDERS = {
     "contains_words": (
         "<your teammate's drawing was disqualified for containing text "
         "(a run of 3+ letters with 2+ distinct chars, consecutive or "
-        "spaced out with punctuation)>"
+        "separated by any non-letter, non-newline characters)>"
     ),
 }
 
@@ -304,18 +304,20 @@ def _art_contains_word(art, word):
 
 _WORD_LIKE_RE = re.compile(r"[A-Za-z]{3,}")
 # Spaced-out labels: 3+ letters interleaved with same-line separators
-# (space/tab/dot/dash/underscore/middle-dot). Excludes newlines so letters
-# in different rows of the art don't chain across a 2D layout into fake
-# words. Catches evasions the consecutive-only _WORD_LIKE_RE misses --
-# 'A R O U N D', 'T.O.P.', 'H-O-U-S-E', 'grid_view'.
-_SPACED_WORD_RE = re.compile(r"[A-Za-z](?:[ \t.\-_·]+[A-Za-z]){2,}")
+# (any run of non-letter, non-newline characters). Excludes newlines so
+# letters in different rows of the art don't chain across a 2D layout
+# into fake words. Digits are treated as separators too, so 'A1B2C' is
+# caught. Any non-letter, non-newline joiner works so models can't evade
+# with pipes ('H|O|U|S|E'), slashes, colons, commas, em-dashes, etc.
+_SPACED_WORD_RE = re.compile(r"[A-Za-z](?:[^A-Za-z\n]+[A-Za-z]){2,}")
 
 
 def _art_contains_any_word(art):
     """Return True if `art` contains any run of 3+ letters with 2+
     distinct characters (case-insensitive), whether the letters are
-    consecutive ('TOP', 'HOUSE') or separated by same-line punctuation
-    ('T O P', 'A.R.O.U.N.D', 'H-O-U-S-E').
+    consecutive ('TOP', 'HOUSE') or separated by any non-letter,
+    non-newline characters ('T O P', 'A.R.O.U.N.D', 'H-O-U-S-E',
+    'H|O|U|S|E', 'grid_view').
 
     Same-letter clusters ('OOO' for eyes, 'III' for columns, 'TTT' for
     texture, 'V V V' for a zigzag) pass so models can still use letters
@@ -464,20 +466,20 @@ def _set_guess_statuses(state, round_idx, wa_state):
 
 
 def _process_team_guess(state, obs0, wa_state, team, env_config, target_norm):
-    """Read the active guesser's action, append to the team's guess list, and
-    return (points_awarded, is_done_now) — both 0/False if the team was already
-    done or inactive this step.
+    """Read the active guesser's action for `team` and mutate wa_state
+    (append to the team's guess list, mark done, award points). No-op if
+    the team was already done or its guesser wasn't asked to act this step.
     """
     max_attempts = obs0.max_attempts
     first_try_bonus = env_config.get("first_try_bonus", 1)
 
     if team == "blue":
         if wa_state.blue_done:
-            return 0, False
+            return
         g_idx = _blue_guesser(obs0.current_round)
     else:
         if wa_state.yellow_done:
-            return 0, False
+            return
         g_idx = _yellow_guesser(obs0.current_round)
 
     if state[g_idx].status != "ACTIVE":
@@ -487,7 +489,7 @@ def _process_team_guess(state, obs0, wa_state, team, env_config, target_norm):
             wa_state.blue_done = True
         else:
             wa_state.yellow_done = True
-        return 0, True
+        return
 
     raw = _unwrap(state[g_idx].action)
     guess_str = raw if isinstance(raw, str) else (str(raw) if raw is not None else "")
@@ -511,16 +513,13 @@ def _process_team_guess(state, obs0, wa_state, team, env_config, target_norm):
             wa_state.yellow_done = True
             state[2].reward = (state[2].reward or 0) + pts
             state[3].reward = (state[3].reward or 0) + pts
-        return pts, True
+        return
 
     if used >= max_attempts:
         if team == "blue":
             wa_state.blue_done = True
         else:
             wa_state.yellow_done = True
-        return 0, True
-
-    return 0, False
 
 
 def _enter_guess_phase(state, wa_state, round_idx, blue_art, yellow_art, max_attempts):
@@ -599,6 +598,17 @@ def _advance_after_round(state, obs0, wa_state, round_idx, words, target):
 
 def process_step(state, env):
     obs0 = state[0].observation
+    if not hasattr(env, "word_art_state"):
+        # env.word_art_state lives on the Environment instance and is
+        # not serialized into steps, so it's lost across env.clone() and
+        # JSON round-trips. Mid-game recovery isn't possible: the target
+        # words for future rounds were sampled from an RNG that's now
+        # gone. Fail loudly rather than silently corrupting the episode.
+        raise RuntimeError(
+            "word_art: env.word_art_state is missing. Round-scoped hidden "
+            "state does not survive env.clone() or JSON round-trips -- run "
+            "an episode start-to-finish in a single Environment instance."
+        )
     wa_state: _WordArtState = env.word_art_state
     phase = obs0.phase
     rnd = obs0.current_round
@@ -648,10 +658,6 @@ def process_step(state, env):
     _process_team_guess(state, obs0, wa_state, "blue", env.configuration, target_norm)
     _process_team_guess(state, obs0, wa_state, "yellow", env.configuration, target_norm)
 
-    blue_used = len(wa_state.blue_guesses)
-    yellow_used = len(wa_state.yellow_guesses)
-    max_attempts = obs0.max_attempts
-
     if wa_state.blue_done and wa_state.yellow_done:
         _advance_after_round(state, obs0, wa_state, rnd, words, target)
         return
@@ -659,26 +665,25 @@ def process_step(state, env):
     # Round still in progress: update per-team counters on every agent's view
     # (these are public; both teams can see how many guesses the other has
     # used), and update each guesser's private `attempts_remaining` and
-    # `previous_guesses` lists.
+    # `previous_guesses` lists. A done guesser's `attempts_remaining` goes
+    # to 0; `previous_guesses` is refreshed either way.
+    blue_used = len(wa_state.blue_guesses)
+    yellow_used = len(wa_state.yellow_guesses)
+    max_attempts = obs0.max_attempts
     blue_g_idx = _blue_guesser(rnd)
     yellow_g_idx = _yellow_guesser(rnd)
     for s in state:
         s.observation.blue_attempts_used = blue_used
         s.observation.yellow_attempts_used = yellow_used
 
-    if not wa_state.blue_done:
-        state[blue_g_idx].observation.attempts_remaining = max_attempts - blue_used
-        state[blue_g_idx].observation.previous_guesses = list(wa_state.blue_guesses)
-    else:
-        state[blue_g_idx].observation.attempts_remaining = 0
-        state[blue_g_idx].observation.previous_guesses = list(wa_state.blue_guesses)
-
-    if not wa_state.yellow_done:
-        state[yellow_g_idx].observation.attempts_remaining = max_attempts - yellow_used
-        state[yellow_g_idx].observation.previous_guesses = list(wa_state.yellow_guesses)
-    else:
-        state[yellow_g_idx].observation.attempts_remaining = 0
-        state[yellow_g_idx].observation.previous_guesses = list(wa_state.yellow_guesses)
+    state[blue_g_idx].observation.previous_guesses = list(wa_state.blue_guesses)
+    state[blue_g_idx].observation.attempts_remaining = (
+        0 if wa_state.blue_done else max_attempts - blue_used
+    )
+    state[yellow_g_idx].observation.previous_guesses = list(wa_state.yellow_guesses)
+    state[yellow_g_idx].observation.attempts_remaining = (
+        0 if wa_state.yellow_done else max_attempts - yellow_used
+    )
 
     _set_guess_statuses(state, rnd, wa_state)
 

--- a/tests/envs/word_art/test_word_art.py
+++ b/tests/envs/word_art/test_word_art.py
@@ -378,6 +378,55 @@ def test_safe_art_is_not_disqualified():
     assert entry["yellow_art_disqualified"] is False
 
 
+# --- Spaced-out non-target labels caught by the any-word check --------------
+#
+# The consecutive-letter check ('TOP', 'HOUSE') and the target-word check
+# (letters-of-the-target with any/no separators) both catch obvious labels.
+# The gap is a non-target label spelled out with same-line separators --
+# 'A R O U N D', 'H-O-U-S-E', 'grid_view' -- which the consecutive check
+# doesn't fire on and the target-word check ignores (wrong word). These
+# tests lock in the same-line separator-aware any-word check.
+
+
+def _art_check(art):
+    from kaggle_environments.envs.word_art.word_art import _art_contains_any_word
+    return _art_contains_any_word(art)
+
+
+@pytest.mark.parametrize("art", [
+    "A R O U N D",       # spaces
+    "A.R.O.U.N.D",       # dots
+    "H-O-U-S-E",         # dashes
+    "T\tO\tP",           # tabs
+    "grid_view",         # underscore compound
+    "T O P",             # 3-letter spaced
+])
+def test_spaced_non_target_label_is_disqualified(art):
+    assert _art_check(art) is True, f"expected {art!r} to be flagged as text"
+
+
+@pytest.mark.parametrize("art", [
+    "OOO",               # eye cluster
+    "III",               # columns
+    "V V V V",           # zigzag decoration
+    "T T T\nT T T",      # texture grid (single letter across a 2D layout)
+    "OO H2",             # short clusters + digit-adjacent
+    "O   O\n  V\n \\_/", # smiley (letters spread across lines)
+    "o o o\n o\no o o",  # die face
+    "\n   *\n \\ | /\n---+---\n / | \\\n   *\n",  # snowflake example
+])
+def test_visual_letter_elements_pass(art):
+    assert _art_check(art) is False, f"expected {art!r} to pass the any-word check"
+
+
+def test_letters_on_different_lines_do_not_chain():
+    """Same-line-only chaining: `T`, `O`, `P` each on their own line should
+    NOT combine into 'TOP' -- otherwise a 2D layout with letter-based
+    visual elements becomes unusable."""
+    art = "T\n O\n  P"
+    assert _art_check(art) is False
+
+
 def test_guesser_sees_placeholder_on_disqualification():
     """When the artist's art is disqualified, the guesser's teammate_art is
     replaced with the placeholder string and the original is NOT leaked."""
@@ -410,11 +459,8 @@ def test_disqualification_does_not_block_guessing():
     def smart_guesser(observation, configuration):
         if observation.role == "artist":
             return observation.target_word  # will be disqualified
-        # Guesser ignores the placeholder, makes a smart guess using history.
-        # On round 1, we cheat by reading target via a side channel: pull from
-        # the global state via the env's hidden _words on agent 0. Not possible
-        # via observation alone, so just guess randomly here -- the test only
-        # checks the structure (3 attempts allowed).
+        # Guesser ignores the placeholder and just guesses wrong every attempt
+        # -- the test only checks structure (3 attempts allowed, no points).
         return f"WRONG{len(observation.previous_guesses)}"
 
     env = make("word_art", configuration={"num_rounds": 1, "seed": 7})
@@ -467,6 +513,35 @@ def test_config_defaults_surfaced_on_observation():
     for s in env.state:
         assert s.observation.first_try_bonus == 1
         assert s.observation.max_art_chars == 4000
+
+
+def test_no_hidden_keys_leak_into_any_observation():
+    """Round-scoped hidden state (word list, in-progress art, guesses, per-team
+    done flags) must live on ``env``, not on any player's observation. A leak
+    onto ``state[i].observation`` (typically under an underscore-prefixed key)
+    would ship the target words and the opposing team's in-progress state
+    into the replay JSON and into whatever the agent process receives -- a
+    custom agent could then short-circuit the art channel entirely, and any
+    future prompt change that dumps the raw obs would silently leak.
+
+    We run a couple of rounds so both the art-phase and guess-phase code
+    paths get a chance to set fields on the observation.
+    """
+    env = _make(num_rounds=2, seed=1)
+    env.run(["random"] * 4)
+    forbidden_prefixes = ("_words", "_round_")
+    forbidden_keys = {"words", "target_words"}  # unprefixed variants
+    for step in env.steps:
+        for i, agent in enumerate(step):
+            obs = agent.observation
+            hidden = [
+                k for k in obs.keys()
+                if k in forbidden_keys or any(k.startswith(p) for p in forbidden_prefixes)
+            ]
+            assert not hidden, (
+                f"agent {i}'s observation leaks hidden keys {hidden}; "
+                "round-scoped state must live on env.word_art_state"
+            )
 
 
 # --- Failure-status preservation across phase / round transitions ----------

--- a/tests/envs/word_art/test_word_art.py
+++ b/tests/envs/word_art/test_word_art.py
@@ -385,7 +385,10 @@ def test_safe_art_is_not_disqualified():
 # The gap is a non-target label spelled out with same-line separators --
 # 'A R O U N D', 'H-O-U-S-E', 'grid_view' -- which the consecutive check
 # doesn't fire on and the target-word check ignores (wrong word). These
-# tests lock in the same-line separator-aware any-word check.
+# tests lock in the same-line separator-aware any-word check. Any
+# non-letter, non-newline joiner is treated as a separator, so evasions
+# via '|', '/', ':', ',', '*', em-dash, non-breaking space etc. are all
+# rejected.
 
 
 def _art_check(art):
@@ -394,12 +397,22 @@ def _art_check(art):
 
 
 @pytest.mark.parametrize("art", [
-    "A R O U N D",       # spaces
-    "A.R.O.U.N.D",       # dots
-    "H-O-U-S-E",         # dashes
-    "T\tO\tP",           # tabs
-    "grid_view",         # underscore compound
-    "T O P",             # 3-letter spaced
+    "A R O U N D",         # spaces
+    "A.R.O.U.N.D",         # dots
+    "H-O-U-S-E",           # dashes
+    "T\tO\tP",             # tabs
+    "grid_view",           # underscore compound
+    "T O P",               # 3-letter spaced
+    "H|O|U|S|E",           # pipes
+    "H/O/U/S/E",           # slashes
+    "H:O:U:S:E",           # colons
+    "H,O,U,S,E",           # commas
+    "H*O*U*S*E",           # asterisks
+    "H=O=U=S=E",           # equals
+    "H—O—U—S—E",  # em-dashes
+    "H–O–U–S–E",  # en-dashes
+    "H\xa0O\xa0U\xa0S\xa0E",         # non-breaking spaces
+    "A1B2C",               # digits used as separators
 ])
 def test_spaced_non_target_label_is_disqualified(art):
     assert _art_check(art) is True, f"expected {art!r} to be flagged as text"
@@ -456,7 +469,7 @@ def test_disqualification_does_not_block_guessing():
     """Even with a disqualified art panel, the guesser still gets their full
     attempt budget and can still score if they correctly guess the word."""
 
-    def smart_guesser(observation, configuration):
+    def wrong_guesser(observation, configuration):
         if observation.role == "artist":
             return observation.target_word  # will be disqualified
         # Guesser ignores the placeholder and just guesses wrong every attempt
@@ -464,7 +477,7 @@ def test_disqualification_does_not_block_guessing():
         return f"WRONG{len(observation.previous_guesses)}"
 
     env = make("word_art", configuration={"num_rounds": 1, "seed": 7})
-    env.run([smart_guesser] * 4)
+    env.run([wrong_guesser] * 4)
     j = env.toJSON()
     entry = j["steps"][-1][0]["observation"]["history"][0]
     # Both teams cheated → both disqualified, guessers still got their 3
@@ -542,6 +555,22 @@ def test_no_hidden_keys_leak_into_any_observation():
                 f"agent {i}'s observation leaks hidden keys {hidden}; "
                 "round-scoped state must live on env.word_art_state"
             )
+
+
+def test_mid_game_missing_word_art_state_raises_clearly():
+    """env.word_art_state is not preserved across env.clone() or JSON
+    round-trips (Environment.clone constructs a fresh instance from
+    ``steps`` and doesn't carry over user attributes). Simulate the
+    lost-state case by deleting the attribute mid-game and confirm the
+    interpreter raises a clear RuntimeError instead of AttributeError-ing
+    deep inside process_step.
+    """
+    env = _make(num_rounds=2, seed=1)
+    env.step([None] * 4)  # advance out of the phase="" init branch
+    assert env.state[0].observation.phase != ""
+    del env.word_art_state
+    with pytest.raises(RuntimeError, match="word_art_state is missing"):
+        env.step([None] * 4)
 
 
 # --- Failure-status preservation across phase / round transitions ----------


### PR DESCRIPTION
* Change the ASCII example in the prompt from CAT to SNOWFLAKE since the former is in the word list.
* Further tighten the ANY-WORD check to catch whitespace, punctuation, and any separators between letters
* Copy Werewolf's `observation` handling such that hidden information is never passed to agents that should not receive it. Not an issue in practice since we control what the harness passes to the LLM, but good practice nonetheless.