### PR TITLE
Harness for capture the flag

### DIFF
--- a/kaggle_environments/envs/open_spiel_env/games/capture_the_flag/harness.py
+++ b/kaggle_environments/envs/open_spiel_env/games/capture_the_flag/harness.py
@@ -37,7 +37,7 @@ Each round both players SIMULTANEOUSLY pick one of five actions:
 After both moves are revealed, a hidden coin flip picks whose move resolves first; you cannot know the order in advance. Consequence: if you both target the same empty cell, only whoever resolves first lands there -- the other stays put.
 
 Move rules:
-  - Moving off-grid or into the OTHER player's cell is a no-op (you stay put; no tag from bumping).
+  - Moving off-grid{obstacle_move_clause} or into the OTHER player's cell is a no-op (you stay put; no tag from bumping).
   - Stepping onto the opponent's LOOSE flag AT the opponent's base picks it up; you now carry it and it moves with you.
   - Moving onto your OWN base while carrying the opponent's flag means you win -- BUT only if your own flag is still sitting at your home base AT THAT MOMENT. Standing still (Stay) never triggers a score; you must step onto the base. If your own flag is loose or held by the opponent, arriving at your base does nothing.
 
@@ -48,7 +48,7 @@ Territory split: A owns columns 0..{a_territory_max}; B owns columns {b_territor
 
 Bases: A base at {a_base}, B base at {b_base}.
 
-Board pieces: '.' = empty, 'A'/'B' = players, 'a'/'b' = loose flag at that cell.
+Board pieces: '.' = empty,{obstacle_legend} 'A'/'B' = players, 'a'/'b' = loose flag at that cell.
 A player standing on their own home base with their own flag still home renders as 'A' or 'B' (the flag is under the player).
 
 Current board (row 0 on top; columns labelled 0..{max_col}):
@@ -232,6 +232,14 @@ def generate_prompt(
         b_territory_min = centre
         neutral_note = ""
 
+    obstacles = state.get("obstacles") or []
+    if obstacles:
+        obstacle_legend = " '*' = obstacle (impassable),"
+        obstacle_move_clause = ", into an obstacle,"
+    else:
+        obstacle_legend = ""
+        obstacle_move_clause = ""
+
     is_player_a = player_id == 0
     player_label = "A" if is_player_a else "B"
     opponent_label = "B" if is_player_a else "A"
@@ -267,6 +275,8 @@ def generate_prompt(
         neutral_note=neutral_note,
         a_base=_pos_str(state.get("a_base")),
         b_base=_pos_str(state.get("b_base")),
+        obstacle_legend=obstacle_legend,
+        obstacle_move_clause=obstacle_move_clause,
         board_ascii=_format_board_ascii(board),
         a_pos=_pos_str(state.get("a_pos")),
         b_pos=_pos_str(state.get("b_pos")),

--- a/kaggle_environments/envs/open_spiel_env/games/capture_the_flag/harness.py
+++ b/kaggle_environments/envs/open_spiel_env/games/capture_the_flag/harness.py
@@ -1,0 +1,308 @@
+"""LLM harness for OpenSpiel Capture the Flag.
+
+Capture the Flag is a 2-player simultaneous-move grid game. Each round both
+players pick one of five actions -- North, East, South, West, Stay -- and
+then a hidden coin flip decides whose move resolves first. A player picks up
+the opponent's flag by stepping onto it at the opponent's base while it is
+loose; scores by carrying it back to their own base while their own flag is
+sitting at home; and gets tagged (respawn at own base, drop the flag) when
+the opposing defender is Manhattan-adjacent and the carrier is inside the
+defender's home territory. Territory is split by column: A owns columns
+strictly left of centre, B owns columns strictly right of centre; on an
+odd-width grid the centre column is neutral. First to ``score_limit``
+captures wins; the game draws at ``horizon`` rounds.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Mapping, Sequence
+
+import pyspiel
+
+from kaggle_environments.core_harness import (
+    ParseResult,
+    parse_json_action,
+    render_rethink_suffix,
+)
+
+_ACTION_NAMES = ["North", "East", "South", "West", "Stay"]
+
+
+CAPTURE_THE_FLAG_PROMPT_TEMPLATE = """Capture the Flag: 2-player simultaneous-move grid game on a {num_rows} x {num_cols} grid.
+Rows 0 (top) to {max_row} (bottom); columns 0 (left) to {max_col} (right).
+Each round both players SIMULTANEOUSLY pick one of five actions:
+  North = row-1, South = row+1, East = col+1, West = col-1, Stay = no move.
+After both moves are revealed, a hidden coin flip picks whose move resolves first; you cannot know the order in advance. Consequence: if you both target the same empty cell, only whoever resolves first lands there -- the other stays put.
+
+Board pieces: '.' = empty, '*' = obstacle (impassable), 'A'/'B' = players, 'a'/'b' = loose flag at that cell.
+A player standing on their own home base with their own flag still home renders as 'A' or 'B' (the flag is under the player).
+
+Mechanics (per player in initiative order):
+  - Moving off-grid, into an obstacle, or into the OTHER player's cell is a no-op (you stay put; no tag from bumping).
+  - Stepping onto the opponent's LOOSE flag AT the opponent's base picks it up; you now carry it and it moves with you.
+  - Moving onto your OWN base while carrying the opponent's flag scores 1 -- BUT only if your own flag is still sitting at your home base AT THAT MOMENT. Standing still (Stay) never triggers a score; you must step onto the base. If your own flag is loose or held by the opponent, arriving at your base does nothing.
+
+Post-turn resolution (after BOTH moves have applied, using final positions):
+  - Tagging: any carrier who is Manhattan-adjacent (up/down/left/right, not diagonal) to the flag's owner AND standing inside the flag-owner's home territory is tagged -- respawn at own base, and the flag returns to its owner's base. Because this uses final positions, a defender who moves adjacent to you during the same turn tags you even if you weren't adjacent when the turn started.
+
+Territory split: A owns columns 0..{a_territory_max}; B owns columns {b_territory_min}..{max_col}.{neutral_note}
+
+Bases: A base at {a_base}, B base at {b_base}.
+{obstacles_line}
+Current board (row 0 on top; columns labelled 0..{max_col}):
+{board_ascii}
+
+Positions: A at {a_pos}, B at {b_pos}.
+Flag A (belongs to A): {flag_a_status}
+Flag B (belongs to B): {flag_b_status}
+
+Score: A={score_a}, B={score_b} (first to {score_limit} wins; draw at {horizon} rounds).
+
+You are Player {player_label}. Your flag is Flag {player_label}; your goal is to carry Flag {opponent_label} to your base at {your_base}.
+
+Round {round_number} of at most {horizon}.
+{move_history_block}
+
+Your turn. Choose one of: North, East, South, West, Stay.
+
+Respond with your reasoning, then end your response with JSON:
+
+```json
+{{"move": "<North|East|South|West|Stay>"}}
+```
+"""
+
+
+RETHINK_ILLEGAL = """
+
+You suggested move "{previous_action}" but this is not a legal move.
+The only legal moves are: North, East, South, West, Stay.
+
+(Keep using the same JSON output format as before -- only the move value needs to change.)
+"""
+
+
+RETHINK_UNPARSABLE = """
+
+Your previous response ended with:
+{previous_response}
+
+No JSON answer could be parsed from that. Conclude your response with your
+final move as JSON in a ```json fenced block, exactly as the original
+instructions required:
+
+```json
+{{"move": "<North|East|South|West|Stay>"}}
+```
+
+For example: `{{"move": "East"}}`
+
+The move you choose must also be one of: North, East, South, West, Stay.
+"""
+
+
+def _parse_observation_payload(observation: Mapping[str, Any]) -> dict[str, Any]:
+    """Pull the structured CTF state dict out of the observation."""
+    raw = observation.get("observationString", "") or ""
+    if raw:
+        try:
+            parsed = json.loads(raw)
+            if isinstance(parsed, dict):
+                return parsed
+        except json.JSONDecodeError:
+            pass
+    serialized = observation.get("serializedGameAndState", "")
+    if serialized:
+        _, state = pyspiel.deserialize_game_and_state(serialized)
+        try:
+            return json.loads(state.observation_string(0))
+        except (json.JSONDecodeError, RuntimeError):
+            pass
+    return {}
+
+
+def _format_board_ascii(board: Sequence[Sequence[str]]) -> str:
+    """Render the board with a column header and row labels on the left."""
+    if not board:
+        return "(unavailable)"
+    num_cols = len(board[0])
+    header = "    " + " ".join(str(c) for c in range(num_cols))
+    lines = [header]
+    for r, row in enumerate(board):
+        lines.append(f"  {r} " + " ".join(row))
+    return "\n".join(lines)
+
+
+def _pos_str(pos: Any) -> str:
+    if isinstance(pos, (list, tuple)) and len(pos) == 2:
+        return f"(row {pos[0]}, col {pos[1]})"
+    return "(unknown)"
+
+
+def _flag_status(carrier: Any, flag_pos: Any, base_pos: Any) -> str:
+    if carrier is None:
+        at_home = (
+            isinstance(flag_pos, (list, tuple))
+            and isinstance(base_pos, (list, tuple))
+            and list(flag_pos) == list(base_pos)
+        )
+        return "at home base" if at_home else f"loose at {_pos_str(flag_pos)}"
+    carrier_label = "A" if carrier == 0 else "B"
+    return f"carried by Player {carrier_label}, currently at {_pos_str(flag_pos)}"
+
+
+def _render_full_history(observation: Mapping[str, Any]) -> str | None:
+    """Reconstruct per-round move history from the serialized pyspiel state.
+
+    Each completed round in CTF appears in ``full_history()`` as three
+    entries: Player A's move, Player B's move, and the initiative chance
+    outcome (0 = A resolved first, 1 = B resolved first).
+    """
+    serialized = observation.get("serializedGameAndState", "")
+    if not serialized:
+        return None
+    try:
+        _, state = pyspiel.deserialize_game_and_state(serialized)
+    except Exception:
+        return None
+
+    rounds: list[tuple[str, str, str]] = []
+    a_move: str | None = None
+    b_move: str | None = None
+    for h in state.full_history():
+        if h.player == 0:
+            a_move = _ACTION_NAMES[h.action] if 0 <= h.action < len(_ACTION_NAMES) else str(h.action)
+        elif h.player == 1:
+            b_move = _ACTION_NAMES[h.action] if 0 <= h.action < len(_ACTION_NAMES) else str(h.action)
+        elif h.player == -1:
+            init = "A" if h.action == 0 else "B"
+            rounds.append((a_move or "?", b_move or "?", init))
+            a_move = b_move = None
+
+    if not rounds:
+        return None
+    lines = ["Move history so far (both players, oldest first):"]
+    for i, (a, b, init) in enumerate(rounds, start=1):
+        lines.append(f"  Round {i}: A={a}, B={b} ({init}'s move resolved first)")
+    return "\n".join(lines)
+
+
+def get_legal_moves(observation: Mapping[str, Any]) -> dict[int, str]:
+    """Return ``{action_id: action_string}`` for the current state."""
+    legal_actions = observation.get("legalActions")
+    legal_action_strings = observation.get("legalActionStrings")
+    if legal_actions and legal_action_strings:
+        return dict(zip(legal_actions, legal_action_strings))
+
+    serialized = observation.get("serializedGameAndState", "")
+    if not serialized:
+        return {}
+    _, state = pyspiel.deserialize_game_and_state(serialized)
+    player_id = observation.get("playerId", 0)
+    actions = state.legal_actions(player_id)
+    return {a: state.action_to_string(player_id, a) for a in actions}
+
+
+def generate_prompt(
+    observation: Mapping[str, Any],
+    move_history: list[str],
+    previous_response: str | None = None,
+    previous_action: str | None = None,
+) -> str:
+    """Build the LLM prompt for the current CTF state."""
+    del move_history  # Full history is reconstructed from the pyspiel state.
+    state = _parse_observation_payload(observation)
+    player_id = observation.get("playerId", 0)
+
+    board = state.get("board") or []
+    num_rows = state.get("num_rows") or (len(board) if board else 5)
+    num_cols = state.get("num_cols") or (len(board[0]) if board and board[0] else 7)
+    max_row = max(num_rows - 1, 0)
+    max_col = max(num_cols - 1, 0)
+
+    centre = num_cols // 2
+    if num_cols % 2 == 1:
+        a_territory_max = centre - 1
+        b_territory_min = centre + 1
+        neutral_note = f" Column {centre} is neutral (belongs to neither)."
+    else:
+        a_territory_max = centre - 1
+        b_territory_min = centre
+        neutral_note = ""
+
+    obstacles = state.get("obstacles") or []
+    if obstacles:
+        obs_positions = ", ".join(f"(row {r}, col {c})" for r, c in obstacles)
+        obstacles_line = f"Obstacles at: {obs_positions}.\n"
+    else:
+        obstacles_line = "Obstacles: none.\n"
+
+    is_player_a = player_id == 0
+    player_label = "A" if is_player_a else "B"
+    opponent_label = "B" if is_player_a else "A"
+    your_base = _pos_str(state.get("a_base") if is_player_a else state.get("b_base"))
+
+    flag_a_status = _flag_status(
+        state.get("carrier_a"),
+        state.get("flag_a_pos"),
+        state.get("a_base"),
+    )
+    flag_b_status = _flag_status(
+        state.get("carrier_b"),
+        state.get("flag_b_pos"),
+        state.get("b_base"),
+    )
+
+    score = state.get("score") or [0, 0]
+    horizon = state.get("horizon", 1000)
+    move_number = state.get("move_number", 0)
+    round_number = int(move_number) + 1
+
+    move_history_block = _render_full_history(observation)
+    if move_history_block is None:
+        move_history_block = "No rounds have been played yet."
+
+    prompt = CAPTURE_THE_FLAG_PROMPT_TEMPLATE.format(
+        num_rows=num_rows,
+        num_cols=num_cols,
+        max_row=max_row,
+        max_col=max_col,
+        a_territory_max=a_territory_max,
+        b_territory_min=b_territory_min,
+        neutral_note=neutral_note,
+        a_base=_pos_str(state.get("a_base")),
+        b_base=_pos_str(state.get("b_base")),
+        obstacles_line=obstacles_line,
+        board_ascii=_format_board_ascii(board),
+        a_pos=_pos_str(state.get("a_pos")),
+        b_pos=_pos_str(state.get("b_pos")),
+        flag_a_status=flag_a_status,
+        flag_b_status=flag_b_status,
+        score_a=score[0],
+        score_b=score[1],
+        score_limit=state.get("score_limit", 1),
+        horizon=horizon,
+        player_label=player_label,
+        opponent_label=opponent_label,
+        your_base=your_base,
+        round_number=round_number,
+        move_history_block=move_history_block,
+    )
+
+    prompt += render_rethink_suffix(
+        RETHINK_ILLEGAL,
+        RETHINK_UNPARSABLE,
+        previous_response,
+        previous_action,
+    )
+
+    return prompt
+
+
+def parse_response(
+    response: str,
+    legal_action_strings: Sequence[str],
+) -> ParseResult:
+    """Trust the model's JSON answer; let the rethink loop fix anything else."""
+    return parse_json_action(response, legal_action_strings)

--- a/kaggle_environments/envs/open_spiel_env/games/capture_the_flag/harness.py
+++ b/kaggle_environments/envs/open_spiel_env/games/capture_the_flag/harness.py
@@ -6,7 +6,8 @@ then a hidden coin flip decides whose move resolves first. A player picks up
 the opponent's flag by stepping onto it at the opponent's base while it is
 loose; scores by carrying it back to their own base while their own flag is
 sitting at home; and gets tagged (respawn at own base, drop the flag) when
-the opposing defender is Manhattan-adjacent and the carrier is inside the
+the opposing defender is standing in one of the four cells directly next
+to them (up/down/left/right, not diagonal) and the carrier is inside the
 defender's home territory. Territory is split by column: A owns columns
 strictly left of centre, B owns columns strictly right of centre; on an
 odd-width grid the centre column is neutral. First to ``score_limit``
@@ -35,21 +36,21 @@ Each round both players SIMULTANEOUSLY pick one of five actions:
   North = row-1, South = row+1, East = col+1, West = col-1, Stay = no move.
 After both moves are revealed, a hidden coin flip picks whose move resolves first; you cannot know the order in advance. Consequence: if you both target the same empty cell, only whoever resolves first lands there -- the other stays put.
 
-Board pieces: '.' = empty, '*' = obstacle (impassable), 'A'/'B' = players, 'a'/'b' = loose flag at that cell.
+Board pieces: '.' = empty, 'A'/'B' = players, 'a'/'b' = loose flag at that cell.
 A player standing on their own home base with their own flag still home renders as 'A' or 'B' (the flag is under the player).
 
-Mechanics (per player in initiative order):
-  - Moving off-grid, into an obstacle, or into the OTHER player's cell is a no-op (you stay put; no tag from bumping).
+Move rules:
+  - Moving off-grid or into the OTHER player's cell is a no-op (you stay put; no tag from bumping).
   - Stepping onto the opponent's LOOSE flag AT the opponent's base picks it up; you now carry it and it moves with you.
-  - Moving onto your OWN base while carrying the opponent's flag scores 1 -- BUT only if your own flag is still sitting at your home base AT THAT MOMENT. Standing still (Stay) never triggers a score; you must step onto the base. If your own flag is loose or held by the opponent, arriving at your base does nothing.
+  - Moving onto your OWN base while carrying the opponent's flag means you win -- BUT only if your own flag is still sitting at your home base AT THAT MOMENT. Standing still (Stay) never triggers a score; you must step onto the base. If your own flag is loose or held by the opponent, arriving at your base does nothing.
 
 Post-turn resolution (after BOTH moves have applied, using final positions):
-  - Tagging: any carrier who is Manhattan-adjacent (up/down/left/right, not diagonal) to the flag's owner AND standing inside the flag-owner's home territory is tagged -- respawn at own base, and the flag returns to its owner's base. Because this uses final positions, a defender who moves adjacent to you during the same turn tags you even if you weren't adjacent when the turn started.
+  - Tagging: any carrier who is directly next to the flag's owner (in one of the four cells up, down, left, or right -- not diagonal) AND standing inside the flag-owner's home territory is tagged -- respawn at own base, and the flag returns to its owner's base. Because this uses final positions, a defender who moves next to you during the same turn tags you even if you weren't next to them when the turn started.
 
 Territory split: A owns columns 0..{a_territory_max}; B owns columns {b_territory_min}..{max_col}.{neutral_note}
 
 Bases: A base at {a_base}, B base at {b_base}.
-{obstacles_line}
+
 Current board (row 0 on top; columns labelled 0..{max_col}):
 {board_ascii}
 
@@ -231,13 +232,6 @@ def generate_prompt(
         b_territory_min = centre
         neutral_note = ""
 
-    obstacles = state.get("obstacles") or []
-    if obstacles:
-        obs_positions = ", ".join(f"(row {r}, col {c})" for r, c in obstacles)
-        obstacles_line = f"Obstacles at: {obs_positions}.\n"
-    else:
-        obstacles_line = "Obstacles: none.\n"
-
     is_player_a = player_id == 0
     player_label = "A" if is_player_a else "B"
     opponent_label = "B" if is_player_a else "A"
@@ -273,7 +267,6 @@ def generate_prompt(
         neutral_note=neutral_note,
         a_base=_pos_str(state.get("a_base")),
         b_base=_pos_str(state.get("b_base")),
-        obstacles_line=obstacles_line,
         board_ascii=_format_board_ascii(board),
         a_pos=_pos_str(state.get("a_pos")),
         b_pos=_pos_str(state.get("b_pos")),

--- a/kaggle_environments/envs/open_spiel_env/games/capture_the_flag/harness.py
+++ b/kaggle_environments/envs/open_spiel_env/games/capture_the_flag/harness.py
@@ -36,9 +36,6 @@ Each round both players SIMULTANEOUSLY pick one of five actions:
   North = row-1, South = row+1, East = col+1, West = col-1, Stay = no move.
 After both moves are revealed, a hidden coin flip picks whose move resolves first; you cannot know the order in advance. Consequence: if you both target the same empty cell, only whoever resolves first lands there -- the other stays put.
 
-Board pieces: '.' = empty, 'A'/'B' = players, 'a'/'b' = loose flag at that cell.
-A player standing on their own home base with their own flag still home renders as 'A' or 'B' (the flag is under the player).
-
 Move rules:
   - Moving off-grid or into the OTHER player's cell is a no-op (you stay put; no tag from bumping).
   - Stepping onto the opponent's LOOSE flag AT the opponent's base picks it up; you now carry it and it moves with you.
@@ -50,6 +47,9 @@ Post-turn resolution (after BOTH moves have applied, using final positions):
 Territory split: A owns columns 0..{a_territory_max}; B owns columns {b_territory_min}..{max_col}.{neutral_note}
 
 Bases: A base at {a_base}, B base at {b_base}.
+
+Board pieces: '.' = empty, 'A'/'B' = players, 'a'/'b' = loose flag at that cell.
+A player standing on their own home base with their own flag still home renders as 'A' or 'B' (the flag is under the player).
 
 Current board (row 0 on top; columns labelled 0..{max_col}):
 {board_ascii}

--- a/kaggle_environments/envs/open_spiel_env/games/capture_the_flag/test_llm_game.py
+++ b/kaggle_environments/envs/open_spiel_env/games/capture_the_flag/test_llm_game.py
@@ -1,0 +1,6 @@
+"""Run a full Capture the Flag game with LLM agents for local integration testing."""
+
+from kaggle_environments.local_harness_runner import run_llm_game
+
+if __name__ == "__main__":
+    run_llm_game("open_spiel_capture_the_flag", caller_file=__file__)

--- a/tests/envs/open_spiel_env/games/capture_the_flag/harness_test.py
+++ b/tests/envs/open_spiel_env/games/capture_the_flag/harness_test.py
@@ -1,0 +1,524 @@
+"""Tests for the Capture the Flag LLM harness."""
+
+from unittest.mock import MagicMock, patch
+
+import pyspiel
+from absl.testing import absltest
+
+from kaggle_environments.core_harness import ParseResult, create_agent_fn
+from kaggle_environments.envs.open_spiel_env.games.capture_the_flag import (
+    capture_the_flag_proxy,
+)
+from kaggle_environments.envs.open_spiel_env.games.capture_the_flag.harness import (
+    generate_prompt,
+    get_legal_moves,
+    parse_response,
+)
+
+
+def _make_observation(
+    state: capture_the_flag_proxy.CaptureTheFlagState,
+    game: capture_the_flag_proxy.CaptureTheFlagGame,
+    player_id: int = 0,
+) -> dict:
+    """Build a harness-style observation dict from a proxy state."""
+    return {
+        "observationString": state.observation_string(player_id),
+        "playerId": player_id,
+        # Sim-move games surface this as PlayerId.SIMULTANEOUS == -2.
+        "currentPlayer": int(state.current_player()),
+        "isTerminal": state.is_terminal(),
+        "legalActions": list(state.legal_actions(player_id)),
+        "legalActionStrings": [state.action_to_string(player_id, a) for a in state.legal_actions(player_id)],
+        "serializedGameAndState": pyspiel.serialize_game_and_state(game.__wrapped__, state.__wrapped__),
+    }
+
+
+def _resolve_chance(state, initiative: int = 0) -> None:
+    """Advance past the post-move chance node, forcing a chosen initiative."""
+    while state.is_chance_node():
+        state.apply_action(initiative)
+
+
+# ---------------------------------------------------------------------------
+# parse_response
+# ---------------------------------------------------------------------------
+
+
+class ParseResponseTest(absltest.TestCase):
+    legal = ["North", "East", "South", "West", "Stay"]
+
+    def test_parse_json_block(self):
+        result = parse_response('```json\n{"move": "North"}\n```', self.legal)
+        self.assertEqual(result.legal_action, "North")
+        self.assertEqual(result.raw_action, "North")
+
+    def test_parse_bare_json(self):
+        result = parse_response('I think {"move": "East"} is best.', self.legal)
+        self.assertEqual(result.legal_action, "East")
+
+    def test_parse_case_insensitive(self):
+        result = parse_response('```json\n{"move": "south"}\n```', self.legal)
+        self.assertEqual(result.legal_action, "South")
+
+    def test_parse_whitespace_tolerated(self):
+        result = parse_response('```json\n{"move": "  West  "}\n```', self.legal)
+        self.assertEqual(result.legal_action, "West")
+
+    def test_prose_move_word_triggers_rethink(self):
+        # A direction word in the prose is not a structured answer. The
+        # parser must NOT silently substitute it (ghost antipattern).
+        result = parse_response("I will move North this round.", self.legal)
+        self.assertIsNone(result.legal_action)
+        self.assertIsNone(result.raw_action)
+
+    def test_parse_illegal_move_returns_raw(self):
+        result = parse_response('```json\n{"move": "diagonal"}\n```', self.legal)
+        self.assertIsNone(result.legal_action)
+        self.assertEqual(result.raw_action, "diagonal")
+
+    def test_parse_no_match_returns_none(self):
+        result = parse_response("I cannot decide.", self.legal)
+        self.assertIsNone(result.legal_action)
+        self.assertIsNone(result.raw_action)
+
+    def test_parse_returns_parse_result_type(self):
+        result = parse_response('```json\n{"move": "Stay"}\n```', self.legal)
+        self.assertIsInstance(result, ParseResult)
+
+    def test_parse_rethink_takes_last_json_block(self):
+        response = '```json\n{"move": "North"}\n```\nWait, actually:\n```json\n{"move": "South"}\n```'
+        result = parse_response(response, self.legal)
+        self.assertEqual(result.legal_action, "South")
+
+    def test_parse_rethink_takes_last_bare_json(self):
+        response = '{"move": "North"} ... reconsidering ... {"move": "East"}'
+        result = parse_response(response, self.legal)
+        self.assertEqual(result.legal_action, "East")
+
+    def test_multiple_move_words_in_prose_trigger_rethink(self):
+        response = "I could go North, South, or East, but maybe West is best."
+        result = parse_response(response, self.legal)
+        self.assertIsNone(result.legal_action)
+        self.assertIsNone(result.raw_action)
+
+    def test_illegal_json_does_not_ghost_substitute_from_prose(self):
+        # Prose mentions a legal direction; JSON commits to an illegal one.
+        # Parser must surface the illegal raw answer, NOT the prose token.
+        response = 'I considered North but going diagonal.\n```json\n{"move": "diagonal"}\n```'
+        result = parse_response(response, self.legal)
+        self.assertIsNone(result.legal_action)
+        self.assertEqual(result.raw_action, "diagonal")
+
+
+# ---------------------------------------------------------------------------
+# generate_prompt
+# ---------------------------------------------------------------------------
+
+
+class GeneratePromptTest(absltest.TestCase):
+    def setUp(self):
+        super().setUp()
+        self.game = capture_the_flag_proxy.CaptureTheFlagGame()
+        self.state = self.game.new_initial_state()
+
+    def test_basic_prompt_contents(self):
+        obs = _make_observation(self.state, self.game, player_id=0)
+        prompt = generate_prompt(obs, [])
+        self.assertIn("Capture the Flag", prompt)
+        self.assertIn("SIMULTANEOUSLY", prompt)
+        self.assertIn("5 x 7 grid", prompt)
+        for action in ("North", "East", "South", "West", "Stay"):
+            self.assertIn(action, prompt)
+
+    def test_critical_capture_precondition_present(self):
+        # The non-obvious mechanic: arriving at your own base with the
+        # opponent's flag only scores when your OWN flag is still home.
+        obs = _make_observation(self.state, self.game, player_id=0)
+        prompt = generate_prompt(obs, [])
+        self.assertIn("your own flag is still sitting at your home base", prompt)
+
+    def test_scoring_requires_move_not_stay(self):
+        # Engine detail: kStay short-circuits ResolveMove, so scoring is
+        # never checked on Stay. If you're already standing at your base
+        # you must leave and step back in to score. The prompt must warn.
+        obs = _make_observation(self.state, self.game, player_id=0)
+        prompt = generate_prompt(obs, [])
+        self.assertIn("Standing still (Stay) never triggers a score", prompt)
+
+    def test_tag_rule_present(self):
+        obs = _make_observation(self.state, self.game, player_id=0)
+        prompt = generate_prompt(obs, [])
+        self.assertIn("Manhattan-adjacent", prompt)
+        self.assertIn("respawn", prompt)
+
+    def test_tag_uses_final_positions_not_per_initiative(self):
+        # Real strategic subtlety: ResolveTags fires ONCE after both moves
+        # applied, based on final positions. A defender who moves adjacent
+        # to a stationary/escaping carrier still tags. Grouping tagging
+        # with the per-initiative mechanics would mislead the model.
+        obs = _make_observation(self.state, self.game, player_id=0)
+        prompt = generate_prompt(obs, [])
+        self.assertIn("Post-turn resolution", prompt)
+        self.assertIn("final positions", prompt)
+
+    def test_hidden_initiative_disclosed(self):
+        # Coin flip picks order after both moves are revealed; the model
+        # must know it can't predict initiative AND what that means for
+        # contested cells (only whoever resolves first lands there).
+        obs = _make_observation(self.state, self.game, player_id=0)
+        prompt = generate_prompt(obs, [])
+        self.assertIn("hidden coin flip", prompt)
+        self.assertIn("cannot know the order in advance", prompt)
+        self.assertIn("if you both target the same empty cell", prompt)
+
+    def test_territory_split_rendered(self):
+        # Default 7-wide grid: A owns 0-2, B owns 4-6, col 3 neutral.
+        obs = _make_observation(self.state, self.game, player_id=0)
+        prompt = generate_prompt(obs, [])
+        self.assertIn("A owns columns 0..2", prompt)
+        self.assertIn("B owns columns 4..6", prompt)
+        self.assertIn("Column 3 is neutral", prompt)
+
+    def test_player_label_swap(self):
+        obs0 = _make_observation(self.state, self.game, player_id=0)
+        obs1 = _make_observation(self.state, self.game, player_id=1)
+        self.assertIn("You are Player A", generate_prompt(obs0, []))
+        self.assertIn("You are Player B", generate_prompt(obs1, []))
+
+    def test_per_player_goal_target(self):
+        obs0 = _make_observation(self.state, self.game, player_id=0)
+        obs1 = _make_observation(self.state, self.game, player_id=1)
+        # A hunts Flag B and returns to (2, 0); B hunts Flag A and returns to (2, 6).
+        self.assertIn("carry Flag B to your base at (row 2, col 0)", generate_prompt(obs0, []))
+        self.assertIn("carry Flag A to your base at (row 2, col 6)", generate_prompt(obs1, []))
+
+    def test_flag_at_home_status_rendered(self):
+        obs = _make_observation(self.state, self.game, player_id=0)
+        prompt = generate_prompt(obs, [])
+        self.assertIn("Flag A (belongs to A): at home base", prompt)
+        self.assertIn("Flag B (belongs to B): at home base", prompt)
+
+    def test_carrier_status_rendered(self):
+        # Force B to pick up A's flag. First walk A far away from its base so
+        # that B doesn't get tagged the moment it steps onto A's flag (a
+        # carrier Manhattan-adjacent to the defender inside the defender's
+        # home is instantly respawned).
+        for _ in range(2):
+            self.state.apply_actions([0, 4])  # A North, B Stay
+            _resolve_chance(self.state, 0)
+        # A is now at (0, 0); A's flag is loose at (2, 0). Walk B west to it.
+        for _ in range(6):
+            self.state.apply_actions([4, 3])  # A Stay, B West
+            _resolve_chance(self.state, 1)
+
+        obs = _make_observation(self.state, self.game, player_id=0)
+        prompt = generate_prompt(obs, [])
+        self.assertIn("Flag A (belongs to A): carried by Player B", prompt)
+
+    def test_no_history_fallback(self):
+        obs = _make_observation(self.state, self.game, player_id=0)
+        prompt = generate_prompt(obs, [])
+        self.assertIn("No rounds have been played yet.", prompt)
+
+    def test_full_history_rendered_for_both_players(self):
+        # Two completed rounds; both players' prompts see identical history.
+        self.state.apply_actions([0, 4])  # R1: A North, B Stay
+        self.state.apply_action(0)  # A first
+        self.state.apply_actions([1, 3])  # R2: A East, B West
+        self.state.apply_action(1)  # B first
+
+        prompt_a = generate_prompt(_make_observation(self.state, self.game, 0), [])
+        prompt_b = generate_prompt(_make_observation(self.state, self.game, 1), [])
+        for prompt in (prompt_a, prompt_b):
+            self.assertIn("Move history so far (both players, oldest first):", prompt)
+            self.assertIn("Round 1: A=North, B=Stay (A's move resolved first)", prompt)
+            self.assertIn("Round 2: A=East, B=West (B's move resolved first)", prompt)
+
+    def test_full_history_ignores_per_agent_history_argument(self):
+        self.state.apply_actions([0, 4])
+        self.state.apply_action(0)
+        obs = _make_observation(self.state, self.game, player_id=0)
+        prompt = generate_prompt(obs, ["nonsense_token_xyz"])
+        self.assertNotIn("nonsense_token_xyz", prompt)
+        self.assertIn("Round 1: A=North, B=Stay", prompt)
+
+    def test_score_and_horizon_disclosed(self):
+        obs = _make_observation(self.state, self.game, player_id=0)
+        prompt = generate_prompt(obs, [])
+        self.assertIn("Score: A=0, B=0", prompt)
+        self.assertIn("first to 1 wins", prompt)
+        self.assertIn("draw at 1000 rounds", prompt)
+
+    def test_round_number_advances(self):
+        obs0 = _make_observation(self.state, self.game, player_id=0)
+        self.assertIn("Round 1 of at most 1000", generate_prompt(obs0, []))
+
+        self.state.apply_actions([0, 0])
+        self.state.apply_action(0)
+        obs1 = _make_observation(self.state, self.game, player_id=0)
+        self.assertIn("Round 2 of at most 1000", generate_prompt(obs1, []))
+
+    def test_rethink_suffix_illegal(self):
+        obs = _make_observation(self.state, self.game, player_id=0)
+        prompt = generate_prompt(obs, [], previous_response="I'll go Northwest", previous_action="Northwest")
+        self.assertIn("You suggested", prompt)
+        self.assertIn("Northwest", prompt)
+        self.assertIn("not a legal move", prompt)
+
+    def test_rethink_suffix_unparsable(self):
+        obs = _make_observation(self.state, self.game, player_id=0)
+        prompt = generate_prompt(obs, [], previous_response="lots of reasoning here", previous_action=None)
+        self.assertIn("No JSON answer could be parsed", prompt)
+        self.assertIn("lots of reasoning here", prompt)
+
+
+# ---------------------------------------------------------------------------
+# get_legal_moves
+# ---------------------------------------------------------------------------
+
+
+class GetLegalMovesTest(absltest.TestCase):
+    def test_from_provided_actions(self):
+        obs = {
+            "legalActions": [0, 1, 2, 3, 4],
+            "legalActionStrings": ["North", "East", "South", "West", "Stay"],
+        }
+        result = get_legal_moves(obs)
+        self.assertEqual(
+            result,
+            {0: "North", 1: "East", 2: "South", 3: "West", 4: "Stay"},
+        )
+
+    def test_from_serialized_state(self):
+        game = capture_the_flag_proxy.CaptureTheFlagGame()
+        state = game.new_initial_state()
+        obs = {
+            "playerId": 0,
+            "serializedGameAndState": pyspiel.serialize_game_and_state(game.__wrapped__, state.__wrapped__),
+        }
+        result = get_legal_moves(obs)
+        self.assertEqual(
+            result,
+            {0: "North", 1: "East", 2: "South", 3: "West", 4: "Stay"},
+        )
+
+    def test_empty_serialized(self):
+        self.assertEqual(get_legal_moves({"serializedGameAndState": ""}), {})
+
+    def test_returns_typed_dict(self):
+        result = get_legal_moves(
+            {
+                "legalActions": [0, 4],
+                "legalActionStrings": ["North", "Stay"],
+            }
+        )
+        self.assertIsInstance(result, dict)
+        for k, v in result.items():
+            self.assertIsInstance(k, int)
+            self.assertIsInstance(v, str)
+
+
+# ---------------------------------------------------------------------------
+# create_agent_fn integration
+# ---------------------------------------------------------------------------
+
+
+class _CaptureTheFlagHarness:
+    """Test-local GameHarness adapter."""
+
+    def get_legal_moves(self, observation):
+        return get_legal_moves(observation)
+
+    def make_prompt(self, observation, move_history, previous_response=None, previous_action=None):
+        return generate_prompt(
+            observation,
+            move_history,
+            previous_response=previous_response,
+            previous_action=previous_action,
+        )
+
+    def parse_response(self, response, legal_action_strings, *, observation):
+        del observation
+        return parse_response(response, legal_action_strings)
+
+
+class _StreamDelta:
+    def __init__(self, content):
+        self.content = content
+
+
+class _StreamChoice:
+    def __init__(self, content, finish_reason=None):
+        self.delta = _StreamDelta(content)
+        self.finish_reason = finish_reason
+
+
+class _StreamChunk:
+    def __init__(self, choices, usage=None):
+        self.choices = choices
+        self.usage = usage
+
+
+def _make_mock_response(content: str):
+    usage = MagicMock(
+        prompt_tokens=10,
+        completion_tokens=20,
+        total_tokens=30,
+        completion_tokens_details=None,
+    )
+    return [
+        _StreamChunk([_StreamChoice(content)]),
+        _StreamChunk([_StreamChoice("", finish_reason="stop")]),
+        _StreamChunk([], usage=usage),
+    ]
+
+
+_ENV = {
+    "MODEL_NAME": "test-model",
+    "MODEL_PROXY_KEY": "test-key",
+    "MODEL_PROXY_URL": "dummy_url",
+}
+
+
+class AgentIntegrationTest(absltest.TestCase):
+    """Run the harness through ``create_agent_fn`` from ``core_harness``."""
+
+    @patch.dict("os.environ", _ENV)
+    @patch("kaggle_environments.core_harness.litellm")
+    def test_setup_step_returns_inactive(self, mock_litellm):
+        mock_litellm.drop_params = True
+        agent = create_agent_fn(_CaptureTheFlagHarness())
+
+        result = agent({"step": 0, "remainingOverageTime": 60}, {})
+
+        self.assertIsNone(result["submission"])
+        self.assertEqual(result["status"], "INACTIVE")
+        mock_litellm.completion.assert_not_called()
+
+    @patch.dict("os.environ", _ENV)
+    @patch("kaggle_environments.core_harness.litellm")
+    def test_sim_move_player_treated_as_active(self, mock_litellm):
+        """currentPlayer is -2 (SIMULTANEOUS); both agents must run."""
+        mock_litellm.drop_params = True
+        mock_litellm.completion.return_value = _make_mock_response('```json\n{"move": "East"}\n```')
+        agent = create_agent_fn(_CaptureTheFlagHarness())
+
+        game = capture_the_flag_proxy.CaptureTheFlagGame()
+        state = game.new_initial_state()
+        self.assertEqual(int(state.current_player()), -2)
+
+        obs = _make_observation(state, game, player_id=1)
+        result = agent(obs, {})
+
+        self.assertEqual(result["submission"], 1)  # East == 1
+        self.assertEqual(result["actionString"], "East")
+        self.assertEqual(result["status"], "OK")
+
+    @patch.dict("os.environ", _ENV)
+    @patch("kaggle_environments.core_harness.litellm")
+    def test_successful_move(self, mock_litellm):
+        mock_litellm.drop_params = True
+        mock_litellm.completion.return_value = _make_mock_response('```json\n{"move": "North"}\n```')
+        agent = create_agent_fn(_CaptureTheFlagHarness())
+
+        game = capture_the_flag_proxy.CaptureTheFlagGame()
+        state = game.new_initial_state()
+        obs = _make_observation(state, game, player_id=0)
+
+        result = agent(obs, {})
+
+        self.assertEqual(result["submission"], 0)  # North == 0
+        self.assertEqual(result["actionString"], "North")
+        self.assertEqual(result["status"], "OK")
+        self.assertIn("thoughts", result)
+
+    @patch.dict("os.environ", _ENV)
+    @patch("kaggle_environments.core_harness.litellm")
+    def test_retry_on_bad_parse(self, mock_litellm):
+        mock_litellm.drop_params = True
+        mock_litellm.completion.side_effect = [
+            _make_mock_response('```json\n{"move": "diagonal"}\n```'),
+            _make_mock_response('```json\n{"move": "Stay"}\n```'),
+        ]
+        agent = create_agent_fn(_CaptureTheFlagHarness())
+
+        game = capture_the_flag_proxy.CaptureTheFlagGame()
+        state = game.new_initial_state()
+        obs = _make_observation(state, game, player_id=0)
+
+        result = agent(obs, {})
+
+        self.assertEqual(result["submission"], 4)  # Stay == 4
+        self.assertEqual(mock_litellm.completion.call_count, 2)
+
+    @patch.dict("os.environ", _ENV)
+    @patch("kaggle_environments.core_harness.litellm")
+    def test_raises_after_two_failures(self, mock_litellm):
+        mock_litellm.drop_params = True
+        mock_litellm.completion.return_value = _make_mock_response("I cannot decide.")
+        agent = create_agent_fn(_CaptureTheFlagHarness())
+
+        game = capture_the_flag_proxy.CaptureTheFlagGame()
+        state = game.new_initial_state()
+        obs = _make_observation(state, game, player_id=0)
+
+        with self.assertRaises(ValueError):
+            agent(obs, {})
+
+        self.assertEqual(mock_litellm.completion.call_count, 2)
+
+    @patch.dict("os.environ", _ENV)
+    @patch("kaggle_environments.core_harness.litellm")
+    def test_terminal_step_returns_inactive(self, mock_litellm):
+        mock_litellm.drop_params = True
+        agent = create_agent_fn(_CaptureTheFlagHarness())
+
+        obs = {"isTerminal": True, "playerId": 0, "currentPlayer": -4}
+        result = agent(obs, {})
+        self.assertIsNone(result["submission"])
+        self.assertEqual(result["status"], "INACTIVE")
+        mock_litellm.completion.assert_not_called()
+
+    @patch.dict("os.environ", _ENV)
+    @patch("kaggle_environments.core_harness.litellm")
+    def test_scripted_game_round_trips_through_pyspiel(self, mock_litellm):
+        """Drive a few rounds with scripted LLM agents. P0 always Stays,
+        P1 walks West. Neither wins — this just proves the harness rounds-
+        trip cleanly against pyspiel without raising."""
+        mock_litellm.drop_params = True
+
+        def fake_completion(*, model, messages, **kwargs):
+            del model, kwargs
+            content = messages[0]["content"]
+            if "You are Player A" in content:
+                return _make_mock_response('```json\n{"move": "Stay"}\n```')
+            return _make_mock_response('```json\n{"move": "West"}\n```')
+
+        mock_litellm.completion.side_effect = fake_completion
+        agent_p0 = create_agent_fn(_CaptureTheFlagHarness())
+        agent_p1 = create_agent_fn(_CaptureTheFlagHarness())
+
+        game = capture_the_flag_proxy.CaptureTheFlagGame()
+        state = game.new_initial_state()
+
+        rounds = 0
+        while not state.is_terminal() and rounds < 8:
+            if state.is_chance_node():
+                state.apply_action(0)
+                continue
+            obs0 = _make_observation(state, game, player_id=0)
+            obs1 = _make_observation(state, game, player_id=1)
+            r0 = agent_p0(obs0, {})
+            r1 = agent_p1(obs1, {})
+            self.assertEqual(r0["status"], "OK")
+            self.assertEqual(r1["status"], "OK")
+            state.apply_actions([r0["submission"], r1["submission"]])
+            rounds += 1
+
+        # Game is far from over at 8 rounds; check it advanced cleanly.
+        self.assertGreater(rounds, 0)
+
+
+if __name__ == "__main__":
+    absltest.main()

--- a/tests/envs/open_spiel_env/games/capture_the_flag/harness_test.py
+++ b/tests/envs/open_spiel_env/games/capture_the_flag/harness_test.py
@@ -149,7 +149,8 @@ class GeneratePromptTest(absltest.TestCase):
     def test_tag_rule_present(self):
         obs = _make_observation(self.state, self.game, player_id=0)
         prompt = generate_prompt(obs, [])
-        self.assertIn("Manhattan-adjacent", prompt)
+        self.assertIn("directly next to the flag's owner", prompt)
+        self.assertIn("not diagonal", prompt)
         self.assertIn("respawn", prompt)
 
     def test_tag_uses_final_positions_not_per_initiative(self):
@@ -202,7 +203,7 @@ class GeneratePromptTest(absltest.TestCase):
     def test_carrier_status_rendered(self):
         # Force B to pick up A's flag. First walk A far away from its base so
         # that B doesn't get tagged the moment it steps onto A's flag (a
-        # carrier Manhattan-adjacent to the defender inside the defender's
+        # carrier directly next to the defender inside the defender's
         # home is instantly respawned).
         for _ in range(2):
             self.state.apply_actions([0, 4])  # A North, B Stay

--- a/tests/envs/open_spiel_env/games/capture_the_flag/harness_test.py
+++ b/tests/envs/open_spiel_env/games/capture_the_flag/harness_test.py
@@ -131,6 +131,24 @@ class GeneratePromptTest(absltest.TestCase):
         for action in ("North", "East", "South", "West", "Stay"):
             self.assertIn(action, prompt)
 
+    def test_default_grid_omits_obstacle_references(self):
+        # The default grid has no '*' cells. Prompt should not mention them.
+        obs = _make_observation(self.state, self.game, player_id=0)
+        prompt = generate_prompt(obs, [])
+        self.assertNotIn("obstacle", prompt.lower())
+        self.assertNotIn("'*'", prompt)
+
+    def test_custom_grid_with_obstacles_documents_them(self):
+        # A custom grid containing '*' cells: the legend must explain them
+        # and the move rules must state that moving into one is a no-op.
+        grid = ".......\n...*...\na..*..b\n...*...\n......."
+        alt_game = capture_the_flag_proxy.CaptureTheFlagGame({"grid": grid})
+        alt_state = alt_game.new_initial_state()
+        obs = _make_observation(alt_state, alt_game, player_id=0)
+        prompt = generate_prompt(obs, [])
+        self.assertIn("'*' = obstacle (impassable)", prompt)
+        self.assertIn("into an obstacle", prompt)
+
     def test_critical_capture_precondition_present(self):
         # The non-obvious mechanic: arriving at your own base with the
         # opponent's flag only scores when your OWN flag is still home.


### PR DESCRIPTION
This set of changes implements the harness for capture the flag.

Example board ASCII if it helps (A/B = players, a/b = flags): 
```
      0 1 2 3 4 5 6
    0 A . . . . . .
    1 . . . . . . .
    2 a . . . B . b
    3 . . . . . . .
    4 . . . . . . .
```