### PR TITLE
Mancala harness: state sow direction by index order

### DIFF
--- a/kaggle_environments/envs/open_spiel_env/games/mancala/harness.py
+++ b/kaggle_environments/envs/open_spiel_env/games/mancala/harness.py
@@ -39,8 +39,8 @@ and one store. Player 0 owns pits 1-6 and store 7. Player 1 owns pits
 8-13 and store 0. Seeds are sown counter-clockwise, which always means
 moving to the NEXT HIGHER cell index, wrapping from 13 back to 0:
 
-    1 -> 2 -> 3 -> 4 -> 5 -> 6 -> [store 7] -> 8 -> 9 -> 10 -> 11
-      -> 12 -> 13 -> [store 0] -> 1 -> ...
+    1 -> 2 -> 3 -> 4 -> 5 -> 6 -> [store 7: P0 only] -> 8 -> 9 -> 10
+      -> 11 -> 12 -> 13 -> [store 0: P1 only] -> 1 -> ...
 
 This direction is the same for both players. You ALWAYS skip the
 opponent's store: Player 0 goes pit 13 -> pit 1 (skipping store 0), and

--- a/kaggle_environments/envs/open_spiel_env/games/mancala/harness.py
+++ b/kaggle_environments/envs/open_spiel_env/games/mancala/harness.py
@@ -36,9 +36,15 @@ MANCALA_PROMPT_TEMPLATE = """Let's play Mancala (Kalah ruleset).
 
 Rules: 14-cell board with two players. Each player owns a row of 6 pits
 and one store. Player 0 owns pits 1-6 and store 7. Player 1 owns pits
-8-13 and store 0. Seeds are sown counter-clockwise -- after pit 6, the
-next cell is store 7, then pit 8; after pit 13, the next cell is store 0,
-then pit 1. A player ALWAYS skips the opponent's store while sowing.
+8-13 and store 0. Seeds are sown counter-clockwise, which always means
+moving to the NEXT HIGHER cell index, wrapping from 13 back to 0:
+
+    1 -> 2 -> 3 -> 4 -> 5 -> 6 -> [store 7] -> 8 -> 9 -> 10 -> 11
+      -> 12 -> 13 -> [store 0] -> 1 -> ...
+
+This direction is the same for both players. You ALWAYS skip the
+opponent's store: Player 0 goes pit 13 -> pit 1 (skipping store 0), and
+Player 1 goes pit 6 -> pit 8 (skipping store 7).
 
 On your turn, pick one of YOUR pits that contains seeds. Pick them all
 up and sow them one-at-a-time counter-clockwise into the following cells.
@@ -63,7 +69,10 @@ side of the board: their store PLUS any seeds remaining in their 6 pits.
 to that side's owner.) The player with the higher final score wins; equal
 scores is a draw.
 
-Board layout (fixed orientation, indices labeled):
+Board layout (fixed orientation, indices labeled). Note that Player 1's
+row is printed with the HIGHEST index on the left, so sowing runs
+right-to-left along that row; Player 0's row is printed lowest-first, so
+sowing runs left-to-right. Both are the same counter-clockwise direction:
 
     Player 1's pits:   [13] [12] [11] [10] [ 9] [ 8]
     Stores:        [0]                              [7]

--- a/tests/envs/open_spiel_env/games/mancala/harness_test.py
+++ b/tests/envs/open_spiel_env/games/mancala/harness_test.py
@@ -165,6 +165,18 @@ class GeneratePromptTest(absltest.TestCase):
         prompt = generate_prompt(obs, [])
         self.assertIn("Last action played: (none yet)", prompt)
 
+    def test_sow_direction_stated_without_per_player_contradiction(self):
+        # The engine sows to the next higher index for BOTH players, skipping
+        # only the opponent's store. Stating the wrap points per-cell instead
+        # ("after pit 6 the next cell is store 7") is false for player 1, who
+        # skips store 7 -- so assert the index-order phrasing is what ships.
+        obs = _make_observation(self.state, self.game, player_id=1)
+        prompt = generate_prompt(obs, [])
+        self.assertIn("NEXT HIGHER cell index", prompt)
+        self.assertIn("pit 6 -> pit 8", prompt)
+        self.assertIn("pit 13 -> pit 1", prompt)
+        self.assertNotIn("after pit 6, the", prompt)
+
     def test_endgame_sweep_rule_disclosed(self):
         obs = _make_observation(self.state, self.game, player_id=0)
         prompt = generate_prompt(obs, [])


### PR DESCRIPTION
## Problem

The Mancala prompt gave the two board wrap points as unconditional facts:

> Seeds are sown counter-clockwise -- after pit 6, the next cell is store 7, then pit 8; after pit 13, the next cell is store 0, then pit 1. A player ALWAYS skips the opponent's store while sowing.

Each half of that is false for one of the two seats, because each player skips a different store:

| | after pit 6 | after pit 13 |
|---|---|---|
| Player 0 | 7 ✓ | **1**, not 0 |
| Player 1 | **8**, not 7 | 0 ✓ |

So the sentence contradicts the one that follows it ("ALWAYS skips the opponent's store") rather than being qualified by it. A model can resolve the conflict, but it has to notice it first — and the prompt never states the invariant that would settle it, namely that sowing simply moves to the next higher index.

This matters more for Player 1, whose row is *printed* highest-index-first (`[13] [12] [11] [10] [ 9] [ 8]`). With no index-order rule stated, "counter-clockwise" has no anchor except the printed order, which for that seat runs opposite to the sow direction.

## Change

Prompt text only — no engine or parser changes.

- State the traversal once, as "next higher cell index", which is what `GetNextPit` implements for both players.
- Give the skip per player rather than as a contradictory blanket claim.
- Note on the board diagram that Player 1's row is printed highest-index-first, so its printed left-to-right order runs opposite to the sow direction for that seat.

## Verification

- All **26** cycle transitions (13 per seat) checked against the engine's `GetNextPit` — 0 mismatches. The previous text described only 2 transitions and got 1 wrong per seat.
- 40 complete games / 1,766 plies driven end-to-end through the patched harness: `get_legal_moves`, board render, direction text, and `parse_response` round-trip all 1766/1766.
- Sow reimplementation validated against the engine over 175,527 random-playout moves (0 mismatches) before being used as ground truth.
- 31 unit tests pass, including a new regression test pinning the index-order phrasing.

