### PR TITLE
Allow farmers/hands to move onto locked tiles in kaggriculture

### DIFF
--- a/kaggle_environments/envs/kaggriculture/kaggriculture.py
+++ b/kaggle_environments/envs/kaggriculture/kaggriculture.py
@@ -310,8 +310,9 @@ def _apply_unit_action(farm, private, idx, action, board_size, day, turns_per_da
         nx, ny = fx + dx, fy + dy
         if not (0 <= nx < board_size and 0 <= ny < board_size):
             return
-        if farm["tiles"][ny][nx] == "LOCKED":
-            return
+        # Movement onto LOCKED tiles is allowed: a hand can spawn on a locked
+        # shed-access tile, and blocking movement would strand it there forever.
+        # Tile operations (PLANT, WATER, etc.) still no-op on LOCKED tiles.
         _set_farmer_position(farm, idx, (nx, ny))
         return
 

--- a/tests/envs/kaggriculture/test_kaggriculture.py
+++ b/tests/envs/kaggriculture/test_kaggriculture.py
@@ -118,15 +118,48 @@ def test_buy_land_rejected_when_too_expensive():
     assert farm["money"] == 500
 
 
-def test_movement_blocked_into_locked_tiles():
+def test_movement_allowed_onto_locked_tiles():
     farm = _new_farm(10, 100)
     private = _new_private()
     # Farmer starts at (4,4). EAST -> (5,4) which is in NE quadrant (locked).
+    # Movement onto locked tiles is permitted so units are never stranded.
     _apply_unit_action(farm, private, 0, ["EAST"], 10, 0, 24)
-    assert farm["farmer"] == [4, 4]
-    # WEST -> (3, 4) is unlocked NW.
+    assert farm["farmer"] == [5, 4]
+    assert farm["tiles"][4][5] == "LOCKED"
+    # And they can step back off the locked tile.
     _apply_unit_action(farm, private, 0, ["WEST"], 10, 0, 24)
-    assert farm["farmer"] == [3, 4]
+    assert farm["farmer"] == [4, 4]
+
+
+def test_hand_spawned_on_locked_tile_can_move_off():
+    """A hand spawned on a locked shed-access tile must not be stranded."""
+    farm = _new_farm(10, 100)
+    private = _new_private()
+    # Force a hand onto a locked SE shed-access tile (5,5).
+    farm["hands"].append([5, 5])
+    private["inventories"].append({})
+    assert farm["tiles"][5][5] == "LOCKED"
+    _apply_unit_action(farm, private, 1, ["NORTH"], 10, 0, 24)
+    assert farm["hands"][0] == [5, 4]
+
+
+def test_movement_blocked_off_map():
+    """Allowing movement onto locked tiles must not allow moving off the board."""
+    farm = _new_farm(10, 100)
+    private = _new_private()
+    # Main farmer at NW corner (0, 0): NORTH and WEST both leave the board.
+    farm["farmer"] = [0, 0]
+    _apply_unit_action(farm, private, 0, ["NORTH"], 10, 0, 24)
+    assert farm["farmer"] == [0, 0]
+    _apply_unit_action(farm, private, 0, ["WEST"], 10, 0, 24)
+    assert farm["farmer"] == [0, 0]
+    # A hand at the SE corner (9, 9) cannot move SOUTH or EAST off the board.
+    farm["hands"].append([9, 9])
+    private["inventories"].append({})
+    _apply_unit_action(farm, private, 1, ["SOUTH"], 10, 0, 24)
+    assert farm["hands"][0] == [9, 9]
+    _apply_unit_action(farm, private, 1, ["EAST"], 10, 0, 24)
+    assert farm["hands"][0] == [9, 9]
 
 
 # --- Shed / pickup / inventory ---------------------------------------------


### PR DESCRIPTION
Farm hands can spawn on a locked shed-access tile (e.g. the SE inner corner when only NW is unlocked), and the movement handler blocked stepping onto LOCKED tiles, stranding them there permanently.

Relax the move code to allow stepping onto (and off) locked tiles. Off-map bounds checking is unchanged, and tile operations (PLANT, WATER, etc.) still no-op on locked tiles.