### PR TITLE
Tolerate missing-underscore unit ids in Lux AI 2021 harness

### DIFF
--- a/kaggle_environments/envs/lux_ai_2021/harness.py
+++ b/kaggle_environments/envs/lux_ai_2021/harness.py
@@ -179,13 +179,16 @@ Opponent state:
 {opponent_summary}
 
 {recent_moves_block}
-Reply with a JSON object of the form:
+First give a short justification of your plan for this turn (a few
+sentences -- which units and city tiles you are acting and why), then
+conclude with your commands as a JSON object of the form:
 
 ```json
 {{"actions": ["m u_1 n", "bcity u_2", "r 5 7"]}}
 ```
 
-An empty list (`{{"actions": []}}`) is legal and means "do nothing this turn".
+Put the JSON object last; it is read as your final answer. An empty list
+(`{{"actions": []}}`) is legal and means "do nothing this turn".
 """
 
 

--- a/kaggle_environments/envs/lux_ai_2021/harness.py
+++ b/kaggle_environments/envs/lux_ai_2021/harness.py
@@ -135,7 +135,10 @@ Commands (one per line in your JSON response):
                                       not on an existing city tile)
   p <unit_id>                      -- worker pillages road at its position
   t <from_id> <to_id> <res> <amt>  -- transfer resources between adjacent units
-                                      (res: wood, coal, or crystal)
+                                      (res: wood, coal, or crystal). BOTH ids
+                                      must be UNIT ids (u_N) -- you cannot
+                                      transfer into a city; a unit fuels a city
+                                      by standing on it or building it.
   r <x> <y>                        -- city tile at (x,y) researches
   bw <x> <y>                       -- city tile at (x,y) builds a worker
   bc <x> <y>                       -- city tile at (x,y) builds a cart
@@ -182,7 +185,11 @@ Reply with a JSON object of the form:
 {{"actions": ["m u_1 n", "bcity u_2", "r 5 7"]}}
 ```
 
-An empty list (`{{"actions": []}}`) is legal and means "do nothing this turn".
+Issue at least one command for every unit and every city tile that is off
+cooldown -- passing on an actor that could act wastes an irrecoverable turn of
+production and leaves your cities closer to collapsing at night. An empty list
+(`{{"actions": []}}`) is accepted by the engine but should only be used when
+every one of your units and city tiles is still on cooldown.
 """
 
 
@@ -400,7 +407,26 @@ _DIRECTION_ALIASES = {
 _LEADING_JUNK_RE = re.compile(r"^[\s\-*•]+|^\d+[.)]\s*")
 _TRAILING_JUNK_RE = re.compile(r"[\s.,;:!?]+$")
 _TRAILING_COMMENT_RE = re.compile(r"\s*(?:#|//).*$")
-_ID_TOKEN_RE = re.compile(r"[uUcC]_\d+")
+# Unit/city id token, tolerating a MISSING underscore. The engine's wire form
+# is ``u_N`` / ``c_N``, but models routinely drop the underscore (``u9``) or
+# uppercase the letter (``U_9``) to match the ASCII map glyphs. The optional
+# ``_`` lets ``_normalize_command`` fold ``u9``/``U9``/``U_9`` all to ``u_9``.
+# The letter class is only ``u``/``c`` so a bare direction (``c`` = stay, no
+# digits) and coordinate integers (``5``) are never mistaken for ids.
+_ID_TOKEN_RE = re.compile(r"([uUcC])_?(\d+)")
+
+
+def _canonical_id(token: str) -> str:
+    """Canonicalise a unit/city id token, or return it unchanged.
+
+    ``u_9``/``U_9``/``u9``/``U9`` (and the ``c`` city variants) all fold to
+    ``u_9`` / ``c_9``. Only a token that is *entirely* an id is rewritten, so
+    coordinate integers and the ``c`` (stay) direction pass through untouched.
+    """
+    m = _ID_TOKEN_RE.fullmatch(token)
+    if m is None:
+        return token
+    return f"{m.group(1).lower()}_{m.group(2)}"
 
 
 def _normalize_command(cmd: str) -> str:
@@ -411,8 +437,9 @@ def _normalize_command(cmd: str) -> str:
     - Strips trailing line-comments (``# ...`` and ``// ...``).
     - Strips ``[]``, ``()``, and ``<>`` wrappers around any token.
     - Collapses runs of internal whitespace to a single space.
-    - Lowercases command head, unit/city id tokens (``U_1`` -> ``u_1``),
-      and full direction names for the ``m`` command.
+    - Lowercases command head, canonicalises unit/city id tokens (folding
+      case AND inserting a missing underscore, so ``U_1``/``u1``/``U1`` all
+      become ``u_1``), and folds full direction names for the ``m`` command.
     - Rewrites the display resource name (``crystal``) back to the engine's
       wire keyword (``uranium``) in ``t`` transfer commands.
     """
@@ -431,10 +458,12 @@ def _normalize_command(cmd: str) -> str:
     # All command heads (``m``, ``bcity``, ``p``, ``t``, ``r``, ``bw``, ``bc``)
     # are lowercase in the engine's grammar.
     parts[0] = parts[0].lower()
-    # Unit and city ids are exclusively lowercase in the engine's wire
-    # protocol (``u_N`` / ``c_N``). Models routinely uppercase them to match
-    # the ASCII map letters (``U``/``T``), so fold every id-shaped token.
-    parts = [p.lower() if _ID_TOKEN_RE.fullmatch(p) else p for p in parts]
+    # Unit and city ids are exclusively lowercase ``u_N`` / ``c_N`` in the
+    # engine's wire protocol. Models routinely uppercase them to match the
+    # ASCII map letters (``U``/``T``) and/or drop the underscore (``u9``), so
+    # canonicalise every id-shaped token: lowercase the letter and insert the
+    # underscore if it's missing.
+    parts = [_canonical_id(p) for p in parts]
     if parts[0] == "m" and len(parts) == 3:
         # direction lowercased and folded from full-word aliases.
         d = parts[2].lower()

--- a/kaggle_environments/envs/lux_ai_2021/harness.py
+++ b/kaggle_environments/envs/lux_ai_2021/harness.py
@@ -185,11 +185,7 @@ Reply with a JSON object of the form:
 {{"actions": ["m u_1 n", "bcity u_2", "r 5 7"]}}
 ```
 
-Issue at least one command for every unit and every city tile that is off
-cooldown -- passing on an actor that could act wastes an irrecoverable turn of
-production and leaves your cities closer to collapsing at night. An empty list
-(`{{"actions": []}}`) is accepted by the engine but should only be used when
-every one of your units and city tiles is still on cooldown.
+An empty list (`{{"actions": []}}`) is legal and means "do nothing this turn".
 """
 
 
@@ -379,7 +375,9 @@ def _render_player(game: Game, player_id: int) -> str:
         total_upkeep = sum(c.light_upkeep for c in player.cities.values())
         lines.append(f"  cities ({len(player.cities)}, {total_tiles} tiles, total night upkeep {total_upkeep:g}/turn):")
         for city in player.cities.values():
-            tiles = ", ".join(f"({t.pos.x},{t.pos.y})" for t in city.citytiles)
+            # Per-tile cooldown so the model can see which tiles can act this
+            # turn (a city tile can issue a command only when cooldown < 1).
+            tiles = ", ".join(f"({t.pos.x},{t.pos.y} cd={t.cooldown:g})" for t in city.citytiles)
             lines.append(f"    {city.cityid} fuel={city.fuel:g} upkeep={city.light_upkeep:g} tiles=[{tiles}]")
     else:
         lines.append("  cities: (none)")
@@ -415,6 +413,17 @@ _TRAILING_COMMENT_RE = re.compile(r"\s*(?:#|//).*$")
 # digits) and coordinate integers (``5``) are never mistaken for ids.
 _ID_TOKEN_RE = re.compile(r"([uUcC])_?(\d+)")
 
+# Which argument slots of each command actually hold a unit/city id (and so are
+# safe to canonicalise). ``r``/``bw``/``bc`` take *coordinate integers*, and a
+# ``c``-prefixed coordinate token (``c5``) would otherwise be mis-rewritten to
+# ``c_5``, so those commands appear here with no id slots at all.
+_ID_ARG_SLOTS: dict[str, tuple[int, ...]] = {
+    "m": (1,),  # m <unit_id> <dir>
+    "bcity": (1,),  # bcity <unit_id>
+    "p": (1,),  # p <unit_id>
+    "t": (1, 2),  # t <from_id> <to_id> <res> <amt>
+}
+
 
 def _canonical_id(token: str) -> str:
     """Canonicalise a unit/city id token, or return it unchanged.
@@ -422,6 +431,9 @@ def _canonical_id(token: str) -> str:
     ``u_9``/``U_9``/``u9``/``U9`` (and the ``c`` city variants) all fold to
     ``u_9`` / ``c_9``. Only a token that is *entirely* an id is rewritten, so
     coordinate integers and the ``c`` (stay) direction pass through untouched.
+    Callers additionally restrict this to id-argument slots (see
+    ``_ID_ARG_SLOTS``) so ``c``-prefixed coordinates in ``r``/``bw``/``bc``
+    are never touched.
     """
     m = _ID_TOKEN_RE.fullmatch(token)
     if m is None:
@@ -461,9 +473,12 @@ def _normalize_command(cmd: str) -> str:
     # Unit and city ids are exclusively lowercase ``u_N`` / ``c_N`` in the
     # engine's wire protocol. Models routinely uppercase them to match the
     # ASCII map letters (``U``/``T``) and/or drop the underscore (``u9``), so
-    # canonicalise every id-shaped token: lowercase the letter and insert the
-    # underscore if it's missing.
-    parts = [_canonical_id(p) for p in parts]
+    # canonicalise the id-shaped tokens: lowercase the letter and insert the
+    # underscore if it's missing. Only the slots that actually hold ids are
+    # touched, so a ``c``-prefixed coordinate (``r c5 c7``) is left intact.
+    for i in _ID_ARG_SLOTS.get(parts[0], ()):
+        if i < len(parts):
+            parts[i] = _canonical_id(parts[i])
     if parts[0] == "m" and len(parts) == 3:
         # direction lowercased and folded from full-word aliases.
         d = parts[2].lower()

--- a/tests/envs/lux_ai_2021/test_harness.py
+++ b/tests/envs/lux_ai_2021/test_harness.py
@@ -191,6 +191,30 @@ class NormalizeCommandTest(absltest.TestCase):
         # already handled elsewhere; the fold is scoped to [uUcC]_\\d+).
         self.assertEqual(_normalize_command("m U_1 N"), "m u_1 n")
 
+    def test_missing_underscore_in_id_inserted(self):
+        # Models routinely drop the underscore in unit/city ids (``u9`` for
+        # ``u_9``), often to match the bare numbers on the ASCII map. The
+        # engine's wire form requires the underscore, so normalization must
+        # insert it or the command is silently dropped.
+        self.assertEqual(_normalize_command("m u9 w"), "m u_9 w")
+        self.assertEqual(_normalize_command("bcity u12"), "bcity u_12")
+        self.assertEqual(_normalize_command("p u3"), "p u_3")
+        self.assertEqual(_normalize_command("t u12 u1 wood 45"), "t u_12 u_1 wood 45")
+        # Case + missing underscore together fold in one pass.
+        self.assertEqual(_normalize_command("M U9 N"), "m u_9 n")
+        # After folding, each is a valid command.
+        for raw in ["m u9 w", "bcity u12", "p u3", "t u12 u1 wood 45", "M U9 N"]:
+            self.assertTrue(_validate_command(_normalize_command(raw)), raw)
+
+    def test_missing_underscore_does_not_touch_directions_or_coords(self):
+        # The ``c`` (stay) direction is a bare letter with no digits, and city
+        # commands take coordinate integers -- neither is an id, so neither
+        # must be rewritten into ``c_N``/``u_N``.
+        self.assertEqual(_normalize_command("m u_1 c"), "m u_1 c")
+        self.assertEqual(_normalize_command("m u1 center"), "m u_1 c")
+        self.assertEqual(_normalize_command("r 5 7"), "r 5 7")
+        self.assertEqual(_normalize_command("bw 0 6"), "bw 0 6")
+
     def test_strips_bracket_wrappers(self):
         for raw in ["m [u_1] n", "bcity <u_2>", "t (u_1) (u_2) wood 40"]:
             normalized = _normalize_command(raw)
@@ -582,7 +606,7 @@ class GeneratePromptTest(absltest.TestCase):
         # City tile upkeep + adjacency bonus formula are surfaced.
         self.assertIn("23", prompt)  # per-tile base
         # Worker/cart night-consumption numbers and the "in a city is safe" carve-out.
-        self.assertIn("4", prompt)   # worker night burn
+        self.assertIn("4", prompt)  # worker night burn
         self.assertIn("10", prompt)  # cart night burn
         self.assertIn("city tile at night", prompt.lower().replace("standing on a friendly ", ""))
 

--- a/tests/envs/lux_ai_2021/test_harness.py
+++ b/tests/envs/lux_ai_2021/test_harness.py
@@ -215,6 +215,15 @@ class NormalizeCommandTest(absltest.TestCase):
         self.assertEqual(_normalize_command("r 5 7"), "r 5 7")
         self.assertEqual(_normalize_command("bw 0 6"), "bw 0 6")
 
+    def test_c_prefixed_coordinates_not_rewritten_as_ids(self):
+        # ``r``/``bw``/``bc`` take coordinate integers, not ids. A stray
+        # ``c``-prefixed coordinate token (``c5``) must NOT be folded to a
+        # ``c_5`` city id -- only the id-argument slots of id-taking commands
+        # are canonicalised.
+        self.assertEqual(_normalize_command("r c5 c7"), "r c5 c7")
+        self.assertEqual(_normalize_command("bw c0 c6"), "bw c0 c6")
+        self.assertEqual(_normalize_command("bc c1 c2"), "bc c1 c2")
+
     def test_strips_bracket_wrappers(self):
         for raw in ["m [u_1] n", "bcity <u_2>", "t (u_1) (u_2) wood 40"]:
             normalized = _normalize_command(raw)


### PR DESCRIPTION
Models routinely emit unit/city ids without the underscore (`u9` for `u_9`, `c7` for `c_7`), often to match the bare numbers on the ASCII map. The normalizer folded case and brackets but not the missing underscore, so these commands failed validation and were silently dropped -- costing units their turns, and pushing some turns over the 50% malformed threshold into a wasted rethink call. A review of 21 post-map-reveal episodes found 117 such drops across 60 turns.

Fold `u9`/`U9`/`U_9` all to `u_9` (and the `c` city variants) via a new `_canonical_id` helper. The letter class is scoped to u/c so the `c` stay-direction and coordinate integers are never rewritten.

Also two prompt clarifications surfaced by the same review:
- state that transfer requires both ids to be UNITs (transfer-into-a- city was a recurring model error the engine rejects), and
- reframe the empty-action line so "do nothing" reads as forfeiting a turn rather than a neutral default (47% of empty turns had an actor off cooldown).