### PR TITLE
Mimic open spiel's 'strictMode: false' in custom Game Arena envs

### DIFF
--- a/.agents/skills/create-environment/SKILL.md
+++ b/.agents/skills/create-environment/SKILL.md
@@ -1,5 +1,34 @@
 # Create / Update an Environment
 
+## Step 0: Ask whether this is a Game Arena environment
+
+**Before writing any code, ask the user** — the answer changes how failures and
+illegal moves must be scored (Step 3b), and there is no way to infer it from the
+game rules alone.
+
+```
+AskUserQuestion({
+  questions: [{
+    question: "Is this a Game Arena environment (LLM-vs-LLM, results feed the Elo leaderboard)?",
+    header: "Env type",
+    multiSelect: false,
+    options: [
+      {label: "Game Arena",
+       description: "Agents are language models behind a harness; episodes are scored into a cross-model Elo rating. Requires the failure semantics in Step 3b."},
+      {label: "Regular",
+       description: "Classic Kaggle simulation competition or a standalone env. Per-agent INVALID/ERROR statuses are fine; use the framework defaults."},
+    ]
+  }]
+})
+```
+
+Signals that it is Game Arena, worth mentioning when you ask: the env ships a
+`harness.py`, agents receive natural-language prompts, or the user talks about
+comparing models rather than comparing submissions.
+
+If **Regular**, skip Step 3b and use the plain patterns in Step 3.
+If **Game Arena**, Step 3b is mandatory.
+
 ## Step 1: Create the directory and files
 
 Create `kaggle_environments/envs/<name>/` with:
@@ -145,7 +174,8 @@ from .agents import agents  # or define inline
 
 ### Common interpreter patterns
 
-**Validate and penalize invalid actions:**
+**Validate and penalize invalid actions** (regular envs only -- Game Arena envs
+must use Step 3b instead):
 ```python
 if state[i].action < 0 or state[i].action >= max_val:
     state[i].status = "INVALID"
@@ -174,6 +204,151 @@ if game_is_over:
 state[0].observation.board = board  # shared fields (if marked shared in spec)
 state[0].observation.lastOpponentAction = state[1].action
 ```
+
+## Step 3b: Failure and illegal-move handling (Game Arena environments)
+
+Skip this section for regular environments.
+
+Game Arena episodes are scored into a **cross-model Elo leaderboard**, so every
+episode either produces a trustworthy result or must produce none at all. That
+forces a distinction the framework does not make for you:
+
+| What happened | Framework status | Correct outcome |
+|---|---|---|
+| Agent process raised, or the model provider errored | `ERROR` | **Void the episode.** Not a game result. |
+| Agent exceeded `actTimeout` | `TIMEOUT` | **Void the episode.** Same as above. |
+| Agent returned a well-formed action that breaks the rules | `INVALID`, or your own rule check | **Scored forfeit.** Offender loses, opponent wins. |
+
+The reason for the split: a crash or a timeout is a *broken participant*, not a
+model playing badly. Scoring it as a loss injects infrastructure flakiness into
+the ratings -- a model on a slow provider would rank below one on a fast
+provider for reasons that have nothing to do with gameplay. An illegal move is
+the opposite: the model *did* play, it just played badly, and failing to follow
+the action format is a genuine capability signal that belongs in the rating.
+
+`open_spiel_env` with `strictMode: false` (the default) is the reference
+implementation -- see `open_spiel_env.py`, the `agent_error` / `invalid_action`
+branches. `word_association` and `word_art` implement the same semantics.
+**New Game Arena environments must match it.** Do not add a config flag for
+this; the behavior is not per-env negotiable.
+
+### The pattern
+
+Define a module-level forfeit reward matching open_spiel's convention:
+
+```python
+# Statuses core.py assigns when an agent crashes or times out, as opposed to
+# returning a well-formed-but-illegal action.
+_FRAMEWORK_FAILURE_STATUSES = ("ERROR", "TIMEOUT")
+
+# Reward applied to the forfeiting side. The opponent receives the negation.
+DEFAULT_INVALID_ACTION_REWARD = -1
+```
+
+**Void on crash/timeout.** Force every seat to `ERROR`, except seats already
+`TIMEOUT` (which voids the episode identically and is more informative in the
+replay). `core.py` then nulls all rewards automatically:
+
+```python
+def _abort_on_agent_failure(state):
+    """Void the episode if the framework marked any seat ERROR or TIMEOUT.
+    Returns True if the episode was ended."""
+    if not any(s.status in _FRAMEWORK_FAILURE_STATUSES for s in state):
+        return False
+    for s in state:
+        if s.status != "TIMEOUT":
+            s.status = "ERROR"
+    return True
+```
+
+**Forfeit on an illegal move.** Every seat ends `DONE` -- including the
+offender -- so the episode scores normally:
+
+```python
+def forfeit(state, offending_seat):
+    for i in range(len(state)):
+        state[i].status = "DONE"
+        state[i].reward = (
+            DEFAULT_INVALID_ACTION_REWARD
+            if i == offending_seat
+            else -DEFAULT_INVALID_ACTION_REWARD
+        )
+```
+
+Never leave a seat in `INVALID` at episode end. `core.py` nulls the reward of
+any `ERROR`/`INVALID`/`TIMEOUT` agent, so an `INVALID` terminal status is
+indistinguishable from a crash downstream -- which is exactly the collapse this
+section exists to prevent.
+
+### Wiring it into the interpreter
+
+Check for framework failures **before** your action-processing code runs, so a
+crash cannot be laundered into a scored forfeit:
+
+```python
+def interpreter(state, env):
+    if env.done:
+        return state
+
+    # A crashed or timed-out seat is a broken participant, not a player
+    # making an illegal move. Void before process_action can rescore it.
+    if _abort_on_agent_failure(state):
+        return state
+
+    forfeited = process_action(state, env.configuration)
+    ...
+```
+
+### Env-shape adjustments
+
+The two rules above are fixed; how they map onto your env is not. Decide these
+explicitly and write the reasoning into a docstring:
+
+* **Team games.** Scope the forfeit to the offender's *team*, not the lone
+  seat -- crediting the offender's own partner would reward a team for its own
+  foul. `word_association` (2v2) gives both offending seats
+  `DEFAULT_INVALID_ACTION_REWARD` and both opponents its negation.
+* **Multi-game episodes.** A forfeit is terminal for the whole episode. Return
+  a flag from your action processor and gate the next-game rollover on it;
+  otherwise the rollover resets the forfeiting seats to `ACTIVE` and overwrites
+  the forfeit rewards. (`word_association` had exactly this bug.)
+* **Running-score rewards.** If `reward` is a cumulative point total rather
+  than a win/loss value, overwriting it with a flat ±1 discards every completed
+  round. `word_art` deliberately diverges here: on `INVALID` it ends all seats
+  `DONE` and **keeps the accumulated points**. Crash/timeout still voids.
+
+### Visualizers
+
+A visualizer that computes terminal state as `status === 'DONE'` will silently
+render nothing on a voided episode. Handle `ERROR`/`TIMEOUT` explicitly and show
+why the episode was voided:
+
+```ts
+const isVoided = step.some((p) => p?.status === 'ERROR' || p?.status === 'TIMEOUT');
+const isGameOver = step.every((p) => p?.status === 'DONE') || isVoided;
+```
+
+### Required tests
+
+```python
+@pytest.mark.parametrize("crash_seat", range(NUM_AGENTS))
+def test_agent_crash_voids_the_episode(crash_seat):
+    def crash(observation, configuration):
+        raise RuntimeError("provider exploded")
+    agents = [legal_agent] * NUM_AGENTS
+    agents[crash_seat] = crash
+    env = make("<name>")
+    env.run(agents)
+    assert [s.status for s in env.state] == ["ERROR"] * NUM_AGENTS
+    assert [s.reward for s in env.state] == [None] * NUM_AGENTS
+```
+
+Cover, at minimum:
+- crash on every seat -> all `ERROR`, all rewards `None`
+- `DeadlineExceeded` on every seat (from `kaggle_environments.errors`) -> the
+  offending seat keeps `TIMEOUT`, the rest are `ERROR`, all rewards `None`
+- an illegal-but-well-formed action -> all `DONE` with ±1 rewards, never `None`
+- if the env supports multi-game episodes: a forfeit does not start a new game
 
 ## Step 4: Write agents
 
@@ -213,6 +388,8 @@ def test_rewards():
 
 
 def test_invalid_action():
+    # Regular envs only. Game Arena envs assert the Step 3b shape instead:
+    #   statuses == ["DONE", "DONE"], rewards == [-1, 1]
     env = make("<name>")
     env.run([bad_agent, good_agent])
     json = env.toJSON()
@@ -241,6 +418,7 @@ Follow the `create-visualizer` skill to build a web-based replay visualizer for 
 
 ## Checklist
 
+- [ ] Asked the user whether this is a Game Arena or regular environment (Step 0)
 - [ ] `<name>.json` spec is valid JSON with all required top-level keys
 - [ ] `<name>.py` exports `specification`, `interpreter`, `renderer`, `html_renderer`
 - [ ] Interpreter handles: normal play, invalid actions, game-over conditions
@@ -248,3 +426,14 @@ Follow the `create-visualizer` skill to build a web-based replay visualizer for 
 - [ ] `__init__.py` exists (can be empty)
 - [ ] Tests cover: normal completion, rewards, invalid actions, renderer output
 - [ ] `uv run ruff check --fix . && uv run ruff format .` passes
+
+Game Arena environments additionally:
+
+- [ ] Crash/timeout voids the episode (all seats `ERROR`/`TIMEOUT`, all rewards `None`)
+- [ ] Illegal move is a scored forfeit (all seats `DONE`, ±`DEFAULT_INVALID_ACTION_REWARD`)
+- [ ] No seat can end an episode in `INVALID`
+- [ ] Failure check runs before action processing in the interpreter
+- [ ] Team scoping, multi-game terminality, and running-score handling decided and documented
+- [ ] Visualizer renders a voided episode instead of silently showing nothing
+- [ ] Per-seat crash and timeout tests exist, plus an illegal-move forfeit test
+- [ ] No config flag was added to make this behavior optional

--- a/kaggle_environments/envs/word_art/visualizer/default/src/renderer.ts
+++ b/kaggle_environments/envs/word_art/visualizer/default/src/renderer.ts
@@ -122,7 +122,12 @@ export function renderer(options: RendererOptions) {
   const blueAttemptsUsed: number = obs0.blue_attempts_used ?? 0;
   const yellowAttemptsUsed: number = obs0.yellow_attempts_used ?? 0;
 
-  const isDone = currentStep?.every?.((p: any) => p?.status === 'DONE') ?? false;
+  // A crashed or timed-out seat voids the episode: every seat ends ERROR
+  // (a timed-out one keeps TIMEOUT) and all rewards are nulled. Those steps
+  // are terminal too, so fold them into isDone or the final panel never
+  // renders and the view sticks on a half-played round.
+  const isVoided = currentStep?.some?.((p: any) => p?.status === 'ERROR' || p?.status === 'TIMEOUT') ?? false;
+  const isDone = (currentStep?.every?.((p: any) => p?.status === 'DONE') ?? false) || isVoided;
 
   // Detect a round-transition step: on the sub-step where both teams
   // finish their guesses, the env immediately clears the round state and
@@ -422,7 +427,10 @@ export function renderer(options: RendererOptions) {
   statusBar.className = 'wa-status-bar sketched-border';
   if (isDone) {
     let outcome: string;
-    if (blueScore > yellowScore) outcome = `Blue wins ${blueScore}–${yellowScore}!`;
+    if (isVoided) {
+      const failed = currentStep.find((p: any) => p?.status === 'ERROR' || p?.status === 'TIMEOUT');
+      outcome = `Episode voided — an agent ${failed?.status === 'TIMEOUT' ? 'timed out' : 'crashed'}`;
+    } else if (blueScore > yellowScore) outcome = `Blue wins ${blueScore}–${yellowScore}!`;
     else if (yellowScore > blueScore) outcome = `Yellow wins ${yellowScore}–${blueScore}!`;
     else outcome = `Tie ${blueScore}–${yellowScore}`;
     const final = document.createElement('span');

--- a/kaggle_environments/envs/word_art/word_art.json
+++ b/kaggle_environments/envs/word_art/word_art.json
@@ -2,7 +2,7 @@
   "name": "word_art",
   "title": "Word Art",
   "description": "A 2v2 cooperative-vs-competitive game. Each round a secret word is shown to one artist per team; that artist draws ASCII art and passes it to their teammate, who has up to max_attempts guesses. Point value awarded on a correct guess is looked up in guess_points by attempt index (element 0 = attempt 1, element 1 = attempt 2, ...); failing all attempts scores 0. After N rounds the higher total wins. The artist and guesser within each team swap every round.",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "agents": [4],
   "configuration": {
     "num_rounds": {

--- a/kaggle_environments/envs/word_art/word_art.py
+++ b/kaggle_environments/envs/word_art/word_art.py
@@ -583,9 +583,10 @@ def initialize_game(state, env):
     env.word_art_state = _WordArtState(sampled)
 
 
-# Statuses the kaggle framework sets when an agent crashes or times out.
-# These end the episode -- see _abort_on_agent_failure.
-_TERMINAL_FAILURE_STATUSES = ("TIMEOUT", "ERROR", "INVALID")
+# Statuses core.py sets when an agent crashes or times out, as opposed to
+# submitting a well-formed-but-illegal action. These void the episode --
+# see _abort_on_agent_failure.
+_FRAMEWORK_FAILURE_STATUSES = ("TIMEOUT", "ERROR")
 
 
 def _abort_on_agent_failure(state):
@@ -596,20 +597,36 @@ def _abort_on_agent_failure(state):
     making a bad move, and word_art cannot score a 2v2 game around one. The
     alternative -- skipping that seat and playing on -- yields an episode
     where one model contributes no art and no guesses for the rest of the
-    game while the scoreboard still reports a winner. Ending here keeps the
-    failure loud: the offending seat retains its status, so core.py nulls its
-    reward and the replay shows an errored episode rather than a lopsided one.
+    game while the scoreboard still reports a winner.
+
+    Two distinct outcomes, matching open_spiel_env's non-strict path:
+
+    * TIMEOUT/ERROR voids the episode. Every seat is forced to ERROR (a
+      TIMEOUT seat keeps TIMEOUT, which voids it the same way) so core.py
+      nulls all four rewards and the replay reads as an errored episode
+      rather than a decided one.
+    * INVALID -- a well-formed action that broke the action schema -- ends
+      the episode as a normal completion: all seats DONE, keeping whatever
+      round points each team had already banked. Unlike open_spiel, the
+      accumulated score is preserved rather than overwritten with a flat
+      +/-1, because word_art's reward channel is a running point total and
+      discarding it would throw away every completed round.
 
     Note this is deliberately NOT the illegalMoveForfeit path. A model that
     answers unparseably forfeits the turn and plays on; a model whose agent
     raised has no working turn to fall back to.
     """
-    if not any(s.status in _TERMINAL_FAILURE_STATUSES for s in state):
-        return False
-    for s in state:
-        if s.status not in _TERMINAL_FAILURE_STATUSES:
+    if any(s.status in _FRAMEWORK_FAILURE_STATUSES for s in state):
+        for s in state:
+            if s.status != "TIMEOUT":
+                s.status = "ERROR"
+        return True
+    if any(s.status == "INVALID" for s in state):
+        for s in state:
             s.status = "DONE"
-    return True
+            s.reward = s.reward or 0
+        return True
+    return False
 
 
 def _set_art_statuses(state, round_idx):

--- a/kaggle_environments/envs/word_association/visualizer/default/src/renderer.tsx
+++ b/kaggle_environments/envs/word_association/visualizer/default/src/renderer.tsx
@@ -591,10 +591,26 @@ export const GameRenderer: React.FC<GameRendererProps> = (options: GameRendererP
     }
   }, [step]);
 
-  const isGameOver = currentEnvStep[0].status === 'DONE';
+  // A crashed or timed-out seat ends the episode with ERROR/TIMEOUT rather
+  // than DONE, so the terminal check must cover all three or the results
+  // panel silently never renders on a voided episode.
+  const isVoided = currentEnvStep.some((p: any) => p?.status === 'ERROR' || p?.status === 'TIMEOUT');
+  const isGameOver = currentEnvStep[0].status === 'DONE' || isVoided;
   let winnerText: React.ReactNode = null;
 
-  if (isGameOver) {
+  if (isVoided) {
+    // Rewards are nulled on a voided episode, so there is no winner to show.
+    const failedSeat = currentEnvStep.findIndex((p: any) => p?.status === 'ERROR' || p?.status === 'TIMEOUT');
+    const reason = currentEnvStep[failedSeat]?.status === 'TIMEOUT' ? 'timed out' : 'crashed';
+    winnerText = (
+      <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', lineHeight: '1.2' }}>
+        <span style={{ color: '#ff6b6b' }}>⚠ EPISODE VOIDED ⚠</span>
+        <span style={{ fontSize: '14px', color: '#aaaaaa', marginTop: '4px', fontWeight: 'normal' }}>
+          (An agent {reason} — no result recorded)
+        </span>
+      </div>
+    );
+  } else if (isGameOver) {
     const trapIndex = renderState.roles.findIndex((role) => role === 'trap');
     const trapRevealed = trapIndex !== -1 && renderState.revealed[trapIndex];
 

--- a/kaggle_environments/envs/word_association/word_association.json
+++ b/kaggle_environments/envs/word_association/word_association.json
@@ -2,7 +2,7 @@
   "name": "word_association",
   "title": "Word Association",
   "description": "A game of word association and deduction, adapted for AI agents.",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "agents": [4],
   "configuration": {
     "board_size": {

--- a/kaggle_environments/envs/word_association/word_association.py
+++ b/kaggle_environments/envs/word_association/word_association.py
@@ -76,7 +76,43 @@ def update_visibility(state):
         else:
             state[i].observation.roles = roles[:]
 
+# Statuses core.py assigns when an agent crashes or times out, as opposed to
+# returning a well-formed-but-illegal action. See _abort_on_agent_failure.
+_FRAMEWORK_FAILURE_STATUSES = ("ERROR", "TIMEOUT")
+
+# Reward applied to the forfeiting team when a seat submits an illegal action.
+# The opposing team receives the negation. Mirrors open_spiel_env's
+# DEFAULT_INVALID_ACTION_REWARD so forfeits score identically across envs.
+DEFAULT_INVALID_ACTION_REWARD = -1
+
+
+def _abort_on_agent_failure(state):
+    """Void the episode if the framework marked any seat ERROR or TIMEOUT.
+    Returns True if the episode was ended.
+
+    A seat that crashed or timed out is a broken participant, not a model
+    making an illegal move, and a 2v2 game cannot be scored around one.
+    Matching open_spiel_env's non-strict path, every seat is forced to ERROR
+    (a TIMEOUT seat keeps TIMEOUT, which voids the episode the same way) so
+    core.py nulls all four rewards and the replay reads as an errored episode
+    rather than a decided one.
+
+    This is deliberately NOT the illegal-move path: a model that returns an
+    unparseable or rule-breaking action forfeits and its opponents are
+    credited, because that is gameplay. A crash is not.
+    """
+    if not any(s.status in _FRAMEWORK_FAILURE_STATUSES for s in state):
+        return False
+    for s in state:
+        if s.status != "TIMEOUT":
+            s.status = "ERROR"
+    return True
+
+
 def process_action(state, config):
+    """Apply the active seat's action. Returns True if the action forfeited
+    the episode, which ends play immediately even when games_per_episode > 1.
+    """
     current_turn = state[0].observation.current_turn
     active_agent = state[current_turn]
     action = active_agent.action
@@ -85,12 +121,11 @@ def process_action(state, config):
     # Extract it so the rest of the interpreter sees the unwrapped value.
     if isinstance(action, dict) and "submission" in action:
         action = action["submission"]
-    
+
     # helper to end game
     def end_game(winner=None):
         for i in range(4):
-            if state[i].status != "INVALID":
-                state[i].status = "DONE"
+            state[i].status = "DONE"
             if winner == "blue":
                 if i in [0, 1]:
                     state[i].reward = (state[i].reward or 0) + 1
@@ -104,18 +139,44 @@ def process_action(state, config):
             else:
                 state[i].reward = state[i].reward or 0
 
-    # Handle Agent Failure / Invalid Action
+    def forfeit():
+        """End the episode because the seat at `current_turn` submitted an
+        illegal action. The offending team takes
+        DEFAULT_INVALID_ACTION_REWARD and the opposing team its negation,
+        matching open_spiel_env's non-strict INVALID path. Every seat ends
+        DONE -- including the offender -- so the episode scores normally.
+
+        The offender's team, not just the offender, absorbs the loss: this is
+        a 2v2 game and a forfeit ends it for both teammates, so crediting the
+        partner of the offending seat would reward a team for its own
+        illegal move.
+
+        Rewards are assigned absolutely rather than accumulated, so under
+        games_per_episode > 1 a forfeit discards prior game wins and ends the
+        episode immediately. That mirrors open_spiel, where a forfeit
+        overrides the game's natural returns; the per-game tally is still
+        readable from observation.blue_wins / yellow_wins.
+        """
+        offending_team = [0, 1] if current_turn in [0, 1] else [2, 3]
+        for i in range(4):
+            state[i].status = "DONE"
+            if i in offending_team:
+                state[i].reward = DEFAULT_INVALID_ACTION_REWARD
+            else:
+                state[i].reward = -DEFAULT_INVALID_ACTION_REWARD
+
+    # Handle Invalid Action. Crashes and timeouts never reach here -- the
+    # interpreter routes them to _abort_on_agent_failure first -- so a None
+    # action at this point means the harness produced no usable move.
     if action is None:
-        active_agent.status = "INVALID"
-        end_game(winner="yellow" if current_turn in [0, 1] else "blue")
-        return
+        forfeit()
+        return True
 
     # CLUEMASTER TURN
     if current_turn in [0, 2]:
         if not isinstance(action, dict) or "clue" not in action or "number" not in action:
-            active_agent.status = "INVALID"
-            end_game(winner="yellow" if current_turn == 0 else "blue")
-            return
+            forfeit()
+            return True
             
         # Clue validation
         normalized_clue = str(action["clue"]).strip().upper()
@@ -180,9 +241,8 @@ def process_action(state, config):
         guess_val = action.get("guess") if isinstance(action, dict) else action
         
         if not isinstance(guess_val, int) or guess_val < -1 or guess_val > BOARD_SIZE - 1:
-            active_agent.status = "INVALID"
-            end_game(winner="yellow" if current_turn == 1 else "blue")
-            return
+            forfeit()
+            return True
             
         # Pass
         if guess_val == -1:
@@ -190,9 +250,8 @@ def process_action(state, config):
             expected_remaining = BOARD_SIZE if clue_num <= 0 else clue_num + 1
             # 0 ("zero") and -1 ("infinity") clues both give unlimited guesses but STILL require at least 1 guess
             if state[0].observation.guesses_remaining == expected_remaining:
-                active_agent.status = "INVALID"
-                end_game(winner="yellow" if current_turn == 1 else "blue")
-                return
+                forfeit()
+                return True
                 
             for s in state:
                 s.observation.clue = ""
@@ -201,9 +260,8 @@ def process_action(state, config):
         else:
             # Check if already revealed
             if state[0].observation.revealed[guess_val]:
-                active_agent.status = "INVALID"
-                end_game(winner="yellow" if current_turn == 1 else "blue")
-                return
+                forfeit()
+                return True
                 
             # Reveal
             for s in state:
@@ -266,6 +324,12 @@ def interpreter(state, env):
     if env.done:
         return state
 
+    # A crashed or timed-out seat is a broken participant, not a player making
+    # an illegal move. Void the episode before process_action can launder the
+    # framework's ERROR/TIMEOUT into a scored forfeit.
+    if _abort_on_agent_failure(state):
+        return state
+
     prev_blue_reward = state[0].reward or 0
     prev_yellow_reward = state[2].reward or 0
 
@@ -277,7 +341,7 @@ def interpreter(state, env):
     acting_action = state[acting_turn].action
     pre_revealed = list(state[0].observation.revealed)
 
-    process_action(state, env.configuration)
+    forfeited = process_action(state, env.configuration)
     update_visibility(state)
 
     # Custom Memory Logic
@@ -290,8 +354,11 @@ def interpreter(state, env):
     for s in state:
         track_turn(s.observation, state, acting_turn, acting_action, pre_revealed)
     
-    if games_per_episode > 1:
-        is_done = all(s.status in ["DONE", "INVALID"] for s in state)
+    # A forfeit ends the whole episode, so never roll into the next game --
+    # doing so would relaunder the forfeiting seats back to ACTIVE and
+    # overwrite the forfeit rewards.
+    if games_per_episode > 1 and not forfeited:
+        is_done = all(s.status == "DONE" for s in state)
         if is_done:
             winner = None
             if (state[0].reward or 0) > prev_blue_reward: winner = "blue"

--- a/tests/envs/word_art/test_word_art.py
+++ b/tests/envs/word_art/test_word_art.py
@@ -834,9 +834,11 @@ def test_agent_failure_ends_the_episode_immediately():
     env.run([crash_blue_artist] * 4)
 
     assert env.done
-    assert env.state[0].status == "ERROR"
-    assert env.state[0].reward is None
-    assert [s.status for s in env.state[1:]] == ["DONE", "DONE", "DONE"]
+    # Matching open_spiel_env's non-strict path, one crashed seat voids the
+    # episode for everyone: all four go ERROR and core.py nulls every reward,
+    # so no team is credited with a win it did not play out.
+    assert [s.status for s in env.state] == ["ERROR"] * 4
+    assert [s.reward for s in env.state] == [None] * 4
     # Aborted during round 0's art phase, so no round ever completed.
     assert env.state[0].observation.history == []
     assert env.state[0].observation.current_round == 0
@@ -916,6 +918,38 @@ def test_guesser_timeout_ends_the_episode_keeping_earlier_scores():
     # Round 0 completed before the failure and its result survives.
     assert len(env.state[0].observation.history) == 1
     assert env.state[0].observation.yellow_score > 0
+
+
+def test_schema_invalid_action_ends_the_episode_keeping_points():
+    """An action that violates the action schema (here: an int, where the
+    schema allows only string/object/null) is a bad move, not a broken seat.
+
+    Unlike ERROR/TIMEOUT it does not void the episode -- every seat ends DONE
+    and each team keeps the points it banked in completed rounds. This
+    deliberately departs from open_spiel_env, which overwrites the natural
+    returns with a flat +/-1 forfeit: word_art's reward channel is a running
+    point total, so overwriting it would discard every completed round.
+    """
+
+    def bad_artist_in_round_2(observation, configuration):
+        if observation.role == "artist" and observation.current_round >= 2:
+            return 12345  # not a string/object/null
+        return cheating(observation, configuration)
+
+    env = _make(num_rounds=5, seed=1)
+    env.run([bad_artist_in_round_2] * 4)
+
+    assert env.done
+    assert [s.status for s in env.state] == ["DONE"] * 4
+    # Two rounds completed before the bad action; their points survive.
+    assert len(env.state[0].observation.history) == 2
+    assert env.state[0].observation.blue_score > 0
+    assert env.state[0].observation.yellow_score > 0
+    for seat in range(4):
+        assert env.state[seat].reward is not None
+    # Team rewards mirror the banked per-team scores.
+    assert env.state[0].reward == env.state[1].reward
+    assert env.state[2].reward == env.state[3].reward
 
 
 # --- Singular/plural guess leniency ---------------------------------------

--- a/tests/envs/word_association/test_word_association.py
+++ b/tests/envs/word_association/test_word_association.py
@@ -1,4 +1,49 @@
+import pytest
+
 from kaggle_environments import make
+from kaggle_environments.envs.word_association.word_association import (
+    DEFAULT_INVALID_ACTION_REWARD,
+)
+from kaggle_environments.errors import DeadlineExceeded
+
+
+def _legal_action(env, seat):
+    """A clue for cluemasters, the first still-unrevealed index for guessers.
+
+    Guessing a fixed index would forfeit the moment that square is revealed,
+    which ends the whole episode -- so multi-game tests must pick a legal
+    square each turn to actually reach a game transition.
+    """
+    if seat in (0, 2):
+        return {"clue": "ANIMAL", "number": 1}
+    revealed = env.state[0].observation.revealed
+    return next((i for i, r in enumerate(revealed) if not r), -1)
+
+
+def _step_legally(env):
+    env.step([
+        None if env.state[i].status != "ACTIVE" else _legal_action(env, i)
+        for i in range(4)
+    ])
+
+
+def _assert_forfeited(state, offending_seat):
+    """An illegal action ends the episode as a team-aware forfeit: every seat
+    goes DONE, the offender's team takes DEFAULT_INVALID_ACTION_REWARD and the
+    opposing team its negation. Mirrors open_spiel_env's non-strict INVALID
+    path, except the loss is scoped to the team rather than the lone seat --
+    crediting the offender's partner would reward a team for its own foul.
+    """
+    assert [s.status for s in state] == ["DONE"] * 4
+    offending_team = [0, 1] if offending_seat in (0, 1) else [2, 3]
+    for i, s in enumerate(state):
+        expected = (
+            DEFAULT_INVALID_ACTION_REWARD
+            if i in offending_team
+            else -DEFAULT_INVALID_ACTION_REWARD
+        )
+        assert s.reward == expected, f"seat {i}: expected {expected}, got {s.reward}"
+
 
 def test_word_association_completes():
     env = make("word_association")
@@ -54,7 +99,7 @@ def test_minimum_one_guess():
     env.step([-1 if i == guesser_turn else None for i in range(4)])
     state = env.state
     
-    assert state[guesser_turn].status == "INVALID"
+    _assert_forfeited(state, guesser_turn)
     assert env.done
 
 def test_unlimited_clues_require_one_guess():
@@ -69,7 +114,7 @@ def test_unlimited_clues_require_one_guess():
     
     guesser_turn = state[0].observation.current_turn
     env.step([-1 if i == guesser_turn else None for i in range(4)])
-    assert env.state[guesser_turn].status == "INVALID"
+    _assert_forfeited(env.state, guesser_turn)
 
 def test_infinity_clues_require_one_guess():
     env = make("word_association")
@@ -83,7 +128,7 @@ def test_infinity_clues_require_one_guess():
     
     guesser_turn = state[0].observation.current_turn
     env.step([-1 if i == guesser_turn else None for i in range(4)])
-    assert env.state[guesser_turn].status == "INVALID"
+    _assert_forfeited(env.state, guesser_turn)
 
 def test_clue_validation():
     env = make("word_association")
@@ -205,11 +250,7 @@ def test_subsequent_game_prompt_has_status_block():
     env = make("word_association", configuration={"games_per_episode": 5, "seed": 0})
     env.reset()
     while env.state[0].observation.current_game == 0 and not env.done:
-        env.step([
-            None if env.state[i].status != "ACTIVE"
-            else ({"clue": "ANIMAL", "number": 1} if i in (0, 2) else 0)
-            for i in range(4)
-        ])
+        _step_legally(env)
     assert env.state[0].observation.current_game >= 1
 
     obs = env.state[0].observation
@@ -231,9 +272,7 @@ def test_multi_game_guessers_dont_see_unmasked_roles_at_transition():
     prev_cg = env.state[0].observation.current_game
     saw_transition = False
     while not env.done:
-        env.step([None if env.state[i].status != "ACTIVE"
-                  else ({"clue": "ANIMAL", "number": 1} if i in (0, 2) else 0)
-                  for i in range(4)])
+        _step_legally(env)
         cg = env.state[0].observation.current_game
         if cg != prev_cg:
             saw_transition = True
@@ -267,6 +306,103 @@ def test_multi_game_per_game_seed_uniqueness():
     env2 = make("word_association", configuration={"games_per_episode": 2, "seed": 7})
     env2.run(["random", "random", "random", "random"])
     assert list(env2.state[0].observation.words) == words_game2
+
+
+# --- Framework failure vs. illegal move -------------------------------------
+#
+# A seat that crashed or timed out is a broken participant, not a model making
+# an illegal move, so the two must not collapse into the same outcome. Matching
+# open_spiel_env's non-strict path: ERROR/TIMEOUT voids the episode (all seats
+# ERROR, all rewards nulled), while an illegal action is a scored forfeit.
+
+
+def _legal_agent(observation, configuration):
+    if observation.current_turn in (0, 2):
+        return {"clue": "ANIMAL", "number": 1}
+    return next((i for i, r in enumerate(observation.revealed) if not r), -1)
+
+
+@pytest.mark.parametrize("crash_seat", [0, 1, 2, 3])
+def test_agent_crash_voids_the_episode(crash_seat):
+    """A raising agent must not be laundered into an INVALID forfeit that
+    credits the opposing team with a win it did not earn."""
+
+    def crash(observation, configuration):
+        raise RuntimeError("provider exploded")
+
+    agents = [_legal_agent] * 4
+    agents[crash_seat] = crash
+    env = make("word_association", configuration={"seed": 3})
+    env.run(agents)
+
+    assert env.done
+    assert [s.status for s in env.state] == ["ERROR"] * 4
+    assert [s.reward for s in env.state] == [None] * 4
+
+
+@pytest.mark.parametrize("timeout_seat", [0, 1, 2, 3])
+def test_agent_timeout_voids_the_episode(timeout_seat):
+    """A timed-out seat keeps TIMEOUT (which voids the episode the same way as
+    ERROR) rather than being relabeled INVALID."""
+    env = make("word_association", configuration={"seed": 3})
+    env.reset()
+    while True:
+        turn = env.state[0].observation.current_turn
+        actions = [None] * 4
+        if turn == timeout_seat:
+            actions[turn] = DeadlineExceeded()
+            env.step(actions)
+            break
+        actions[turn] = _legal_agent(env.state[turn].observation, None)
+        env.step(actions)
+
+    assert env.done
+    assert env.state[timeout_seat].status == "TIMEOUT"
+    assert all(s.status in ("ERROR", "TIMEOUT") for s in env.state)
+    assert [s.reward for s in env.state] == [None] * 4
+
+
+def test_illegal_move_is_a_scored_forfeit_not_an_error():
+    """The counterpart to the tests above: a well-formed but rule-breaking
+    action still ends the episode with a real result."""
+
+    def bad_guesser(observation, configuration):
+        if observation.current_turn in (0, 2):
+            return {"clue": "ANIMAL", "number": 1}
+        return 999  # out of range
+
+    env = make("word_association", configuration={"seed": 3})
+    env.reset()
+    # Whichever team leads, its guesser is the first seat to offend.
+    offending_seat = env.state[0].observation.current_turn + 1
+    env.run([_legal_agent, bad_guesser, _legal_agent, bad_guesser])
+
+    assert env.done
+    _assert_forfeited(env.state, offending_seat)
+
+
+def test_forfeit_ends_a_multi_game_episode_immediately():
+    """A forfeit is terminal: the next game must not start and relaunder the
+    forfeiting seats back to ACTIVE."""
+
+    def bad_guesser(observation, configuration):
+        if observation.current_turn in (0, 2):
+            return {"clue": "ANIMAL", "number": 1}
+        return 999
+
+    env = make(
+        "word_association",
+        configuration={"games_per_episode": 5, "seed": 0},
+    )
+    # Whichever team leads, its guesser is the first seat to submit the
+    # out-of-range guess.
+    env.reset()
+    offending_seat = env.state[0].observation.current_turn + 1
+    env.run([_legal_agent, bad_guesser, _legal_agent, bad_guesser])
+
+    assert env.done
+    assert env.state[0].observation.current_game == 0
+    _assert_forfeited(env.state, offending_seat)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
* If any of the agents raise an exception or timeout, error out the whole game
* If an agent makes an invalid move, set "DONE" status on all agents and use default forfeit rewards