### PR TITLE
Decrease max game steps in CTF

### DIFF
--- a/kaggle_environments/envs/open_spiel_env/games/capture_the_flag/harness.py
+++ b/kaggle_environments/envs/open_spiel_env/games/capture_the_flag/harness.py
@@ -257,7 +257,7 @@ def generate_prompt(
     )
 
     score = state.get("score") or [0, 0]
-    horizon = state.get("horizon", 1000)
+    horizon = state.get("horizon", 500)
     move_number = state.get("move_number", 0)
     round_number = int(move_number) + 1
 

--- a/kaggle_environments/envs/open_spiel_env/games/capture_the_flag/harness.py
+++ b/kaggle_environments/envs/open_spiel_env/games/capture_the_flag/harness.py
@@ -257,7 +257,7 @@ def generate_prompt(
     )
 
     score = state.get("score") or [0, 0]
-    horizon = state.get("horizon", 500)
+    horizon = state.get("horizon", 300)
     move_number = state.get("move_number", 0)
     round_number = int(move_number) + 1
 

--- a/kaggle_environments/envs/open_spiel_env/open_spiel_env.py
+++ b/kaggle_environments/envs/open_spiel_env/open_spiel_env.py
@@ -1095,7 +1095,7 @@ GAMES_LIST = [
     "python_ant_foraging",
     "breakthrough",
     "bridge_arena",
-    "capture_the_flag",
+    "capture_the_flag(horizon=500)",
     "checkers",
     "chess",
     "clobber",

--- a/kaggle_environments/envs/open_spiel_env/open_spiel_env.py
+++ b/kaggle_environments/envs/open_spiel_env/open_spiel_env.py
@@ -1095,7 +1095,7 @@ GAMES_LIST = [
     "python_ant_foraging",
     "breakthrough",
     "bridge_arena",
-    "capture_the_flag(horizon=500)",
+    "capture_the_flag(horizon=300)",
     "checkers",
     "chess",
     "clobber",


### PR DESCRIPTION
I found in practice that most games were less than 150 steps, and the rest ran right up to 1000 and resulted in a tie. I want to lower this threshold since I doubt it will make a significant difference in the draw rate results we see, and it will speed the next run up. 