### PR TITLE
Nudge model to answer concisely after output-token truncation

### DIFF
--- a/kaggle_environments/core_harness.py
+++ b/kaggle_environments/core_harness.py
@@ -156,19 +156,56 @@ Your previously suggested move was: {last_move}, which is an illegal move.
 Please think carefully and generate a new and legal move.
 """
 
-# Rethink suffix appended (in addition to any illegal/unparsable suffix) when
+# Rethink suffixes appended (in addition to any illegal/unparsable suffix) when
 # the previous attempt hit the output-token limit (finish_reason="length")
 # before emitting a usable move. The model spent its entire budget on reasoning
 # and produced a truncated (often empty) answer, so the correction it needs is
 # not "your move was wrong" but "stop over-reasoning and answer concisely".
-# No placeholders -- game-agnostic so it can be appended by the core loop for
-# every harness. Prepended with a blank line so it reads as its own paragraph
-# regardless of what precedes it.
-BASIC_RETHINK_TRUNCATED = """
+#
+# The nudge RAMPS with the number of consecutive truncations: the first retry
+# asks for "less" reasoning (cutting reasoning too hard can hurt move quality,
+# so we start gentle), and each further truncation escalates the demand. A
+# forfeit from repeated overthinking is catastrophic -- worse than any move --
+# so by the last stage we insist on answering almost immediately.
+#
+# No placeholders -- game-agnostic so the core loop can append the right stage
+# for every harness. Each begins with a blank line so it reads as its own
+# paragraph regardless of what precedes it.
+BASIC_RETHINK_TRUNCATED_RAMP = (
+    """
 
 In your last answer you reasoned for so long that you used your entire \
-output-token budget before giving a move, so no move was recorded. Spend far \
-less time reasoning this turn and output your final move quickly and concisely."""
+output-token budget before giving a move, so no move was recorded. Spend less \
+time reasoning this turn and make sure you output your final move.""",
+    """
+
+Once again you ran out of output-token budget while reasoning and recorded no \
+move. Spend much less time reasoning this turn -- decide quickly and output \
+your final move well before you run out of budget.""",
+    """
+
+You have repeatedly used your entire output-token budget on reasoning without \
+recording a move, which will cause you to forfeit. Reason as briefly as \
+possible -- even a quick, imperfect move is far better than none. Output your \
+final move immediately.""",
+)
+
+# Back-compat alias: the strongest stage of the ramp.
+BASIC_RETHINK_TRUNCATED = BASIC_RETHINK_TRUNCATED_RAMP[-1]
+
+
+def render_truncation_nudge(consecutive_truncations: int) -> str:
+    """Pick the ramped truncation nudge for ``consecutive_truncations`` (>=1).
+
+    Clamps to the strongest stage once the count exceeds the ramp length, so
+    the demand keeps applying (at maximum intensity) no matter how many
+    retries a harness allows. Returns ``""`` for a non-positive count so the
+    caller can append unconditionally.
+    """
+    if consecutive_truncations < 1:
+        return ""
+    idx = min(consecutive_truncations, len(BASIC_RETHINK_TRUNCATED_RAMP)) - 1
+    return BASIC_RETHINK_TRUNCATED_RAMP[idx]
 
 
 # ---------------------------------------------------------------------------
@@ -893,7 +930,7 @@ def create_agent_fn(
         # -- prompt / parse / retry loop --
         previous_response: str | None = None
         previous_action: str | None = None
-        previous_truncated = False
+        consecutive_truncations = 0
         last_content = ""
         all_responses: list[str] = []
         call_records: list[dict[str, Any]] = []
@@ -919,8 +956,8 @@ def create_agent_fn(
             # Append the concise-answer nudge on top of whatever rethink suffix
             # the harness already produced, so it applies uniformly across
             # every game without threading a new signal through each make_prompt.
-            if previous_truncated:
-                prompt += BASIC_RETHINK_TRUNCATED
+            # The nudge ramps with consecutive truncations (see the ramp docs).
+            prompt += render_truncation_nudge(consecutive_truncations)
 
             try:
                 content, call_details = _call_llm(
@@ -1017,7 +1054,12 @@ def create_agent_fn(
             )
             previous_action = result.raw_action
             previous_response = content
-            previous_truncated = failure_category == "TRUNCATED"
+            # Track a RUN of truncations so the nudge can escalate; a single
+            # non-truncated attempt resets the ramp to its gentlest stage.
+            if failure_category == "TRUNCATED":
+                consecutive_truncations += 1
+            else:
+                consecutive_truncations = 0
             _log.warning(
                 "Attempt %d: failed to parse a legal move.", attempt + 1,
             )

--- a/kaggle_environments/core_harness.py
+++ b/kaggle_environments/core_harness.py
@@ -156,6 +156,20 @@ Your previously suggested move was: {last_move}, which is an illegal move.
 Please think carefully and generate a new and legal move.
 """
 
+# Rethink suffix appended (in addition to any illegal/unparsable suffix) when
+# the previous attempt hit the output-token limit (finish_reason="length")
+# before emitting a usable move. The model spent its entire budget on reasoning
+# and produced a truncated (often empty) answer, so the correction it needs is
+# not "your move was wrong" but "stop over-reasoning and answer concisely".
+# No placeholders -- game-agnostic so it can be appended by the core loop for
+# every harness. Prepended with a blank line so it reads as its own paragraph
+# regardless of what precedes it.
+BASIC_RETHINK_TRUNCATED = """
+
+In your last answer you reasoned for so long that you used your entire \
+output-token budget before giving a move, so no move was recorded. Spend far \
+less time reasoning this turn and output your final move quickly and concisely."""
+
 
 # ---------------------------------------------------------------------------
 # JSON extraction helper
@@ -879,6 +893,7 @@ def create_agent_fn(
         # -- prompt / parse / retry loop --
         previous_response: str | None = None
         previous_action: str | None = None
+        previous_truncated = False
         last_content = ""
         all_responses: list[str] = []
         call_records: list[dict[str, Any]] = []
@@ -899,6 +914,13 @@ def create_agent_fn(
                 previous_response=previous_response,
                 previous_action=previous_action,
             )
+            # A truncated previous attempt needs a different correction than a
+            # wrong move: the model ran out of output budget while reasoning.
+            # Append the concise-answer nudge on top of whatever rethink suffix
+            # the harness already produced, so it applies uniformly across
+            # every game without threading a new signal through each make_prompt.
+            if previous_truncated:
+                prompt += BASIC_RETHINK_TRUNCATED
 
             try:
                 content, call_details = _call_llm(
@@ -995,6 +1017,7 @@ def create_agent_fn(
             )
             previous_action = result.raw_action
             previous_response = content
+            previous_truncated = failure_category == "TRUNCATED"
             _log.warning(
                 "Attempt %d: failed to parse a legal move.", attempt + 1,
             )

--- a/tests/core_harness_test.py
+++ b/tests/core_harness_test.py
@@ -276,8 +276,8 @@ class CoreHarnessTest(absltest.TestCase):
 
     def test_truncated_attempt_appends_concise_nudge_to_retry(self):
         # After a length-truncated attempt, the retry prompt must carry the
-        # "answer concisely" nudge so the model stops over-reasoning; a normal
-        # unparsable/illegal attempt must not.
+        # (gentlest-stage) "answer concisely" nudge so the model stops
+        # over-reasoning; the first attempt itself must not.
         harness = _SimpleHarness()
         agent = create_agent_fn(harness, max_retries=2)
         side_effects = [
@@ -291,8 +291,74 @@ class CoreHarnessTest(absltest.TestCase):
 
         self.assertEqual(result["submission"], 1)
         prompts = [cd["prompt"] for cd in result["call_details"]]
-        self.assertNotIn(core_harness.BASIC_RETHINK_TRUNCATED, prompts[0])
-        self.assertIn(core_harness.BASIC_RETHINK_TRUNCATED, prompts[1])
+        stage1 = core_harness.BASIC_RETHINK_TRUNCATED_RAMP[0]
+        self.assertNotIn(stage1, prompts[0])
+        self.assertIn(stage1, prompts[1])
+
+    def test_truncation_nudge_ramps_across_consecutive_truncations(self):
+        # Each consecutive truncation escalates the nudge to the next, stronger
+        # ramp stage, so repeated overthinking is pushed toward answering fast.
+        ramp = core_harness.BASIC_RETHINK_TRUNCATED_RAMP
+        harness = _SimpleHarness()
+        agent = create_agent_fn(harness, max_retries=4)
+        side_effects = [
+            _fake_completion("", pieces=1, finish_reason="length"),
+            _fake_completion("", pieces=1, finish_reason="length"),
+            _fake_completion("", pieces=1, finish_reason="length"),
+            _fake_completion("move_1"),
+        ]
+        with patch.dict("os.environ", _ENV, clear=False), patch.object(
+            core_harness.litellm, "completion", side_effect=side_effects,
+        ):
+            result = agent({}, {})
+
+        self.assertEqual(result["submission"], 1)
+        prompts = [cd["prompt"] for cd in result["call_details"]]
+        # Attempt 0: no prior truncation, no nudge.
+        for stage in ramp:
+            self.assertNotIn(stage, prompts[0])
+        # Attempts 1/2/3 carry ramp stages 0/1/2 respectively.
+        self.assertIn(ramp[0], prompts[1])
+        self.assertIn(ramp[1], prompts[2])
+        self.assertIn(ramp[2], prompts[3])
+
+    def test_truncation_nudge_clamps_at_strongest_stage(self):
+        # Beyond the ramp length the nudge stays at the strongest stage rather
+        # than falling off, so long retry budgets keep the maximum pressure.
+        ramp = core_harness.BASIC_RETHINK_TRUNCATED_RAMP
+        n = len(ramp)
+        self.assertEqual(core_harness.render_truncation_nudge(0), "")
+        self.assertEqual(core_harness.render_truncation_nudge(1), ramp[0])
+        self.assertEqual(core_harness.render_truncation_nudge(n), ramp[-1])
+        self.assertEqual(core_harness.render_truncation_nudge(n + 5), ramp[-1])
+
+    def test_truncation_ramp_resets_after_non_truncated_attempt(self):
+        # A single non-truncated failure between truncations resets the ramp,
+        # so the next truncation starts gentle again rather than escalating.
+        ramp = core_harness.BASIC_RETHINK_TRUNCATED_RAMP
+        harness = _SimpleHarness()
+        agent = create_agent_fn(harness, max_retries=4)
+        side_effects = [
+            _fake_completion("", pieces=1, finish_reason="length"),  # truncate
+            _fake_completion("not_a_legal_move"),                    # illegal -> reset
+            _fake_completion("", pieces=1, finish_reason="length"),  # truncate again
+            _fake_completion("move_1"),
+        ]
+        with patch.dict("os.environ", _ENV, clear=False), patch.object(
+            core_harness.litellm, "completion", side_effect=side_effects,
+        ):
+            result = agent({}, {})
+
+        self.assertEqual(result["submission"], 1)
+        prompts = [cd["prompt"] for cd in result["call_details"]]
+        # Attempt 1 (after first truncation) -> stage 0.
+        self.assertIn(ramp[0], prompts[1])
+        # Attempt 2 (after non-truncated illegal) -> no nudge at all.
+        for stage in ramp:
+            self.assertNotIn(stage, prompts[2])
+        # Attempt 3 (after truncation resumes) -> stage 0 again, not escalated.
+        self.assertIn(ramp[0], prompts[3])
+        self.assertNotIn(ramp[1], prompts[3])
 
     def test_non_truncated_failure_omits_concise_nudge(self):
         # A plain illegal move (finish_reason="stop") must retry WITHOUT the
@@ -310,7 +376,8 @@ class CoreHarnessTest(absltest.TestCase):
 
         self.assertEqual(result["submission"], 1)
         prompts = [cd["prompt"] for cd in result["call_details"]]
-        self.assertNotIn(core_harness.BASIC_RETHINK_TRUNCATED, prompts[1])
+        for stage in core_harness.BASIC_RETHINK_TRUNCATED_RAMP:
+            self.assertNotIn(stage, prompts[1])
 
     def test_truncated_response_with_legal_move_still_succeeds(self):
         # Truncation changes no game behaviour: if the cut-off text still

--- a/tests/core_harness_test.py
+++ b/tests/core_harness_test.py
@@ -274,6 +274,44 @@ class CoreHarnessTest(absltest.TestCase):
         self.assertEqual(result["submission"], -1)
         self.assertEqual(result["failureCategory"], "TRUNCATED")
 
+    def test_truncated_attempt_appends_concise_nudge_to_retry(self):
+        # After a length-truncated attempt, the retry prompt must carry the
+        # "answer concisely" nudge so the model stops over-reasoning; a normal
+        # unparsable/illegal attempt must not.
+        harness = _SimpleHarness()
+        agent = create_agent_fn(harness, max_retries=2)
+        side_effects = [
+            _fake_completion("", pieces=1, finish_reason="length"),
+            _fake_completion("move_1"),
+        ]
+        with patch.dict("os.environ", _ENV, clear=False), patch.object(
+            core_harness.litellm, "completion", side_effect=side_effects,
+        ):
+            result = agent({}, {})
+
+        self.assertEqual(result["submission"], 1)
+        prompts = [cd["prompt"] for cd in result["call_details"]]
+        self.assertNotIn(core_harness.BASIC_RETHINK_TRUNCATED, prompts[0])
+        self.assertIn(core_harness.BASIC_RETHINK_TRUNCATED, prompts[1])
+
+    def test_non_truncated_failure_omits_concise_nudge(self):
+        # A plain illegal move (finish_reason="stop") must retry WITHOUT the
+        # truncation nudge -- that correction only applies to budget blowups.
+        harness = _SimpleHarness()
+        agent = create_agent_fn(harness, max_retries=2)
+        side_effects = [
+            _fake_completion("not_a_legal_move"),
+            _fake_completion("move_1"),
+        ]
+        with patch.dict("os.environ", _ENV, clear=False), patch.object(
+            core_harness.litellm, "completion", side_effect=side_effects,
+        ):
+            result = agent({}, {})
+
+        self.assertEqual(result["submission"], 1)
+        prompts = [cd["prompt"] for cd in result["call_details"]]
+        self.assertNotIn(core_harness.BASIC_RETHINK_TRUNCATED, prompts[1])
+
     def test_truncated_response_with_legal_move_still_succeeds(self):
         # Truncation changes no game behaviour: if the cut-off text still
         # contains a legal move, the action is returned as normal. The only


### PR DESCRIPTION
When an attempt hits the output-token limit (finish_reason="length") before emitting a usable move, the model spent its whole budget on reasoning. Retrying with the generic illegal/unparsable rethink suffix doesn't address the real problem, so the model often blows the budget again and the episode forfeits.

Append a game-agnostic BASIC_RETHINK_TRUNCATED nudge to the retry prompt whenever the previous attempt was categorized TRUNCATED, telling the model to reason less and answer quickly. Centralized in the core retry loop so it applies to every harness without threading a new signal through each make_prompt.