### PR TITLE
[Shogi] Agent Review w/ Gameplay Dataset

### DIFF
--- a/kaggle_environments/envs/open_spiel_env/games/shogi/harness.py
+++ b/kaggle_environments/envs/open_spiel_env/games/shogi/harness.py
@@ -20,6 +20,7 @@ Sente's back rank).
 from __future__ import annotations
 
 import json
+import re
 from typing import Any, Mapping, Sequence
 
 import pyspiel
@@ -70,11 +71,18 @@ toward rank i (downward).
 Promotion: the promotion zone is the opponent's three back ranks -- ranks
 a, b, c for Sente; ranks g, h, i for Gote. When a piece moves into,
 within, or out of the promotion zone you may choose to promote it (append
-``+`` to the move). Promotion is compulsory when a non-promoted piece
+``+`` to the move). Promotion is OPTIONAL: for such a move both ``7c7b``
+and ``7c7b+`` are legal and they are different moves, so choose
+deliberately. Promotion is compulsory only when a non-promoted piece
 would otherwise have no legal move next turn (a pawn or lance on the
 opponent's back rank; a knight on either of the opponent's last two
-ranks). Promoted pieces are shown with a
-``+`` prefix on the board (e.g. ``+P`` is a promoted pawn). Promoted
+ranks).
+
+Watch the two meanings of ``+``: as a *prefix* on the board it marks a
+piece that is ALREADY promoted (e.g. ``+P`` is a promoted pawn); as a
+*suffix* on a move it requests promotion now. Never append ``+`` when
+moving a piece already shown with a ``+`` prefix -- promotions do not
+stack. Drops never promote. Promoted
 pawn, lance, knight, and silver all move like a gold general. Promoted
 bishop ("horse") moves like a bishop and also one square in any
 orthogonal direction. Promoted rook ("dragon") moves like a rook and also
@@ -94,6 +102,14 @@ restrictions:
 - You may not deliver immediate checkmate by dropping a pawn
   ("uchifuzume"). Delivering mate by dropping any other piece, or by a
   regular pawn move, is allowed.
+
+King safety: a move is ILLEGAL if it leaves your own king attacked --
+including moving a piece that is currently blocking an attack on your
+king (a pinned piece), and including a king move to a square the
+opponent still attacks. When you are in check your move MUST resolve it:
+capture the checking piece, block the line of attack, or move the king
+to safety. Any move that does not is rejected. Before answering, verify
+your king is safe after the move you chose.
 
 Game end (there are five terminal conditions the engine enforces; the
 king is never actually captured, because any move that would leave your
@@ -132,14 +148,7 @@ Board (files 9-1 across the top, ranks a-i down the left side; '.' =
 empty, uppercase = Sente, lowercase = Gote, '+X'/'+x' = promoted):
 {board_ascii}
 
-SFEN (Shogi Forsyth-Edwards Notation) for the same position: {sfen}
-The four SFEN fields are: board (nine ``/``-separated ranks a..i, each
-rank run-length-encoded where digits count empty squares, letters are
-pieces, and a ``+`` prefix marks a promoted piece), side to move (``b``
-= Sente, ``w`` = Gote), pieces in hand (``-`` if both empty; otherwise
-concatenated ``<count><PIECE>`` entries, uppercase for Sente and
-lowercase for Gote, count omitted when it is 1), and the SFEN full-move
-counter (Sente + Gote reply = 1 full move).
+SFEN (board / side to move / pieces in hand / full-move counter): {sfen}
 
 Pieces in hand (rendered with uppercase piece letters for both sides
 because USI drop notation uses ``<UPPERCASE_PIECE>*<square>``
@@ -156,13 +165,10 @@ letters, ``+`` prefix marks promoted): {own_roster}
 Move number: {move_number}
 Last move played: {last_move}
 Moves played so far this game (both players, oldest first): {full_history}
-
-Action notation reminder: a board move is ``<from><to>``, e.g. ``7g7f``
-means "the piece on 7g moves to 7f". Append ``+`` to promote when the
-move enters, stays within, or leaves the promotion zone: e.g. ``8h2b+``
-means "the piece on 8h moves to 2b and promotes". A drop is
-``<PIECE>*<square>`` using the uppercase piece letter, e.g. ``P*5e``
-drops a pawn from hand onto 5e.
+{check_status}
+Action notation reminder: ``7g7f`` moves the piece on 7g to 7f;
+``8h2b+`` moves 8h to 2b AND promotes; ``P*5e`` drops a pawn from hand
+onto 5e.
 
 It is your turn. Choose a legal move.
 
@@ -221,6 +227,9 @@ _RANK_LABELS = "abcdefghi"  # row 0 is rank a, row 8 is rank i
 
 # Iteration order for hand / roster displays (major -> minor).
 _PIECE_ORDER = ["K", "R", "B", "G", "S", "N", "L", "P"]
+
+# Lowercase piece letters, for stripping a SAN-style prefix in the matcher.
+_PIECE_LETTERS = "krbgsnlp"
 
 EMPTY_CELL = "."
 
@@ -321,6 +330,8 @@ def _diagnose_illegal_move(
     board: Sequence[Sequence[str]],
     captured: Mapping[str, Mapping[str, int]],
     player_id: int,
+    legal_action_strings: Sequence[str] | None = None,
+    in_check: bool = False,
 ) -> str:
     """Explain WHY ``move`` is illegal from the given position.
 
@@ -329,6 +340,11 @@ def _diagnose_illegal_move(
     it, so this only needs to help common cases (empty source,
     opponent-source, out-of-hand drop, occupied-drop, own-square
     capture, non-promotable geometry).
+
+    ``legal_action_strings`` (the engine's own legal moves for this position)
+    and ``in_check`` are optional: when supplied they let the board-move path
+    tell "that piece cannot reach that square" apart from "that move leaves
+    your king in check", which the board alone cannot distinguish.
     """
     if not move:
         return ""
@@ -417,7 +433,131 @@ def _diagnose_illegal_move(
                 f"Reason: promotion requires the move to start in, end in, or leave "
                 f"your promotion zone (ranks {zone}); {core[:2]}->{core[2:4]} touches neither."
             )
+
+    # Everything above is a rule the board alone can settle. What remains is
+    # either bad geometry (the piece cannot reach that square) or king safety
+    # (the move is geometrically fine but leaves the king attacked) -- between
+    # them the largest slice of illegal moves in the replay archive, and both
+    # previously fell through to no diagnosis at all. Distinguish them from the
+    # engine's own legal list rather than re-deriving movement rules here: if
+    # the piece has some other legal destination, geometry is the problem; if
+    # it has none, the piece is pinned or the king is under attack.
+    if legal_action_strings is not None:
+        same_source = [
+            legal
+            for legal in legal_action_strings
+            if "*" not in legal and legal[:2] == core[:2]
+        ]
+        if same_source:
+            destinations = sorted({legal[2:4] for legal in same_source})
+            return (
+                f"Reason: the {piece!r} on {core[:2]} cannot legally move to "
+                f"{core[2:4]}. From {core[:2]} your legal destinations are: "
+                f"{', '.join(destinations)}."
+            )
+        if in_check:
+            return (
+                f"Reason: you are in check, and moving the {piece!r} on "
+                f"{core[:2]} does not resolve it. You must capture the checking "
+                f"piece, block the line of attack, or move your king to safety."
+            )
+        return (
+            f"Reason: the {piece!r} on {core[:2]} has no legal move at all -- "
+            f"moving it would leave your own king under attack (it is pinned). "
+            f"Choose a different piece."
+        )
     return ""
+
+
+def _is_player_to_move(state: Mapping[str, Any], player_id: int) -> bool:
+    """Is ``player_id`` the side to move? Defaults to True when unknown.
+
+    The proxy reports ``current_player`` as ``"b"`` (Sente / player 0) or
+    ``"w"`` (Gote / player 1); on a terminal state it is a player-id name
+    instead, which matches neither and correctly suppresses the warning.
+    """
+    current = state.get("current_player")
+    if current not in ("b", "w"):
+        return "current_player" not in state
+    return (current == "b") == (player_id == 0)
+
+
+def _find_king_square(board: Sequence[Sequence[str]], player_id: int) -> str | None:
+    """USI square of ``player_id``'s king, or ``None`` if it is not on the board."""
+    want = "K" if player_id == 0 else "k"
+    for row_idx, row in enumerate(board):
+        for col_idx, cell in enumerate(row):
+            if cell == want:
+                return _square_label(row_idx, col_idx)
+    return None
+
+
+def _format_check_status(
+    board: Sequence[Sequence[str]], player_id: int, in_check: bool
+) -> str:
+    """Render the in-check warning block, or ``""`` when the king is safe.
+
+    Whether the side to move is in check comes from the engine
+    (``ShogiState::InCheck`` via the proxy's ``state_dict``), not from any
+    move generation here. The checking piece is deliberately not named: that
+    would need an attack scan, and the prompt intentionally withholds the
+    legal-move list so the model still has to do the work.
+    """
+    if not in_check:
+        return ""
+    king_square = _find_king_square(board, player_id)
+    where = f" Your king is on {king_square}." if king_square else ""
+    return (
+        "\n>>> YOU ARE IN CHECK." + where + " Your move MUST leave your king"
+        "\nsafe -- capture the checking piece, block the line of attack, or"
+        "\nmove the king to a square the opponent does not attack. Any other"
+        "\nmove is illegal and will be rejected.\n"
+    )
+
+
+def _match_shogi_move(raw: str, legals: Sequence[str]) -> str | None:
+    """Match a model's move against the legal set, tolerating notation slips.
+
+    Exact forms always win. Shogi promotion is *optional*, so most from-to
+    pairs that touch the promotion zone appear in the legal set twice --
+    ``7c7b`` and ``7c7b+`` are different, both-legal moves. Exact matching
+    therefore runs first and promotion-suffix tolerance runs LAST, so a model
+    that deliberately promotes (or deliberately declines) always gets the move
+    it asked for. The tolerant pass only ever fires when the requested form is
+    not legal at all, where the alternative is a forfeit.
+
+    The slips it recovers, in descending order of frequency in the replay
+    archive: a ``+`` appended to a move that touches no promotion zone; a
+    ``+`` copied from the board's promoted-piece *prefix* (``+R`` on the board
+    is already promoted, but models echo it as a promote suffix); a compulsory
+    ``+`` omitted; and a SAN-style leading piece letter (``S3i2h``).
+    """
+    by_norm = {"".join(legal.split()).lower(): legal for legal in legals}
+    squashed = "".join(str(raw).split()).lower()
+
+    candidates: list[str] = []
+    for base in (squashed, re.sub(r"[^0-9a-z*+]", "", squashed)):
+        if not base:
+            continue
+        candidates.append(base)
+        # SAN habit leaking into USI: "S3i2h" -> "3i2h". Only strip a leading
+        # letter when a file digit follows it, so drops ("P*5e") are untouched.
+        if len(base) >= 5 and base[0] in _PIECE_LETTERS and base[1].isdigit():
+            candidates.append(base[1:])
+    # Promotion-suffix tolerance is appended last: every exact-form candidate
+    # above is tried before any '+'-flipped one.
+    candidates += [
+        cand[:-1] if cand.endswith("+") else cand + "+" for cand in list(candidates)
+    ]
+
+    seen: set[str] = set()
+    for cand in candidates:
+        if cand in seen:
+            continue
+        seen.add(cand)
+        if cand in by_norm:
+            return by_norm[cand]
+    return None
 
 
 def _format_hand(hand: Mapping[str, int]) -> str:
@@ -489,6 +629,10 @@ def generate_prompt(
     side_label = "Sente" if player_id == 0 else "Gote"
     piece_case = "uppercase" if player_id == 0 else "lowercase"
 
+    # Only warn the side actually to move: `in_check` describes the current
+    # player, so it says nothing about a player_id who is merely observing.
+    in_check = bool(state.get("in_check")) and _is_player_to_move(state, player_id)
+
     prompt = SHOGI_PROMPT_TEMPLATE.format(
         board_ascii=_format_board_ascii(board),
         sfen=sfen,
@@ -501,6 +645,7 @@ def generate_prompt(
         move_number=move_number,
         last_move=last_move,
         full_history=full_history,
+        check_status=_format_check_status(board, player_id, in_check),
     )
 
     # Pre-fill {diagnosis} on the ILLEGAL template so render_rethink_suffix
@@ -513,7 +658,12 @@ def generate_prompt(
     diagnosis = ""
     if previous_action:
         diagnosis = _diagnose_illegal_move(
-            previous_action, board, captured, player_id
+            previous_action,
+            board,
+            captured,
+            player_id,
+            legal_action_strings=sorted(get_legal_moves(observation).values()) or None,
+            in_check=in_check,
         )
     escaped_diagnosis = diagnosis.replace("{", "{{").replace("}", "}}")
     illegal_template = RETHINK_ILLEGAL.replace(
@@ -534,5 +684,11 @@ def parse_response(
     response: str,
     legal_action_strings: Sequence[str],
 ) -> ParseResult:
-    """Trust the model's JSON answer; let the rethink loop fix anything else."""
-    return parse_json_action(response, legal_action_strings)
+    """Trust the model's JSON answer; let the rethink loop fix anything else.
+
+    The custom matcher only relaxes *notation*, never intent: an exactly-legal
+    move string is always taken as written (see ``_match_shogi_move``).
+    """
+    return parse_json_action(
+        response, legal_action_strings, matcher=_match_shogi_move
+    )

--- a/kaggle_environments/envs/open_spiel_env/games/shogi/shogi_proxy.py
+++ b/kaggle_environments/envs/open_spiel_env/games/shogi/shogi_proxy.py
@@ -142,6 +142,12 @@ class ShogiState(proxy.State):
             clone.apply_action(action)
         last_move = move_history[-1] if move_history else None
 
+        # Whether the side to move is in check. SFEN does not encode this and
+        # recomputing it needs full attack generation, so take the engine's
+        # own answer (``ShogiState::InCheck``, shogi.h:138) rather than
+        # re-deriving it downstream.
+        in_check = bool(self.__wrapped__.in_check())
+
         return {
             "board": parsed["board"],
             "current_player": _player_string(self.current_player()),
@@ -150,6 +156,7 @@ class ShogiState(proxy.State):
             "captured": parsed["captured"],
             "move_number": parsed["move_number"],
             "last_move": last_move,
+            "in_check": in_check,
             "move_history": move_history,
             "sfen": parsed["sfen"],
         }

--- a/tests/envs/open_spiel_env/games/shogi/harness_test.py
+++ b/tests/envs/open_spiel_env/games/shogi/harness_test.py
@@ -1,6 +1,7 @@
 """Tests for the Shogi LLM harness."""
 
 import json
+import random
 from unittest.mock import MagicMock, patch
 
 import pyspiel
@@ -109,6 +110,96 @@ class ParseResponseTest(absltest.TestCase):
         result = parse_response(response, self.legal)
         self.assertIsNone(result.legal_action)
         self.assertEqual(result.raw_action, "z9z9")
+
+
+class NotationToleranceTest(absltest.TestCase):
+    """Shogi promotion is OPTIONAL, so a from-to pair that touches the
+    promotion zone is usually in the legal set TWICE (``7c7b`` and
+    ``7c7b+``) as two different moves. The matcher must therefore never
+    let tolerance override an exactly-legal form -- but where the
+    requested form is not legal at all, the alternative is a forfeit.
+
+    Across the 1391-episode shogi-v2 archive (103,714 turns) this matcher
+    changed 0 of 103,374 already-correct parses and recovered 229 of 3,584
+    failures, 23 of them on turns that actually ended in a forfeit.
+    """
+
+    # Both forms of 7c7b are legal, as they are in most real positions.
+    both = ["7c7b", "7c7b+", "7g7f", "P*5e", "8h2b+"]
+
+    def test_exact_form_always_wins_when_both_legal(self):
+        # The load-bearing case: when both forms are legal each must map
+        # to ITSELF. If tolerance ran first it could silently promote a
+        # deliberate non-promotion (or vice versa) -- a real strategic
+        # difference, not a notation detail.
+        for move in ("7c7b", "7c7b+"):
+            result = parse_response(f'```json\n{{"move": "{move}"}}\n```', self.both)
+            self.assertEqual(result.legal_action, move)
+
+    def test_stray_promotion_suffix_recovered(self):
+        # 160 archive turns appended '+' to a move touching no promotion
+        # zone. Only "7g7f" is legal, so "7g7f+" is unambiguous.
+        result = parse_response('```json\n{"move": "7g7f+"}\n```', self.both)
+        self.assertEqual(result.legal_action, "7g7f")
+
+    def test_promoted_piece_prefix_echoed_as_suffix_recovered(self):
+        # 15 archive turns moved an ALREADY-promoted piece (rendered
+        # "+R" on the board) and copied that '+' onto the move. The
+        # board's '+' is a prefix meaning "already promoted"; the move's
+        # '+' is a suffix meaning "promote now".
+        legal = ["8b8a", "8b7b"]
+        result = parse_response('```json\n{"move": "8b8a+"}\n```', legal)
+        self.assertEqual(result.legal_action, "8b8a")
+
+    def test_omitted_compulsory_promotion_recovered(self):
+        # Compulsory promotion: only the '+' form is legal (a pawn on the
+        # opponent's back rank would otherwise have no move).
+        legal = ["1c1b+", "7g7f"]
+        result = parse_response('```json\n{"move": "1c1b"}\n```', legal)
+        self.assertEqual(result.legal_action, "1c1b+")
+
+    def test_san_style_piece_prefix_recovered(self):
+        # 47 archive turns wrote chess-style "S3i2h" instead of "3i2h".
+        legal = ["3i2h", "7g7f"]
+        result = parse_response('```json\n{"move": "S3i2h"}\n```', legal)
+        self.assertEqual(result.legal_action, "3i2h")
+
+    def test_decorative_punctuation_stripped(self):
+        result = parse_response('```json\n{"move": "7g-7f"}\n```', self.both)
+        self.assertEqual(result.legal_action, "7g7f")
+
+    def test_drop_is_not_mangled_by_piece_prefix_stripping(self):
+        # "P*5e" starts with a piece letter but must NOT have it stripped.
+        result = parse_response('```json\n{"move": "P*5e"}\n```', self.both)
+        self.assertEqual(result.legal_action, "P*5e")
+
+    def test_genuinely_illegal_move_still_rejected(self):
+        # Tolerance must not manufacture a move out of nothing: the
+        # rethink loop needs to see this failure.
+        result = parse_response('```json\n{"move": "9a9b"}\n```', self.both)
+        self.assertIsNone(result.legal_action)
+        self.assertEqual(result.raw_action, "9a9b")
+
+    def test_tolerance_never_overrides_an_exactly_legal_move(self):
+        # Property check over every legal move of a real position: each
+        # must round-trip to itself.
+        game = shogi_proxy.ShogiGame()
+        state = game.new_initial_state()
+        # This line opens the long diagonal, so Gote's bishop on 2b can
+        # reach 8h/7g either promoting or not -- both forms legal, which
+        # is the case that makes matcher ordering observable.
+        _apply_sequence(state, ["7g7f", "3c3d", "7f7e", "3d3e", "7e7d"])
+        pid = int(state.current_player())
+        legal = [state.action_to_string(pid, a) for a in state.legal_actions()]
+        promo_pairs = 0
+        for move in legal:
+            result = parse_response(f'```json\n{{"move": "{move}"}}\n```', legal)
+            self.assertEqual(result.legal_action, move)
+            if not move.endswith("+") and "*" not in move and move + "+" in legal:
+                promo_pairs += 1
+        # Guard the guard: this position must actually contain both-form
+        # pairs, or the assertion above proves nothing about ordering.
+        self.assertGreater(promo_pairs, 0)
 
 
 # ---------------------------------------------------------------------------
@@ -760,6 +851,201 @@ class DiagnoseIllegalMoveTest(absltest.TestCase):
         obs = _make_observation(self.state, self.game, player_id=0)
         prompt = generate_prompt(obs, [])
         self.assertNotIn("Reason:", prompt)
+
+
+def _reach_check(max_plies: int = 120) -> tuple[shogi_proxy.ShogiGame, shogi_proxy.ShogiState]:
+    """Play a deterministic line until the side to move is in check.
+
+    Uses a fixed seed and prefers checking moves so the search terminates
+    quickly; asserts rather than returning a non-check position, so a test
+    can never silently pass on a position it did not intend.
+    """
+    rng = random.Random(23)
+    game = shogi_proxy.ShogiGame()
+    for _ in range(500):
+        state = game.new_initial_state()
+        for _ in range(max_plies):
+            if state.is_terminal():
+                break
+            legal = state.legal_actions()
+            if not legal:
+                break
+            checking = []
+            for action in legal:
+                nxt = state.clone()
+                nxt.apply_action(action)
+                if not nxt.is_terminal() and nxt.__wrapped__.in_check():
+                    checking.append(action)
+            state.apply_action(rng.choice(checking or legal))
+            if not state.is_terminal() and state.__wrapped__.in_check():
+                return game, state
+    raise AssertionError("could not reach an in-check position")
+
+
+class InCheckDisclosureTest(absltest.TestCase):
+    """The prompt must tell the model when its king is under attack.
+
+    In the shogi-v2 archive, 822 of 3,402 illegal moves were geometrically
+    valid but rejected purely on king safety (603 while in check, 219 with a
+    pinned piece). In-check turns were 16.8% of all turns but produced 48.5%
+    of all forfeits, failing ~3x as often as safe turns.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.game, cls.state = _reach_check()
+
+    def _obs(self, player_id):
+        return _make_observation(self.state, self.game, player_id=player_id)
+
+    def test_state_dict_exposes_in_check(self):
+        parsed = json.loads(self.state.observation_string(0))
+        self.assertTrue(parsed["in_check"])
+        # And it must track the engine, not a re-derivation.
+        self.assertEqual(parsed["in_check"], self.state.__wrapped__.in_check())
+
+    def test_initial_position_is_not_in_check(self):
+        state = shogi_proxy.ShogiGame().new_initial_state()
+        self.assertFalse(json.loads(state.observation_string(0))["in_check"])
+
+    def test_prompt_warns_when_in_check(self):
+        prompt = generate_prompt(self._obs(int(self.state.current_player())), [])
+        self.assertIn("YOU ARE IN CHECK", prompt)
+        self.assertIn("MUST leave your king", prompt)
+
+    def test_warning_names_the_king_square(self):
+        pid = int(self.state.current_player())
+        prompt = generate_prompt(self._obs(pid), [])
+        board = json.loads(self.state.observation_string(0))["board"]
+        want = "K" if pid == 0 else "k"
+        square = next(
+            f"{'987654321'[c]}{'abcdefghi'[r]}"
+            for r, row in enumerate(board)
+            for c, cell in enumerate(row)
+            if cell == want
+        )
+        self.assertIn(f"Your king is on {square}", prompt)
+
+    def test_no_warning_when_king_is_safe(self):
+        state = shogi_proxy.ShogiGame().new_initial_state()
+        obs = _make_observation(state, shogi_proxy.ShogiGame(), player_id=0)
+        self.assertNotIn("IN CHECK", generate_prompt(obs, []))
+
+    def test_no_warning_for_the_player_not_to_move(self):
+        # `in_check` describes the side to move. Rendering the warning for
+        # the opponent would tell the wrong player their king is attacked.
+        other = 1 - int(self.state.current_player())
+        self.assertNotIn("YOU ARE IN CHECK", generate_prompt(self._obs(other), []))
+
+    def test_king_safety_rule_always_stated(self):
+        # The pin case needs a standing rule, not a per-turn warning:
+        # 219 archive failures moved a pinned piece while NOT in check.
+        state = shogi_proxy.ShogiGame().new_initial_state()
+        obs = _make_observation(state, shogi_proxy.ShogiGame(), player_id=0)
+        prompt = generate_prompt(obs, [])
+        self.assertIn("pinned piece", prompt)
+        self.assertIn("leaves your own king attacked", prompt)
+
+
+class PromotionOptionalityTest(absltest.TestCase):
+    """182 archive turns were rejected over a '+'-only difference, the
+    single largest notation failure. The prompt must say promotion is
+    optional and disambiguate the two meanings of '+'.
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.game = shogi_proxy.ShogiGame()
+        self.state = self.game.new_initial_state()
+        self.prompt = generate_prompt(
+            _make_observation(self.state, self.game, player_id=0), []
+        )
+
+    def test_promotion_stated_as_optional(self):
+        self.assertIn("Promotion is OPTIONAL", self.prompt)
+
+    def test_both_forms_shown_as_distinct_moves(self):
+        self.assertIn("``7c7b``", self.prompt)
+        self.assertIn("``7c7b+``", self.prompt)
+
+    def test_prefix_versus_suffix_disambiguated(self):
+        self.assertIn("prefix", self.prompt)
+        self.assertIn("suffix", self.prompt)
+        self.assertIn("ALREADY promoted", self.prompt)
+
+    def test_drops_never_promote(self):
+        self.assertIn("Drops never promote", self.prompt)
+
+
+class DiagnoseKingSafetyAndGeometryTest(absltest.TestCase):
+    """_diagnose_illegal_move returned "" on 1,465 of 3,723 failed
+    attempts in the archive -- exactly the king-safety and bad-geometry
+    cases. With only one rethink before forfeit, a contentless retry is
+    close to a wasted one.
+    """
+
+    def test_unreachable_destination_lists_real_destinations(self):
+        game = shogi_proxy.ShogiGame()
+        state = game.new_initial_state()
+        obs = _make_observation(state, game, player_id=0)
+        # The rook on 2h cannot reach 5e, but it does have legal moves.
+        prompt = generate_prompt(
+            obs, [], previous_response="x", previous_action="2h5e"
+        )
+        self.assertIn("cannot legally move to 5e", prompt)
+        self.assertIn("legal destinations", prompt)
+
+    def test_in_check_move_that_ignores_the_check_is_explained(self):
+        game, state = _reach_check()
+        pid = int(state.current_player())
+        obs = _make_observation(state, game, player_id=pid)
+        legal = set(obs["legalActionStrings"])
+        board = json.loads(state.observation_string(0))["board"]
+        # Find an own-piece move that is NOT legal and whose source piece
+        # also has no legal move -- i.e. rejected for king safety only.
+        own_upper = pid == 0
+        candidate = None
+        for r, row in enumerate(board):
+            for c, cell in enumerate(row):
+                if cell == "." or cell[-1].isupper() != own_upper:
+                    continue
+                src = f"{'987654321'[c]}{'abcdefghi'[r]}"
+                if any(m[:2] == src for m in legal if "*" not in m):
+                    continue
+                for dr, dc in ((-1, 0), (1, 0), (0, -1), (0, 1)):
+                    rr, cc = r + dr, c + dc
+                    if not (0 <= rr < 9 and 0 <= cc < 9):
+                        continue
+                    dest = board[rr][cc]
+                    if dest != "." and dest[-1].isupper() == own_upper:
+                        continue
+                    move = f"{src}{'987654321'[cc]}{'abcdefghi'[rr]}"
+                    if move not in legal:
+                        candidate = move
+                        break
+                if candidate:
+                    break
+            if candidate:
+                break
+        self.assertIsNotNone(candidate, "no king-safety-only candidate found")
+        prompt = generate_prompt(
+            obs, [], previous_response="x", previous_action=candidate
+        )
+        self.assertIn("Reason:", prompt)
+        self.assertIn("check", prompt.lower())
+
+    def test_diagnosis_degrades_gracefully_without_legal_moves(self):
+        # Called with no legal-move list (the older 4-arg form), the
+        # geometry/king-safety branch must stay silent rather than guess.
+        from kaggle_environments.envs.open_spiel_env.games.shogi.harness import (
+            _diagnose_illegal_move,
+        )
+        board = [["."] * 9 for _ in range(9)]
+        board[8][4] = "K"
+        self.assertEqual(
+            _diagnose_illegal_move("5i5a", board, {"b": {}, "w": {}}, 0), ""
+        )
 
 
 class GoteRookPromotionRegressionTest(absltest.TestCase):


### PR DESCRIPTION
An audit of the 1,391-episode shogi-v2-gameplay archive found that 340 episodes (24.4%) ended in a forfeit, and every forfeiting player lost — roughly a quarter of games decided by the harness failing to extract a legal move rather than by play. The two largest causes
  were the parser rejecting moves that differed only in a + promotion suffix, and the prompt never telling a model its king was in check. This PR fixes both, plus the rethink diagnosis that returned nothing on 39% of failed attempts, with each change measured against the
  same archive.
  
  Changes

  - shogi_proxy.py: expose in_check in state_dict(), sourced from the engine's own ShogiState::InCheck() rather than re-derived. Validated first: across 18,484 positions (3,323 genuinely in check) the engine call and an independent detector agreed with zero mismatches.
  - harness.py: add _match_shogi_move and wire it into parse_response. Promotion in shogi is optional, so 112,968 moves in the archive have both x and x+ legal at once — exact matching therefore runs first and promotion-suffix tolerance runs last, so a deliberate
  promote/decline is never silently flipped. Also recovers SAN-style piece prefixes (S3i2h) and decorative punctuation (7g-7f). Measured: 0 regressions on 103,374 correct parses, 229 recoveries on 3,584 failures (23 on forfeit turns, 206 on retries).
  - harness.py: disclose check state in the prompt. Adds a standing king-safety rule covering pinned pieces, plus a per-turn >>> YOU ARE IN CHECK block naming the king square, suppressed for the player not to move. Targets the 822 illegal moves that were geometrically
  valid but rejected on king safety (603 while in check, 219 pinned); in-check turns were 16.8% of all turns but produced 48.5% of forfeits.
  - harness.py: clarify promotion notation. States that promotion is optional with both forms legal, and separates the board's + prefix (already promoted) from a move's + suffix (promote now) — 15 archive turns conflated the two, e.g. 8b8a+ on a piece already rendered +R.
  - harness.py: extend _diagnose_illegal_move with geometry and king-safety branches, distinguished via the engine's legal-move list rather than duplicated movement rules. The geometry branch lists the piece's actual legal destinations. Measured: empty diagnoses 1,460 → 0 
  (1,059 geometry, 311 in-check, 90 pinned), with 0 existing diagnoses changed. This matters because max_retries=2 allows only one rethink before forfeit.
  - harness.py: trim redundant prompt text — the SFEN field-by-field gloss (duplicated by the ASCII board directly below it) and the notation reminder, cutting static prompt length with no rule loss. 131 archive calls hit finish_reason: length, 129 of them producing no
  move.
  - harness_test.py: 58 → 85 tests. Covers the matcher (including a property test asserting each of a position's legal moves round-trips to itself, guarded so it fails if the position contains no both-form pairs), in-check disclosure and its suppression for the observing
  player, promotion optionality, and the new diagnosis branches. Full suite: 1,337 passing.