### PR TITLE
Gate open_spiel_env logs behind debug mode

### DIFF
--- a/kaggle_environments/envs/open_spiel_env/open_spiel_env.py
+++ b/kaggle_environments/envs/open_spiel_env/open_spiel_env.py
@@ -76,7 +76,11 @@ TIMEOUT = "TIMEOUT"
 INVALID = "INVALID"
 
 _log = logging.getLogger(__name__)
-_log.setLevel(logging.INFO)
+# Silent by default. Enable at import time via OPEN_SPIEL_ENV_DEBUG, or per-run
+# via the framework's debug flag (see interpreter, which bumps the level when
+# env.debug is set).
+_DEBUG = os.environ.get("OPEN_SPIEL_ENV_DEBUG", "").lower() in ("1", "true", "yes")
+_log.setLevel(logging.DEBUG if _DEBUG else logging.WARNING)
 _handler = logging.StreamHandler(sys.stdout)
 _formatter = logging.Formatter("[%(name)s] %(levelname)s: %(message)s")
 _handler.setFormatter(_formatter)
@@ -457,6 +461,10 @@ def interpreter(
     """Updates environment using player responses and returns new observations."""
     kaggle_state = state  # Not to be confused with OpenSpiel state.
     del state
+
+    # Surface this module's logs when the run is in debug mode.
+    if getattr(env, "debug", False):
+        _log.setLevel(logging.DEBUG)
 
     # TODO(jhtschultz): Test reset behavior. Currently containers are restarted
     # after each episode.


### PR DESCRIPTION
The core module logger was pinned to INFO, printing informational lines during normal use (env load summary at import, agent-error / invalid-action notices per run). Default the logger to WARNING so it is silent, and enable verbose output either via the OPEN_SPIEL_ENV_DEBUG env var (import time) or the framework's env.debug flag (runtime).