### PR TITLE
Fix Word Art visualization and fix harness nits

### DIFF
--- a/kaggle_environments/envs/word_art/harness.py
+++ b/kaggle_environments/envs/word_art/harness.py
@@ -343,10 +343,7 @@ either fires, your teammate sees a placeholder instead of your drawing
      Same-character clusters ('OOO' eyes, 'III' columns, 'TTT'
      texture, 'V V V' zigzag) always pass. Two-letter decorative
      patterns like 'o X X X o' (dice pips), 'A B A B' (brickwork)
-     also pass -- letters remain fine as visual elements. A spelled-
-     out 2-distinct word like 'POP' still trips via the consecutive
-     rule, but 'P O P' (spaced) slips through, so this check is a
-     backstop, not a proof; don't rely on it to hide the target word.
+     also pass -- letters remain fine as visual elements.
 
 Your art is silently sanitized before scoring: combining marks, wide
 characters (CJK, most emoji), and other non-single-cell Unicode are

--- a/kaggle_environments/envs/word_art/harness.py
+++ b/kaggle_environments/envs/word_art/harness.py
@@ -71,8 +71,9 @@ def _slice_thoughts(response: str, answer_start: int) -> str | None:
 _DISQ_REASON_TEXT = {
     "target_word": "contained the target word",
     "contains_words": (
-        "contained text (a run of 3+ letters with 2+ distinct chars, "
-        "consecutive or separated by any non-letter, non-newline chars)"
+        "contained text (3+ consecutive letters with 2+ distinct chars, "
+        "or 3+ letters with 3+ distinct chars separated by non-letter, "
+        "non-newline chars)"
     ),
 }
 
@@ -332,14 +333,20 @@ either fires, your teammate sees a placeholder instead of your drawing
      '(scale: CAT)', arrow labels like '<- CAT', or section headers
      like 'CAT close-up:'.
 
-  2. ANY-WORD check. Any run of 3+ letters with 2+ distinct characters
-     (case-insensitive) disqualifies the drawing, whether the letters
-     are consecutive ('top', 'HOUSE', 'grid', 'axe') or separated by
-     any non-letter, non-newline characters ('T O P', 'A.R.O.U.N.D',
-     'H-O-U-S-E', 'H|O|U|S|E', 'grid_view'). Same-character clusters
-     ('OOO' for eyes, 'III' for columns, 'TTT' for texture, 'V V V'
-     for a zigzag) always pass, as do 1- and 2-letter clusters ('V',
-     'OO', 'H2') -- so letters remain fine as visual elements.
+  2. ANY-WORD check. Two thresholds:
+       * Consecutive letters: a run of 3+ with 2+ distinct chars
+         disqualifies ('top', 'HOUSE', 'grid', 'axe' all trip).
+       * Spaced-out letters (letters separated by any non-letter,
+         non-newline characters): a run of 3+ with 3+ distinct chars
+         disqualifies ('A R O U N D', 'T.O.P.', 'H-O-U-S-E',
+         'H|O|U|S|E', 'grid_view').
+     Same-character clusters ('OOO' eyes, 'III' columns, 'TTT'
+     texture, 'V V V' zigzag) always pass. Two-letter decorative
+     patterns like 'o X X X o' (dice pips), 'A B A B' (brickwork)
+     also pass -- letters remain fine as visual elements. A spelled-
+     out 2-distinct word like 'POP' still trips via the consecutive
+     rule, but 'P O P' (spaced) slips through, so this check is a
+     backstop, not a proof; don't rely on it to hide the target word.
 
 Your art is silently sanitized before scoring: combining marks, wide
 characters (CJK, most emoji), and other non-single-cell Unicode are

--- a/kaggle_environments/envs/word_art/harness.py
+++ b/kaggle_environments/envs/word_art/harness.py
@@ -395,12 +395,13 @@ def _build_guesser_prompt(
         prev_block = "This is your first guess this round."
 
     if attempt_number == 1:
-        attempt_pitch = f"This is attempt 1 of {max_attempts}. A correct guess NOW earns the first-try bonus."
+        attempt_pitch = f"This is attempt 1 of {max_attempts} in the current round. A correct guess NOW earns the first-try bonus."
     else:
         attempt_pitch = (
-            f"This is attempt {attempt_number} of {max_attempts}. You have "
-            f"{attempts_remaining} attempt(s) left (including this one). No "
-            "bonus is available now, but a correct guess still scores 1 point."
+            f"This is attempt {attempt_number} of {max_attempts} in the "
+            f"current round. You have {attempts_remaining} attempt(s) left "
+            "(including this one). No bonus is available now, but a correct "
+            "guess still scores 1 point."
         )
 
     return f"""You are the GUESSER on Team {team_label} in Word Art (a 2v2 game).
@@ -417,18 +418,18 @@ Rules:
 - The opposing team plays the same secret word each round in parallel
   and cannot see your art or guesses.
 - The engine mechanically disqualifies art that contains either the
-  target word or any run of 3+ letters with 2+ distinct characters
-  (labels, captions, headings). When that happens you'll see a
-  placeholder marker instead of a picture. Past rounds in the history
-  below are likewise labelled "DISQUALIFIED" when this happened.
+  target word or any run of letters that reads like a label (captions,
+  headings, annotations). When that happens you'll see a placeholder
+  marker instead of a picture. Past rounds in the history below are
+  likewise labelled "DISQUALIFIED" when this happened.
 
 {scoring}
 
-{attempt_pitch}
-{prev_block}
-
 Past rounds in this game so far:
 {history_text}
+
+{attempt_pitch}
+{prev_block}
 
 Your teammate's drawing (be aware that monospace alignment matters):
 {teammate_art if teammate_art else "(your teammate submitted nothing)"}

--- a/kaggle_environments/envs/word_art/visualizer/default/src/renderer.ts
+++ b/kaggle_environments/envs/word_art/visualizer/default/src/renderer.ts
@@ -85,7 +85,7 @@ function disqReasonText(reason: DisqReason): string {
   // Matches the phrasing the harness uses in the artist prompt so the
   // visualizer reader sees the same rule name the model was told about.
   if (reason === 'contains_words') {
-    return 'contained text (a run of 3+ letters with 2+ distinct chars)';
+    return 'contained text (3+ consecutive letters with 2+ distinct chars, or 3+ spaced-out letters with 3+ distinct chars)';
   }
   return 'contained the target word';
 }

--- a/kaggle_environments/envs/word_art/visualizer/default/src/renderer.ts
+++ b/kaggle_environments/envs/word_art/visualizer/default/src/renderer.ts
@@ -181,24 +181,49 @@ export function renderer(options: RendererOptions) {
   } else {
     blueGuesses = getLiveGuesses(currentStep, 'blue', displayRound);
     yellowGuesses = getLiveGuesses(currentStep, 'yellow', displayRound);
-    // Reading _round_* fields directly: they're technically "private"
-    // (underscore-prefixed) but the replay JSON exposes them and they
-    // are the only in-round signal for correct-guess detection and
-    // disqualification reason before the round rolls into history.
-    bluePoints = typeof obs0._round_blue_points === 'number' ? obs0._round_blue_points : null;
-    yellowPoints = typeof obs0._round_yellow_points === 'number' ? obs0._round_yellow_points : null;
-    const rawBlueReason = obs0._round_blue_disq_reason as DisqReason | undefined;
-    const rawYellowReason = obs0._round_yellow_disq_reason as DisqReason | undefined;
-    // Fallback: if reason isn't present but the bool is (or the
-    // placeholder text made it into teammate_art), still show as
-    // disqualified with the older "target_word" default.
+    // Live per-team points are derived from the public
+    // `{team}_guessed_correctly` bool + the guess count + first_try_bonus.
+    // We can't just look at the last guess and compare it to the target
+    // ourselves because _matches_target does singular/plural leniency
+    // (CAT<->CATS, CHILD<->CHILDREN, CACTUS<->CACTI, ...) that we won't
+    // reproduce here. Old replays predate the bool and expose the
+    // pre-computed points under an underscore-prefixed field instead;
+    // fall back to that so historical replays still color correctly.
+    const firstTryBonus: number = obs0.first_try_bonus ?? 1;
+    const derivePoints = (correct: boolean | undefined, guessCount: number): number | null => {
+      if (correct === undefined) return null;
+      if (!correct) return 0;
+      return guessCount === 1 ? 1 + firstTryBonus : 1;
+    };
+    const blueCorrect = obs0.blue_guessed_correctly as boolean | undefined;
+    const yellowCorrect = obs0.yellow_guessed_correctly as boolean | undefined;
+    bluePoints =
+      blueCorrect !== undefined
+        ? derivePoints(blueCorrect, blueGuesses.length)
+        : typeof obs0._round_blue_points === 'number'
+          ? obs0._round_blue_points
+          : null;
+    yellowPoints =
+      yellowCorrect !== undefined
+        ? derivePoints(yellowCorrect, yellowGuesses.length)
+        : typeof obs0._round_yellow_points === 'number'
+          ? obs0._round_yellow_points
+          : null;
+    const rawBlueReason =
+      (obs0.blue_art_disqualification_reason as DisqReason | undefined) ??
+      (obs0._round_blue_disq_reason as DisqReason | undefined);
+    const rawYellowReason =
+      (obs0.yellow_art_disqualification_reason as DisqReason | undefined) ??
+      (obs0._round_yellow_disq_reason as DisqReason | undefined);
+    const blueDisqFlag = obs0.blue_art_disqualified ?? obs0._round_blue_art_disqualified;
+    const yellowDisqFlag = obs0.yellow_art_disqualified ?? obs0._round_yellow_art_disqualified;
     blueDisqReason =
       rawBlueReason ??
-      (obs0._round_blue_art_disqualified ? 'target_word' : null) ??
+      (blueDisqFlag ? 'target_word' : null) ??
       (typeof blueArt === 'string' && blueArt.includes('disqualified') ? 'target_word' : null);
     yellowDisqReason =
       rawYellowReason ??
-      (obs0._round_yellow_art_disqualified ? 'target_word' : null) ??
+      (yellowDisqFlag ? 'target_word' : null) ??
       (typeof yellowArt === 'string' && yellowArt.includes('disqualified') ? 'target_word' : null);
   }
   const blueDisqualified = blueDisqReason !== null;

--- a/kaggle_environments/envs/word_art/word_art.json
+++ b/kaggle_environments/envs/word_art/word_art.json
@@ -141,6 +141,36 @@
       "type": "integer",
       "default": 0
     },
+    "blue_guessed_correctly": {
+      "description": "True if team Blue has already made a correct guess this round. Resets to false at each round boundary. Public across agents so the visualizer can distinguish a correct final guess from a wrong one before the round rolls into history (the visualizer would otherwise have to reimplement _matches_target's singular/plural leniency in TypeScript to reproduce this signal).",
+      "type": "boolean",
+      "default": false
+    },
+    "yellow_guessed_correctly": {
+      "description": "True if team Yellow has already made a correct guess this round. Resets to false at each round boundary. Public across agents so the visualizer can distinguish a correct final guess from a wrong one before the round rolls into history.",
+      "type": "boolean",
+      "default": false
+    },
+    "blue_art_disqualified": {
+      "description": "True if team Blue's art this round was disqualified by the engine (target-word check or any-word check). Public across agents; set at guess-phase entry and cleared at each round boundary.",
+      "type": "boolean",
+      "default": false
+    },
+    "yellow_art_disqualified": {
+      "description": "True if team Yellow's art this round was disqualified by the engine. Public across agents; set at guess-phase entry and cleared at each round boundary.",
+      "type": "boolean",
+      "default": false
+    },
+    "blue_art_disqualification_reason": {
+      "description": "Reason team Blue's art was disqualified ('target_word' or 'contains_words'), or null when the art passed. Public across agents; set at guess-phase entry and cleared at each round boundary.",
+      "type": ["string", "null"],
+      "default": null
+    },
+    "yellow_art_disqualification_reason": {
+      "description": "Reason team Yellow's art was disqualified ('target_word' or 'contains_words'), or null when the art passed. Public across agents; set at guess-phase entry and cleared at each round boundary.",
+      "type": ["string", "null"],
+      "default": null
+    },
     "history": {
       "description": "List of completed rounds, each {word, blue_art, blue_art_disqualified, blue_guesses (list), blue_points, yellow_art, yellow_art_disqualified, yellow_guesses (list), yellow_points}. blue_art / yellow_art are the artist's raw submission (preserved for replay transparency even when the env disqualified it).",
       "type": "array",

--- a/kaggle_environments/envs/word_art/word_art.py
+++ b/kaggle_environments/envs/word_art/word_art.py
@@ -270,8 +270,9 @@ DISQUALIFIED_ART_PLACEHOLDERS = {
     ),
     "contains_words": (
         "<your teammate's drawing was disqualified for containing text "
-        "(a run of 3+ letters with 2+ distinct chars, consecutive or "
-        "separated by any non-letter, non-newline characters)>"
+        "(3+ consecutive letters with 2+ distinct chars, or 3+ letters "
+        "with 3+ distinct chars separated by non-letter, non-newline "
+        "characters)>"
     ),
 }
 
@@ -313,29 +314,39 @@ _SPACED_WORD_RE = re.compile(r"[A-Za-z](?:[^A-Za-z\n]+[A-Za-z]){2,}")
 
 
 def _art_contains_any_word(art):
-    """Return True if `art` contains any run of 3+ letters with 2+
-    distinct characters (case-insensitive), whether the letters are
-    consecutive ('TOP', 'HOUSE') or separated by any non-letter,
-    non-newline characters ('T O P', 'A.R.O.U.N.D', 'H-O-U-S-E',
-    'H|O|U|S|E', 'grid_view').
+    """Return True if `art` contains a text-like run of letters. Two
+    thresholds, chosen so decoration passes but labels don't:
 
-    Same-letter clusters ('OOO' for eyes, 'III' for columns, 'TTT' for
-    texture, 'V V V' for a zigzag) pass so models can still use letters
-    as visual elements. Complementary to _art_contains_word; that catches
-    only the target word, this catches every OTHER word.
+    * Consecutive letters (`_WORD_LIKE_RE`): 3+ letters, 2+ distinct.
+      Catches 'top', 'HOUSE', 'grid', 'axe'. Same-letter clusters like
+      'OOO' (eyes), 'III' (columns), 'TTT' (texture) pass.
+
+    * Spaced-out letters (`_SPACED_WORD_RE`): 3+ letters separated by
+      non-letter, non-newline characters, and 3+ distinct. Catches
+      'A R O U N D', 'H|O|U|S|E', 'T O P', 'A.R.O.U.N.D'. Two-letter
+      decorations like 'o X X X o' (dice pips), 'A B A B' (brickwork),
+      or 'V W V W' pass -- they're almost always visual patterns, not
+      labels. A 2-distinct spelled-out word ('POP', 'EYE') will slip
+      through when spaced ('P O P'), but the consecutive check still
+      catches the tightly-written form.
+
+    Complementary to _art_contains_word; that catches only the target
+    word, this catches every OTHER word.
 
     The distinct-character count considers LETTERS only (not the
-    separators between them), so a decorative row like 'V V V' evaluates
-    as one distinct letter and passes even though the raw match string
-    contains both 'v' and ' '.
+    separators between them), so 'V V V' evaluates as one distinct
+    letter even though the raw match string contains both 'v' and ' '.
     """
     if not art:
         return False
-    for regex in (_WORD_LIKE_RE, _SPACED_WORD_RE):
-        for m in regex.finditer(art):
-            distinct_letters = {c for c in m.group(0).lower() if c.isalpha()}
-            if len(distinct_letters) > 1:
-                return True
+    for m in _WORD_LIKE_RE.finditer(art):
+        distinct_letters = {c for c in m.group(0).lower() if c.isalpha()}
+        if len(distinct_letters) >= 2:
+            return True
+    for m in _SPACED_WORD_RE.finditer(art):
+        distinct_letters = {c for c in m.group(0).lower() if c.isalpha()}
+        if len(distinct_letters) >= 3:
+            return True
     return False
 
 

--- a/kaggle_environments/envs/word_art/word_art.py
+++ b/kaggle_environments/envs/word_art/word_art.py
@@ -425,6 +425,12 @@ def initialize_game(state, env):
         s.observation.yellow_score = 0
         s.observation.blue_attempts_used = 0
         s.observation.yellow_attempts_used = 0
+        s.observation.blue_guessed_correctly = False
+        s.observation.yellow_guessed_correctly = False
+        s.observation.blue_art_disqualified = False
+        s.observation.yellow_art_disqualified = False
+        s.observation.blue_art_disqualification_reason = None
+        s.observation.yellow_art_disqualification_reason = None
         s.observation.history = []
 
     env.word_art_state = _WordArtState(sampled)
@@ -525,12 +531,23 @@ def _process_team_guess(state, obs0, wa_state, team, env_config, target_norm):
 def _enter_guess_phase(state, wa_state, round_idx, blue_art, yellow_art, max_attempts):
     """Mutate every agent's observation for the start of the guess phase and
     activate both guessers.
+
+    The artist's `target_word` is intentionally NOT cleared here: the artist
+    is INACTIVE for the rest of the round so the LLM never sees it again,
+    but keeping it on the observation lets the visualizer surface the
+    current-round target while guessing is in progress (guessers already
+    have `target_word == ""` from the art phase, so they don't see it).
     """
     for i, s in enumerate(state):
         s.observation.phase = "guess"
-        s.observation.target_word = ""
         s.observation.blue_attempts_used = 0
         s.observation.yellow_attempts_used = 0
+        s.observation.blue_guessed_correctly = False
+        s.observation.yellow_guessed_correctly = False
+        s.observation.blue_art_disqualified = wa_state.blue_art_disqualified
+        s.observation.yellow_art_disqualified = wa_state.yellow_art_disqualified
+        s.observation.blue_art_disqualification_reason = wa_state.blue_disq_reason
+        s.observation.yellow_art_disqualification_reason = wa_state.yellow_disq_reason
         if get_role(i, round_idx) == "guesser":
             team = get_team(i)
             s.observation.teammate_art = blue_art if team == "blue" else yellow_art
@@ -578,6 +595,12 @@ def _advance_after_round(state, obs0, wa_state, round_idx, words, target):
         s.observation.attempts_remaining = 0
         s.observation.blue_attempts_used = 0
         s.observation.yellow_attempts_used = 0
+        s.observation.blue_guessed_correctly = False
+        s.observation.yellow_guessed_correctly = False
+        s.observation.blue_art_disqualified = False
+        s.observation.yellow_art_disqualified = False
+        s.observation.blue_art_disqualification_reason = None
+        s.observation.yellow_art_disqualification_reason = None
         if not is_done:
             s.observation.current_round = next_round
             s.observation.phase = "art"
@@ -675,6 +698,8 @@ def process_step(state, env):
     for s in state:
         s.observation.blue_attempts_used = blue_used
         s.observation.yellow_attempts_used = yellow_used
+        s.observation.blue_guessed_correctly = wa_state.blue_points > 0
+        s.observation.yellow_guessed_correctly = wa_state.yellow_points > 0
 
     state[blue_g_idx].observation.previous_guesses = list(wa_state.blue_guesses)
     state[blue_g_idx].observation.attempts_remaining = (

--- a/tests/envs/word_art/test_word_art.py
+++ b/tests/envs/word_art/test_word_art.py
@@ -427,6 +427,14 @@ def test_spaced_non_target_label_is_disqualified(art):
     "O   O\n  V\n \\_/", # smiley (letters spread across lines)
     "o o o\n o\no o o",  # die face
     "\n   *\n \\ | /\n---+---\n / | \\\n   *\n",  # snowflake example
+    # Two-letter decorative patterns with separators. The spaced-out check
+    # requires 3+ distinct letters, so these pass -- they're visual
+    # patterns (dice, brickwork, zigzag), not spelled-out labels.
+    "| o   X     X     X  o  |",  # die/domino row: 5 letters, 2 distinct
+    "A B A B A B",                 # brick row
+    "X . X . X . X",               # single-letter row with dot spacers
+    "V W V W V W",                 # alternating zigzag
+    "o X o",                       # 3-letter, 2-distinct decoration
 ])
 def test_visual_letter_elements_pass(art):
     assert _art_check(art) is False, f"expected {art!r} to pass the any-word check"

--- a/tests/envs/word_art/test_word_art.py
+++ b/tests/envs/word_art/test_word_art.py
@@ -557,6 +557,127 @@ def test_no_hidden_keys_leak_into_any_observation():
             )
 
 
+def test_guessed_correctly_visible_mid_round():
+    """When one team scores on their first try but the other keeps guessing,
+    the winning team's `{team}_guessed_correctly` bool must be True on
+    intermediate steps -- the visualizer keys its correct/wrong slot
+    coloring off this field. Before it was exposed publicly, the correct
+    guess showed red until the round rolled into history.
+    """
+    def blue_scores_first(observation, configuration):
+        # Round 0: agent 0 is blue artist. Encode the word; agent 1 is blue
+        # guesser and decodes on attempt 1 for the win.
+        role = observation.role
+        team = observation.team
+        if role == "artist" and team == "blue":
+            return _encode_word(observation.target_word)
+        if role == "guesser" and team == "blue":
+            return _decode_art(observation.teammate_art)
+        # Yellow team: always wrong so the round drags on for max_attempts.
+        if role == "artist":
+            return "* * *"
+        return f"WRONG{len(observation.previous_guesses)}"
+
+    env = _make(num_rounds=1, max_attempts=3, seed=1)
+    env.run([blue_scores_first] * 4)
+
+    # There must be at least one intermediate guess-phase step where blue
+    # is flagged correct but yellow is still guessing.
+    saw_intermediate = False
+    for step in env.steps:
+        obs0 = step[0].observation
+        if obs0.phase != "guess" or obs0.current_round < len(obs0.history):
+            continue
+        if obs0.blue_guessed_correctly and not obs0.yellow_guessed_correctly:
+            saw_intermediate = True
+            # Every agent's obs sees the same snapshot.
+            for i in range(4):
+                assert step[i].observation.blue_guessed_correctly is True
+                assert step[i].observation.yellow_guessed_correctly is False
+    assert saw_intermediate, (
+        "test setup: no intermediate step where blue had scored and yellow "
+        "was still guessing; can't verify the visualizer signal"
+    )
+
+
+def test_disqualification_flags_public_during_guess_phase():
+    """The public per-team art_disqualified bool + reason are set at
+    guess-phase entry and mirrored to every agent's observation, so the
+    visualizer can render the DISQUALIFIED label on the losing team's art
+    without relying on the removed `_round_*` private fields."""
+    def blue_cheats(observation, configuration):
+        role = observation.role
+        team = observation.team
+        if role == "artist" and team == "blue":
+            return observation.target_word  # trip the target-word check
+        if role == "artist":
+            return "* * *"
+        return "WRONG"
+
+    env = _make(num_rounds=1, seed=1)
+    env.run([blue_cheats] * 4)
+    saw_guess = False
+    for step in env.steps:
+        obs0 = step[0].observation
+        if obs0.phase != "guess" or obs0.current_round < len(obs0.history):
+            continue
+        saw_guess = True
+        for i in range(4):
+            assert step[i].observation.blue_art_disqualified is True
+            assert step[i].observation.yellow_art_disqualified is False
+            assert step[i].observation.blue_art_disqualification_reason == "target_word"
+            assert step[i].observation.yellow_art_disqualification_reason is None
+    assert saw_guess
+
+
+def test_current_target_visible_in_replay_during_guess_phase():
+    """The visualizer relies on `target_word` being present on SOME agent's
+    observation during the guess phase so it can show the reader which word
+    is currently being guessed (history only covers COMPLETED rounds). The
+    artist is INACTIVE during the guess phase, so keeping target_word on
+    their observation is safe: the LLM never gets called again this round,
+    but the field remains in the serialized step for the renderer to find.
+    """
+    from kaggle_environments.envs.word_art.word_art import (
+        _blue_artist, _yellow_artist, _blue_guesser, _yellow_guesser,
+    )
+
+    env = _make(num_rounds=2, seed=1)
+    env.run(["random"] * 4)
+    # Walk every step; on any guess-phase step where the round is still
+    # live (not yet rolled into history), at least one agent's
+    # target_word must be set so the renderer has something to show.
+    saw_guess_step = False
+    for step in env.steps:
+        obs0 = step[0].observation
+        if obs0.phase != "guess":
+            continue
+        rnd = obs0.current_round
+        if rnd < len(obs0.history):
+            # Round already closed and rolled into history; the renderer
+            # reads the target from history[rnd], no live field needed.
+            continue
+        saw_guess_step = True
+        targets = {step[i].observation.target_word for i in range(4)}
+        targets.discard("")
+        assert targets, (
+            f"no agent exposes target_word at guess-phase step "
+            f"(round {rnd}); the visualizer would show a blank"
+        )
+        # And the guessers must NOT see it (agents only see their own obs,
+        # but assert anyway since target_word is what the renderer keys on).
+        for g_idx in (_blue_guesser(rnd), _yellow_guesser(rnd)):
+            assert step[g_idx].observation.target_word == "", (
+                f"guesser {g_idx} sees target_word leak in round {rnd}"
+            )
+        # The artist(s) are where the target lives, and both artists on the
+        # two teams share the same target this round.
+        blue_target = step[_blue_artist(rnd)].observation.target_word
+        yellow_target = step[_yellow_artist(rnd)].observation.target_word
+        assert blue_target and blue_target == yellow_target
+    assert saw_guess_step, "test setup: no guess-phase step was observed"
+
+
 def test_mid_game_missing_word_art_state_raises_clearly():
     """env.word_art_state is not preserved across env.clone() or JSON
     round-trips (Environment.clone constructs a fresh instance from


### PR DESCRIPTION
Fix visualization after we previously started obscuring hidden info.

Also loosen the ANY-WORD check for spaced-out letters to 3+ distinct instead of 2+ to avoid false positives, e.g.:
    /   \_/   \_/   \_/   \
   | o   X     X     X  o  |
    \___/ \___/ \___/ \___/

And re-arrange the guesser prompt.