### PR TITLE
Ensure proper stream cleanup in core_harness

### DIFF
--- a/kaggle_environments/core_harness.py
+++ b/kaggle_environments/core_harness.py
@@ -477,17 +477,31 @@ class GameHarness(Protocol):
 def _close_stream(stream: Any) -> None:
     """Best-effort close of a litellm streaming response.
 
-    litellm's ``CustomStreamWrapper`` wraps an httpx streaming response;
-    ``close()`` returns the connection to the pool and sends a
-    client-close signal upstream. Missing close = leaked queue slot on
-    the model proxy.
+    litellm's ``CustomStreamWrapper`` has no sync ``close()`` and does
+    NOT clean up its wrapped provider stream on ``__next__`` errors
+    (only re-raises via ``_handle_stream_fallback_error``). The wrapped
+    ``openai.Stream`` stored in ``.completion_stream`` does have a
+    ``close()`` that releases the underlying ``httpx.Response`` — this
+    is what actually sends the client-close signal upstream and
+    releases the model-proxy queue slot. On the success path the
+    OpenAI SDK closes automatically when the body is read to
+    completion; only the mid-stream error path needs this explicit
+    reach-through.
     """
     if stream is None:
         return
-    try:
-        stream.close()
-    except Exception:
-        pass
+    # Prefer the wrapper's own close if a future litellm version adds
+    # one; otherwise reach through to the provider stream.
+    for target in (stream, getattr(stream, "completion_stream", None)):
+        if target is None:
+            continue
+        close = getattr(target, "close", None)
+        if callable(close):
+            try:
+                close()
+            except Exception:
+                pass
+            return
 
 
 def _call_llm(

--- a/kaggle_environments/core_harness.py
+++ b/kaggle_environments/core_harness.py
@@ -474,6 +474,22 @@ class GameHarness(Protocol):
 # ---------------------------------------------------------------------------
 
 
+def _close_stream(stream: Any) -> None:
+    """Best-effort close of a litellm streaming response.
+
+    litellm's ``CustomStreamWrapper`` wraps an httpx streaming response;
+    ``close()`` returns the connection to the pool and sends a
+    client-close signal upstream. Missing close = leaked queue slot on
+    the model proxy.
+    """
+    if stream is None:
+        return
+    try:
+        stream.close()
+    except Exception:
+        pass
+
+
 def _call_llm(
     prompt: str,
     model_name: str,
@@ -530,6 +546,7 @@ def _call_llm(
         content_parts: list[str] = []
         finish_reason: str | None = None
         usage_obj: Any = None
+        stream: Any = None
         try:
             stream = litellm.completion(
                 model=model_name,
@@ -637,6 +654,8 @@ def _call_llm(
             )
             if backoff > 0:
                 time.sleep(backoff)
+        finally:
+            _close_stream(stream)
 
 
 def _build_call_detail(

--- a/kaggle_environments/core_harness.py
+++ b/kaggle_environments/core_harness.py
@@ -499,9 +499,20 @@ def _close_stream(stream: Any) -> None:
         if callable(close):
             try:
                 close()
-            except Exception:
-                pass
+            except Exception as exc:
+                _log.warning(
+                    "Failed to close LLM stream (%s: %s); connection may "
+                    "leak until GC and MP queue slot may remain held",
+                    type(exc).__name__, exc,
+                )
             return
+    # No callable close() at either level -- means litellm's stream
+    # structure changed and our reach-through no longer applies.
+    _log.warning(
+        "No close() on LLM stream (type=%s); connection cannot be "
+        "released and MP queue slots may pile up",
+        type(stream).__name__,
+    )
 
 
 def _call_llm(

--- a/tests/core_harness_test.py
+++ b/tests/core_harness_test.py
@@ -731,6 +731,120 @@ class TransportRetryTest(absltest.TestCase):
         failures = [e for e in self.events if "llm_call_exception" in e]
         self.assertTrue(any(e.get("exceeded_deadline") for e in failures))
 
+    def test_stream_closed_after_success(self):
+        """Fully-consumed streams must still be closed so the httpx
+        connection is returned to the pool promptly."""
+
+        class _ClosableStream:
+            def __init__(self, gen):
+                self._gen = gen
+                self.close_calls = 0
+
+            def __iter__(self):
+                return self._gen
+
+            def close(self):
+                self.close_calls += 1
+
+        stream = _ClosableStream(_fake_completion("move_0"))
+        harness = _SimpleHarness()
+        agent = create_agent_fn(harness)
+        with patch.dict("os.environ", self._env(), clear=False), patch.object(
+            core_harness.litellm, "completion", return_value=stream,
+        ):
+            result = agent({}, {})
+        self.assertEqual(result["submission"], 0)
+        self.assertEqual(stream.close_calls, 1)
+
+    def test_stream_closed_on_transport_error_before_retry(self):
+        """The whole point of this test: on a mid-stream transport error
+        we MUST close the abandoned stream before opening a new one, or
+        the model proxy sees N concurrent queued requests per logical call."""
+
+        class _ExplodingStream:
+            def __init__(self):
+                self.close_calls = 0
+                self._iter_started = False
+
+            def __iter__(self):
+                self._iter_started = True
+                return self
+
+            def __next__(self):
+                raise httpx.ReadTimeout("socket died mid-stream")
+
+            def close(self):
+                self.close_calls += 1
+
+        exploding = _ExplodingStream()
+        side_effects = [exploding, _fake_completion("move_2")]
+        harness = _SimpleHarness()
+        agent = create_agent_fn(harness)
+        with patch.dict("os.environ", self._env(), clear=False), patch.object(
+            core_harness.litellm, "completion", side_effect=side_effects,
+        ) as mock_call:
+            result = agent({}, {})
+        self.assertEqual(result["submission"], 2)
+        self.assertEqual(mock_call.call_count, 2)
+        # The abandoned stream must have been closed exactly once BEFORE
+        # the retry call reached litellm.
+        self.assertEqual(exploding.close_calls, 1)
+        self.assertTrue(exploding._iter_started)
+
+    def test_stream_closed_on_non_retryable_exception(self):
+        """Even for terminal (non-retryable) errors, don't leak the response."""
+
+        class _ExplodingStream:
+            def __init__(self):
+                self.close_calls = 0
+
+            def __iter__(self):
+                return self
+
+            def __next__(self):
+                raise RuntimeError("parser blew up")  # not in retryable set
+
+            def close(self):
+                self.close_calls += 1
+
+        exploding = _ExplodingStream()
+        harness = _SimpleHarness()
+        agent = create_agent_fn(harness, max_retries=1)
+        with patch.dict("os.environ", self._env(), clear=False), patch.object(
+            core_harness.litellm, "completion", return_value=exploding,
+        ):
+            with self.assertRaisesRegex(RuntimeError, "parser blew up"):
+                agent({}, {})
+        self.assertEqual(exploding.close_calls, 1)
+
+    def test_close_failure_does_not_mask_original_error(self):
+        """If close() itself raises, we swallow it so the retry logic
+        (or the caller) sees the original transport error, not the close
+        exception."""
+
+        class _StubbornStream:
+            def __iter__(self):
+                return self
+
+            def __next__(self):
+                raise httpx.ReadTimeout("socket died mid-stream")
+
+            def close(self):
+                raise RuntimeError("close blew up too")
+
+        side_effects = [_StubbornStream(), _fake_completion("move_1")]
+        harness = _SimpleHarness()
+        agent = create_agent_fn(harness)
+        with patch.dict("os.environ", self._env(), clear=False), patch.object(
+            core_harness.litellm, "completion", side_effect=side_effects,
+        ):
+            result = agent({}, {})
+        # Retry proceeded despite the close-time exception.
+        self.assertEqual(result["submission"], 1)
+        retries = self._retry_events()
+        self.assertLen(retries, 1)
+        self.assertEqual(retries[0]["error_class"], "ReadTimeout")
+
     def test_first_try_success_reports_transport_attempts_1(self):
         harness = _SimpleHarness()
         agent = create_agent_fn(harness)

--- a/tests/core_harness_test.py
+++ b/tests/core_harness_test.py
@@ -731,13 +731,58 @@ class TransportRetryTest(absltest.TestCase):
         failures = [e for e in self.events if "llm_call_exception" in e]
         self.assertTrue(any(e.get("exceeded_deadline") for e in failures))
 
-    def test_stream_closed_after_success(self):
-        """Fully-consumed streams must still be closed so the httpx
-        connection is returned to the pool promptly."""
+    def test_inner_stream_closed_after_success(self):
+        """Fully-consumed streams must still trigger the reach-through
+        close so the underlying httpx connection is returned to the pool
+        promptly. Models the litellm CustomStreamWrapper structure: the
+        outer wrapper has no sync close(), so we reach through to
+        .completion_stream (the openai.Stream / provider stream)."""
 
-        class _ClosableStream:
-            def __init__(self, gen):
+        class _InnerStream:
+            def __init__(self):
+                self.close_calls = 0
+
+            def close(self):
+                self.close_calls += 1
+
+        class _WrappedStream:
+            """Mirrors litellm CustomStreamWrapper: iterates chunks but
+            has NO sync close(); the real close lives on .completion_stream."""
+
+            def __init__(self, gen, inner):
                 self._gen = gen
+                self.completion_stream = inner
+
+            def __iter__(self):
+                return self._gen
+
+        inner = _InnerStream()
+        wrapper = _WrappedStream(_fake_completion("move_0"), inner)
+        harness = _SimpleHarness()
+        agent = create_agent_fn(harness)
+        with patch.dict("os.environ", self._env(), clear=False), patch.object(
+            core_harness.litellm, "completion", return_value=wrapper,
+        ):
+            result = agent({}, {})
+        self.assertEqual(result["submission"], 0)
+        self.assertEqual(inner.close_calls, 1)
+
+    def test_outer_close_preferred_when_present(self):
+        """If a future litellm exposes a sync close() on the wrapper
+        itself, we should call that and NOT double-close by also
+        invoking the inner close."""
+
+        class _InnerStream:
+            def __init__(self):
+                self.close_calls = 0
+
+            def close(self):
+                self.close_calls += 1
+
+        class _WrapperWithClose:
+            def __init__(self, gen, inner):
+                self._gen = gen
+                self.completion_stream = inner
                 self.close_calls = 0
 
             def __iter__(self):
@@ -746,24 +791,33 @@ class TransportRetryTest(absltest.TestCase):
             def close(self):
                 self.close_calls += 1
 
-        stream = _ClosableStream(_fake_completion("move_0"))
+        inner = _InnerStream()
+        wrapper = _WrapperWithClose(_fake_completion("move_0"), inner)
         harness = _SimpleHarness()
         agent = create_agent_fn(harness)
         with patch.dict("os.environ", self._env(), clear=False), patch.object(
-            core_harness.litellm, "completion", return_value=stream,
+            core_harness.litellm, "completion", return_value=wrapper,
         ):
-            result = agent({}, {})
-        self.assertEqual(result["submission"], 0)
-        self.assertEqual(stream.close_calls, 1)
+            agent({}, {})
+        self.assertEqual(wrapper.close_calls, 1)
+        self.assertEqual(inner.close_calls, 0)
 
-    def test_stream_closed_on_transport_error_before_retry(self):
+    def test_inner_stream_closed_on_transport_error_before_retry(self):
         """The whole point of this test: on a mid-stream transport error
-        we MUST close the abandoned stream before opening a new one, or
-        the model proxy sees N concurrent queued requests per logical call."""
+        we MUST close the abandoned inner stream before opening a new
+        one, or the model proxy sees N concurrent queued requests per
+        logical call."""
 
-        class _ExplodingStream:
+        class _InnerStream:
             def __init__(self):
                 self.close_calls = 0
+
+            def close(self):
+                self.close_calls += 1
+
+        class _ExplodingWrapper:
+            def __init__(self, inner):
+                self.completion_stream = inner
                 self._iter_started = False
 
             def __iter__(self):
@@ -773,10 +827,8 @@ class TransportRetryTest(absltest.TestCase):
             def __next__(self):
                 raise httpx.ReadTimeout("socket died mid-stream")
 
-            def close(self):
-                self.close_calls += 1
-
-        exploding = _ExplodingStream()
+        inner = _InnerStream()
+        exploding = _ExplodingWrapper(inner)
         side_effects = [exploding, _fake_completion("move_2")]
         harness = _SimpleHarness()
         agent = create_agent_fn(harness)
@@ -786,17 +838,24 @@ class TransportRetryTest(absltest.TestCase):
             result = agent({}, {})
         self.assertEqual(result["submission"], 2)
         self.assertEqual(mock_call.call_count, 2)
-        # The abandoned stream must have been closed exactly once BEFORE
-        # the retry call reached litellm.
-        self.assertEqual(exploding.close_calls, 1)
+        # The abandoned inner stream must have been closed exactly once
+        # BEFORE the retry call reached litellm.
+        self.assertEqual(inner.close_calls, 1)
         self.assertTrue(exploding._iter_started)
 
-    def test_stream_closed_on_non_retryable_exception(self):
+    def test_inner_stream_closed_on_non_retryable_exception(self):
         """Even for terminal (non-retryable) errors, don't leak the response."""
 
-        class _ExplodingStream:
+        class _InnerStream:
             def __init__(self):
                 self.close_calls = 0
+
+            def close(self):
+                self.close_calls += 1
+
+        class _ExplodingWrapper:
+            def __init__(self, inner):
+                self.completion_stream = inner
 
             def __iter__(self):
                 return self
@@ -804,10 +863,8 @@ class TransportRetryTest(absltest.TestCase):
             def __next__(self):
                 raise RuntimeError("parser blew up")  # not in retryable set
 
-            def close(self):
-                self.close_calls += 1
-
-        exploding = _ExplodingStream()
+        inner = _InnerStream()
+        exploding = _ExplodingWrapper(inner)
         harness = _SimpleHarness()
         agent = create_agent_fn(harness, max_retries=1)
         with patch.dict("os.environ", self._env(), clear=False), patch.object(
@@ -815,24 +872,28 @@ class TransportRetryTest(absltest.TestCase):
         ):
             with self.assertRaisesRegex(RuntimeError, "parser blew up"):
                 agent({}, {})
-        self.assertEqual(exploding.close_calls, 1)
+        self.assertEqual(inner.close_calls, 1)
 
     def test_close_failure_does_not_mask_original_error(self):
         """If close() itself raises, we swallow it so the retry logic
         (or the caller) sees the original transport error, not the close
         exception."""
 
-        class _StubbornStream:
+        class _StubbornInner:
+            def close(self):
+                raise RuntimeError("close blew up too")
+
+        class _StubbornWrapper:
+            def __init__(self):
+                self.completion_stream = _StubbornInner()
+
             def __iter__(self):
                 return self
 
             def __next__(self):
                 raise httpx.ReadTimeout("socket died mid-stream")
 
-            def close(self):
-                raise RuntimeError("close blew up too")
-
-        side_effects = [_StubbornStream(), _fake_completion("move_1")]
+        side_effects = [_StubbornWrapper(), _fake_completion("move_1")]
         harness = _SimpleHarness()
         agent = create_agent_fn(harness)
         with patch.dict("os.environ", self._env(), clear=False), patch.object(


### PR DESCRIPTION
A recent change added retries after a few minutes of Model Proxy queuing, but without explicitly closing the stream, the retried requests would pile up and compound the queuing issue.