### PR TITLE
Kaggriculture town rebalance

### DIFF
--- a/kaggle_environments/envs/kaggriculture/AGENTS.md
+++ b/kaggle_environments/envs/kaggriculture/AGENTS.md
@@ -19,7 +19,7 @@ Kaggriculture is a two-player farming sim. Each player manages a farm and compet
 - **Weeds** — every empty unlocked tile has a `weedSpawnChance` (default 0.005) of spawning a weed at end-of-day; clear with `DIG`
 - **Shed** — non-seed inventory cap of 100 items. Items beyond the cap at end-of-day drop are discarded. Seeds live in their own slot (no cap, never picked up by `PICKUP` — `PLANT` consumes them directly)
 - **Market** — fixed prices for seeds, animals, and `BUY_PRODUCT` orders; sale prices for harvested produce vary dynamically with market inventory. Price is `base` at the shared starting inventory `I0`, rises as inventory falls, and falls as inventory grows, using a per-resource shape function (`linear`, `sq`, `sqrt`, or `log`) that can differ on each side of `I0` — so gluts hit premium goods (strawberry, melon, milk, wool) hard, driving them to the $1 floor, while staples absorb oversupply more gently (see the Price Function table in [README.md](README.md)). Only wheat and fertilizer can be bought back via `BUY_PRODUCT`; every product can be sold via `SELL`. Each turn, at most `maxMarketOrdersPerTurn` (default 10) orders are processed per player; extras are silently dropped
-- **Town** — town center always demands product (1 of each non-fertilizer product every `townCenterSellInterval` turns, default 12, scaling to 2× after day 10 and 4× after day 20). Additional shops unlock every `townShopUnlockInterval` days (default 3, random selection from the remaining pool); each unlocked shop consumes one of every product it demands every `townShopSellInterval` turns (default 4, single-product shops consume 2×) — see the Town Buildings table in [README.md](README.md)
+- **Town** — town center always demands product (1 of each non-fertilizer product every `townCenterSellInterval` turns, default 24 — once per day, flat for the whole season). Additional shops unlock every `townShopUnlockInterval` days (default 3, drawn uniformly at random **with replacement**, so duplicates are possible; capped at 8 instances); each unlocked shop instance consumes one of every product it demands every `townShopSellInterval` turns (default 4, single-product shops consume 2×) — see the Town Buildings table in [README.md](README.md)
 - **Season length** — 24 turns per day × 30 days = 720 turns by default
 - **Win condition** — most coins in the bank at the end of the season; ties are possible
 
@@ -46,7 +46,7 @@ Your agent is a function that receives an observation and returns an action dict
 - `market` — shared:
   - `inventory` — `{product: int}` current market supply
   - `prices` — `{product: int}` current per-unit sale price (rounded, floor 1)
-- `town` — shared: `unlocked_shops` — list of currently-active shop names
+- `town` — shared: `unlocked_shops` — list of currently-active shop names; names may repeat (shops are drawn with replacement) and each entry consumes independently
 
 **Action format:**
 

--- a/kaggle_environments/envs/kaggriculture/README.md
+++ b/kaggle_environments/envs/kaggriculture/README.md
@@ -166,11 +166,11 @@ The shed sits at the center of the board and is not a tile — it never appears 
 
 ### Town Buildings
 
-As the season progresses, new shops unlock at regular intervals (every `townShopUnlockInterval` days, default 3). Each unlock is randomly selected from the shops that have not yet been added; once unlocked, a shop stays active for the rest of the game. Total demand grows monotonically as more shops unlock.
+As the season progresses, new shops unlock at regular intervals (every `townShopUnlockInterval` days, default 3). Each unlock is drawn uniformly at random **with replacement** from the full shop table, so the same shop can unlock more than once — a season might end up with three bakeries and no yarn store. Once unlocked, a shop stays active for the rest of the game, and unlocking stops after 8 total instances. Total demand grows monotonically as more shops unlock.
 
-Each unlocked shop consumes one of every product it demands every `townShopSellInterval` turns (default 4). So with the default interval, a shop demanding wheat removes 6 wheat from the market per day. Single-product shops consume 2x.
+Each unlocked shop *instance* consumes one of every product it demands every `townShopSellInterval` turns (default 4). So with the default interval, a shop demanding wheat removes 6 wheat from the market per day, and two copies of that shop remove 12. Single-product shops consume 2x.
 
-In addition, the town center consumes one of every product (excluding fertilizer) every `townCenterSellInterval` turns (default 12). After day 10 this is increased to 2 of each, and after day 20 it is increased to 4 of each.
+In addition, the town center consumes one of every product (excluding fertilizer) every `townCenterSellInterval` turns (default 24, i.e. once per day). This rate is flat for the whole season — it does not ramp.
 
 | Shop Type | Increases Demand For |
 | :---- | :---- |
@@ -268,7 +268,7 @@ The top-level observation passed to each agent:
     "prices":    { "WHEAT": int, "CARROT": int, ... },
   },
   "town": {                # shared
-    "unlocked_shops": ["BAKERY", ...],
+    "unlocked_shops": ["BAKERY", "BAKERY", ...],   # may repeat; each entry consumes independently
   },
   "private": {             # this player only; opponent's private state is not visible
     "shed":        { "WHEAT": int, "GOOSE": int, "FERTILIZER": int, ... },
@@ -355,8 +355,8 @@ Per-crop seed costs and per-product base prices are not configurable; they are d
 | turnsPerDay | 24 | Number of turns that make up one in-game day |
 | shedCapacity | 100 | Max non-seed items the shed can hold; overflow at end-of-day drop is discarded |
 | weedSpawnChance | 0.005 | Per-tile probability of a weed spawning on an empty unlocked tile during end-of-day refresh |
-| townShopUnlockInterval | 3 | Days between successive town shop unlocks |
-| townShopSellInterval | 4 | Turns between consumption ticks by every unlocked town shop |
-| townCenterSellInterval | 12 | Turns between consumption ticks by the town center |
+| townShopUnlockInterval | 3 | Days between successive town shop unlocks (drawn with replacement, capped at 8 instances) |
+| townShopSellInterval | 4 | Turns between consumption ticks by every unlocked town shop instance |
+| townCenterSellInterval | 24 | Turns between consumption ticks by the town center (flat rate, once per day) |
 | seed | null | Optional input seed for deterministic episode generation; cleared from config after read so it stays out of agent observations |
 

--- a/kaggle_environments/envs/kaggriculture/kaggriculture.json
+++ b/kaggle_environments/envs/kaggriculture/kaggriculture.json
@@ -44,21 +44,21 @@
       "minimum": 0
     },
     "townShopUnlockInterval": {
-      "description": "Days between successive town shop unlocks. First shop unlocks on day equal to this value.",
+      "description": "Days between successive town shop unlocks. First shop unlocks on day equal to this value. Shops are drawn with replacement, so the same shop can unlock more than once; unlocking stops after 8 instances.",
       "type": "integer",
       "default": 3,
       "minimum": 1
     },
     "townShopSellInterval": {
-      "description": "Number of turns between successive consumption ticks by every unlocked town shop. Each shop pulls one of each of its products per tick (single-product shops pull 2x). Total demand grows monotonically as more shops are unlocked.",
+      "description": "Number of turns between successive consumption ticks by every unlocked town shop instance. Each instance pulls one of each of its products per tick (single-product shops pull 2x), so a duplicated shop consumes once per copy. Total demand grows monotonically as more shops are unlocked.",
       "type": "integer",
       "default": 4,
       "minimum": 1
     },
     "townCenterSellInterval": {
-      "description": "Number of turns between successive consumption ticks by the town center (one of every product per tick).",
+      "description": "Number of turns between successive consumption ticks by the town center (one of every non-fertilizer product per tick). At the default of 24 with turnsPerDay 24, the town center buys once per day at a flat rate for the whole season.",
       "type": "integer",
-      "default": 12,
+      "default": 24,
       "minimum": 1
     },
     "seed": {

--- a/kaggle_environments/envs/kaggriculture/kaggriculture.py
+++ b/kaggle_environments/envs/kaggriculture/kaggriculture.py
@@ -100,8 +100,9 @@ SHOPS = {
 
 TOWN_CENTER_PRODUCTS = [p for p in PRODUCTS if p != "FERTILIZER"]
 
-# Town center demand schedule: (day_threshold, multiplier), highest threshold first.
-TOWN_CENTER_DEMAND_SCHEDULE = [(20, 4), (10, 2), (0, 1)]
+# Maximum number of shop instances the town will ever unlock. Shops are drawn
+# with replacement, so this caps total count, not variety.
+MAX_SHOP_INSTANCES = 8
 
 
 def get(d, key, default):
@@ -717,11 +718,11 @@ def _town_consume(env, state, step):
     town = obs0.town
     cfg = env.configuration
     shop_interval = max(1, int(get(cfg, "townShopSellInterval", 4)))
-    center_interval = max(1, int(get(cfg, "townCenterSellInterval", 12)))
-    turns_per_day = max(1, int(get(cfg, "turnsPerDay", 24)))
-    day = step // turns_per_day
+    center_interval = max(1, int(get(cfg, "townCenterSellInterval", 24)))
 
     if step % shop_interval == 0:
+        # unlocked_shops may list the same shop more than once (shops are drawn
+        # with replacement); each instance consumes independently.
         for shop_name in town.get("unlocked_shops", []):
             products = SHOPS[shop_name]
             multiplier = 2 if len(products) == 1 else 1
@@ -729,9 +730,8 @@ def _town_consume(env, state, step):
                 market["inventory"][item] -= multiplier
 
     if step % center_interval == 0:
-        center_mult = next(m for threshold, m in TOWN_CENTER_DEMAND_SCHEDULE if day >= threshold)
         for item in TOWN_CENTER_PRODUCTS:
-            market["inventory"][item] -= center_mult
+            market["inventory"][item] -= 1
 
     _refresh_prices(market)
 
@@ -871,10 +871,11 @@ def _end_of_day(state, env, day):
     next_day = day + 1
     town = obs0.town
     if next_day > 0 and next_day % shop_interval == 0:
-        remaining = [s for s in SHOPS if s not in town["unlocked_shops"]]
-        if remaining:
-            choice = rng.choice(sorted(remaining))
-            town["unlocked_shops"].append(choice)
+        # Drawn with replacement: the same shop can unlock repeatedly, and each
+        # copy consumes independently. Variety is not guaranteed; only the total
+        # instance count is capped.
+        if len(town["unlocked_shops"]) < MAX_SHOP_INSTANCES:
+            town["unlocked_shops"].append(rng.choice(sorted(SHOPS)))
 
 
 def interpreter(state, env):

--- a/kaggle_environments/envs/kaggriculture/visualizer/default/src/renderFarm.ts
+++ b/kaggle_environments/envs/kaggriculture/visualizer/default/src/renderFarm.ts
@@ -612,28 +612,50 @@ function renderMarket(refs: LayoutRefs, market: MarketPublic, priceHistory: Reco
 }
 
 function renderTown(refs: LayoutRefs, town: TownPublic): void {
-  const active = new Set(town?.unlocked_shops ?? []);
+  // Shops are drawn with replacement, so a name can appear more than once and
+  // each copy consumes independently. There is one slot per shop name, so show
+  // the instance count rather than a second sprite.
+  const counts = new Map<string, number>();
+  for (const shop of town?.unlocked_shops ?? []) {
+    counts.set(shop, (counts.get(shop) ?? 0) + 1);
+  }
   // Look up by interpreter shop key.
   const buildingByShop = new Map<string, { sprite: string; label: string }>();
   for (const b of Object.values(SURROUNDING_BUILDINGS)) buildingByShop.set(b.shop, b);
 
   for (const slot of refs.shopSlots) {
     const shop = slot.dataset.building ?? '';
-    const isActive = active.has(shop);
+    const count = counts.get(shop) ?? 0;
     const meta = buildingByShop.get(shop);
     const existing = slot.querySelector<HTMLImageElement>('.town-sprite');
-    if (isActive && meta) {
+    const existingBadge = slot.querySelector<HTMLElement>('.town-shop-count');
+    if (count > 0 && meta) {
+      const label = count > 1 ? `${meta.label} x${count}` : meta.label;
       if (!existing) {
         const img = document.createElement('img');
         img.className = 'town-sprite';
         img.src = spriteSrc(meta.sprite);
         img.alt = meta.label;
-        img.title = meta.label;
+        img.title = label;
         // Insert before flower overlays so flowers stay on top.
         slot.insertBefore(img, slot.firstChild);
+      } else {
+        existing.title = label;
       }
-    } else if (existing) {
-      existing.remove();
+      if (count > 1) {
+        const badge = existingBadge ?? document.createElement('div');
+        if (!existingBadge) {
+          badge.className = 'town-shop-count';
+          slot.appendChild(badge);
+        }
+        const text = `x${count}`;
+        if (badge.textContent !== text) badge.textContent = text;
+      } else if (existingBadge) {
+        existingBadge.remove();
+      }
+    } else {
+      if (existing) existing.remove();
+      if (existingBadge) existingBadge.remove();
     }
   }
 }

--- a/kaggle_environments/envs/kaggriculture/visualizer/default/src/renderFarm.ts
+++ b/kaggle_environments/envs/kaggriculture/visualizer/default/src/renderFarm.ts
@@ -4,11 +4,12 @@ import {
   MARKET_ITEMS,
   QUADRANT_BY_SEGMENT,
   SEGMENT,
-  SURROUNDING_BUILDINGS,
+  SHOP_BUILDINGS,
   TOWN_CENTER_INDEX,
   TOWN_EMPTY_BRICK_INDICES,
   TOWN_GRID_COLS,
   TOWN_GRID_ROWS,
+  TOWN_SHOP_SLOT_ORDER,
   TOWN_SIGN_INDEX,
   type BoardSize,
   type CellRefs,
@@ -187,10 +188,12 @@ function townPanel(): string {
                       <img class="town-sprite" src="${spriteSrc('town_sign')}" alt="" title="Welcome to Kaggriculture!" />
                     </div>`;
           }
-          const building = SURROUNDING_BUILDINGS[i];
-          if (building) {
-            // renderTown injects the shop sprite once the shop unlocks.
-            return `<div class="town-slot town-slot--shop" data-slot="${i}" data-building="${building.shop}" style="${BG_BRICK_SLOT}"></div>`;
+          const shopOrder = TOWN_SHOP_SLOT_ORDER.indexOf(i);
+          if (shopOrder !== -1) {
+            // Slots are generic: renderTown fills them in unlock order, so the
+            // n-th unlocked shop lands in the n-th slot regardless of which
+            // shop it is.
+            return `<div class="town-slot town-slot--shop" data-slot="${i}" data-shop-order="${shopOrder}" style="${BG_BRICK_SLOT}"></div>`;
           }
           if (TOWN_EMPTY_BRICK_INDICES.has(i)) {
             return `<div class="town-slot" data-slot="${i}" style="${BG_BRICK_SLOT}"></div>`;
@@ -303,7 +306,10 @@ export function collectRefs(root: HTMLElement, board: BoardSize): LayoutRefs {
     dayValues: Array.from(root.querySelectorAll<HTMLElement>('.day-value')),
     turnValues: Array.from(root.querySelectorAll<HTMLElement>('.turn-value')),
     marketItems,
-    shopSlots: Array.from(root.querySelectorAll<HTMLElement>('.town-slot--shop')),
+    // Sorted by fill order so shopSlots[n] is where the n-th unlocked shop goes.
+    shopSlots: Array.from(root.querySelectorAll<HTMLElement>('.town-slot--shop')).sort(
+      (a, b) => Number(a.dataset.shopOrder) - Number(b.dataset.shopOrder)
+    ),
     townGeese: Array.from(root.querySelectorAll<HTMLImageElement>('.town-goose')),
     players: [1, 2].map((p) =>
       collectPlayerRefs(root.querySelector<HTMLElement>(`.farm-panel[data-player="${p}"]`)!, board)
@@ -612,52 +618,35 @@ function renderMarket(refs: LayoutRefs, market: MarketPublic, priceHistory: Reco
 }
 
 function renderTown(refs: LayoutRefs, town: TownPublic): void {
-  // Shops are drawn with replacement, so a name can appear more than once and
-  // each copy consumes independently. There is one slot per shop name, so show
-  // the instance count rather than a second sprite.
-  const counts = new Map<string, number>();
-  for (const shop of town?.unlocked_shops ?? []) {
-    counts.set(shop, (counts.get(shop) ?? 0) + 1);
-  }
-  // Look up by interpreter shop key.
-  const buildingByShop = new Map<string, { sprite: string; label: string }>();
-  for (const b of Object.values(SURROUNDING_BUILDINGS)) buildingByShop.set(b.shop, b);
+  // Shops are drawn with replacement, so unlocked_shops may repeat a name.
+  // Slots are generic and filled in unlock order, so every instance gets its
+  // own building -- three farmers' markets show as three sprites.
+  const unlocked = town?.unlocked_shops ?? [];
 
-  for (const slot of refs.shopSlots) {
-    const shop = slot.dataset.building ?? '';
-    const count = counts.get(shop) ?? 0;
-    const meta = buildingByShop.get(shop);
+  refs.shopSlots.forEach((slot, i) => {
+    const shop = unlocked[i];
+    const meta = shop ? SHOP_BUILDINGS[shop] : undefined;
     const existing = slot.querySelector<HTMLImageElement>('.town-sprite');
-    const existingBadge = slot.querySelector<HTMLElement>('.town-shop-count');
-    if (count > 0 && meta) {
-      const label = count > 1 ? `${meta.label} x${count}` : meta.label;
-      if (!existing) {
-        const img = document.createElement('img');
-        img.className = 'town-sprite';
-        img.src = spriteSrc(meta.sprite);
-        img.alt = meta.label;
-        img.title = label;
-        // Insert before flower overlays so flowers stay on top.
-        slot.insertBefore(img, slot.firstChild);
-      } else {
-        existing.title = label;
-      }
-      if (count > 1) {
-        const badge = existingBadge ?? document.createElement('div');
-        if (!existingBadge) {
-          badge.className = 'town-shop-count';
-          slot.appendChild(badge);
-        }
-        const text = `x${count}`;
-        if (badge.textContent !== text) badge.textContent = text;
-      } else if (existingBadge) {
-        existingBadge.remove();
-      }
-    } else {
+    if (!meta) {
       if (existing) existing.remove();
-      if (existingBadge) existingBadge.remove();
+      return;
     }
-  }
+    const src = spriteSrc(meta.sprite);
+    if (!existing) {
+      const img = document.createElement('img');
+      img.className = 'town-sprite';
+      img.src = src;
+      img.alt = meta.label;
+      img.title = meta.label;
+      // Insert before flower overlays so flowers stay on top.
+      slot.insertBefore(img, slot.firstChild);
+    } else if (existing.getAttribute('src') !== src) {
+      // Scrubbing backwards can leave a different shop in this slot.
+      existing.src = src;
+      existing.alt = meta.label;
+      existing.title = meta.label;
+    }
+  });
 }
 
 function renderGeese(refs: LayoutRefs, day: number, hour: number): void {

--- a/kaggle_environments/envs/kaggriculture/visualizer/default/src/style.css
+++ b/kaggle_environments/envs/kaggriculture/visualizer/default/src/style.css
@@ -531,6 +531,27 @@ body {
   image-rendering: pixelated;
 }
 
+/* Instance count for a shop unlocked more than once (shops are drawn with
+   replacement). One slot per shop name, so the count stands in for duplicate
+   sprites. */
+.town-shop-count {
+  position: absolute;
+  right: 4%;
+  top: 4%;
+  z-index: 7;
+  min-width: 1.1em;
+  padding: 0 0.25em;
+  border-radius: 0.6em;
+  background: rgba(0, 0, 0, 0.72);
+  color: #fff;
+  font-size: 0.68rem;
+  font-weight: 700;
+  line-height: 1.45;
+  text-align: center;
+  image-rendering: auto;
+  pointer-events: none;
+}
+
 /* The sign lives in slot 4 but should visually hang halfway across the
    slot 4/7 boundary, so absolute-position it on the bottom edge and
    translate it down by half its height. */

--- a/kaggle_environments/envs/kaggriculture/visualizer/default/src/style.css
+++ b/kaggle_environments/envs/kaggriculture/visualizer/default/src/style.css
@@ -531,27 +531,6 @@ body {
   image-rendering: pixelated;
 }
 
-/* Instance count for a shop unlocked more than once (shops are drawn with
-   replacement). One slot per shop name, so the count stands in for duplicate
-   sprites. */
-.town-shop-count {
-  position: absolute;
-  right: 4%;
-  top: 4%;
-  z-index: 7;
-  min-width: 1.1em;
-  padding: 0 0.25em;
-  border-radius: 0.6em;
-  background: rgba(0, 0, 0, 0.72);
-  color: #fff;
-  font-size: 0.68rem;
-  font-weight: 700;
-  line-height: 1.45;
-  text-align: center;
-  image-rendering: auto;
-  pointer-events: none;
-}
-
 /* The sign lives in slot 4 but should visually hang halfway across the
    slot 4/7 boundary, so absolute-position it on the bottom edge and
    translate it down by half its height. */

--- a/kaggle_environments/envs/kaggriculture/visualizer/default/src/types.ts
+++ b/kaggle_environments/envs/kaggriculture/visualizer/default/src/types.ts
@@ -4,11 +4,11 @@ export const SEGMENT = 5;
 // always empty.
 export const INVENTORY_SLOTS = 18;
 
-// 3x4 grid: top row holds the bakery, town center, and pizza shop. The
-// town sign sits on bare grass at row 2 middle, with a grass-empty slot
-// below it and a brick-empty slot at the bottom of the middle column.
-// The remaining 6 shops line the left and right columns. Shops unlock
-// one per 3 in-game days.
+// 3x4 grid: the town center sits at row 1 middle and the town sign on bare
+// grass at row 2 middle, with a grass-empty slot below it and a brick-empty
+// slot at the bottom of the middle column. The remaining 8 slots hold shops,
+// filled in unlock order (see TOWN_SHOP_SLOT_ORDER). Shops unlock one per 3
+// in-game days.
 export const TOWN_GRID_COLS = 3;
 export const TOWN_GRID_ROWS = 4;
 export const TOWN_CENTER_INDEX = 1;
@@ -26,19 +26,25 @@ export const QUADRANT_BY_SEGMENT: Record<number, string> = {
   3: 'SE',
 };
 
-// Shop slot index in the 3x4 grid (skipping center=1, sign=4, grass-empty
-// cell 7, and brick-empty cell 10) -> { interpreter shop key, sprite name,
-// label }.
-export const SURROUNDING_BUILDINGS: Record<number, { shop: string; sprite: string; label: string }> = {
-  0: { shop: 'BAKERY', sprite: 'bakery', label: 'Bakery' },
-  2: { shop: 'PIZZA_SHOP', sprite: 'pizza', label: 'Pizza Shop' },
-  3: { shop: 'BRUNCH_SPOT', sprite: 'brunch', label: 'Brunch Spot' },
-  5: { shop: 'YARN_STORE', sprite: 'yarn', label: 'Yarn Store' },
-  6: { shop: 'ICE_CREAM_SHOP', sprite: 'icecream', label: 'Ice Cream Shop' },
-  8: { shop: 'PET_CAFE', sprite: 'petcafe', label: 'Pet Cafe' },
-  9: { shop: 'SMOOTHIE_SHOP', sprite: 'smoothie', label: 'Smoothie Shop' },
-  11: { shop: 'FARMERS_MARKET', sprite: 'farmersmarket', label: "Farmers' Market" },
+// Interpreter shop key -> { sprite name, label }. Slot position is not fixed
+// per shop: shops are drawn with replacement, so the same shop can unlock
+// several times and each instance gets its own slot.
+export const SHOP_BUILDINGS: Record<string, { sprite: string; label: string }> = {
+  BAKERY: { sprite: 'bakery', label: 'Bakery' },
+  PIZZA_SHOP: { sprite: 'pizza', label: 'Pizza Shop' },
+  BRUNCH_SPOT: { sprite: 'brunch', label: 'Brunch Spot' },
+  YARN_STORE: { sprite: 'yarn', label: 'Yarn Store' },
+  ICE_CREAM_SHOP: { sprite: 'icecream', label: 'Ice Cream Shop' },
+  PET_CAFE: { sprite: 'petcafe', label: 'Pet Cafe' },
+  SMOOTHIE_SHOP: { sprite: 'smoothie', label: 'Smoothie Shop' },
+  FARMERS_MARKET: { sprite: 'farmersmarket', label: "Farmers' Market" },
 };
+
+// Grid indices that hold shops, in the order they get filled as shops unlock:
+// down the left column and right column together, skipping center=1, sign=4,
+// grass-empty=7, and brick-empty=10. Length must be >= the interpreter's
+// MAX_SHOP_INSTANCES (8) so every unlocked instance has a home.
+export const TOWN_SHOP_SLOT_ORDER: readonly number[] = [0, 2, 3, 5, 6, 8, 9, 11];
 
 // Visible market items. `key` is the interpreter's PRODUCTS key; `sprite` is the asset name.
 export const MARKET_ITEMS: { sprite: string; key: string }[] = [

--- a/kaggle_environments/envs/kaggriculture/visualizer/playable/src/engine/__tests__/interpreter.spec.ts
+++ b/kaggle_environments/envs/kaggriculture/visualizer/playable/src/engine/__tests__/interpreter.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { ANIMALS, CROPS, MARKET_PARAMS, PRODUCTS } from '../constants';
+import { ANIMALS, CROPS, MARKET_PARAMS, MAX_SHOP_INSTANCES, PRODUCTS, TOWN_CENTER_PRODUCTS } from '../constants';
 import {
   applyUnitAction,
   dailyRefreshAnimals,
@@ -302,6 +302,41 @@ describe('townConsume + decayPlants', () => {
     expect(s.market.inventory.EGG).toBe(eggBefore - 1 - 1);
   });
 
+  it('townConsume charges each duplicate shop instance independently', () => {
+    const s = fresh();
+    s.town.unlocked_shops = ['BAKERY', 'BAKERY'];
+    const wheatBefore = s.market.inventory.WHEAT;
+    const eggBefore = s.market.inventory.EGG;
+    townConsume(s.market, s.town, 1, { ...cfg, townShopSellInterval: 1 }); // step 1: shops only
+    expect(s.market.inventory.WHEAT).toBe(wheatBefore - 2);
+    expect(s.market.inventory.EGG).toBe(eggBefore - 2);
+  });
+
+  it('town center pulls a flat 1 of each non-fertilizer product all season', () => {
+    for (const stepIdx of [0, TPD * 29]) {
+      const s = fresh();
+      s.town.unlocked_shops = [];
+      const before = { ...s.market.inventory };
+      townConsume(s.market, s.town, stepIdx, cfg);
+      for (const item of TOWN_CENTER_PRODUCTS) {
+        expect(before[item] - s.market.inventory[item]).toBe(1);
+      }
+    }
+  });
+
+  it('town center ticks exactly once per day by default', () => {
+    expect(cfg.townCenterSellInterval).toBe(cfg.turnsPerDay);
+    let ticks = 0;
+    for (let stepIdx = 0; stepIdx < TPD; stepIdx++) {
+      const s = fresh();
+      s.town.unlocked_shops = [];
+      const before = s.market.inventory.WHEAT;
+      townConsume(s.market, s.town, stepIdx, cfg);
+      if (s.market.inventory.WHEAT < before) ticks++;
+    }
+    expect(ticks).toBe(1);
+  });
+
   it('decayPlants ticks yield_units down every 2 steps past max_lifespan_step', () => {
     const s = fresh();
     const f = s.farms[0];
@@ -422,6 +457,28 @@ describe('endOfDay', () => {
     // From day=3, nextDay=4 → no unlock.
     endOfDay(s.farms, s.privates, s.town, 3, cfg, s.seed);
     expect(s.town.unlocked_shops).toHaveLength(1);
+  });
+
+  it('stops unlocking at MAX_SHOP_INSTANCES', () => {
+    const s = fresh();
+    const everyDay = { ...cfg, townShopUnlockInterval: 1 };
+    for (let day = 0; day < 40; day++) {
+      endOfDay(s.farms, s.privates, s.town, day, everyDay, s.seed);
+    }
+    expect(s.town.unlocked_shops).toHaveLength(MAX_SHOP_INSTANCES);
+  });
+
+  it('draws shops with replacement, so duplicates can appear', () => {
+    const everyDay = { ...cfg, townShopUnlockInterval: 1 };
+    let sawDuplicate = false;
+    for (let seed = 0; seed < 8 && !sawDuplicate; seed++) {
+      const s = fresh(2, seed);
+      for (let day = 0; day < 40; day++) {
+        endOfDay(s.farms, s.privates, s.town, day, everyDay, s.seed);
+      }
+      sawDuplicate = new Set(s.town.unlocked_shops).size < s.town.unlocked_shops.length;
+    }
+    expect(sawDuplicate).toBe(true);
   });
 });
 

--- a/kaggle_environments/envs/kaggriculture/visualizer/playable/src/engine/constants.ts
+++ b/kaggle_environments/envs/kaggriculture/visualizer/playable/src/engine/constants.ts
@@ -154,12 +154,9 @@ export const SHOP_NAMES: ShopName[] = Object.keys(SHOPS) as ShopName[];
 
 export const TOWN_CENTER_PRODUCTS: ProductId[] = PRODUCTS.filter((p) => p !== 'FERTILIZER');
 
-// Highest threshold first — matches the next-match-wins lookup in Python.
-export const TOWN_CENTER_DEMAND_SCHEDULE: ReadonlyArray<readonly [number, number]> = [
-  [20, 4],
-  [10, 2],
-  [0, 1],
-];
+// Maximum number of shop instances the town will ever unlock. Shops are drawn
+// with replacement, so this caps total count, not variety.
+export const MAX_SHOP_INSTANCES = 8;
 
 // Default configuration — pulled directly from kaggriculture.json so the TS
 // engine stays in sync with the Python source of truth automatically.

--- a/kaggle_environments/envs/kaggriculture/visualizer/playable/src/engine/interpreter.ts
+++ b/kaggle_environments/envs/kaggriculture/visualizer/playable/src/engine/interpreter.ts
@@ -17,7 +17,7 @@ import {
   LAND_PRICES,
   SHOPS,
   SHOP_NAMES,
-  TOWN_CENTER_DEMAND_SCHEDULE,
+  MAX_SHOP_INSTANCES,
   TOWN_CENTER_PRODUCTS,
 } from './constants';
 import { marketPrice, refreshPrices } from './market';
@@ -530,10 +530,10 @@ export function processMarket(
 export function townConsume(market: Market, town: Town, step: number, config: Config): void {
   const shopInterval = Math.max(1, config.townShopSellInterval);
   const centerInterval = Math.max(1, config.townCenterSellInterval);
-  const turnsPerDay = Math.max(1, config.turnsPerDay);
-  const day = Math.floor(step / turnsPerDay);
 
   if (step % shopInterval === 0) {
+    // unlocked_shops may list the same shop more than once (shops are drawn
+    // with replacement); each instance consumes independently.
     for (const shop of town.unlocked_shops) {
       const products = SHOPS[shop];
       const mult = products.length === 1 ? 2 : 1;
@@ -544,15 +544,8 @@ export function townConsume(market: Market, town: Town, step: number, config: Co
   }
 
   if (step % centerInterval === 0) {
-    let centerMult = 1;
-    for (const [threshold, m] of TOWN_CENTER_DEMAND_SCHEDULE) {
-      if (day >= threshold) {
-        centerMult = m;
-        break;
-      }
-    }
     for (const item of TOWN_CENTER_PRODUCTS) {
-      market.inventory[item] -= centerMult;
+      market.inventory[item] -= 1;
     }
   }
 
@@ -701,10 +694,10 @@ export function endOfDay(
 
   const nextDay = day + 1;
   if (nextDay > 0 && nextDay % shopInterval === 0) {
-    const remaining = SHOP_NAMES.filter((s) => !town.unlocked_shops.includes(s));
-    if (remaining.length > 0) {
-      const choice = rng.choice([...remaining].sort());
-      town.unlocked_shops.push(choice);
+    // Drawn with replacement: the same shop can unlock repeatedly, and each
+    // copy consumes independently. Only the total instance count is capped.
+    if (town.unlocked_shops.length < MAX_SHOP_INSTANCES) {
+      town.unlocked_shops.push(rng.choice([...SHOP_NAMES].sort()));
     }
   }
 }

--- a/tests/envs/kaggriculture/test_kaggriculture.py
+++ b/tests/envs/kaggriculture/test_kaggriculture.py
@@ -6,6 +6,7 @@ from kaggle_environments.envs.kaggriculture.kaggriculture import (
     LAND_ORDER,
     LAND_PRICES,
     MARKET_PARAMS,
+    MAX_SHOP_INSTANCES,
     PRODUCTS,
     SHOPS,
     TOWN_CENTER_PRODUCTS,
@@ -17,6 +18,7 @@ from kaggle_environments.envs.kaggriculture.kaggriculture import (
     _do_buy_land,
     _do_hire,
     _drop_inventories_to_shed,
+    _end_of_day,
     _new_animal,
     _new_farm,
     _new_market,
@@ -24,6 +26,7 @@ from kaggle_environments.envs.kaggriculture.kaggriculture import (
     _new_private,
     _quadrant_of,
     _shed_access_tiles,
+    _town_consume,
     market_price,
 )
 
@@ -879,6 +882,84 @@ def test_town_unlocks_a_shop_after_three_days():
     final_town = j["steps"][-1][0]["observation"]["town"]
     assert len(final_town["unlocked_shops"]) >= 1
     assert all(s in SHOPS for s in final_town["unlocked_shops"])
+
+
+def test_town_shops_can_unlock_duplicates():
+    """Shops are drawn with replacement, so over a full season at least one
+    seed should produce a repeated shop. Sample a handful of seeds and assert
+    duplicates occur (the with-replacement draw makes this overwhelmingly likely)."""
+    saw_duplicate = False
+    for seed in range(8):
+        env = make("kaggriculture", configuration={"episodeSteps": 24 * 30, "seed": seed, "turnsPerDay": 24})
+        env.run(["pass", "pass"])
+        shops = env.toJSON()["steps"][-1][0]["observation"]["town"]["unlocked_shops"]
+        assert all(s in SHOPS for s in shops)
+        if len(set(shops)) < len(shops):
+            saw_duplicate = True
+            break
+    assert saw_duplicate, "expected at least one duplicated shop across sampled seeds"
+
+
+def test_shop_unlocks_stop_at_the_instance_cap():
+    """_end_of_day must not push past MAX_SHOP_INSTANCES."""
+    env = make("kaggriculture", configuration={"seed": 3, "turnsPerDay": 24, "townShopUnlockInterval": 1})
+    state = env.reset()
+    town = state[0].observation.town
+    # 40 unlock opportunities against a cap of 8.
+    for day in range(40):
+        _end_of_day(state, env, day)
+    assert len(town["unlocked_shops"]) == MAX_SHOP_INSTANCES
+
+
+def test_duplicate_shops_consume_independently():
+    """Two copies of a shop must drain twice as much as one copy."""
+    def drain(shops):
+        env = make("kaggriculture", configuration={"seed": 5, "townShopSellInterval": 1})
+        state = env.reset()
+        market = state[0].observation.market
+        state[0].observation.town["unlocked_shops"] = list(shops)
+        before = dict(market["inventory"])
+        _town_consume(env, state, 1)  # step 1: shops tick, town center does not
+        return {k: before[k] - v for k, v in market["inventory"].items()}
+
+    one = drain(["BAKERY"])
+    two = drain(["BAKERY", "BAKERY"])
+    assert one["WHEAT"] == 1 and one["EGG"] == 1
+    assert two["WHEAT"] == 2 and two["EGG"] == 2
+
+
+def test_town_center_rate_is_flat_across_the_season():
+    """No ramp: the center pulls exactly 1 of each non-fertilizer product on
+    every center tick, on day 0 and on day 29 alike."""
+    for step in (0, 24 * 29):
+        env = make("kaggriculture", configuration={"seed": 5, "turnsPerDay": 24})
+        state = env.reset()
+        market = state[0].observation.market
+        state[0].observation.town["unlocked_shops"] = []
+        before = dict(market["inventory"])
+        _town_consume(env, state, step)
+        for item in TOWN_CENTER_PRODUCTS:
+            assert before[item] - market["inventory"][item] == 1, f"{item} at step {step}"
+
+
+def test_town_center_buys_once_per_day_by_default():
+    """Default townCenterSellInterval equals turnsPerDay, so exactly one center
+    tick lands in each day."""
+    env = make("kaggriculture", configuration={"turnsPerDay": 24})
+    cfg = env.configuration
+    assert cfg.townCenterSellInterval == 24
+    assert cfg.townCenterSellInterval == cfg.turnsPerDay
+
+    ticks = 0
+    for step in range(24):
+        state = env.reset()
+        market = state[0].observation.market
+        state[0].observation.town["unlocked_shops"] = []
+        before = market["inventory"]["WHEAT"]
+        _town_consume(env, state, step)
+        if market["inventory"]["WHEAT"] < before:
+            ticks += 1
+    assert ticks == 1
 
 
 def test_town_consumes_market_inventory():


### PR DESCRIPTION
Changes

  1. Town center rate is flat 1× for the whole season. The 2× after day 10 / 4× after day 20 ramp (TOWN_CENTER_DEMAND_SCHEDULE) is removed.

  2. Town center buys once per day. townCenterSellInterval 12 → 24, so with the default turnsPerDay = 24 there's exactly one center tick per day instead of two.

  3. Shops are drawn with replacement. _end_of_day no longer filters out already-unlocked shops, so the same shop can unlock repeatedly and each instance consumes independently — a season might end up with three farmers' markets and no yarn store. Unlocking is capped at 8 total instances (new MAX_SHOP_INSTANCES), which is where the old "one of each of 8 shops" ceiling effectively sat.
