### PR TITLE
Normalize LLM dict actions in Lux AI 2021 visualizer

### DIFF
--- a/kaggle_environments/envs/lux_ai_2021/visualizer/default/src/luxTransformer.ts
+++ b/kaggle_environments/envs/lux_ai_2021/visualizer/default/src/luxTransformer.ts
@@ -1,0 +1,54 @@
+import { ReplayData } from '@kaggle-environments/core';
+
+/**
+ * Normalize per-team actions down to a bare list of Lux command strings so the
+ * external `lux-viewer-2021` board renderer can consume them.
+ *
+ * Background: the env's `action` spec was widened (env commit "Persist LLM
+ * thoughts in Lux AI 2021 replays") so LLM-harness agents now emit a dict
+ * wrapper -- `{ submission, thoughts, actionString, call_details,
+ * generate_returns }` -- rather than a bare `string[]`. That wrapper is what
+ * carries the thoughts into the replay. The external viewer, however, parses
+ * each step with `action.map(cmd => ...)`, which throws `TypeError:
+ * action.map is not a function` on the dict shape, breaking exactly the LLM
+ * replays we care about.
+ *
+ * This mirrors the Python `_command_list` projection in
+ * `kaggle_environments/envs/lux_ai_2021/lux_ai_2021.py`: legacy bot agents send
+ * a bare list (left untouched), harness agents send `{ submission: [...] }`
+ * (projected to the list), and anything else becomes an empty command list. The
+ * dict's other fields (thoughts, etc.) are simply dropped for the viewer -- the
+ * external renderer has no thoughts UI, and the raw thoughts remain in the
+ * persisted replay for other consumers.
+ */
+
+function commandList(action: unknown): string[] {
+  if (Array.isArray(action)) {
+    return action as string[];
+  }
+  if (action && typeof action === 'object') {
+    const submission = (action as { submission?: unknown }).submission;
+    return Array.isArray(submission) ? (submission as string[]) : [];
+  }
+  return [];
+}
+
+export function luxNormalizeReplay(replay: ReplayData): ReplayData {
+  if (!replay || !Array.isArray(replay.steps)) {
+    return replay;
+  }
+
+  const steps = (replay.steps as any[]).map((step) => {
+    if (!Array.isArray(step)) {
+      return step;
+    }
+    return step.map((teamEntry) => {
+      if (!teamEntry || typeof teamEntry !== 'object') {
+        return teamEntry;
+      }
+      return { ...teamEntry, action: commandList(teamEntry.action) };
+    });
+  });
+
+  return { ...replay, steps } as ReplayData;
+}

--- a/kaggle_environments/envs/lux_ai_2021/visualizer/default/src/main.ts
+++ b/kaggle_environments/envs/lux_ai_2021/visualizer/default/src/main.ts
@@ -5,6 +5,7 @@ import {
   ReplayData,
   BaseGameStep,
 } from '@kaggle-environments/core';
+import { luxNormalizeReplay } from './luxTransformer';
 
 // Helper to load a script
 function loadScript(src: string): Promise<void> {
@@ -85,6 +86,9 @@ class LuxAdapter implements GameAdapter<BaseGameStep[]> {
 const app = document.getElementById('app');
 if (app) {
   createReplayVisualizer(app, new LuxAdapter(), {
-    transformer: (replay) => processEpisodeData(replay, 'lux_ai_2021'),
+    // Normalize LLM-harness dict actions ({submission, thoughts, ...}) down to
+    // the bare command list the external lux-viewer-2021 board renderer expects.
+    // Without this the viewer throws on `action.map` for LLM replays.
+    transformer: (replay) => luxNormalizeReplay(processEpisodeData(replay, 'lux_ai_2021')),
   });
 }


### PR DESCRIPTION
Env commit #1362 widened the action spec so LLM-harness agents persist a dict wrapper ({submission, thoughts, actionString, ...}) into the replay. The external lux-viewer-2021 board renderer parses each step with action.map(...), which throws on the dict shape and breaks exactly the LLM replays that carry thoughts.

Add a luxNormalizeReplay transformer that projects each per-team action down to its bare command list (mirroring the Python _command_list): bare lists pass through untouched, {submission:[...]} projects to the list, and null/malformed become []. Wire it into the visualizer transformer chain so the normalized replay reaches the external viewer.

Thoughts remain persisted in the replay JSON; displaying them in the viewer is out of scope (the external CDN viewer owns its own timeline and cannot be synced).