### PR TITLE
Ensure agent exceptions terminate Word Art games

### DIFF
--- a/kaggle_environments/envs/word_art/word_art.json
+++ b/kaggle_environments/envs/word_art/word_art.json
@@ -36,8 +36,8 @@
     },
     "actTimeout": {
       "type": "number",
-      "default": 180,
-      "description": "Timeout in seconds for agent actions. Bumped from the framework default to accommodate reasoning-heavy LLM artists: a 60s budget caused observed wall durations of 70-140s with current frontier reasoning models, silently forfeiting artist turns once banked overage was exhausted."
+      "default": 3600,
+      "description": "Timeout in seconds for agent actions. Matches the core harness LLM_CALL_TIMEOUT budget of 3600s, which spans all transport retries of a single call. Anything lower lets the framework kill a seat that the harness still considers in-flight, and since word_art ends the episode on a timed-out seat that would abort otherwise-healthy games. Reasoning-heavy artists were already exceeding 140s at the old 60s default."
     },
     "seed": {
       "type": ["integer", "null"],

--- a/kaggle_environments/envs/word_art/word_art.py
+++ b/kaggle_environments/envs/word_art/word_art.py
@@ -583,19 +583,37 @@ def initialize_game(state, env):
     env.word_art_state = _WordArtState(sampled)
 
 
-# Statuses set by the kaggle framework when an agent fails. We must NOT
-# overwrite them on phase transitions: a TIMEOUT'd or ERROR'd agent has
-# forfeited and should stay in that state for the rest of the episode, so
-# the framework stops calling them and the failure remains visible in the
-# replay. Without this guard, an artist that times out gets silently
-# resurrected as ACTIVE on the next round and times out again.
+# Statuses the kaggle framework sets when an agent crashes or times out.
+# These end the episode -- see _abort_on_agent_failure.
 _TERMINAL_FAILURE_STATUSES = ("TIMEOUT", "ERROR", "INVALID")
+
+
+def _abort_on_agent_failure(state):
+    """End the episode if the framework marked any seat TIMEOUT/ERROR/INVALID.
+    Returns True if the episode was ended.
+
+    A seat that crashed or timed out is a broken participant, not a player
+    making a bad move, and word_art cannot score a 2v2 game around one. The
+    alternative -- skipping that seat and playing on -- yields an episode
+    where one model contributes no art and no guesses for the rest of the
+    game while the scoreboard still reports a winner. Ending here keeps the
+    failure loud: the offending seat retains its status, so core.py nulls its
+    reward and the replay shows an errored episode rather than a lopsided one.
+
+    Note this is deliberately NOT the illegalMoveForfeit path. A model that
+    answers unparseably forfeits the turn and plays on; a model whose agent
+    raised has no working turn to fall back to.
+    """
+    if not any(s.status in _TERMINAL_FAILURE_STATUSES for s in state):
+        return False
+    for s in state:
+        if s.status not in _TERMINAL_FAILURE_STATUSES:
+            s.status = "DONE"
+    return True
 
 
 def _set_art_statuses(state, round_idx):
     for i in range(4):
-        if state[i].status in _TERMINAL_FAILURE_STATUSES:
-            continue
         role = get_role(i, round_idx)
         state[i].status = "ACTIVE" if role == "artist" else "INACTIVE"
 
@@ -603,12 +621,9 @@ def _set_art_statuses(state, round_idx):
 def _set_guess_statuses(state, round_idx, wa_state):
     """During the guess phase: a team's guesser stays ACTIVE until they score
     or exhaust attempts; once done, they go INACTIVE. Artists are always
-    INACTIVE in the guess phase. Agents in a terminal failure state
-    (TIMEOUT/ERROR/INVALID) are left alone -- see _TERMINAL_FAILURE_STATUSES.
+    INACTIVE in the guess phase.
     """
     for i in range(4):
-        if state[i].status in _TERMINAL_FAILURE_STATUSES:
-            continue
         role = get_role(i, round_idx)
         if role == "artist":
             state[i].status = "INACTIVE"
@@ -636,15 +651,6 @@ def _process_team_guess(state, obs0, wa_state, team, target_norm):
         if wa_state.yellow_done:
             return
         g_idx = _yellow_guesser(obs0.current_round)
-
-    if state[g_idx].status != "ACTIVE":
-        # Guesser was not asked for an action this step (e.g. ERROR/TIMEOUT
-        # propagated from a prior step). Treat as out of the round.
-        if team == "blue":
-            wa_state.blue_done = True
-        else:
-            wa_state.yellow_done = True
-        return
 
     raw = _unwrap(state[g_idx].action)
     guess_str = raw if isinstance(raw, str) else (str(raw) if raw is not None else "")
@@ -761,8 +767,6 @@ def _advance_after_round(state, obs0, wa_state, round_idx, words, target):
 
     if is_done:
         for i in range(4):
-            if state[i].status in _TERMINAL_FAILURE_STATUSES:
-                continue
             state[i].status = "DONE"
     else:
         _set_art_statuses(state, next_round)
@@ -869,6 +873,9 @@ def interpreter(state, env):
         return state
 
     if env.done:
+        return state
+
+    if _abort_on_agent_failure(state):
         return state
 
     process_step(state, env)

--- a/tests/envs/word_art/test_word_art.py
+++ b/tests/envs/word_art/test_word_art.py
@@ -810,18 +810,41 @@ def test_mid_game_missing_word_art_state_raises_clearly():
         env.step([None] * 4)
 
 
-# --- Failure-status preservation across phase / round transitions ----------
+# --- Agent failure ends the episode ----------------------------------------
 #
-# When the framework marks an agent TIMEOUT/ERROR/INVALID, the interpreter
-# must NOT flip that status back to ACTIVE on the next phase transition.
-# Otherwise a timed-out artist gets silently resurrected, times out again,
-# and the round's failure is invisible in the replay.
+# When the framework marks an agent TIMEOUT/ERROR/INVALID, the seat is broken,
+# not merely playing badly, and word_art cannot score a 2v2 game around one.
+# The interpreter ends the episode instead of playing on without that seat --
+# which would silently produce a game where one model draws nothing and
+# guesses nothing while the scoreboard still reports a winner.
 
 
-def test_artist_timeout_preserved_into_guess_phase():
-    """An artist that raises DeadlineExceeded during the art phase must
-    remain TIMEOUT after the env transitions into the guess phase — NOT
-    get flipped to INACTIVE by _set_guess_statuses."""
+def test_agent_failure_ends_the_episode_immediately():
+    """One crashed seat ends the whole game — the remaining three must not
+    keep playing out the rest of the rounds."""
+
+    def crash_blue_artist(observation, configuration):
+        if observation.role == "artist" and observation.team == "blue":
+            raise RuntimeError("provider exploded")
+        if observation.role == "artist":
+            return observation.target_word
+        return observation.teammate_art
+
+    env = _make(num_rounds=5, seed=1)
+    env.run([crash_blue_artist] * 4)
+
+    assert env.done
+    assert env.state[0].status == "ERROR"
+    assert env.state[0].reward is None
+    assert [s.status for s in env.state[1:]] == ["DONE", "DONE", "DONE"]
+    # Aborted during round 0's art phase, so no round ever completed.
+    assert env.state[0].observation.history == []
+    assert env.state[0].observation.current_round == 0
+
+
+def test_artist_timeout_ends_the_episode():
+    """A timed-out artist keeps TIMEOUT rather than being laundered into
+    INACTIVE by the art->guess transition, and the game stops there."""
 
     def slow_artist(observation, configuration):
         if observation.role == "artist":
@@ -830,17 +853,15 @@ def test_artist_timeout_preserved_into_guess_phase():
 
     env = _make(num_rounds=2, seed=1)
     env.run([slow_artist, slow_artist, slow_artist, slow_artist])
-    # After the env runs, both timed-out artists from round 0 (agents 0 and 2)
-    # should still carry TIMEOUT — not be silently flipped back to ACTIVE/DONE.
+    assert env.done
     assert env.state[0].status == "TIMEOUT"
     assert env.state[2].status == "TIMEOUT"
+    assert env.state[0].observation.history == []
 
 
-def test_timed_out_artist_not_resurrected_in_later_round():
-    """An agent that timed out in round 0's art phase must NOT be flipped
-    back to ACTIVE when _set_art_statuses runs at the start of round 2
-    (the next even-numbered round, where agent 0 would otherwise be the
-    blue artist again)."""
+def test_timed_out_artist_never_acts_again():
+    """The framework must stop calling a seat once it has failed, even
+    though _set_art_statuses would otherwise hand it a role in round 2."""
 
     # Time out the first artist call; thereafter everyone plays normally.
     state_bag = {"timed_out_once": False}
@@ -860,9 +881,6 @@ def test_timed_out_artist_not_resurrected_in_later_round():
 
     env = _make(num_rounds=3, seed=1)
     env.run([timeout_first_blue_artist] * 4)
-    # Agent 0 (blue artist on even rounds) must stay TIMEOUT for the whole
-    # episode — even though _set_art_statuses runs at the start of round 2
-    # and would otherwise flip them back to ACTIVE.
     assert env.state[0].status == "TIMEOUT"
     assert env.state[0].reward is None
     # Scan every recorded step: agent 0 was never ACTIVE after the timeout
@@ -878,23 +896,26 @@ def test_timed_out_artist_not_resurrected_in_later_round():
     )
 
 
-def test_guesser_timeout_preserved_across_round_boundary():
-    """A guesser that errors out in round 1 must not be reactivated for
-    round 2's art phase."""
+def test_guesser_timeout_ends_the_episode_keeping_earlier_scores():
+    """A failure partway through ends the game, but the rounds that did
+    complete stay on the board."""
 
-    def fail_guesser(observation, configuration):
-        if observation.role == "guesser" and observation.team == "yellow":
+    def fail_yellow_guesser_in_round_1(observation, configuration):
+        if observation.role == "guesser" and observation.current_round == 1:
             return DeadlineExceeded()
-        if observation.role == "artist":
-            return observation.target_word
-        return observation.teammate_art
+        return cheating(observation, configuration)
 
-    env = _make(num_rounds=2, seed=1)
-    env.run([fail_guesser] * 4)
-    # Yellow guesser in round 0 is agent 3. Should stay TIMEOUT — must not
-    # be flipped to ACTIVE/INACTIVE for the round-1 art phase, and must
-    # remain TIMEOUT after the game DONE sweep.
-    assert env.state[3].status == "TIMEOUT"
+    env = _make(num_rounds=3, seed=1)
+    # `cheating` smuggles the word through the art, so round 0 scores for both.
+    env.run([cheating] * 2 + [fail_yellow_guesser_in_round_1] * 2)
+
+    assert env.done
+    # Round 1's yellow guesser is seat 2 (the artist alternates each round).
+    assert env.state[2].status == "TIMEOUT"
+    assert env.state[2].reward is None
+    # Round 0 completed before the failure and its result survives.
+    assert len(env.state[0].observation.history) == 1
+    assert env.state[0].observation.yellow_score > 0
 
 
 # --- Singular/plural guess leniency ---------------------------------------


### PR DESCRIPTION
Currently if one of the agents throws an exception, it goes silent while the rest of the game plays out normally for the other team.